### PR TITLE
Improving simulation of parent & child processes in VirtualSystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ name = "yash-env"
 version = "0.1.0"
 dependencies = [
  "either",
+ "futures",
  "itertools",
  "nix",
  "yash-syntax",

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 
 [dependencies]
 either = "1.6.1"
+futures = "0.3.15"
 itertools = "0.10.1"
 nix = "0.21.0"
 yash-syntax = { path = "../yash-syntax", version = "0.1.0" }

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -42,26 +42,10 @@ fn is_regular_file(path: &CStr) -> bool {
 ///
 /// `RealSystem` has no state at the Rust level because the relevant state of
 /// the environment is managed by the underlying operating system.
-///
-/// # Cloning semantics
-///
-/// Although this struct implements `System::clone_box`, the state of the
-/// underlying system cannot be cloned. It just returns another `Box` of
-/// `RealSystem`. Having more than one instance of `RealSystem` to manipulate
-/// the system concurrently is not a good idea since all the `RealSystem`s
-/// interact with one and the same system.
 #[derive(Debug)]
 pub struct RealSystem;
 
 impl System for RealSystem {
-    /// Returns `RealSystem` in a new box.
-    ///
-    /// See the [documentation for the struct](RealSystem) for the implications
-    /// of cloning `RealSystem`.
-    fn clone_box(&self) -> Box<dyn System> {
-        Box::new(RealSystem)
-    }
-
     fn is_executable_file(&self, path: &CStr) -> bool {
         is_regular_file(path) && is_executable(path)
     }

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -64,10 +64,6 @@ impl VirtualSystem {
 }
 
 impl System for VirtualSystem {
-    fn clone_box(&self) -> Box<dyn System> {
-        Box::new(self.clone())
-    }
-
     /// Tests whether the specified file is executable or not.
     ///
     /// The current implementation only checks if the file has any executable

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -111,7 +111,7 @@ impl PathEnv for Env {
         self.variables.get("PATH")
     }
     fn is_executable_file(&self, path: &CStr) -> bool {
-        self.system.is_executable_file(path)
+        self.system.borrow().is_executable_file(path)
     }
 }
 

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -26,7 +26,9 @@ async fn parse_and_print() -> i32 {
     use env::Env;
     use env::RealSystem;
     use semantics::Command;
+    use std::cell::RefCell;
     use std::num::NonZeroU64;
+    use std::rc::Rc;
     use yash_env::variable::Value::Scalar;
     use yash_env::variable::Variable;
 
@@ -55,7 +57,7 @@ async fn parse_and_print() -> i32 {
         functions: Default::default(),
         jobs: Default::default(),
         variables: Default::default(),
-        system: Box::new(RealSystem),
+        system: Rc::new(RefCell::new(RealSystem)),
     };
     // TODO std::env::vars() would panic on broken UTF-8, which should rather be
     // ignored.


### PR DESCRIPTION
Closes #63

- [x] Wrap System in Rc & RefCell
- [x] Define process
- [x] Define spawner
- [ ] Define new fork that takes as an argument a task to execute in a subshell
- [ ] Wrap process in Rc & RefCell
- [ ] Define new wait that returns a future
    - Describe the borrow-and-await problem in doc for the new wait function
- [ ] (Re)implement run_in_subshell
- [ ] Remove old functions
- [ ] Rename new functions to desired names
- [ ] Add example code illustrating the borrow-and-await problem in doc for Env::system