### PR TITLE
Executing pipeline

### DIFF
--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use yash_env::builtin::Builtin;
-    use yash_env::builtin::Type::{NonIntrinsic, Special};
+    use yash_env::builtin::Type::{Intrinsic, Special};
     use yash_env::exec::Divert;
     use yash_env::exec::ExitStatus;
     use yash_env::expansion::Field;
@@ -115,7 +115,7 @@ pub(crate) mod tests {
     /// Returns a minimal implementation of the `echo` built-in.
     pub fn echo_builtin() -> Builtin {
         Builtin {
-            r#type: NonIntrinsic,
+            r#type: Intrinsic,
             execute: echo_builtin_main,
         }
     }
@@ -127,6 +127,7 @@ pub(crate) mod tests {
         fn inner(env: &mut Env) -> nix::Result<()> {
             let mut buffer = [0; 1024];
             loop {
+                // TODO wait until fd is ready for reading
                 let count = env.system.read(Fd::STDIN, &mut buffer)?;
                 if count == 0 {
                     break Ok(());
@@ -144,7 +145,7 @@ pub(crate) mod tests {
     /// Returns a minimal implementation of the `cat` built-in.
     pub fn cat_builtin() -> Builtin {
         Builtin {
-            r#type: NonIntrinsic,
+            r#type: Intrinsic,
             execute: cat_builtin_main,
         }
     }

--- a/yash-semantics/src/pipeline.rs
+++ b/yash-semantics/src/pipeline.rs
@@ -18,6 +18,7 @@
 
 use super::Command;
 use async_trait::async_trait;
+use std::rc::Rc;
 use yash_env::exec::ExitStatus;
 use yash_env::exec::Result;
 use yash_env::io::Fd;
@@ -67,7 +68,7 @@ impl Command for syntax::Pipeline {
     }
 }
 
-async fn execute_commands_in_pipeline(env: &mut Env, commands: &[syntax::Command]) -> Result {
+async fn execute_commands_in_pipeline(env: &mut Env, commands: &[Rc<syntax::Command>]) -> Result {
     match commands.len() {
         0 => {
             env.exit_status = ExitStatus::SUCCESS;
@@ -78,10 +79,9 @@ async fn execute_commands_in_pipeline(env: &mut Env, commands: &[syntax::Command
     }
 }
 
-async fn execute_multi_command_pipeline(env: &mut Env, commands: &[syntax::Command]) -> Result {
+async fn execute_multi_command_pipeline(env: &mut Env, commands: &[Rc<syntax::Command>]) -> Result {
     // Start commands
-    // TODO avoid cloning commands for efficiency
-    let mut commands = commands.to_owned().into_iter().peekable();
+    let mut commands = commands.iter().cloned().peekable();
     let mut pipes = PipeSet::new();
     let mut pids = Vec::new();
     while let Some(command) = commands.next() {

--- a/yash-semantics/src/simple_command.rs
+++ b/yash-semantics/src/simple_command.rs
@@ -22,6 +22,7 @@ use crate::command_search::Target::{Builtin, External, Function};
 use async_trait::async_trait;
 use nix::errno::Errno;
 use std::ffi::CString;
+use std::future::ready;
 use yash_env::exec::ExitStatus;
 use yash_env::exec::Result;
 use yash_env::expansion::Field;
@@ -94,6 +95,7 @@ impl Command for syntax::SimpleCommand {
                             }
                             // TODO The error message should be printed via Env
                             eprintln!("command execution failed: {:?}", e);
+                            Box::pin(ready(()))
                         })
                         .await;
 

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -250,7 +250,7 @@ mod tests {
         let Pipeline { commands, negation } = first;
         assert_eq!(*negation, false);
         assert_eq!(commands.len(), 1);
-        let cmd = match commands[0] {
+        let cmd = match *commands[0] {
             Command::Simple(ref c) => c,
             _ => panic!("Expected a simple command but got {:?}", commands[0]),
         };

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -26,6 +26,7 @@ use super::lex::Keyword::Bang;
 use super::lex::Operator::Bar;
 use super::lex::TokenId::{Operator, Token};
 use crate::syntax::Pipeline;
+use std::rc::Rc;
 
 impl Parser<'_> {
     /// Parses a pipeline.
@@ -67,7 +68,7 @@ impl Parser<'_> {
         };
 
         // Parse `|`
-        let mut commands = vec![first];
+        let mut commands = vec![Rc::new(first)];
         while self.peek_token().await?.id == Operator(Bar) {
             let bar_location = self.take_token_raw().await?.word.location;
 
@@ -77,7 +78,7 @@ impl Parser<'_> {
                 // Parse the next command
                 if let Rec::Parsed(option) = self.command().await? {
                     if let Some(next) = option {
-                        break next;
+                        break Rc::new(next);
                     }
 
                     // Error: the command is missing


### PR DESCRIPTION
Implements #62

- [x] Allow async subshell task
- [x] Execute commands in a pipeline concurrently
- [x] Connect commands with a pipe
- [x] Avoid cloning commands when starting subshells
- [x] Test `PipeSet`
- [x] What if self.next.reader == stdin or stdout?