### PR TITLE
Move some error locations

### DIFF
--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -55,7 +55,7 @@ impl Parser<'_> {
         // TODO allow empty do clause if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptyDoClause.into();
-            let location = open.word.location;
+            let location = close.word.location;
             return Err(Error { cause, location });
         }
 
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(e.location.line.value, "do done");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.column.get(), 4);
     }
 
     #[test]

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -82,7 +82,7 @@ impl Parser<'_> {
         // TODO allow empty subshell if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptySubshell.into();
-            let location = open.word.location;
+            let location = close.word.location;
             return Err(Error { cause, location });
         }
 
@@ -254,6 +254,6 @@ mod tests {
         assert_eq!(e.location.line.value, "( )");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -51,7 +51,7 @@ impl Parser<'_> {
         // TODO allow empty subshell if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptyGrouping.into();
-            let location = open.word.location;
+            let location = close.word.location;
             return Err(Error { cause, location });
         }
 
@@ -159,7 +159,7 @@ mod tests {
         assert_eq!(e.location.line.value, "{ }");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.column.get(), 3);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -1292,6 +1292,6 @@ mod tests {
         assert_eq!(e.location.line.value, "<< )");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.column.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -39,6 +39,13 @@ impl Parser<'_> {
 
         let condition = self.maybe_compound_list_boxed().await?;
 
+        // TODO allow empty condition if not POSIXly-correct
+        if condition.0.is_empty() {
+            let cause = SyntaxError::EmptyWhileCondition.into();
+            let location = self.take_token_raw().await?.word.location;
+            return Err(Error { cause, location });
+        }
+
         let body = match self.do_clause().await? {
             Some(body) => body,
             None => {
@@ -48,13 +55,6 @@ impl Parser<'_> {
                 return Err(Error { cause, location });
             }
         };
-
-        // TODO allow empty condition if not POSIXly-correct
-        if condition.0.is_empty() {
-            let cause = SyntaxError::EmptyWhileCondition.into();
-            let location = open.word.location;
-            return Err(Error { cause, location });
-        }
 
         Ok(CompoundCommand::While { condition, body })
     }
@@ -72,6 +72,13 @@ impl Parser<'_> {
 
         let condition = self.maybe_compound_list_boxed().await?;
 
+        // TODO allow empty condition if not POSIXly-correct
+        if condition.0.is_empty() {
+            let cause = SyntaxError::EmptyUntilCondition.into();
+            let location = self.take_token_raw().await?.word.location;
+            return Err(Error { cause, location });
+        }
+
         let body = match self.do_clause().await? {
             Some(body) => body,
             None => {
@@ -81,13 +88,6 @@ impl Parser<'_> {
                 return Err(Error { cause, location });
             }
         };
-
-        // TODO allow empty condition if not POSIXly-correct
-        if condition.0.is_empty() {
-            let cause = SyntaxError::EmptyUntilCondition.into();
-            let location = open.word.location;
-            return Err(Error { cause, location });
-        }
 
         Ok(CompoundCommand::Until { condition, body })
     }
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(e.location.line.value, " while do :; done");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.column.get(), 8);
     }
 
     #[test]
@@ -273,7 +273,7 @@ mod tests {
         assert_eq!(e.location.line.value, "  until do :; done");
         assert_eq!(e.location.line.number.get(), 1);
         assert_eq!(e.location.line.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.column.get(), 9);
     }
 
     #[test]


### PR DESCRIPTION
The error location should point to the position where the unexpected token was first encountered so that it agrees with the wording of the annotation in the error message (implemented in #84).

- [x] MissingRedirOperand
- [x] MissingHereDocDelimiter
- [x] EmptyGrouping
- [x] EmptySubshell
- [x] EmptyDoClause
- [x] EmptyWhileCondition
- [x] EmptyUntilCondition
- [x] EmptyIfCondition
- [x] EmptyIfBody
- [x] EmptyElifCondition
- [x] EmptyElifBody
- [x] EmptyElse
- [x] MissingCommandAfterBang
- [x] DoubleNegation
- [x] MissingCommandAfterBar