### PR TITLE
Selecting in child processes

### DIFF
--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -306,7 +306,7 @@ impl Env {
             functions: self.functions.clone(),
             jobs: self.jobs.clone(),
             variables: self.variables.clone(),
-            system: self.system.clone_with_system(system),
+            system: SharedSystem::new(system),
         }
     }
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -88,6 +88,13 @@ use std::task::Waker;
 /// let number = executor.run_until(read_task.unwrap());
 /// assert_eq!(number, 123);
 /// ```
+///
+/// If there is a child process in the [`VirtualSystem`](crate::VirtualSystem),
+/// you should call
+/// [`SystemState::select_all`](crate::virtual_system::SystemState) in addition
+/// to [`SharedSystem::select`](crate::SharedSystem) so that the child process
+/// task is woken up when needed.
+/// (TBD code example)
 #[derive(Clone, Debug)]
 pub struct SharedSystem(pub(crate) Rc<RefCell<SelectSystem>>);
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -89,7 +89,7 @@ use std::task::Waker;
 /// assert_eq!(number, 123);
 /// ```
 #[derive(Clone, Debug)]
-pub struct SharedSystem(Rc<RefCell<SelectSystem>>);
+pub struct SharedSystem(pub(crate) Rc<RefCell<SelectSystem>>);
 
 impl SharedSystem {
     /// Creates a new shared system.
@@ -212,7 +212,7 @@ impl System for SharedSystem {
 ///
 /// TODO Elaborate
 #[derive(Debug)]
-struct SelectSystem {
+pub(crate) struct SelectSystem {
     system: Box<dyn System>,
     io: AsyncIo,
 }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -97,17 +97,6 @@ impl SharedSystem {
         SharedSystem(Rc::new(RefCell::new(SelectSystem::new(system))))
     }
 
-    /// Clones this `SharedSystem` using the provided `System`.
-    ///
-    /// This function clones the internal state of the `SharedSystem`. However,
-    /// `System` does not implement `Clone` and an instance for the cloned
-    /// `SharedSystem` must be provided.
-    pub fn clone_with_system(&self, system: Box<dyn System>) -> Self {
-        SharedSystem(Rc::new(RefCell::new(
-            self.0.borrow().clone_with_system(system),
-        )))
-    }
-
     /// Reads from the file descriptor.
     ///
     /// This function waits for one or more bytes to be available for reading.
@@ -264,18 +253,6 @@ impl SelectSystem {
         SelectSystem {
             system,
             io: AsyncIo::new(),
-        }
-    }
-
-    /// Clones this `SelectSystem` using the provided `System`.
-    ///
-    /// This function clones the internal state of the `SelectSystem`. However,
-    /// `System` does not implement `Clone` and an instance for the cloned
-    /// `SelectSystem` must be provided.
-    pub fn clone_with_system(&self, system: Box<dyn System>) -> Self {
-        SelectSystem {
-            system,
-            io: self.io.clone(),
         }
     }
 }

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -490,6 +490,17 @@ pub struct SystemState {
     pub file_system: FileSystem,
 }
 
+impl SystemState {
+    /// Performs [`select`](Process::select) on all processes in the system.
+    ///
+    /// Any errors are ignored.
+    pub fn select_all(&self) {
+        for process in self.processes.values() {
+            let _: nix::Result<()> = process.select();
+        }
+    }
+}
+
 /// Executor that can start new async tasks.
 ///
 /// This trait abstracts the executor interface so that [`SystemState`] does not

--- a/yash-env/src/virtual_system/process.rs
+++ b/yash-env/src/virtual_system/process.rs
@@ -186,6 +186,25 @@ impl Process {
         }
     }
 
+    /// Performs [`SharedSystem::select`](crate::SharedSystem::select) for this
+    /// process.
+    ///
+    /// If this process is a child process created from another process in the
+    /// system, this function calls `SharedSystem::select` to wake tasks that
+    /// are ready to resume in the process.
+    ///
+    /// For the initial process created when creating a new
+    /// [`VirtualSystem`](crate::VirtualSystem), this function does nothing. To
+    /// `select` on the initial process, directly call `SharedSystem::select`
+    /// for the [`Env`](crate::Env) controlling the process.
+    pub fn select(&self) -> nix::Result<()> {
+        if let Some(system) = Weak::upgrade(&self.selector) {
+            system.borrow_mut().select()
+        } else {
+            Ok(())
+        }
+    }
+
     /// Returns the arguments to the last call to
     /// [`execve`](crate::VirtualSystem::execve) on this process.
     #[inline(always)]

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -61,7 +61,7 @@ pub trait Word {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use itertools::Itertools;
+    // use itertools::Itertools;
     use std::future::ready;
     use std::future::Future;
     use std::pin::Pin;
@@ -99,6 +99,7 @@ pub(crate) mod tests {
         }
     }
 
+    /*
     fn echo_builtin_main(
         env: &mut Env,
         args: Vec<Field>,
@@ -121,6 +122,7 @@ pub(crate) mod tests {
             execute: echo_builtin_main,
         }
     }
+    */
 
     fn cat_builtin_main(
         env: &mut Env,


### PR DESCRIPTION
`SharedSystem::select` only selects on the main process in a virtual system. We need a method to select on child processes in the system.

This PR enables some tests that have been ignored.