### PR TITLE
Parsing length modifier for parameter expansion

### DIFF
--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -123,6 +123,7 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "@");
+        assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
         assert_eq!(result.location.line.value, "$");
         assert_eq!(result.location.line.number.get(), 1);
@@ -139,6 +140,7 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "foo_123");
+        assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
         assert_eq!(result.location.line.value, "$");
         assert_eq!(result.location.line.number.get(), 1);
@@ -155,6 +157,7 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "123");
+        assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
         assert_eq!(result.location.line.value, "$");
         assert_eq!(result.location.line.number.get(), 1);
@@ -224,6 +227,7 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "a_1");
+        assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
         assert_eq!(result.location.line.value, "$");
         assert_eq!(result.location.line.number.get(), 1);

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -24,6 +24,7 @@ use crate::parser::core::Result;
 use crate::parser::core::SyntaxError;
 use crate::source::Location;
 use crate::source::SourceChar;
+use crate::syntax::Modifier;
 use crate::syntax::Param;
 
 /// Tests if a character can be part of a variable name.
@@ -99,7 +100,12 @@ impl Lexer {
             return Err(Error { cause, location });
         }
 
-        Ok(Ok(Param { name, location }))
+        let modifier = Modifier::None;
+        Ok(Ok(Param {
+            name,
+            modifier,
+            location,
+        }))
     }
 }
 

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -168,6 +168,15 @@ impl<T: MaybeLiteral> MaybeLiteral for [T] {
     }
 }
 
+/// Attribute that modifies a parameter expansion.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Modifier {
+    /// No modifier.
+    None,
+    /// `#` prefix. (`${#foo}`)
+    Length,
+}
+
 /// Parameter expansion enclosed in braces.
 ///
 /// This struct is used only for parameter expansions that are enclosed braces.
@@ -175,12 +184,12 @@ impl<T: MaybeLiteral> MaybeLiteral for [T] {
 /// [`TextUnit::RawParam`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Param {
-    // TODO length prefix
     // TODO recursive expansion
     /// Parameter name.
     pub name: String,
     // TODO index
-    // TODO modifier
+    /// Modifier.
+    pub modifier: Modifier,
     /// Location of the initial `$` character of this parameter expansion.
     pub location: Location,
 }


### PR DESCRIPTION
- [x] Define syntax
- [x] Implement Display for the new syntax
- [x] Modify existing parser tests to check the resultant modifiers
- [x] Parse the modifier
- [x] Parse line continuations on the modifier
- [ ] Refactor

----

`${##}`, `${#-}` and `${#?}` yield the length modifier.