### PR TITLE
Parsing braced parameter expansion (basic form)

### DIFF
--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -43,6 +43,10 @@ pub enum SyntaxError {
     UnclosedSingleQuote { opening_location: Location },
     /// A double quotation lacks a closing `"`.
     UnclosedDoubleQuote { opening_location: Location },
+    /// A parameter expansion lacks a closing `}`.
+    UnclosedParam { opening_location: Location },
+    /// A parameter expansion lacks a name.
+    EmptyParam,
     /// A command substitution started with `$(` but lacks a closing `)`.
     UnclosedCommandSubstitution { opening_location: Location },
     /// A command substitution started with `` ` `` but lacks a closing `` ` ``.
@@ -150,6 +154,8 @@ impl fmt::Display for SyntaxError {
             UnclosedParen { .. } => f.write_str("The parenthesis is not closed."),
             UnclosedSingleQuote { .. } => f.write_str("The single quote is not closed."),
             UnclosedDoubleQuote { .. } => f.write_str("The double quote is not closed."),
+            UnclosedParam { .. } => f.write_str("The parameter expansion is not closed."),
+            EmptyParam => f.write_str("The parameter name is missing."),
             UnclosedCommandSubstitution { .. } => {
                 f.write_str("The command substitution is not closed")
             }

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -50,6 +50,17 @@ impl<T, E> Shift for Result<Option<T>, E> {
     }
 }
 
+impl FromStr for Param {
+    type Err = Option<Error>;
+    fn from_str(s: &str) -> Result<Param, Option<Error>> {
+        match TextUnit::from_str(s) {
+            Err(e) => Err(Some(e)),
+            Ok(TextUnit::BracedParam(param)) => Ok(param),
+            Ok(_) => Err(None),
+        }
+    }
+}
+
 impl FromStr for TextUnit {
     type Err = Error;
     /// Parses a [`TextUnit`] by `lexer.text_unit(|_| false, |_| true)`.
@@ -266,6 +277,12 @@ impl FromStr for List {
 mod tests {
     use super::*;
     use std::iter::empty;
+
+    #[test]
+    fn param_from_str() {
+        let parse: Param = "${foo}".parse().unwrap();
+        assert_eq!(parse.to_string(), "${foo}");
+    }
 
     #[test]
     fn text_unit_from_str() {

--- a/yash-syntax/src/parser/lex.rs
+++ b/yash-syntax/src/parser/lex.rs
@@ -22,6 +22,7 @@ mod core;
 
 mod arith;
 mod backquote;
+mod braced_param;
 mod command_subst;
 mod dollar;
 mod heredoc;
@@ -34,6 +35,7 @@ mod tilde;
 mod token;
 mod word;
 
+pub use self::braced_param::is_name_char;
 pub use self::core::*;
 pub use self::heredoc::PartialHereDoc;
 pub use self::keyword::Keyword;

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -1,0 +1,207 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Part of the lexer that parses braced parameter expansion.
+
+use super::core::Lexer;
+use super::raw_param::is_portable_name_char;
+use super::raw_param::is_special_parameter_char;
+use crate::parser::core::Error;
+use crate::parser::core::Result;
+use crate::parser::core::SyntaxError;
+use crate::source::Location;
+use crate::source::SourceChar;
+use crate::syntax::Param;
+
+pub fn is_name_char(c: char) -> bool {
+    // TODO support other Unicode name characters
+    is_portable_name_char(c)
+}
+
+impl Lexer {
+    /// Consumes a POSIXly-portable name character optionally preceded by line
+    /// continuations.
+    async fn consume_name_char(&mut self) -> Result<Option<&SourceChar>> {
+        self.line_continuations().await?;
+        self.consume_char_if(is_name_char).await
+    }
+
+    /// Parses a parameter expansion that is enclosed in braces.
+    ///
+    /// The initial `$` must have been consumed before calling this function.
+    /// This functions checks if the next character is an opening brace. If so,
+    /// the following characters are parsed as a parameter expansion up to and
+    /// including the closing brace. Otherwise, no characters are consumed and
+    /// the return value is `Ok(Err(location))`.
+    ///
+    /// The `location` parameter should be the location of the initial `$`. It
+    /// is used to construct the result, but this function does not check if it
+    /// actually is a location of `$`.
+    ///
+    /// This function does not consume line continuations after the initial `$`.
+    /// They should have been consumed beforehand.
+    pub async fn braced_param(
+        &mut self,
+        location: Location,
+    ) -> Result<std::result::Result<Param, Location>> {
+        if !self.skip_if(|c| c == '{').await? {
+            return Ok(Err(location));
+        }
+
+        // TODO line continuations
+        let sc = self.peek_char().await?.unwrap();
+        let c = sc.value;
+        let name = if is_special_parameter_char(c) {
+            self.consume_char();
+            c.to_string()
+        } else if is_name_char(c) {
+            self.consume_char();
+            let mut name = c.to_string();
+            while let Some(c) = self.consume_name_char().await? {
+                name.push(c.value);
+            }
+            name
+        } else if c == '}' {
+            let cause = SyntaxError::EmptyParam.into();
+            let location = sc.location.clone();
+            return Err(Error { cause, location });
+        } else {
+            let opening_location = location;
+            let cause = SyntaxError::UnclosedParam { opening_location }.into();
+            let location = sc.location.clone();
+            return Err(Error { cause, location });
+        };
+
+        // TODO line continuations
+        if !self.skip_if(|c| c == '}').await? {
+            let opening_location = location;
+            let cause = SyntaxError::UnclosedParam { opening_location }.into();
+            let location = self.location().await?.clone();
+            return Err(Error { cause, location });
+        }
+
+        Ok(Ok(Param { name, location }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::core::ErrorCause;
+    use crate::source::Source;
+    use futures::executor::block_on;
+
+    #[test]
+    fn lexer_braced_param_minimum() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{@};");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "@");
+        // TODO assert about other result members
+        assert_eq!(result.location.line.value, "$");
+        assert_eq!(result.location.line.number.get(), 1);
+        assert_eq!(result.location.line.source, Source::Unknown);
+        assert_eq!(result.location.column.get(), 1);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, ';');
+    }
+
+    #[test]
+    fn lexer_braced_param_alphanumeric_name() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{foo_123}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "foo_123");
+        // TODO assert about other result members
+        assert_eq!(result.location.line.value, "$");
+        assert_eq!(result.location.line.number.get(), 1);
+        assert_eq!(result.location.line.source, Source::Unknown);
+        assert_eq!(result.location.column.get(), 1);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_numeric_name() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{123}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "123");
+        // TODO assert about other result members
+        assert_eq!(result.location.line.value, "$");
+        assert_eq!(result.location.line.number.get(), 1);
+        assert_eq!(result.location.line.source, Source::Unknown);
+        assert_eq!(result.location.column.get(), 1);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_missing_name() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{};");
+        let location = Location::dummy("$".to_string());
+
+        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
+        assert_eq!(e.location.line.value, "{};");
+        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.column.get(), 2);
+    }
+
+    #[test]
+    fn lexer_braced_param_unclosed_without_name() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{;");
+        let location = Location::dummy("$".to_string());
+
+        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        if let ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) = e.cause {
+            assert_eq!(opening_location.line.value, "$");
+            assert_eq!(opening_location.line.number.get(), 1);
+            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.column.get(), 1);
+        } else {
+            panic!("Unexpected cause: {:?}", e.cause);
+        }
+        assert_eq!(e.location.line.value, "{;");
+        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.column.get(), 2);
+    }
+
+    #[test]
+    fn lexer_braced_param_unclosed_with_name() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{_;");
+        let location = Location::dummy("$".to_string());
+
+        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        if let ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) = e.cause {
+            assert_eq!(opening_location.line.value, "$");
+            assert_eq!(opening_location.line.number.get(), 1);
+            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.column.get(), 1);
+        } else {
+            panic!("Unexpected cause: {:?}", e.cause);
+        }
+        assert_eq!(e.location.line.value, "{_;");
+        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.column.get(), 3);
+    }
+}

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -37,10 +37,14 @@ impl Lexer {
         };
 
         // TODO line continuations following $
