### PR TITLE
First step for implementing word expansion semantics

### DIFF
--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -205,7 +205,7 @@ impl<E: Env> Expansion for Expander<'_, E> {
 
 /// Syntactic construct that can be subjected to the word expansion.
 #[async_trait(?Send)]
-pub trait Word {
+pub trait Expand {
     /// Performs the word expansion.
     ///
     /// The results should be pushed to the expander.

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -242,7 +242,28 @@ pub trait ExpandToField {
     ///
     /// This is usually used in contexts where field splitting will be performed
     /// on the result.
-    async fn expand_to_fields<E: Env>(&self, env: &mut E) -> Result<Vec<AttrField>>;
+    ///
+    /// This function inserts the results into `fields`.
+    /// See also [`expand_to_fields`](Self::expand_to_fields).
+    async fn expand_to_fields_into<E: Env, F: Extend<AttrField>>(
+        &self,
+        env: &mut E,
+        fields: &mut F,
+    ) -> Result;
+
+    /// Performs the initial expansion on `self`, producing any number of
+    /// fields.
+    ///
+    /// This is usually used in contexts where field splitting will be performed
+    /// on the result.
+    ///
+    /// This function returns a vector of resultant fields.
+    /// See also [`expand_to_fields_into`](Self::expand_to_fields_into).
+    async fn expand_to_fields<E: Env>(&self, env: &mut E) -> Result<Vec<AttrField>> {
+        let mut fields = Vec::new();
+        self.expand_to_fields_into(env, &mut fields).await?;
+        Ok(fields)
+    }
 }
 
 #[cfg(test)]

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -31,6 +31,7 @@
 //! TODO Elaborate
 
 mod text;
+mod word;
 
 use async_trait::async_trait;
 use std::ops::Deref;

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -119,6 +119,21 @@ pub struct AttrField {
 pub trait Expansion: std::fmt::Debug {
     /// Appends a character to the current field.
     fn push_char(&mut self, c: AttrChar);
+
+    /// Appends characters to the current field.
+    ///
+    /// The appended characters share the same `origin`, `is_quoted`, and
+    /// `is_quoting` attributes.
+    fn push_str(&mut self, s: &str, origin: Origin, is_quoted: bool, is_quoting: bool) {
+        for c in s.chars() {
+            self.push_char(AttrChar {
+                value: c,
+                origin,
+                is_quoted,
+                is_quoting,
+            });
+        }
+    }
 }
 // TODO impl Expansion::push_fields
 
@@ -200,6 +215,32 @@ pub trait Word {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn expansion_push_str() {
+        let a = AttrChar {
+            value: 'a',
+            origin: Origin::SoftExpansion,
+            is_quoted: true,
+            is_quoting: false,
+        };
+        let to = AttrChar {
+            value: '-',
+            origin: Origin::SoftExpansion,
+            is_quoted: true,
+            is_quoting: false,
+        };
+        let z = AttrChar {
+            value: 'z',
+            origin: Origin::SoftExpansion,
+            is_quoted: true,
+            is_quoting: false,
+        };
+
+        let mut field = AttrField::default();
+        field.push_str("a-z", Origin::SoftExpansion, true, false);
+        assert_eq!(field.0, [a, to, z]);
+    }
 
     #[test]
     fn attr_field_push_char() {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -30,6 +30,7 @@
 //!
 //! TODO Elaborate
 
+mod quote_removal;
 mod text;
 mod word;
 
@@ -40,6 +41,8 @@ use yash_syntax::source::Location;
 
 #[doc(no_inline)]
 pub use yash_env::expansion::*;
+
+pub use quote_removal::*;
 
 /// Types of errors that may occur in the word expansion.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -38,6 +38,7 @@ use async_trait::async_trait;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use yash_syntax::source::Location;
+use yash_syntax::syntax::Word;
 
 #[doc(no_inline)]
 pub use yash_env::expansion::*;
@@ -264,6 +265,26 @@ pub trait ExpandToField {
         self.expand_to_fields_into(env, &mut fields).await?;
         Ok(fields)
     }
+}
+
+/// Expands words to fields.
+///
+/// This function performs all of the initial expansion, multi-field expansion,
+/// and quote removal.
+pub async fn expand_words<'a, E, I>(env: &mut E, words: I) -> Result<Vec<Field>>
+where
+    E: Env,
+    I: IntoIterator<Item = &'a Word>,
+{
+    let mut fields = Vec::new();
+    for word in words {
+        word.expand_to_fields_into(env, &mut fields).await?;
+    }
+    // TODO multi-field expansion
+    Ok(fields
+        .into_iter()
+        .map(QuoteRemoval::do_quote_removal)
+        .collect())
 }
 
 #[cfg(test)]

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -1,0 +1,177 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Word expansion.
+//!
+//! # Initial expansion
+//!
+//! TODO Elaborate: Tilde expansion, parameter expansion, command substitution,
+//! and arithmetic expansion.
+//!
+//! # Multi-field expansion
+//!
+//! TODO Elaborate: Brace expansion, field splitting, pathname expansion, empty
+//! field removal.
+//!
+//! # Quote removal
+//!
+//! TODO Elaborate
+
+use async_trait::async_trait;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use yash_syntax::source::Location;
+
+#[doc(no_inline)]
+pub use yash_env::expansion::*;
+
+/// Types of errors that may occur in the word expansion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErrorCause {
+    // TODO Define error cause types
+}
+
+/// Explanation of an expansion failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Error {
+    pub cause: ErrorCause,
+    pub location: Location,
+}
+
+/// Result of word expansion.
+///
+/// Because fields resulting from the expansion are stored in the [`Expander`],
+/// the OK value of the result is usually `()`.
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+/// Part of the shell execution environment the word expansion depends on.
+pub trait Env: std::fmt::Debug {
+    // TODO define Env methods
+}
+// TODO Should we split Env for the initial expansion and multi-field expansion?
+
+impl Env for yash_env::Env {
+    // TODO implement Env methods for yash_env::Env
+}
+
+/// Origin of a character produced in the initial expansion.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Origin {
+    /// The character appeared literally in the original word.
+    Literal,
+    /// The character originates from a tilde expansion or sequencing brace expansion.
+    ///
+    /// This kind of character is treated literally in the pathname expansion.
+    HardExpansion,
+    /// The character originates from a parameter expansion, command substitution, or arithmetic expansion.
+    ///
+    /// This kind of character is subject to field splitting where applicable.
+    SoftExpansion,
+}
+
+/// Character with attributes describing its origin.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct AttrChar {
+    /// Character value.
+    pub value: char,
+    /// Character origin.
+    pub origin: Origin,
+    /// Whether this character is quoted by another character.
+    pub is_quoted: bool,
+    /// Whether this is a quotation character that quotes another character.
+    ///
+    /// Note that a character can be both quoting and quoted. For example, the
+    /// backslash in the word `"\$"` quotes the dollar and is quoted by the
+    /// double-quotes.
+    pub is_quoting: bool,
+}
+
+/// Result of the initial expansion.
+///
+/// An `AttrField` is a string of `AttrChar`s.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AttrField(pub Vec<AttrChar>);
+/*
+pub struct AttrField {
+    /// Value of the field.
+    pub value: Vec<AttrChar>,
+    /// Location of the word this field resulted from.
+    pub origin: Location,
+}
+*/
+
+/// Result of the initial expansion.
+pub trait Expansion: std::fmt::Debug {}
+// TODO impl Expansion::push_char
+// TODO impl Expansion::push_fields
+
+/// Result of the initial expansion for expanding to a single field.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Single(pub AttrField);
+
+/// Result of the initial expansion for subjecting to field splitting.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Multiple(pub Vec<AttrField>);
+// TODO Consider using smallvec instead of Vec
+
+/// Shell execution environment for performing the word expansion in.
+///
+/// TODO Elaborate
+#[derive(Debug)]
+pub struct Expander<'e, E: Env> {
+    /// Environment used in the word expansion.
+    env: &'e mut E,
+    /// Fields resulting from the word expansion.
+    result: &'e mut dyn Expansion,
+    // TODO inside double-quotes?
+}
+
+impl<'e, E: Env> Expander<'e, E> {
+    /// Creates a new expander.
+    ///
+    /// This function requires two parameters:
+    ///
+    /// - `env`: An environment in which the expansion is performed.
+    /// - `result`: An implementor of `Expansion` into which the expansion
+    ///   results are inserted.
+    pub fn new(env: &'e mut E, result: &'e mut dyn Expansion) -> Self {
+        Expander { env, result }
+    }
+}
+
+impl<E: Env> Deref for Expander<'_, E> {
+    type Target = E;
+    fn deref(&self) -> &E {
+        self.env
+    }
+}
+
+impl<E: Env> DerefMut for Expander<'_, E> {
+    fn deref_mut(&mut self) -> &mut E {
+        self.env
+    }
+}
+
+impl<E: Env> Expansion for Expander<'_, E> {}
+
+/// Syntactic construct that can be subjected to the word expansion.
+#[async_trait(?Send)]
+pub trait Word {
+    /// Performs the word expansion.
+    ///
+    /// The results should be pushed to the expander.
+    async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result;
+}

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -120,31 +120,22 @@ pub trait Expansion: std::fmt::Debug {
 }
 // TODO impl Expansion::push_fields
 
