### PR TITLE
Basic parameter expansion semantics

### DIFF
--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -110,7 +110,7 @@ impl VariableSet {
         Default::default()
     }
 
-    /// Get a reference to the variable with the specified name.
+    /// Gets a reference to the variable with the specified name.
     #[must_use]
     pub fn get<N: ?Sized>(&self, name: &N) -> Option<&Variable>
     where

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -57,6 +57,7 @@
 //! that removes quotes from the field. It takes an [`AttrField`] input and
 //! returns a [`Field`].
 
+mod param;
 mod quote_removal;
 mod text;
 mod word;

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -64,6 +64,7 @@ mod word;
 use async_trait::async_trait;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use yash_env::variable::Variable;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::Word;
 
@@ -94,12 +95,18 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 
 /// Part of the shell execution environment the word expansion depends on.
 pub trait Env: std::fmt::Debug {
+    /// Gets a reference to the variable with the specified name.
+    #[must_use]
+    fn get_variable(&self, name: &str) -> Option<&Variable>;
+
     // TODO define Env methods
 }
 // TODO Should we split Env for the initial expansion and multi-field expansion?
 
 impl Env for yash_env::Env {
-    // TODO implement Env methods for yash_env::Env
+    fn get_variable(&self, name: &str) -> Option<&Variable> {
+        self.variables.get(name)
+    }
 }
 
 /// Origin of a character produced in the initial expansion.
@@ -423,9 +430,13 @@ mod tests {
     use super::*;
 
     #[derive(Debug)]
-    struct NullEnv;
+    pub(crate) struct NullEnv;
 
-    impl Env for NullEnv {}
+    impl Env for NullEnv {
+        fn get_variable(&self, _: &str) -> Option<&Variable> {
+            unimplemented!("NullEnv's method must not be called")
+        }
+    }
 
     #[test]
     fn expansion_push_str() {

--- a/yash-semantics/src/expansion/param.rs
+++ b/yash-semantics/src/expansion/param.rs
@@ -25,6 +25,7 @@ use super::Result;
 use async_trait::async_trait;
 use yash_env::variable::Value;
 use yash_syntax::source::Location;
+use yash_syntax::syntax::Param;
 
 /// Reference to a `RawParam` or `BracedParam`.
 pub struct ParamRef<'a> {
@@ -36,6 +37,15 @@ pub struct ParamRef<'a> {
 impl<'a> ParamRef<'a> {
     pub fn from_name_and_location(name: &'a str, location: &'a Location) -> Self {
         ParamRef { name, location }
+    }
+}
+
+impl<'a> From<&'a Param> for ParamRef<'a> {
+    fn from(param: &'a Param) -> Self {
+        ParamRef {
+            name: &param.name,
+            location: &param.location,
+        }
     }
 }
 

--- a/yash-semantics/src/expansion/param.rs
+++ b/yash-semantics/src/expansion/param.rs
@@ -1,0 +1,89 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Parameter expansion semantics.
+
+use super::Env;
+use super::Expand;
+use super::Expander;
+use super::Expansion;
+use super::Origin;
+use super::Result;
+use async_trait::async_trait;
+use yash_env::variable::Value;
+use yash_syntax::source::Location;
+
+/// Reference to a `RawParam` or `BracedParam`.
+pub struct ParamRef<'a> {
+    name: &'a str,
+    location: &'a Location,
+}
+
+impl<'a> ParamRef<'a> {
+    pub fn from_name_and_location(name: &'a str, location: &'a Location) -> Self {
+        ParamRef { name, location }
+    }
+}
+
+#[async_trait(?Send)]
+impl Expand for ParamRef<'_> {
+    async fn expand<E: Env>(&self, _e: &mut Expander<'_, E>) -> Result {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AttrChar;
+    use super::*;
+    use futures_executor::block_on;
+    use yash_env::variable::Value;
+    use yash_env::variable::Variable;
+
+    #[derive(Debug)]
+    struct Singleton {
+        name: String,
+        value: Variable,
+    }
+
+    impl Env for Singleton {
+        fn get_variable(&self, name: &str) -> Option<&Variable> {
+            if name == self.name {
+                Some(&self.value)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn name_only_param_unset() {
+        let name = "foo".to_string();
+        let value = Variable {
+            value: Value::Scalar("!".to_string()),
+            last_assigned_location: None,
+            is_exported: false,
+            read_only_location: None,
+        };
+        let mut env = Singleton { name, value };
+        let mut field = Vec::<AttrChar>::default();
+        let mut e = Expander::new(&mut env, &mut field);
+        let location = Location::dummy("");
+        let p = ParamRef::from_name_and_location("bar", &location);
+        block_on(p.expand(&mut e)).unwrap();
+        assert_eq!(field, []);
+    }
+}

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -78,13 +78,9 @@ impl Expand for Text {
 mod tests {
     use super::super::AttrChar;
     use super::*;
+    use crate::expansion::tests::NullEnv;
     use futures_executor::block_on;
     use yash_syntax::syntax::TextUnit;
-
-    #[derive(Debug)]
-    struct NullEnv;
-
-    impl Env for NullEnv {}
 
     #[test]
     fn literal_expand_unquoted() {

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -61,11 +61,10 @@ impl Expand for TextUnit {
                 Ok(())
             }
             RawParam { name, location } => {
-                ParamRef::from_name_and_location(name, location)
-                    .expand(env, output)
-                    .await
+                let param = ParamRef::from_name_and_location(name, location);
+                param.expand(env, output).await
             }
-            // TODO Expand BracedParam correctly
+            BracedParam(param) => ParamRef::from(param).expand(env, output).await,
             // TODO Expand CommandSubst correctly
             // TODO Expand Backquote correctly
             // TODO Expand Arith correctly

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -114,12 +114,8 @@ impl ExpandToField for Word {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::expansion::tests::NullEnv;
     use futures_executor::block_on;
-
-    #[derive(Debug)]
-    struct NullEnv;
-
-    impl Env for NullEnv {}
 
     #[test]
     fn unquoted_expand() {


### PR DESCRIPTION
- [x] Add get_variable to expansion Env
- [x] Expand unset variable with ParamRef
- [x] Split Expander into Env and Output = (Expansion, is_quoted)
- [x] Expand existing variable with ParamRef
- [x] Use ParamRef from TextUnit::expand
