### PR TITLE
Parsing switch in braced parameter

### DIFF
--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -39,6 +39,10 @@ use std::rc::Rc;
 pub enum SyntaxError {
     /// A `(` lacks a closing `)`.
     UnclosedParen { opening_location: Location },
+    /// A modifier does not have a valid form in a parameter expansion.
+    InvalidModifier,
+    /// A braced parameter expansion has both a prefix and suffix modifier.
+    MultipleModifier,
     /// A single quotation lacks a closing `'`.
     UnclosedSingleQuote { opening_location: Location },
     /// A double quotation lacks a closing `"`.
@@ -152,6 +156,10 @@ impl fmt::Display for SyntaxError {
         use SyntaxError::*;
         match self {
             UnclosedParen { .. } => f.write_str("The parenthesis is not closed"),
+            InvalidModifier => f.write_str("The parameter expansion contains a malformed modifier"),
+            MultipleModifier => {
+                f.write_str("A suffix modifier cannot be used together with a prefix modifier")
+            }
             UnclosedSingleQuote { .. } => f.write_str("The single quote is not closed"),
             UnclosedDoubleQuote { .. } => f.write_str("The double quote is not closed"),
             UnclosedParam { .. } => f.write_str("The parameter expansion is not closed"),

--- a/yash-syntax/src/parser/lex.rs
+++ b/yash-syntax/src/parser/lex.rs
@@ -29,6 +29,7 @@ mod dollar;
 mod heredoc;
 mod keyword;
 mod misc;
+mod modifier;
 mod op;
 mod raw_param;
 mod text;

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -96,6 +96,9 @@ impl Lexer {
             return Err(Error { cause, location });
         };
 
+        let suffix_location = self.location().await?.clone();
+        let suffix = self.suffix_modifier().await?;
+
         if !self.skip_if(|c| c == '}').await? {
             let opening_location = location;
             let cause = SyntaxError::UnclosedParam { opening_location }.into();
@@ -103,11 +106,16 @@ impl Lexer {
             return Err(Error { cause, location });
         }
 
-        let modifier = if has_length_prefix {
-            Modifier::Length
-        } else {
-            Modifier::None
+        let modifier = match (has_length_prefix, suffix) {
+            (true, Modifier::None) => Modifier::Length,
+            (true, _) => {
+                let cause = SyntaxError::MultipleModifier.into();
+                let location = suffix_location;
+                return Err(Error { cause, location });
+            }
+            (false, suffix) => suffix,
         };
+
         Ok(Ok(Param {
             name,
             modifier,
@@ -121,6 +129,8 @@ mod tests {
     use super::*;
     use crate::parser::core::ErrorCause;
     use crate::source::Source;
+    use crate::syntax::SwitchCondition;
+    use crate::syntax::SwitchType;
     use futures::executor::block_on;
 
     fn assert_opening_location(location: &Location) {
@@ -289,7 +299,58 @@ mod tests {
         assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
     }
 
+    #[test]
+    fn lexer_braced_param_switch_minimum() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{x+})");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "x");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.to_string(), "");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, ')');
+    }
+
+    #[test]
+    fn lexer_braced_param_switch_full() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{foo:?'!'})");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "foo");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(switch.word.to_string(), "'!'");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, ')');
+    }
+
     // TODO ${###} ${#%}
+
+    #[test]
+    fn lexer_braced_param_multiple_modifier() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#x+};");
+        let location = Location::dummy("$".to_string());
+
+        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
+        assert_eq!(e.location.line.value, "{#x+};");
+        assert_eq!(e.location.column.get(), 4);
+    }
 
     #[test]
     fn lexer_braced_param_line_continuations() {

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -23,7 +23,6 @@ use crate::parser::core::Error;
 use crate::parser::core::Result;
 use crate::parser::core::SyntaxError;
 use crate::source::Location;
-use crate::source::SourceChar;
 use crate::syntax::Modifier;
 use crate::syntax::Param;
 
@@ -37,19 +36,45 @@ pub fn is_name_char(c: char) -> bool {
 }
 
 impl Lexer {
-    /// Consumes a length prefix (`#`) if any.
-    async fn length_prefix(&mut self) -> Result<bool> {
-        let index = self.index();
+    /// Tests if there is a length prefix (`#`).
+    ///
+    /// This function may consume many characters, possibly beyond the length
+    /// prefix, regardless of the result. The caller should rewind to the index
+    /// this function returns.
+    async fn has_length_prefix(&mut self) -> Result<bool> {
         if !self.skip_if(|c| c == '#').await? {
             return Ok(false);
         }
 
-        if let Some(&SourceChar { value: '}', .. }) = self.peek_char().await? {
-            self.rewind(index);
-            Ok(false)
-        } else {
-            Ok(true)
+        // Remember that a parameter expansion cannot have both a prefix and
+        // suffix modifier. For example, `${#-?}` is not considered to have a
+        // prefix. We need to look ahead to see if it is okay to treat the `#`
+        // as a prefix.
+        if let Some(c) = self.peek_char().await? {
+            if matches!(c.value, '}' | '+' | '=' | ':') {
+                return Ok(false);
+            }
+            if matches!(c.value, '-' | '?') {
+                self.consume_char();
+                if let Some(c) = self.peek_char().await? {
+                    return Ok(c.value == '}');
+                }
+            }
         }
+
+        Ok(true)
+    }
+
+    /// Consumes a length prefix (`#`) if any.
+    async fn length_prefix(&mut self) -> Result<bool> {
+        let initial_index = self.index();
+        let has_length_prefix = self.has_length_prefix().await?;
+        self.rewind(initial_index);
+        if has_length_prefix {
+            self.peek_char().await?;
+            self.consume_char();
+        }
+        Ok(has_length_prefix)
     }
 
     /// Parses a parameter expansion that is enclosed in braces.
@@ -337,6 +362,106 @@ mod tests {
         assert_opening_location(&result.location);
 
         assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, ')');
+    }
+
+    #[test]
+    fn lexer_braced_param_hash_suffix_alter() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#+?}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "#");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.to_string(), "?");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_hash_suffix_default() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#--}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "#");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.to_string(), "-");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_hash_suffix_assign() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#=?}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "#");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.to_string(), "?");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_hash_suffix_error() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#??}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "#");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.to_string(), "?");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
+    }
+
+    #[test]
+    fn lexer_braced_param_hash_suffix_with_colon() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "{#:-}<");
+        let location = Location::dummy("$".to_string());
+
+        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        assert_eq!(result.name, "#");
+        if let Modifier::Switch(switch) = result.modifier {
+            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(switch.word.to_string(), "");
+        } else {
+            panic!("Not a switch: {:?}", result.modifier);
+        }
+        // TODO assert about other result members
+        assert_opening_location(&result.location);
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '<');
     }
 
     // TODO ${###} ${#%}

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -24,6 +24,9 @@ use crate::syntax::Modifier;
 use crate::syntax::Switch;
 use crate::syntax::SwitchCondition;
 use crate::syntax::SwitchType;
+use crate::syntax::Word;
+use std::future::Future;
+use std::pin::Pin;
 
 impl Lexer {
     async fn suffix_modifier_not_found(&mut self, colon: bool) -> Result<Modifier> {
@@ -59,10 +62,14 @@ impl Lexer {
             SwitchCondition::Unset
         };
 
+        // Boxing needed for recursion
+        let word = Box::pin(self.word(|c| c == '}')) as Pin<Box<dyn Future<Output = Result<Word>>>>;
+        let word = word.await?;
+
         let switch = Switch {
             r#type,
             condition,
-            word: self.word(|c| c == '}').await?,
+            word,
         };
         Ok(Modifier::Switch(switch))
     }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -1,0 +1,308 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Part of the lexer that parses suffix modifiers.
+
+use super::core::Lexer;
+use crate::parser::core::Error;
+use crate::parser::core::Result;
+use crate::parser::core::SyntaxError;
+use crate::syntax::Modifier;
+use crate::syntax::Switch;
+use crate::syntax::SwitchCondition;
+use crate::syntax::SwitchType;
+
+impl Lexer {
+    async fn suffix_modifier_not_found(&mut self, colon: bool) -> Result<Modifier> {
+        if colon {
+            let cause = SyntaxError::InvalidModifier.into();
+            let location = self.location().await?.clone();
+            Err(Error { cause, location })
+        } else {
+            Ok(Modifier::None)
+        }
+    }
+
+    /// Parses a suffix modifier, i.e., a modifier other than the length prefix.
+    pub async fn suffix_modifier(&mut self) -> Result<Modifier> {
+        let colon = self.skip_if(|c| c == ':').await?;
+
+        let r#type = if let Some(c) = self.peek_char().await? {
+            match c.value {
+                '+' => SwitchType::Alter,
+                '-' => SwitchType::Default,
+                '=' => SwitchType::Assign,
+                '?' => SwitchType::Error,
+                _ => return self.suffix_modifier_not_found(colon).await,
+            }
+        } else {
+            return self.suffix_modifier_not_found(colon).await;
+        };
+        self.consume_char();
+
+        let condition = if colon {
+            SwitchCondition::UnsetOrEmpty
+        } else {
+            SwitchCondition::Unset
+        };
+
+        let switch = Switch {
+            r#type,
+            condition,
+            word: self.word(|c| c == '}').await?,
+        };
+        Ok(Modifier::Switch(switch))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::core::ErrorCause;
+    use crate::source::Source;
+    use crate::syntax::TextUnit;
+    use crate::syntax::WordUnit;
+    use futures::executor::block_on;
+
+    #[test]
+    fn lexer_suffix_modifier_eof() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "");
+
+        let result = block_on(lexer.suffix_modifier());
+        assert_eq!(result, Ok(Modifier::None));
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_none() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "}");
+
+        let result = block_on(lexer.suffix_modifier());
+        assert_eq!(result, Ok(Modifier::None));
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_alter_empty() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "+}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.units, []);
+            assert_eq!(switch.word.location.line.value, "+}");
+            assert_eq!(switch.word.location.column.get(), 2);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_alter_word() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r"+a  z}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(
+                switch.word.units,
+                [
+                    WordUnit::Unquoted(TextUnit::Literal('a')),
+                    WordUnit::Unquoted(TextUnit::Literal(' ')),
+                    WordUnit::Unquoted(TextUnit::Literal(' ')),
+                    WordUnit::Unquoted(TextUnit::Literal('z')),
+                ]
+            );
+            assert_eq!(switch.word.location.line.value, "+a  z}");
+            assert_eq!(switch.word.location.column.get(), 2);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_colon_alter_empty() {
+        let mut lexer = Lexer::with_source(Source::Unknown, ":+}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(switch.word.units, []);
+            assert_eq!(switch.word.location.line.value, ":+}");
+            assert_eq!(switch.word.location.column.get(), 3);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_default_empty() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "-}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.units, []);
+            assert_eq!(switch.word.location.line.value, "-}");
+            assert_eq!(switch.word.location.column.get(), 2);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_colon_default_word() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r":-cool}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(
+                switch.word.units,
+                [
+                    WordUnit::Unquoted(TextUnit::Literal('c')),
+                    WordUnit::Unquoted(TextUnit::Literal('o')),
+                    WordUnit::Unquoted(TextUnit::Literal('o')),
+                    WordUnit::Unquoted(TextUnit::Literal('l')),
+                ]
+            );
+            assert_eq!(switch.word.location.line.value, ":-cool}");
+            assert_eq!(switch.word.location.column.get(), 3);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_colon_assign_empty() {
+        let mut lexer = Lexer::with_source(Source::Unknown, ":=}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(switch.word.units, []);
+            assert_eq!(switch.word.location.line.value, ":=}");
+            assert_eq!(switch.word.location.column.get(), 3);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_assign_word() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r"=Yes}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(
+                switch.word.units,
+                [
+                    WordUnit::Unquoted(TextUnit::Literal('Y')),
+                    WordUnit::Unquoted(TextUnit::Literal('e')),
+                    WordUnit::Unquoted(TextUnit::Literal('s')),
+                ]
+            );
+            assert_eq!(switch.word.location.line.value, "=Yes}");
+            assert_eq!(switch.word.location.column.get(), 2);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_error_empty() {
+        let mut lexer = Lexer::with_source(Source::Unknown, "?}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.condition, SwitchCondition::Unset);
+            assert_eq!(switch.word.units, []);
+            assert_eq!(switch.word.location.line.value, "?}");
+            assert_eq!(switch.word.location.column.get(), 2);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_colon_error_word() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r":?No}");
+
+        let result = block_on(lexer.suffix_modifier()).unwrap();
+        if let Modifier::Switch(switch) = result {
+            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
+            assert_eq!(
+                switch.word.units,
+                [
+                    WordUnit::Unquoted(TextUnit::Literal('N')),
+                    WordUnit::Unquoted(TextUnit::Literal('o')),
+                ]
+            );
+            assert_eq!(switch.word.location.line.value, ":?No}");
+            assert_eq!(switch.word.location.column.get(), 3);
+        } else {
+            panic!("Not a switch: {:?}", result);
+        }
+
+        assert_eq!(block_on(lexer.peek_char()).unwrap().unwrap().value, '}');
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_orphan_colon_eof() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r":");
+
+        let e = block_on(lexer.suffix_modifier()).unwrap_err();
+        assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
+        assert_eq!(e.location.line.value, ":");
+        assert_eq!(e.location.column.get(), 2);
+    }
+
+    #[test]
+    fn lexer_suffix_modifier_orphan_colon() {
+        let mut lexer = Lexer::with_source(Source::Unknown, r":x}");
+
+        let e = block_on(lexer.suffix_modifier()).unwrap_err();
+        assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
+        assert_eq!(e.location.line.value, ":x}");
+        assert_eq!(e.location.column.get(), 2);
+    }
+}

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -168,6 +168,49 @@ impl<T: MaybeLiteral> MaybeLiteral for [T] {
     }
 }
 
+/// Flag that specifies how the value is substituted in a [switch](Switch).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SwitchType {
+    /// Alter an existing value, if any. (`+`)
+    Alter,
+    /// Substitute a missing value with a default. (`-`)
+    Default,
+    /// Assign a default to the variable if the value is missing. (`=`)
+    Assign,
+    /// Error out if the value is missing. (`?`)
+    Error,
+}
+
+/// Condition that triggers a [switch](Switch).
+///
+/// In the lexical grammar of the shell language, a switch condition is an
+/// optional colon that precedes a switch type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SwitchCondition {
+    /// Without a colon, the switch is triggered if the parameter is unset.
+    Unset,
+    /// With a colon, the switch is triggered if the parameter is unset or
+    /// empty.
+    UnsetOrEmpty,
+}
+
+/// Parameter expansion [modifier](Modifier) that conditionally substitutes the
+/// value being expanded.
+///
+/// Examples of switches include `+foo`, `:-bar` and `:=baz`.
+///
+/// A switch is composed of a [condition](SwitchCondition) (an optional `:`), a
+/// [type](SwitchType) (one of `+`, `-`, `=` and `?`) and a [word](Word).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Switch {
+    /// How the value is substituted.
+    pub r#type: SwitchType,
+    /// Condition that determines whether the value is substituted or not.
+    pub condition: SwitchCondition,
+    /// Word that substitutes the parameter value.
+    pub word: Word,
+}
+
 /// Attribute that modifies a parameter expansion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Modifier {