-// TODO Remove Simple and Multiple and directly implement Expansion for
-// AttrField and Vec<AttrField>
-/// Result of the initial expansion for expanding to a single field.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Single(pub AttrField);
-
-impl Expansion for Single {
+/// Produces a single field as a result of the expansion.
+impl Expansion for AttrField {
     fn push_char(&mut self, c: AttrChar) {
-        self.0 .0.push(c)
+        self.0.push(c)
     }
 }
 
-/// Result of the initial expansion for subjecting to field splitting.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Multiple(pub Vec<AttrField>);
-// TODO Consider using smallvec instead of Vec
-
-impl Expansion for Multiple {
+/// Produces any number of fields as a result of the expansion.
+impl Expansion for Vec<AttrField> {
     fn push_char(&mut self, c: AttrChar) {
-        if let Some(field) = self.0.last_mut() {
+        if let Some(field) = self.last_mut() {
             field.0.push(c);
         } else {
             let mut field = AttrField::default();
             field.0.push(c);
-            self.0.push(field);
+            self.push(field);
         }
     }
 }
@@ -209,7 +200,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn single_push_char() {
+    fn attr_field_push_char() {
         let c = AttrChar {
             value: 'X',
             origin: Origin::Literal,
@@ -222,15 +213,15 @@ mod tests {
             is_quoted: true,
             is_quoting: false,
         };
-        let mut s = Single::default();
-        s.push_char(c);
-        assert_eq!(s.0 .0, [c]);
-        s.push_char(d);
-        assert_eq!(s.0 .0, [c, d]);
+        let mut field = AttrField::default();
+        field.push_char(c);
+        assert_eq!(field.0, [c]);
+        field.push_char(d);
+        assert_eq!(field.0, [c, d]);
     }
 
     #[test]
-    fn multiple_push_char() {
+    fn vec_attr_field_push_char() {
         let c = AttrChar {
             value: 'X',
             origin: Origin::Literal,
@@ -243,14 +234,14 @@ mod tests {
             is_quoted: false,
             is_quoting: true,
         };
-        let mut m = Multiple::default();
-        m.push_char(c);
-        assert_eq!(m.0.len(), 1);
-        assert_eq!(m.0[0].0, [c]);
-        m.push_char(d);
-        assert_eq!(m.0.len(), 1);
-        assert_eq!(m.0[0].0, [c, d]);
+        let mut fields = Vec::<AttrField>::default();
+        fields.push_char(c);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].0, [c]);
+        fields.push_char(d);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].0, [c, d]);
     }
 
-    // TODO Test Multiple push_char with multiple existing fields
+    // TODO Test Vec<AttrField>::push_char with multiple existing fields
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -102,12 +102,12 @@ pub struct AttrChar {
     pub is_quoting: bool,
 }
 
+/*
 /// Result of the initial expansion.
 ///
 /// An `AttrField` is a string of `AttrChar`s.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AttrField(pub Vec<AttrChar>);
-/*
 pub struct AttrField {
     /// Value of the field.
     pub value: Vec<AttrChar>,
@@ -139,21 +139,19 @@ pub trait Expansion: std::fmt::Debug {
 // TODO impl Expansion::push_fields
 
 /// Produces a single field as a result of the expansion.
-impl Expansion for AttrField {
+impl Expansion for Vec<AttrChar> {
     fn push_char(&mut self, c: AttrChar) {
-        self.0.push(c)
+        self.push(c)
     }
 }
 
 /// Produces any number of fields as a result of the expansion.
-impl Expansion for Vec<AttrField> {
+impl Expansion for Vec<Vec<AttrChar>> {
     fn push_char(&mut self, c: AttrChar) {
         if let Some(field) = self.last_mut() {
-            field.0.push(c);
+            field.push(c);
         } else {
-            let mut field = AttrField::default();
-            field.0.push(c);
-            self.push(field);
+            self.push(vec![c]);
         }
     }
 }
@@ -248,9 +246,9 @@ mod tests {
             is_quoting: false,
         };
 
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         field.push_str("a-z", Origin::SoftExpansion, true, false);
-        assert_eq!(field.0, [a, to, z]);
+        assert_eq!(field, [a, to, z]);
     }
 
     #[test]
@@ -267,11 +265,11 @@ mod tests {
             is_quoted: true,
             is_quoting: false,
         };
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         field.push_char(c);
-        assert_eq!(field.0, [c]);
+        assert_eq!(field, [c]);
         field.push_char(d);
-        assert_eq!(field.0, [c, d]);
+        assert_eq!(field, [c, d]);
     }
 
     #[test]
@@ -288,14 +286,14 @@ mod tests {
             is_quoted: false,
             is_quoting: true,
         };
-        let mut fields = Vec::<AttrField>::default();
+        let mut fields = Vec::<Vec<AttrChar>>::default();
         fields.push_char(c);
         assert_eq!(fields.len(), 1);
-        assert_eq!(fields[0].0, [c]);
+        assert_eq!(fields[0], [c]);
         fields.push_char(d);
         assert_eq!(fields.len(), 1);
-        assert_eq!(fields[0].0, [c, d]);
+        assert_eq!(fields[0], [c, d]);
     }
 
-    // TODO Test Vec<AttrField>::push_char with multiple existing fields
+    // TODO Test Vec<Vec<AttrChar>>::push_char with multiple existing fields
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -213,6 +213,16 @@ pub trait Expand {
     async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result;
 }
 
+#[async_trait(?Send)]
+impl<T: Expand> Expand for [T] {
+    async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
+        for item in self {
+            item.expand(e).await?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -30,6 +30,8 @@
 //!
 //! TODO Elaborate
 
+mod text;
+
 use async_trait::async_trait;
 use std::ops::Deref;
 use std::ops::DerefMut;

--- a/yash-semantics/src/expansion/quote_removal.rs
+++ b/yash-semantics/src/expansion/quote_removal.rs
@@ -24,10 +24,11 @@ use super::Field;
 ///
 /// The quote removal is a step of the word expansion that removes quotes from
 /// the field. The [`do_quote_removal`](Self::do_quote_removal) function
-/// converts an [`AttrChar`] string to a normal string.
+/// converts an [`AttrChar`] string to a regular string.
 pub trait QuoteRemoval {
     /// Return type of [`do_quote_removal`](Self::do_quote_removal).
     type Output;
+
     /// Performs the quote removal on `self`.
     ///
     /// TODO Add a parameter to specify how characters in the result should be

--- a/yash-semantics/src/expansion/quote_removal.rs
+++ b/yash-semantics/src/expansion/quote_removal.rs
@@ -1,0 +1,53 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Quote removal.
+
+use super::AttrChar;
+use super::AttrField;
+use super::Field;
+
+/// Quote removal.
+///
+/// The quote removal is a step of the word expansion that removes quotes from
+/// the field. The [`do_quote_removal`](Self::do_quote_removal) function
+/// converts an [`AttrChar`] string to a normal string.
+pub trait QuoteRemoval {
+    /// Return type of [`do_quote_removal`](Self::do_quote_removal).
+    type Output;
+    /// Performs the quote removal on `self`.
+    ///
+    /// TODO Add a parameter to specify how characters in the result should be
+    /// escaped.
+    fn do_quote_removal(self) -> Self::Output;
+}
+
+impl QuoteRemoval for &[AttrChar] {
+    type Output = String;
+    fn do_quote_removal(self) -> String {
+        // TODO Remove quotes correctly
+        self.iter().map(|c| c.value).collect()
+    }
+}
+
+impl QuoteRemoval for AttrField {
+    type Output = Field;
+    fn do_quote_removal(self) -> Field {
+        let AttrField { chars, origin } = self;
+        let value = chars.do_quote_removal();
+        Field { value, origin }
+    }
+}

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -60,7 +60,7 @@ impl Expand for Text {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AttrField;
+    use super::super::AttrChar;
     use super::*;
     use futures_executor::block_on;
     use yash_syntax::syntax::TextUnit;
@@ -72,13 +72,13 @@ mod tests {
 
     #[test]
     fn literal_expand_unquoted() {
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         let mut env = NullEnv;
         let mut e = Expander::new(&mut env, &mut field);
         let l = TextUnit::Literal('&');
         block_on(l.expand(&mut e)).unwrap();
         assert_eq!(
-            field.0,
+            field,
             [AttrChar {
                 value: '&',
                 origin: Origin::Literal,
@@ -90,13 +90,13 @@ mod tests {
 
     #[test]
     fn text_expand() {
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         let mut env = NullEnv;
         let mut e = Expander::new(&mut env, &mut field);
         let text: Text = "<->".parse().unwrap();
         block_on(text.expand(&mut e)).unwrap();
         assert_eq!(
-            field.0,
+            field,
             [
                 AttrChar {
                     value: '<',

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -18,17 +18,17 @@
 
 use super::AttrChar;
 use super::Env;
+use super::Expand;
 use super::Expander;
 use super::Expansion;
 use super::Origin;
 use super::Result;
-use super::Word;
 use async_trait::async_trait;
 use yash_syntax::syntax::Text;
 use yash_syntax::syntax::TextUnit;
 
 #[async_trait(?Send)]
-impl Word for TextUnit {
+impl Expand for TextUnit {
     async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
         use TextUnit::*;
         match self {
@@ -52,7 +52,7 @@ impl Word for TextUnit {
 }
 
 #[async_trait(?Send)]
-impl Word for Text {
+impl Expand for Text {
     async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
         for text_unit in &self.0 {
             text_unit.expand(e).await?;

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -38,7 +38,13 @@ impl Word for TextUnit {
                 is_quoted: false,
                 is_quoting: false,
             }),
-            _ => todo!(),
+            // TODO Expand Backslashed correctly
+            // TODO Expand RawParam correctly
+            // TODO Expand BracedParam correctly
+            // TODO Expand CommandSubst correctly
+            // TODO Expand Backquote correctly
+            // TODO Expand Arith correctly
+            _ => e.push_str(&self.to_string(), Origin::Literal, false, false),
         }
         Ok(())
     }

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -1,0 +1,76 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Initial expansion of text.
+
+use super::AttrChar;
+use super::Env;
+use super::Expander;
+use super::Expansion;
+use super::Origin;
+use super::Result;
+use super::Word;
+use async_trait::async_trait;
+use yash_syntax::syntax::TextUnit;
+
+#[async_trait(?Send)]
+impl Word for TextUnit {
+    async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
+        use TextUnit::*;
+        match self {
+            Literal(c) => e.push_char(AttrChar {
+                value: *c,
+                origin: Origin::Literal,
+                // TODO is_quoted may be true depending on the context
+                is_quoted: false,
+                is_quoting: false,
+            }),
+            _ => todo!(),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AttrField;
+    use super::*;
+    use futures_executor::block_on;
+    use yash_syntax::syntax::TextUnit;
+
+    #[derive(Debug)]
+    struct NullEnv;
+
+    impl Env for NullEnv {}
+
+    #[test]
+    fn literal_expand_unquoted() {
+        let mut field = AttrField::default();
+        let mut env = NullEnv;
+        let mut e = Expander::new(&mut env, &mut field);
+        let l = TextUnit::Literal('&');
+        block_on(l.expand(&mut e)).unwrap();
+        assert_eq!(
+            field.0,
+            [AttrChar {
+                value: '&',
+                origin: Origin::Literal,
+                is_quoted: false,
+                is_quoting: false
+            }]
+        );
+    }
+}

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -54,10 +54,7 @@ impl Expand for TextUnit {
 #[async_trait(?Send)]
 impl Expand for Text {
     async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
-        for text_unit in &self.0 {
-            text_unit.expand(e).await?;
-        }
-        Ok(())
+        self.0.expand(e).await
     }
 }
 

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -53,7 +53,6 @@ impl Expand for Word {
 #[cfg(test)]
 mod tests {
     use super::super::AttrChar;
-    use super::super::AttrField;
     use super::*;
     use futures_executor::block_on;
 
@@ -64,13 +63,13 @@ mod tests {
 
     #[test]
     fn unquoted_expand() {
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         let mut env = NullEnv;
         let mut e = Expander::new(&mut env, &mut field);
         let u: WordUnit = "x".parse().unwrap();
         block_on(u.expand(&mut e)).unwrap();
         assert_eq!(
-            field.0,
+            field,
             [AttrChar {
                 value: 'x',
                 origin: Origin::Literal,
@@ -82,13 +81,13 @@ mod tests {
 
     #[test]
     fn word_expand() {
-        let mut field = AttrField::default();
+        let mut field = Vec::<AttrChar>::default();
         let mut env = NullEnv;
         let mut e = Expander::new(&mut env, &mut field);
         let w: Word = "xyz".parse().unwrap();
         block_on(w.expand(&mut e)).unwrap();
         assert_eq!(
-            field.0,
+            field,
             [
                 AttrChar {
                     value: 'x',

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -1,0 +1,74 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Initial expansion of word.
+
+use super::Env;
+use super::Expand;
+use super::Expander;
+use super::Expansion;
+use super::Origin;
+use super::Result;
+use async_trait::async_trait;
+use yash_syntax::syntax::WordUnit;
+
+#[async_trait(?Send)]
+impl Expand for WordUnit {
+    async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
+        use WordUnit::*;
+        match self {
+            Unquoted(text_unit) => text_unit.expand(e).await,
+            // TODO Expand Tilde correctly
+            // TODO Expand SingleQuote correctly
+            // TODO Expand DoubleQuote correctly
+            _ => {
+                e.push_str(&self.to_string(), Origin::Literal, false, false);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AttrChar;
+    use super::super::AttrField;
+    use super::*;
+    use futures_executor::block_on;
+
+    #[derive(Debug)]
+    struct NullEnv;
+
+    impl Env for NullEnv {}
+
+    #[test]
+    fn unquoted_expand() {
+        let mut field = AttrField::default();
+        let mut env = NullEnv;
+        let mut e = Expander::new(&mut env, &mut field);
+        let u: WordUnit = "x".parse().unwrap();
+        block_on(u.expand(&mut e)).unwrap();
+        assert_eq!(
+            field.0,
+            [AttrChar {
+                value: 'x',
+                origin: Origin::Literal,
+                is_quoted: false,
+                is_quoting: false
+            }]
+        );
+    }
+}

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -63,18 +63,20 @@ impl ExpandToField for Word {
         Ok(AttrField { chars, origin })
     }
 
-    async fn expand_to_fields<E: Env>(&self, env: &mut E) -> Result<Vec<AttrField>> {
-        let mut fields = Vec::new();
+    async fn expand_to_fields_into<E: Env, F: Extend<AttrField>>(
+        &self,
+        env: &mut E,
+        fields: &mut F,
+    ) -> Result {
+        let mut fields_without_origin = Vec::new();
         self.units
-            .expand(&mut Expander::new(env, &mut fields))
+            .expand(&mut Expander::new(env, &mut fields_without_origin))
             .await?;
-        Ok(fields
-            .into_iter()
-            .map(|chars| AttrField {
-                chars,
-                origin: self.location.clone(),
-            })
-            .collect())
+        fields.extend(fields_without_origin.into_iter().map(|chars| AttrField {
+            chars,
+            origin: self.location.clone(),
+        }));
+        Ok(())
     }
 }
 

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -46,10 +46,7 @@ impl Expand for WordUnit {
 #[async_trait(?Send)]
 impl Expand for Word {
     async fn expand<E: Env>(&self, e: &mut Expander<'_, E>) -> Result {
-        for word_unit in &self.units {
-            word_unit.expand(e).await?;
-        }
-        Ok(())
+        self.units.expand(e).await
     }
 }
 

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -25,6 +25,7 @@
 mod command_impl;
 pub mod command_search;
 mod compound;
+pub mod expansion;
 mod pipeline;
 mod simple_command;
 
@@ -41,22 +42,6 @@ pub trait Command {
     ///
     /// TODO Elaborate: The exit status must be updated during execution.
     async fn execute(&self, env: &mut Env) -> Result;
-}
-
-/// Result of expansion.
-///
-/// TODO elaborate
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Expansion {
-    // TODO define value
-}
-
-// TODO Reconsider the name
-/// TODO describe
-#[async_trait(?Send)]
-pub trait Word {
-    /// TODO describe
-    async fn expand(&self, env: &mut Env) -> Result<Expansion>;
 }
 
 // TODO Probably we should implement a read-execute loop in here

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -17,10 +17,10 @@
 //! Semantics of the shell language.
 //!
 //! This crate defines the standard semantics for the shell language. The core
-//! of the semantics is word expansion and command execution. They respectively
-//! have a corresponding trait that is implemented by syntactic constructs.
-//!
-//! TODO Elaborate
+//! of the semantics is command execution and word expansion.
+//! A command can be executed by calling [`Command::execute`].
+//! A word can be expanded by using functions and traits defined in
+//! [`expansion`].
 
 mod command_impl;
 pub mod command_search;


### PR DESCRIPTION
- [x] Defining basic types
- [x] Implementing minimal expansion semantics
    - Implement `Expand` for `TextUnit`, `Text`, `WordUnit`, and `Word`
    - Define `Expansion::push_chars`
    - Stub multi-field expansion
- [x] Use the expansion in the simple command execution
- [x] Update documentation for `yash_semantics::expansion`
- [x] Clean up commits (squash and fixup)