### PR TITLE
Refactor backquote parser

### DIFF
--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -66,11 +66,7 @@ impl WordLexer<'_> {
             return Ok(Some(u));
         }
 
-        let double_quote_escapable = match self.context {
-            WordContext::Word => false,
-            WordContext::Text => true,
-        };
-        if let Some(u) = self.backquote(double_quote_escapable).await? {
+        if let Some(u) = self.backquote().await? {
             return Ok(Some(u));
         }
 

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -31,7 +31,8 @@ impl WordLexer<'_> {
     /// Parses a [`TextUnit`].
     ///
     /// This function parses a literal character, backslash-escaped character,
-    /// [dollar unit](WordLexer::dollar_unit), or [backquote](Lexer::backquote).
+    /// [dollar unit](WordLexer::dollar_unit), or
+    /// [backquote](WordLexer::backquote).
     ///
     /// `is_delimiter` is a function that decides if a character is a delimiter.
     /// An unquoted character is parsed only if `is_delimiter` returns false for

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -350,7 +350,12 @@ mod tests {
             context: WordContext::Text,
         };
 
-        let result = block_on(lexer.word_unit(|_| false)).unwrap().unwrap();
+        let result = block_on(lexer.word_unit(|c| {
+            assert_eq!(c, '\'', "unexpected call to is_delimiter({:?})", c);
+            false
+        }))
+        .unwrap()
+        .unwrap();
         assert_eq!(result, Unquoted(Literal('\'')));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));


### PR DESCRIPTION
This pull request refactors the backquote parser.

The behavior of the backquote parser depends on whether or not the backquote is enclosed in double quotes. In the previous code the backquote parser changed the behavior depending on whether an underscore can be escaped, which was a hacky trick. The new code uses `WordContext` to switch the behavior. This design is aligned with other parts of the lexer.