@@ -175,6 +218,10 @@ pub enum Modifier {
     None,
     /// `#` prefix. (`${#foo}`)
     Length,
+    /// `+`, `-`, `=` or `?` suffix, optionally with `:`. (`${foo:-bar}`)
+    Switch(Switch),
+    // TODO Trim
+    // TODO Subst
 }
 
 /// Parameter expansion enclosed in braces.


### PR DESCRIPTION
- [x] Define syntax
- [x] Define errors that may happen while parsing
- [x] Implement parser
- [x] Use parser
- [x] Ensure corner cases are tested (e.g. `${#-?}`, `${#:-}`)
- [ ] Support context-dependent results (text v. word)
   - [ ] Tilde expansion
   - [ ] Single- and double-quotes
   - [ ] Allow escaping `}`
- ~~Implement `FromStr`~~
- [ ] Refactor

----

unit|`word`|`${x-word}`|`"text"`|`"${x-text}"`
:-:|:-:|:-:|:-:|:-:
Tilde|Special|Special|_Literal_|_Literal_
Single quotes|Special|Special|_Literal_|_Literal_
Double quotes|Special|Special|Special|Special
`\\`|Special|Special|Special|Special
`\"`|Special|Special|Special|Special
`\}`|Special|Special|_Literal_|Special
`\{`|Special|Special|_Literal_|_Literal_
