### PR TITLE
Refactoring VirtualSystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ name = "yash-env"
 version = "0.1.0"
 dependencies = [
  "either",
+ "futures",
  "itertools",
  "nix",
  "yash-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
 name = "yash-env"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "either",
  "futures",
  "itertools",

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["command-line-utilities"]
 publish = false
 
 [dependencies]
+async-trait = "0.1.50"
 either = "1.6.1"
 futures = "0.3.15"
 itertools = "0.10.1"

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 
 [dependencies]
 either = "1.6.1"
+futures = "0.3.15"
 itertools = "0.10.1"
 nix = "0.21.0"
 yash-syntax = { path = "../yash-syntax", version = "0.1.0" }

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -259,9 +259,12 @@ mod tests {
         let status = 97;
         let mut system = VirtualSystem::default();
         system
+            .state
+            .borrow_mut()
             .pending_forks
             .push_back(Ok(ForkResult::Parent { child }));
         system
+            .current_process_mut()
             .pending_waits
             .push_back(Ok(WaitStatus::Exited(child, status)));
         let mut env = Env::with_system(Box::new(system));
@@ -274,8 +277,12 @@ mod tests {
     #[test]
     fn run_in_subshell_child() {
         let status = ExitStatus(71);
-        let mut system = VirtualSystem::default();
-        system.pending_forks.push_back(Ok(ForkResult::Child));
+        let system = VirtualSystem::default();
+        system
+            .state
+            .borrow_mut()
+            .pending_forks
+            .push_back(Ok(ForkResult::Child));
         let mut env = Env::with_system(Box::new(system));
         let result = env.run_in_subshell(|env| env.exit_status = status);
         assert_eq!(result, Err(Divert::Exit(status)));

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -133,11 +133,10 @@ pub trait System: Debug {
 
     /// Reports updated status of a child process.
     ///
-    /// This is a thin wrapper around the `waitpid` system call. Users of `Env`
+    /// This is a thin wrapper around the `waitpid` system call. It calls
+    /// `waitpid(-1, ..., WUNTRACED | WCONTINUED | WNOHANG)`. Users of `Env`
     /// should not call it directly. Use dedicated job-managing functions
     /// instead.
-    ///
-    /// TODO Describe the non-blocking nature of this function
     fn wait(&mut self) -> nix::Result<nix::sys::wait::WaitStatus>;
 
     /// Reports updated status of a child process.

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -97,19 +97,6 @@ pub trait System: Debug {
     /// Whether there is an executable file at the specified path.
     fn is_executable_file(&self, path: &CStr) -> bool;
 
-    /// Clones the current shell process.
-    ///
-    /// This is a thin wrapper around the `fork` system call. Users of `Env`
-    /// should not call it directly. Instead, use [`Env::run_in_subshell`] so
-    /// that the environment can manage the created child process as a job
-    /// member.
-    ///
-    /// # Safety
-    ///
-    /// See [nix's documentation](nix::unistd::fork) to learn why this function
-    /// is unsafe.
-    unsafe fn fork(&mut self) -> nix::Result<nix::unistd::ForkResult>;
-
     /// Creates a new child process.
     ///
     /// This is a thin wrapper around the `fork` system call. Users of `Env`

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -17,19 +17,19 @@
 //! This crate defines the shell execution environment.
 //!
 //! A shell execution environment, [`Env`], is a collection of data that may
-//! affect or be affected by execution of commands. The environment consists of
-//! application-managed parts and system-managed parts. Application-managed
+//! affect or be affected by the execution of commands. The environment consists
+//! of application-managed parts and system-managed parts. Application-managed
 //! parts are implemented in pure Rust in this crate. Many application-managed
 //! parts like [function]s and [variable]s can be manipulated independently of
 //! interactions with the underlying system. System-managed parts, on the other
 //! hand, depend on the underlying system. Attributes like the working directory
-//! and umask are managed by the system, so they can be accessed only by
-//! interaction with the system interface.
+//! and umask are managed by the system to be accessed only by interaction with
+//! the system interface.
 //!
-//! The system-managed parts are abstracted as the [`System`] trait.
+//! The [`System`] trait is the interface to the system-managed parts.
 //! [`RealSystem`] provides an implementation for `System` that interacts with
-//! the underlying system. [`VirtualSystem`] is a dummy for simulation that
-//! works without affecting the actual system.
+//! the underlying system. [`VirtualSystem`] is a dummy for simulating the
+//! system's behavior without affecting the actual system.
 
 pub mod builtin;
 pub mod exec;

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -160,6 +160,21 @@ pub trait System: Debug {
     /// TODO Describe the non-blocking nature of this function
     fn wait(&mut self) -> nix::Result<nix::sys::wait::WaitStatus>;
 
+    /// Reports updated status of a child process.
+    ///
+    /// This is a thin wrapper around the `waitpid` system call. Users of `Env`
+    /// should not call it directly. Use dedicated job-managing functions
+    /// instead.
+    ///
+    /// This function is a temporary API that performs synchronous wait by
+    /// blocking in the function or by returning a future you need to await.
+    /// Eventually, a new function that only polls the state of children will
+    /// substitute this function.
+    #[deprecated]
+    fn wait_sync(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = nix::Result<nix::sys::wait::WaitStatus>> + '_>>;
+
     // TODO Consider passing raw pointers for optimization
     /// Replaces the current process with an external utility.
     ///

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -100,6 +100,20 @@ impl System for RealSystem {
         nix::sys::wait::waitpid(None, options.into())
     }
 
+    /// Reports updated status of a child process.
+    ///
+    /// This implementation blocks inside the function and returns a future that
+    /// will immediately return a `Ready`.
+    fn wait_sync(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = nix::Result<nix::sys::wait::WaitStatus>> + '_>> {
+        use nix::sys::wait::WaitPidFlag;
+        let options = WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED;
+        // TODO Should set WNOHANG too
+        let result = nix::sys::wait::waitpid(None, options.into());
+        Box::pin(std::future::ready(result))
+    }
+
     fn execve(
         &mut self,
         path: &CStr,

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -56,10 +56,6 @@ impl System for RealSystem {
         is_regular_file(path) && is_executable(path)
     }
 
-    unsafe fn fork(&mut self) -> nix::Result<nix::unistd::ForkResult> {
-        nix::unistd::fork()
-    }
-
     /// Creates a new child process.
     ///
     /// This implementation calls the `fork` system call and returns both in the

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -48,26 +48,10 @@ fn is_regular_file(path: &CStr) -> bool {
 ///
 /// `RealSystem` has no state at the Rust level because the relevant state of
 /// the environment is managed by the underlying operating system.
-///
-/// # Cloning semantics
-///
-/// Although this struct implements `System::clone_box`, the state of the
-/// underlying system cannot be cloned. It just returns another `Box` of
-/// `RealSystem`. Having more than one instance of `RealSystem` to manipulate
-/// the system concurrently is not a good idea since all the `RealSystem`s
-/// interact with one and the same system.
 #[derive(Debug)]
 pub struct RealSystem;
 
 impl System for RealSystem {
-    /// Returns `RealSystem` in a new box.
-    ///
-    /// See the [documentation for the struct](RealSystem) for the implications
-    /// of cloning `RealSystem`.
-    fn clone_box(&self) -> Box<dyn System> {
-        Box::new(RealSystem)
-    }
-
     fn is_executable_file(&self, path: &CStr) -> bool {
         is_regular_file(path) && is_executable(path)
     }

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -75,8 +75,7 @@ impl System for RealSystem {
 
     fn wait(&mut self) -> nix::Result<nix::sys::wait::WaitStatus> {
         use nix::sys::wait::WaitPidFlag;
-        let options = WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED;
-        // TODO Should set WNOHANG too
+        let options = WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED | WaitPidFlag::WNOHANG;
         nix::sys::wait::waitpid(None, options.into())
     }
 

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -37,7 +37,6 @@ use std::cell::RefCell;
 use std::cell::RefMut;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -176,16 +175,9 @@ impl System for VirtualSystem {
         }))
     }
 
-    /// Simulates awaiting child process status update.
-    ///
-    /// This implementation pops the first entry from
-    /// [`pending_waits`](Process::pending_waits) and returns it.
-    /// If `pending_waits` is empty, this function will **panic**!
+    /// This function is currently not implemented.
     fn wait(&mut self) -> nix::Result<WaitStatus> {
-        self.current_process_mut()
-            .pending_waits
-            .pop_front()
-            .expect("pending_waits must be filled before calling wait")
+        todo!()
     }
 
     /// Reports updated status of a child process.
@@ -432,9 +424,6 @@ pub struct Process {
 
     /// Copy of arguments passed to [`execve`](VirtualSystem::execve).
     last_exec: Option<(CString, Vec<CString>, Vec<CString>)>,
-
-    /// Results of future calls to [`wait`](VirtualSystem::wait).
-    pub pending_waits: VecDeque<nix::Result<WaitStatus>>,
 }
 
 impl Process {
@@ -445,7 +434,6 @@ impl Process {
             state: ProcessState::Running,
             state_awaiters: Some(Vec::new()),
             last_exec: None,
-            pending_waits: VecDeque::new(),
         }
     }
 

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -52,7 +52,6 @@ use std::rc::Rc;
 use std::task::Poll;
 use std::task::Waker;
 
-// TODO VirtualSystem is not PartialEq because ForkResult is not.
 /// Simulated system.
 ///
 /// See the [module-level documentation](self) to grasp a basic understanding of
@@ -141,24 +140,6 @@ impl System for VirtualSystem {
             None => false,
             Some(inode) => inode.permissions.0 & 0o111 != 0,
         }
-    }
-
-    /// Simulates cloning the current shell process.
-    ///
-    /// This implementation pops the first entry from
-    /// [`pending_forks`](SystemState::pending_forks) and returns it.
-    /// If `pending_forks` is empty, this function will **panic**!
-    ///
-    /// # Safety
-    ///
-    /// Though [`System::fork`] is declared `unsafe`, this implementation of
-    /// `fork` is safe.
-    unsafe fn fork(&mut self) -> nix::Result<nix::unistd::ForkResult> {
-        self.state
-            .borrow_mut()
-            .pending_forks
-            .pop_front()
-            .expect("pending_forks must be filled before calling fork")
     }
 
     /// Creates a new child process.
@@ -328,7 +309,6 @@ impl ChildProcess for DummyChildProcess {
     }
 }
 
-// TODO SystemState is not Eq because ForkResult is not.
 /// State of the virtual system.
 #[derive(Clone, Debug, Default)]
 pub struct SystemState {
@@ -343,9 +323,6 @@ pub struct SystemState {
 
     /// Collection of files existing in the virtual system.
     pub file_system: FileSystem,
-
-    /// Results of future calls to [`fork`](VirtualSystem::fork).
-    pub pending_forks: VecDeque<nix::Result<nix::unistd::ForkResult>>,
 }
 
 /// Collection of files.

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -25,6 +25,11 @@
 
 use crate::System;
 use nix::errno::Errno;
+use nix::unistd::Pid;
+use std::cell::Ref;
+use std::cell::RefCell;
+use std::cell::RefMut;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::convert::Infallible;
@@ -35,6 +40,7 @@ use std::fmt::Debug;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 // TODO VirtualSystem is not PartialEq because ForkResult is not.
 /// Simulated system.
@@ -42,24 +48,71 @@ use std::path::PathBuf;
 /// See the [module-level documentation](self) to grasp a basic understanding of
 /// `VirtualSystem`.
 ///
-/// The `Clone` implementation for `VirtualSystem` creates an entire copy that
-/// works independently of the original.
-#[derive(Clone, Debug, Default)]
+/// A `VirtualSystem` instance has two members: `state` and `process_id`. The
+/// former is a [`SystemState`] that effectively contains the state of the
+/// system. The state is contained in `Rc` so that processes can share the same
+/// state. The latter is a process ID that identifies a process calling the
+/// [`System`] interface.
+///
+/// When you clone a virtual system, the clone will have the same `process_id`
+/// as the original. To simulate the `fork` system call, you would probably want
+/// to assign a new process ID and add a new [`Process`] to the system state.
+#[derive(Clone, Debug)]
 pub struct VirtualSystem {
-    /// Collection of files existing in the virtual system.
-    pub file_system: FileSystem,
+    /// State of the system.
+    pub state: Rc<RefCell<SystemState>>,
 
-    /// Results of future calls to [`fork`](Self::fork).
-    pub pending_forks: VecDeque<nix::Result<nix::unistd::ForkResult>>,
-
-    /// Results of future calls to [`wait`](Self::wait).
-    pub pending_waits: VecDeque<nix::Result<nix::sys::wait::WaitStatus>>,
+    /// Process ID of the process that is interacting with the system.
+    pub process_id: Pid,
 }
 
 impl VirtualSystem {
-    /// Creates a virtual system with an empty state.
+    /// Creates a virtual system with an almost empty state.
+    ///
+    /// The `process_id` of the returned `VirtualSystem` will be 2.
+    /// (Process ID 1 has special meaning in some system calls, so we don't use
+    /// it as a default value.)
+    ///
+    /// The `state` of the returned `VirtualSystem` will have a [`Process`] with
+    /// process ID 2 in the process set ([`SystemState::processes`]). Other
+    /// members of `SystemState` will be empty.
     pub fn new() -> VirtualSystem {
-        VirtualSystem::default()
+        let mut state = SystemState::default();
+        let process_id = Pid::from_raw(2);
+        state.processes.insert(process_id, Process::new());
+
+        let state = Rc::new(RefCell::new(state));
+        VirtualSystem { state, process_id }
+    }
+
+    /// Finds the current process from the system state.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it cannot find a process having
+    /// `self.process_id`.
+    pub fn current_process(&self) -> Ref<'_, Process> {
+        Ref::map(self.state.borrow(), |state| {
+            &state.processes[&self.process_id]
+        })
+    }
+
+    /// Finds the current process from the system state.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it cannot find a process having
+    /// `self.process_id`.
+    pub fn current_process_mut(&mut self) -> RefMut<'_, Process> {
+        RefMut::map(self.state.borrow_mut(), |state| {
+            state.processes.get_mut(&self.process_id).unwrap()
+        })
+    }
+}
+
+impl Default for VirtualSystem {
+    fn default() -> Self {
+        VirtualSystem::new()
     }
 }
 
@@ -77,7 +130,7 @@ impl System for VirtualSystem {
             Ok(path) => PathBuf::from(path),
             Err(_) => return false,
         };
-        match self.file_system.get(&path) {
+        match self.state.borrow().file_system.get(&path) {
             None => false,
             Some(inode) => inode.permissions.0 & 0o111 != 0,
         }
@@ -86,7 +139,7 @@ impl System for VirtualSystem {
     /// Simulates cloning the current shell process.
     ///
     /// This implementation pops the first entry from
-    /// [`pending_forks`](VirtualSystem::pending_forks) and returns it.
+    /// [`pending_forks`](SystemState::pending_forks) and returns it.
     /// If `pending_forks` is empty, this function will **panic**!
     ///
     /// # Safety
@@ -94,7 +147,9 @@ impl System for VirtualSystem {
     /// Though [`System::fork`] is declared `unsafe`, this implementation of
     /// `fork` is safe.
     unsafe fn fork(&mut self) -> nix::Result<nix::unistd::ForkResult> {
-        self.pending_forks
+        self.state
+            .borrow_mut()
+            .pending_forks
             .pop_front()
             .expect("pending_forks must be filled before calling fork")
     }
@@ -102,10 +157,11 @@ impl System for VirtualSystem {
     /// Simulates awaiting child process status update.
     ///
     /// This implementation pops the first entry from
-    /// [`pending_waits`](VirtualSystem::pending_waits) and returns it.
+    /// [`pending_waits`](Process::pending_waits) and returns it.
     /// If `pending_waits` is empty, this function will **panic**!
     fn wait(&mut self) -> nix::Result<nix::sys::wait::WaitStatus> {
-        self.pending_waits
+        self.current_process_mut()
+            .pending_waits
             .pop_front()
             .expect("pending_waits must be filled before calling wait")
     }
@@ -122,7 +178,8 @@ impl System for VirtualSystem {
         _envs: &[CString],
     ) -> nix::Result<Infallible> {
         let path = OsStr::from_bytes(path.to_bytes()).as_ref();
-        if let Some(file) = self.file_system.get(path) {
+        let fs = &self.state.borrow().file_system;
+        if let Some(file) = fs.get(path) {
             // TODO Check file permissions
             if file.is_native_executable {
                 panic!(
@@ -137,6 +194,20 @@ impl System for VirtualSystem {
             Err(Errno::ENOENT.into())
         }
     }
+}
+
+// TODO SystemState is not Eq because ForkResult is not.
+/// State of the virtual system.
+#[derive(Clone, Debug, Default)]
+pub struct SystemState {
+    /// Processes running in the system.
+    pub processes: BTreeMap<Pid, Process>,
+
+    /// Collection of files existing in the virtual system.
+    pub file_system: FileSystem,
+
+    /// Results of future calls to [`fork`](VirtualSystem::fork).
+    pub pending_forks: VecDeque<nix::Result<nix::unistd::ForkResult>>,
 }
 
 /// Collection of files.
@@ -197,6 +268,28 @@ impl Default for Mode {
     }
 }
 
+/// Process in a virtual system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Process {
+    /// Results of future calls to [`wait`](VirtualSystem::wait).
+    pub pending_waits: VecDeque<nix::Result<nix::sys::wait::WaitStatus>>,
+}
+
+impl Process {
+    /// Creates a new process that is alive.
+    pub fn new() -> Process {
+        Process {
+            pending_waits: Default::default(),
+        }
+    }
+}
+
+impl Default for Process {
+    fn default() -> Self {
+        Process::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,20 +303,20 @@ mod tests {
 
     #[test]
     fn is_executable_file_existing_but_non_executable_file() {
-        let mut system = VirtualSystem::new();
+        let system = VirtualSystem::new();
         let path = PathBuf::from("/some/file");
         let content = INode::default();
-        system.file_system.save(path, content);
+        system.state.borrow_mut().file_system.save(path, content);
         assert!(!system.is_executable_file(&CString::new("/some/file").unwrap()));
     }
 
     #[test]
     fn is_executable_file_with_executable_file() {
-        let mut system = VirtualSystem::new();
+        let system = VirtualSystem::new();
         let path = PathBuf::from("/some/file");
         let mut content = INode::default();
         content.permissions.0 |= 0o100;
-        system.file_system.save(path, content);
+        system.state.borrow_mut().file_system.save(path, content);
         assert!(system.is_executable_file(&CString::new("/some/file").unwrap()));
     }
 
@@ -235,7 +328,11 @@ mod tests {
         let mut content = INode::default();
         content.permissions.0 |= 0o100;
         content.is_native_executable = true;
-        system.file_system.save(path.clone(), content);
+        system
+            .state
+            .borrow_mut()
+            .file_system
+            .save(path.clone(), content);
         let path = CString::new(path.as_os_str().as_bytes()).unwrap();
         let result = system.execve(&path, &[], &[]);
         unreachable!("{:?}", result);
@@ -247,7 +344,11 @@ mod tests {
         let path = PathBuf::from("/some/file");
         let mut content = INode::default();
         content.permissions.0 |= 0o100;
-        system.file_system.save(path.clone(), content);
+        system
+            .state
+            .borrow_mut()
+            .file_system
+            .save(path.clone(), content);
         let path = CString::new(path.as_os_str().as_bytes()).unwrap();
         let result = system.execve(&path, &[], &[]);
         assert_eq!(result, Err(Errno::ENOEXEC.into()));

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -128,10 +128,6 @@ impl Default for VirtualSystem {
 }
 
 impl System for VirtualSystem {
-    fn clone_box(&self) -> Box<dyn System> {
-        Box::new(self.clone())
-    }
-
     /// Tests whether the specified file is executable or not.
     ///
     /// The current implementation only checks if the file has any executable
@@ -308,8 +304,7 @@ impl ChildProcess for DummyChildProcess {
         let state = self.state.clone();
         let process_id = self.process_id;
         let system = VirtualSystem { state, process_id };
-        let mut child_env = env.clone();
-        child_env.system = Box::new(system);
+        let mut child_env = env.clone_with_system(Box::new(system));
 
         let state = self.state.clone();
         let run_task_and_set_exit_status = Box::pin(async move {

--- a/yash-semantics/src/command_impl.rs
+++ b/yash-semantics/src/command_impl.rs
@@ -253,9 +253,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = r#"VirtualSystem::execve called for path="/some/file", args=["/some/file", "foo", "bar"]"#
-    )]
     fn simple_command_invokes_external_utility_in_subshell() {
         let system = VirtualSystem::new();
         let path = PathBuf::from("/some/file");
@@ -272,7 +269,7 @@ mod tests {
         let mut env = Env::with_system(Box::new(system));
         let command: syntax::SimpleCommand = "/some/file foo bar".parse().unwrap();
         let result = block_on(command.execute(&mut env));
-        unreachable!("{:?}", result);
+        assert_eq!(result, Err(Divert::Exit(ExitStatus::NOEXEC)));
     }
 
     #[test]

--- a/yash-semantics/src/command_impl.rs
+++ b/yash-semantics/src/command_impl.rs
@@ -95,7 +95,7 @@ impl Command for syntax::SimpleCommand {
                             // TODO The error message should be printed via Env
                             eprintln!("command execution failed: {:?}", e);
                         })
-                        .await?;
+                        .await;
 
                     match result {
                         Ok(exit_status) => {


### PR DESCRIPTION
Closes #63

- [x] Split the content of VirtualSystem into two parts: Process and SystemState
    - file_system and pending_forks  to SystemState
    - pending_waits to Process
- [x] Define state (WaitStatus) and state_awaiters in Process
- [x] Define processes in SystemState
- [x] Define executor in SystemState
- [x] Define System::new_child_process
- [x] Reimplement wait, returning a future
- [x] Reimplement execve
- [x] (Re)implement run_in_subshell
- [x] Test arguments to execve
- [x] Remove `impl Clone for Box<dyn System>` and add `Env::clone_with_system(system: Box<dyn System>)`
- [x] Remove System::fork
- [x] Remove (or comment out) System::wait
- [x] Remove pending_forks
- [x] Remove pending_waits
- [ ] Update doc
    - Describe the borrow-and-await problem in doc