### PR TITLE
Context-dependent parsing of switch word

### DIFF
--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -1061,10 +1061,9 @@ mod tests {
 
     #[test]
     fn parser_reading_one_here_doc_content() {
-        block_on(async {
-            let mut lexer = Lexer::with_source(Source::Unknown, "END");
-            let delimiter = lexer.word(|_| false).await.unwrap();
+        let delimiter = "END".parse().unwrap();
 
+        block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "END\nX");
             let mut parser = Parser::new(&mut lexer);
             let remove_tabs = false;
@@ -1089,14 +1088,11 @@ mod tests {
 
     #[test]
     fn parser_reading_many_here_doc_contents() {
-        block_on(async {
-            let mut lexer = Lexer::with_source(Source::Unknown, "ONE");
-            let delimiter1 = lexer.word(|_| false).await.unwrap();
-            let mut lexer = Lexer::with_source(Source::Unknown, "TWO");
-            let delimiter2 = lexer.word(|_| false).await.unwrap();
-            let mut lexer = Lexer::with_source(Source::Unknown, "THREE");
-            let delimiter3 = lexer.word(|_| false).await.unwrap();
+        let delimiter1 = "ONE".parse().unwrap();
+        let delimiter2 = "TWO".parse().unwrap();
+        let delimiter3 = "THREE".parse().unwrap();
 
+        block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "1\nONE\nTWO\n3\nTHREE\nX");
             let mut parser = Parser::new(&mut lexer);
             parser.memorize_unread_here_doc(PartialHereDoc {
@@ -1128,12 +1124,10 @@ mod tests {
 
     #[test]
     fn parser_reading_here_doc_contents_twice() {
-        block_on(async {
-            let mut lexer = Lexer::with_source(Source::Unknown, "ONE");
-            let delimiter1 = lexer.word(|_| false).await.unwrap();
-            let mut lexer = Lexer::with_source(Source::Unknown, "TWO");
-            let delimiter2 = lexer.word(|_| false).await.unwrap();
+        let delimiter1 = "ONE".parse().unwrap();
+        let delimiter2 = "TWO".parse().unwrap();
 
+        block_on(async {
             let mut lexer = Lexer::with_source(Source::Unknown, "1\nONE\n2\nTWO\n");
             let mut parser = Parser::new(&mut lexer);
             parser.memorize_unread_here_doc(PartialHereDoc {

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -68,6 +68,10 @@ impl FromStr for TextUnit {
     /// Parses a [`TextUnit`] by `lexer.text_unit(|_| false, |_| true)`.
     fn from_str(s: &str) -> Result<TextUnit, Error> {
         let mut lexer = Lexer::with_source(Source::Unknown, s);
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         block_on(lexer.text_unit(|_| false, |_| true)).map(Option::unwrap)
     }
 }

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -19,6 +19,8 @@ use super::fill::MissingHereDoc;
 use super::lex::Lexer;
 use super::lex::Operator;
 use super::lex::TokenId;
+use super::lex::WordContext;
+use super::lex::WordLexer;
 use super::Error;
 use super::Parser;
 use super::Rec;
@@ -83,6 +85,10 @@ impl FromStr for WordUnit {
     type Err = Error;
     fn from_str(s: &str) -> Result<WordUnit, Error> {
         let mut lexer = Lexer::with_source(Source::Unknown, s);
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         block_on(lexer.word_unit(|_| false)).map(Option::unwrap)
     }
 }
@@ -97,6 +103,10 @@ impl FromStr for Word {
     /// [`Word::parse_tilde_everywhere`] on the resultant word.
     fn from_str(s: &str) -> Result<Word, Error> {
         let mut lexer = Lexer::with_source(Source::Unknown, s);
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         block_on(lexer.word(|_| false))
     }
 }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -16,7 +16,7 @@
 
 //! Part of the lexer that parses braced parameter expansion.
 
-use super::core::Lexer;
+use super::core::WordLexer;
 use super::raw_param::is_portable_name_char;
 use super::raw_param::is_special_parameter_char;
 use crate::parser::core::Error;
@@ -35,7 +35,7 @@ pub fn is_name_char(c: char) -> bool {
     is_portable_name_char(c)
 }
 
-impl Lexer {
+impl WordLexer<'_> {
     /// Tests if there is a length prefix (`#`).
     ///
     /// This function may consume many characters, possibly beyond the length
@@ -153,6 +153,8 @@ impl Lexer {
 mod tests {
     use super::*;
     use crate::parser::core::ErrorCause;
+    use crate::parser::lex::Lexer;
+    use crate::parser::lex::WordContext;
     use crate::source::Source;
     use crate::syntax::SwitchCondition;
     use crate::syntax::SwitchType;
@@ -168,6 +170,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_minimum() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{@};");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -182,6 +188,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_alphanumeric_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{foo_123}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -196,6 +206,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_numeric_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{123}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -210,6 +224,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -224,6 +242,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_missing_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{};");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
@@ -237,6 +259,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_unclosed_without_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{;");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
@@ -254,6 +280,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_unclosed_with_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{_;");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
@@ -271,6 +301,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_length_alphanumeric_name() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#foo_123}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -285,6 +319,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_length_hash() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{##}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -299,6 +337,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_length_question() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#?}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -313,6 +355,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_length_hyphen() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#-}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -327,6 +373,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_switch_minimum() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{x+})");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -347,6 +397,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_switch_full() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{foo:?'!'})");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -367,6 +421,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash_suffix_alter() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#+?}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -387,6 +445,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash_suffix_default() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#--}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -407,6 +469,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash_suffix_assign() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#=?}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -427,6 +493,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash_suffix_error() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#??}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -447,6 +517,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_hash_suffix_with_colon() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#:-}<");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -469,6 +543,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_multiple_modifier() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#x+};");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
@@ -480,6 +558,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_line_continuations() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{\\\n#\\\n\\\na_\\\n1\\\n\\\n}z");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
@@ -494,6 +576,10 @@ mod tests {
     #[test]
     fn lexer_braced_param_line_continuations_hash() {
         let mut lexer = Lexer::with_source(Source::Unknown, "{#\\\n\\\n}z");
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
         let location = Location::dummy("$".to_string());
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -32,6 +32,8 @@ use crate::syntax::Word;
 use std::fmt;
 use std::future::Future;
 use std::num::NonZeroU64;
+use std::ops::Deref;
+use std::ops::DerefMut;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::slice::SliceIndex;
@@ -570,6 +572,43 @@ impl Lexer {
     /// Like [`Lexer::inner_program`], but returns the future in a pinned box.
     pub fn inner_program_boxed(&mut self) -> Pin<Box<dyn Future<Output = Result<String>> + '_>> {
         Box::pin(self.inner_program())
+    }
+}
+
+/// Context in which a [word](crate::syntax::Word) is parsed.
+///
+/// The parse of the word of a [switch](crate::syntax::Switch) depends on
+/// whether the parameter expansion containing the switch is part of a text or a
+/// word. A `WordContext` value is used to decide the behavior of the lexer.
+///
+/// Parser functions that depend on the context are implemented in
+/// [`WordLexer`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WordContext {
+    /// The text unit being parsed is part of a [text](crate::syntax::Text).
+    Text,
+    /// The text unit being parsed is part of a [word](crate::syntax::Word).
+    Word,
+}
+
+/// Lexer with additional information for parsing [texts](crate::syntax::Text)
+/// and [words](crate::syntax::Word).
+#[derive(Debug)]
+pub struct WordLexer<'a> {
+    pub lexer: &'a mut Lexer,
+    pub context: WordContext,
+}
+
+impl Deref for WordLexer<'_> {
+    type Target = Lexer;
+    fn deref(&self) -> &Lexer {
+        &self.lexer
+    }
+}
+
+impl DerefMut for WordLexer<'_> {
+    fn deref_mut(&mut self) -> &mut Lexer {
+        &mut self.lexer
     }
 }
 

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -525,7 +525,7 @@ impl Lexer {
 
     /// Performs alias substitution right before the current position.
     ///
-    /// This function must be called just after a [word](Lexer::word) has been parsed that
+    /// This function must be called just after a [word](WordLexer::word) has been parsed that
     /// matches the name of the argument alias. No check is done in this function that there is
     /// a matching word before the current position. The characters starting from the `begin`
     /// index up to the current position are silently replaced with the alias value.

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -17,6 +17,8 @@
 //! Part of the lexer that parses suffix modifiers.
 
 use super::core::Lexer;
+use super::core::WordContext;
+use super::core::WordLexer;
 use crate::parser::core::Error;
 use crate::parser::core::Result;
 use crate::parser::core::SyntaxError;
@@ -62,8 +64,14 @@ impl Lexer {
             SwitchCondition::Unset
         };
 
+        // TODO use correct word context
+        let mut word_lexer = WordLexer {
+            lexer: self,
+            context: WordContext::Word,
+        };
         // Boxing needed for recursion
-        let word = Box::pin(self.word(|c| c == '}')) as Pin<Box<dyn Future<Output = Result<Word>>>>;
+        let word =
+            Box::pin(word_lexer.word(|c| c == '}')) as Pin<Box<dyn Future<Output = Result<Word>>>>;
         let word = word.await?;
 
         let switch = Switch {

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -44,6 +44,13 @@ impl Lexer {
 
 impl WordLexer<'_> {
     /// Parses a suffix modifier, i.e., a modifier other than the length prefix.
+    ///
+    /// If there is a [switch](Switch), [`self.context`](Self::context) affects
+    /// how the word of the switch is parsed: If the context is `Word`, a tilde
+    /// expansion is recognized at the beginning of the word and any character
+    /// can be escaped by a backslash. If the context is `Text`, only `$`, `"`,
+    /// `` ` ``, `\` and `}` can be escaped and single quotes are not recognized
+    /// in the word.
     pub async fn suffix_modifier(&mut self) -> Result<Modifier> {
         let colon = self.skip_if(|c| c == ':').await?;
 

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -82,8 +82,8 @@ impl Lexer {
     /// Parses a text, i.e., a (possibly empty) sequence of [`TextUnit`]s.
     ///
     /// `is_delimiter` tests if an unquoted character is a delimiter. When
-    /// `is_delimiter` returns true, the parser ends parsing and returns the text
-    /// up to the character as a result.
+    /// `is_delimiter` returns true, the parser stops parsing and returns the
+    /// text up to the delimiter.
     ///
     /// `is_escapable` tests if a backslash can escape a character. When the
     /// parser founds an unquoted backslash, the next character is passed to
@@ -92,7 +92,8 @@ impl Lexer {
     /// literal (`TextUnit::Literal`).
     ///
     /// `is_escapable` also affects escaping of double-quotes inside backquotes.
-    /// See [`text_unit`](WordLexer::text_unit) for details.
+    /// See [`text_unit`](WordLexer::text_unit) for details. Note that this
+    /// function calls `text_unit` with [`WordContext::Text`].
     pub async fn text<F, G>(&mut self, mut is_delimiter: F, mut is_escapable: G) -> Result<Text>
     where
         F: FnMut(char) -> bool,

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -31,7 +31,7 @@ impl WordLexer<'_> {
     /// Parses a [`TextUnit`].
     ///
     /// This function parses a literal character, backslash-escaped character,
-    /// [dollar unit](Lexer::dollar_unit), or [backquote](Lexer::backquote).
+    /// [dollar unit](WordLexer::dollar_unit), or [backquote](Lexer::backquote).
     ///
     /// `is_delimiter` is a function that decides if a character is a delimiter.
     /// An unquoted character is parsed only if `is_delimiter` returns false for

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -20,6 +20,8 @@ use super::core::is_blank;
 use super::core::Lexer;
 use super::core::Token;
 use super::core::TokenId;
+use super::core::WordContext;
+use super::core::WordLexer;
 use super::keyword::Keyword;
 use super::op::is_operator_char;
 use crate::parser::core::Result;
@@ -71,9 +73,16 @@ impl Lexer {
         }
 
         let index = self.index();
-        let mut word = self.word(is_token_delimiter_char).await?;
+
+        let mut word_lexer = WordLexer {
+            lexer: self,
+            context: WordContext::Word,
+        };
+        let mut word = word_lexer.word(is_token_delimiter_char).await?;
         word.parse_tilde_front();
+
         let id = self.token_id(&word).await?;
+
         Ok(Token { word, id, index })
     }
 }

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -89,8 +89,9 @@ impl WordLexer<'_> {
     /// unquoted character is parsed only if `is_delimiter` returns false for it.
     ///
     /// The word context defines what characters can be escaped by a backslash.
-    /// If the context is `Word`, any character can be escaped. If `Text`, then
-    /// `$`, `"`, `` ` `` and `\` can be escaped as well as delimiters.
+    /// If [`self.context`](Self::context) is `Word`, any character can be
+    /// escaped. If `Text`, then `$`, `"`, `` ` `` and `\` can be escaped as
+    /// well as delimiters.
     ///
     /// This function does not parse tilde expansion. See [`word`](Self::word).
     pub async fn word_unit<F>(&mut self, is_delimiter: F) -> Result<Option<WordUnit>>


### PR DESCRIPTION
This PR follows up #44.

- [x] Define `WordContext` and `WordLexer`
- [x] Move relevant functions from `Lexer` to `WordLexer`
- [x] Parse tilde expansion depending on context
- [x] Parse Single-quotes depending on context
- [x] Allow escaping `}` depending on context
- [x] Update documentation
- [ ] (Refactor)

----

unit|`word`|`${x-word}`|`"text"`|`"${x-text}"`
:-:|:-:|:-:|:-:|:-:
Tilde|Special|Special|_Literal_|_Literal_
Single quotes|Special|Special|_Literal_|_Literal_
Double quotes|Special|Special|Special|Special
`\\`|Special|Special|Special|Special
`\"`|Special|Special|Special|Special
`\}`|Special|Special|_Literal_|Special
`\{`|Special|Special|_Literal_|_Literal_