-        // TODO braced parameter expansion
 
         let location = match self.raw_param(location).await? {
             Ok(result) => return Ok(Some(result)),
+            Err(location) => location,
+        };
+
+        let location = match self.braced_param(location).await? {
+            Ok(result) => return Ok(Some(TextUnit::BracedParam(result))),
             Err(location) => location,
         };
 

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -52,7 +52,7 @@ pub fn is_single_char_name(c: char) -> bool {
 impl Lexer {
     /// Consumes a POSIXly-portable name character optionally preceded by line
     /// continuations.
-    async fn consume_name_char(&mut self) -> Result<Option<&SourceChar>> {
+    async fn consume_portable_name_char(&mut self) -> Result<Option<&SourceChar>> {
         self.line_continuations().await?;
         self.consume_char_if(is_portable_name_char).await
     }
@@ -79,7 +79,7 @@ impl Lexer {
             Ok(Ok(TextUnit::RawParam { name, location }))
         } else if let Some(c) = self.consume_char_if(is_portable_name_char).await? {
             let mut name = c.value.to_string();
-            while let Some(c) = self.consume_name_char().await? {
+            while let Some(c) = self.consume_portable_name_char().await? {
                 name.push(c.value);
             }
             Ok(Ok(TextUnit::RawParam { name, location }))


### PR DESCRIPTION
- [x] Define syntax
- [x] Define errors that may happen while parsing
- [x] Implement parser for `BracedParam`
- [x] Support `BracedParam` in `Lexer::dollar_unit`
- [x] `impl FromStr for BracedParam`
- [ ] Refactor
