### PR TITLE
Minimum redirection semantics

### DIFF
--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -53,6 +53,7 @@ use async_trait::async_trait;
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
+use nix::sys::stat::Mode;
 use nix::unistd::Pid;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -137,6 +138,11 @@ pub trait System: Debug {
     /// This is a thin wrapper around the `dup2` system call. If successful,
     /// returns `Ok(to)`. On error, returns `Err(_)`.
     fn dup2(&mut self, from: Fd, to: Fd) -> nix::Result<Fd>;
+
+    /// Opens a file descriptor.
+    ///
+    /// This is a thin wrapper around the `open` system call.
+    fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> nix::Result<Fd>;
 
     /// Closes a file descriptor.
     ///

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -26,6 +26,7 @@ use nix::fcntl::OFlag;
 use nix::libc::{S_IFMT, S_IFREG};
 use nix::sys::select::FdSet;
 use nix::sys::stat::stat;
+use nix::sys::stat::Mode;
 use nix::unistd::access;
 use nix::unistd::AccessFlags;
 use nix::unistd::Pid;
@@ -95,6 +96,10 @@ impl System for RealSystem {
                 Err(e) => return Err(e),
             }
         }
+    }
+
+    fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> nix::Result<Fd> {
+        nix::fcntl::open(path, option, mode).map(Fd)
     }
 
     fn close(&mut self, fd: Fd) -> nix::Result<()> {

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -24,6 +24,7 @@ use futures_util::task::Poll;
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
+use nix::sys::stat::Mode;
 use nix::sys::wait::WaitStatus;
 use std::cell::RefCell;
 use std::convert::Infallible;
@@ -208,6 +209,9 @@ impl System for SharedSystem {
     }
     fn dup2(&mut self, from: Fd, to: Fd) -> nix::Result<Fd> {
         self.0.borrow_mut().dup2(from, to)
+    }
+    fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> nix::Result<Fd> {
+        self.0.borrow_mut().open(path, option, mode)
     }
     fn close(&mut self, fd: Fd) -> nix::Result<()> {
         self.0.borrow_mut().close(fd)

--- a/yash-semantics/src/command_impl/simple_command.rs
+++ b/yash-semantics/src/command_impl/simple_command.rs
@@ -20,6 +20,7 @@ use crate::assign::perform_assignments;
 use crate::command_search::search;
 use crate::expansion::expand_words;
 use crate::print_error;
+use crate::redir;
 use crate::Command;
 use async_trait::async_trait;
 use nix::errno::Errno;
@@ -35,6 +36,7 @@ use yash_env::Env;
 use yash_env::System;
 use yash_syntax::syntax;
 use yash_syntax::syntax::Assign;
+use yash_syntax::syntax::Redir;
 
 #[async_trait(?Send)]
 impl Command for syntax::SimpleCommand {
@@ -161,7 +163,9 @@ impl Command for syntax::SimpleCommand {
             match search(env, &name.value) {
                 Some(Builtin(builtin)) => execute_builtin(env, builtin, fields).await,
                 Some(Function(function)) => execute_function(env, function).await,
-                Some(External { path }) => execute_external_utility(env, path, fields).await,
+                Some(External { path }) => {
+                    execute_external_utility(env, path, fields, Rc::clone(&self.redirs)).await
+                }
                 None => {
                     // TODO open redirections
                     // TODO expand and perform assignments
@@ -206,7 +210,12 @@ async fn execute_function(env: &mut Env, function: Rc<Function>) -> Result {
     Continue(())
 }
 
-async fn execute_external_utility(env: &mut Env, path: CString, fields: Vec<Field>) -> Result {
+async fn execute_external_utility(
+    env: &mut Env,
+    path: CString,
+    fields: Vec<Field>,
+    redirs: Rc<Vec<Redir>>,
+) -> Result {
     let name = fields[0].clone();
     let location = name.origin.clone();
     let args = to_c_strings(fields);
@@ -214,7 +223,11 @@ async fn execute_external_utility(env: &mut Env, path: CString, fields: Vec<Fiel
     let result = env
         .run_in_subshell(move |env| {
             Box::pin(async move {
-                // TODO open redirections
+                let mut env = match redir::perform(env, &redirs).await {
+                    Ok(env) => env,
+                    Err(_) => return, // TODO drop(e.handle(env).await),
+                };
+
                 // TODO expand and perform assignments
 
                 // TODO Remove signal handlers not set by current traps
@@ -232,7 +245,7 @@ async fn execute_external_utility(env: &mut Env, path: CString, fields: Vec<Fiel
                     }
                 }
                 print_error(
-                    env,
+                    &mut env,
                     format!("cannot execute external command {:?}", path).into(),
                     errno.desc().into(),
                     &location,

--- a/yash-semantics/src/handle_impl.rs
+++ b/yash-semantics/src/handle_impl.rs
@@ -42,3 +42,22 @@ impl crate::expansion::Error {
         Continue(())
     }
 }
+
+impl crate::redir::Error {
+    /// Prints an error message and sets the exit status to non-zero.
+    ///
+    /// This function handles a redirection error by printing an error message
+    /// that describes the error to the standard error and setting the exit
+    /// status to [`ExitStatus::ERROR`]. Note that other POSIX-compliant
+    /// implementations may use different non-zero exit statuses.
+    pub async fn handle(&self, env: &mut Env) -> super::Result {
+        let m = Message::from(self);
+        let mut s = Snippet::from(&m);
+        s.opt.color = true;
+        let f = format!("{}\n", DisplayList::from(s));
+        let _ = env.system.write_all(Fd::STDERR, f.as_bytes()).await;
+
+        env.exit_status = ExitStatus::ERROR;
+        Continue(())
+    }
+}

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -27,6 +27,7 @@ mod command_impl;
 pub mod command_search;
 pub mod expansion;
 mod handle_impl;
+pub mod redir;
 
 use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::snippet::Snippet;

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -1,0 +1,138 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Redirection semantics.
+//!
+//! TODO Elaborate
+
+use std::ops::Deref;
+use std::ops::DerefMut;
+use yash_env::io::Fd;
+use yash_env::Env;
+use yash_syntax::source::Location;
+use yash_syntax::syntax::Redir;
+
+/// Record of saving an open file description in another file descriptor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SavedFd {
+    /// File descriptor by which the original open file description was
+    /// previously accessible.
+    original: Fd,
+    /// Temporary file descriptor that remembers the original open file
+    /// description.
+    save: Option<Fd>,
+}
+
+/// Environment (temporarily) modified by redirections.
+///
+/// This is an RAII-style guard that cancels the effect of redirections when the
+/// instance is dropped. The [`perform`] function returns an instance of
+/// `RedirEnv`. When you drop the instance, the file descriptors modified by the
+/// redirections are restored to the original state.
+///
+/// Instead of restoring the state, you can optionally preserve the effect of
+/// redirections permanently even after the instance is dropped. To do so, call
+/// the [`preserve_redirs`](Self::preserve_redirs) function.
+#[derive(Debug)]
+#[must_use = "Redirections are cancelled when you drop RedirEnv"]
+pub struct RedirEnv<'e> {
+    /// Environment in which redirections are performed.
+    env: &'e mut Env,
+    /// Records of file descriptors that have been modified by redirections.
+    saved_fds: Vec<SavedFd>,
+}
+
+impl Deref for RedirEnv<'_> {
+    type Target = Env;
+    fn deref(&self) -> &Env {
+        self.env
+    }
+}
+
+impl DerefMut for RedirEnv<'_> {
+    fn deref_mut(&mut self) -> &mut Env {
+        self.env
+    }
+}
+
+impl std::ops::Drop for RedirEnv<'_> {
+    fn drop(&mut self) {
+        // TODO undo redirections
+    }
+}
+
+impl RedirEnv<'_> {
+    /// Undo the effect of the redirections.
+    pub fn undo_redirs(self) {
+        drop(self)
+    }
+
+    /// Make the redirections permanent.
+    ///
+    /// This function drops the `RedirEnv` without undoing the effect of the
+    /// redirections.
+    pub fn preserve_redirs(self) {
+        todo!()
+    }
+}
+
+/// Types of errors that may occur in the redirection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ErrorCause {
+    /// Expansion error.
+    Expansion(crate::expansion::ErrorCause),
+    // TODO Other errors
+}
+
+impl From<crate::expansion::ErrorCause> for ErrorCause {
+    fn from(cause: crate::expansion::ErrorCause) -> Self {
+        ErrorCause::Expansion(cause)
+    }
+}
+
+/// Explanation of a redirection error.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Error {
+    pub cause: ErrorCause,
+    pub location: Location,
+}
+
+impl From<crate::expansion::Error> for Error {
+    fn from(e: crate::expansion::Error) -> Self {
+        Error {
+            cause: e.cause.into(),
+            location: e.location,
+        }
+    }
+}
+
+/// Performs redirections.
+pub async fn perform<'e, 'r>(
+    env: &'e mut Env,
+    _redirs: &'r [Redir],
+) -> Result<RedirEnv<'e>, Error> {
+    Ok(RedirEnv {
+        env,
+        saved_fds: vec![],
+    })
+    /*
+    TODO
+    1. Expand filename
+    2. Open FD (open file, prepare here-document content, open pipe)
+    3. Save original FD
+    4. Move FD (dup2)
+        */
+}

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -18,12 +18,20 @@
 //!
 //! TODO Elaborate
 
+use crate::expansion::expand_word;
+use nix::fcntl::OFlag;
+use std::ffi::CString;
+use std::ffi::NulError;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use yash_env::expansion::Field;
 use yash_env::io::Fd;
 use yash_env::Env;
+use yash_env::System;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::Redir;
+use yash_syntax::syntax::RedirBody;
+use yash_syntax::syntax::RedirOp;
 
 /// Record of saving an open file description in another file descriptor.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -94,12 +102,20 @@ impl RedirEnv<'_> {
 pub enum ErrorCause {
     /// Expansion error.
     Expansion(crate::expansion::ErrorCause),
+    /// Pathname containing a nul byte.
+    NulByte(NulError),
     // TODO Other errors
 }
 
 impl From<crate::expansion::ErrorCause> for ErrorCause {
     fn from(cause: crate::expansion::ErrorCause) -> Self {
         ErrorCause::Expansion(cause)
+    }
+}
+
+impl From<NulError> for ErrorCause {
+    fn from(e: NulError) -> Self {
+        ErrorCause::NulByte(e)
     }
 }
 
@@ -119,20 +135,118 @@ impl From<crate::expansion::Error> for Error {
     }
 }
 
-/// Performs redirections.
-pub async fn perform<'e, 'r>(
-    env: &'e mut Env,
-    _redirs: &'r [Redir],
-) -> Result<RedirEnv<'e>, Error> {
-    Ok(RedirEnv {
-        env,
-        saved_fds: vec![],
+/// Opens a file for redirection.
+fn open_file<S: System>(
+    system: &mut S,
+    option: OFlag,
+    path: Field,
+) -> Result<(Fd, Location), Error> {
+    let Field { value, origin } = path;
+    let path = match CString::new(value) {
+        Ok(path) => path,
+        Err(e) => {
+            return Err(Error {
+                cause: ErrorCause::NulByte(e),
+                location: origin,
+            })
+        }
+    };
+
+    use nix::sys::stat::Mode;
+    let mode = Mode::S_IRUSR
+        | Mode::S_IWUSR
+        | Mode::S_IRGRP
+        | Mode::S_IWGRP
+        | Mode::S_IROTH
+        | Mode::S_IWOTH;
+
+    match system.open(&path, option, mode) {
+        Ok(fd) => Ok((fd, origin)),
+        Err(e) => todo!("error handling not implemented: {:?}", e),
+    }
+}
+
+/// Opens the file for a normal redirection.
+async fn open_normal(
+    env: &mut Env,
+    operator: RedirOp,
+    operand: Field,
+) -> Result<(Fd, Location), Error> {
+    use RedirOp::*;
+    match operator {
+        FileIn => open_file(&mut env.system, OFlag::O_RDONLY, operand),
+        _ => todo!(),
+    }
+}
+
+/// Performs a redirection.
+async fn perform_one(env: &mut Env, redir: &Redir) -> Result<SavedFd, Error> {
+    let (fd, _location) = match &redir.body {
+        RedirBody::Normal { operator, operand } => {
+            // TODO perform pathname expansion if applicable
+            let expansion = expand_word(env, operand).await?;
+            open_normal(env, *operator, expansion).await
+        }
+        RedirBody::HereDoc(_) => todo!(),
+    }?;
+
+    assert_eq!(
+        fd,
+        redir.fd_or_default(),
+        "moving the FD is not yet supported"
+    );
+    // TODO Save original FD
+    // TODO Move FD (dup2)
+
+    Ok(SavedFd {
+        original: fd,
+        save: None,
     })
-    /*
-    TODO
-    1. Expand filename
-    2. Open FD (open file, prepare here-document content, open pipe)
-    3. Save original FD
-    4. Move FD (dup2)
-        */
+}
+
+/// Performs redirections.
+pub async fn perform<'e, 'r>(env: &'e mut Env, redirs: &'r [Redir]) -> Result<RedirEnv<'e>, Error> {
+    let saved_fds = Vec::with_capacity(redirs.len());
+    let mut env = RedirEnv { env, saved_fds };
+    for redir in redirs {
+        let saved_fd = perform_one(&mut env, redir).await?;
+        env.saved_fds.push(saved_fd);
+    }
+    Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_executor::block_on;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+    use std::rc::Rc;
+    use yash_env::virtual_system::INode;
+    use yash_env::VirtualSystem;
+
+    #[test]
+    fn basic_file_in_redirection() {
+        let mut file = INode::new();
+        file.content = vec![42, 123, 254];
+        let system = VirtualSystem::new();
+        system
+            .state
+            .borrow_mut()
+            .file_system
+            .save(PathBuf::from("foo"), Rc::new(RefCell::new(file)));
+        let mut env = Env::with_system(Box::new(system));
+        let redir = "3< foo".parse().unwrap();
+        let mut env = block_on(perform(&mut env, std::slice::from_ref(&redir))).unwrap();
+
+        let mut buffer = [0; 4];
+        let read_count = env.system.read(Fd(3), &mut buffer).unwrap();
+        assert_eq!(read_count, 3);
+        assert_eq!(buffer, [42, 123, 254, 0]);
+    }
+
+    #[test]
+    fn first_saved_fd_is_undone_when_second_fails() {
+        // TODO implement test case
+    }
 }

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -260,7 +260,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["foo".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let result = block_on(parser.short_function_definition(c)).unwrap();

--- a/yash-syntax/src/parser/fill.rs
+++ b/yash-syntax/src/parser/fill.rs
@@ -114,15 +114,15 @@ impl Fill for Redir<MissingHereDoc> {
 
 impl Fill for SimpleCommand<MissingHereDoc> {
     type Full = SimpleCommand;
-    fn fill(self, i: &mut dyn Iterator<Item = HereDoc>) -> Result<SimpleCommand> {
+    fn fill(mut self, i: &mut dyn Iterator<Item = HereDoc>) -> Result<SimpleCommand> {
         Ok(SimpleCommand {
             assigns: self.assigns,
             words: self.words,
-            redirs: self
-                .redirs
-                .into_iter()
+            redirs: Rc::make_mut(&mut self.redirs)
+                .drain(..)
                 .map(|redir| redir.fill(i))
-                .collect::<Result<Vec<_>>>()?,
+                .collect::<Result<Vec<_>>>()?
+                .into(),
         })
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -109,7 +109,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec![],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let result = block_on(parser.short_function_definition(c)).unwrap();
@@ -131,7 +131,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["foo".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let result = block_on(parser.short_function_definition(c)).unwrap();
@@ -150,7 +150,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["foo".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let e = block_on(parser.short_function_definition(c)).unwrap_err();
@@ -171,7 +171,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["foo".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let e = block_on(parser.short_function_definition(c)).unwrap_err();
@@ -192,7 +192,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["foo".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let e = block_on(parser.short_function_definition(c)).unwrap_err();
@@ -313,7 +313,7 @@ mod tests {
         let c = SimpleCommand {
             assigns: vec![],
             words: vec!["f".parse().unwrap()],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
 
         let e = block_on(parser.short_function_definition(c)).unwrap_err();

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -929,7 +929,7 @@ impl<H: fmt::Display> fmt::Display for Redir<H> {
 pub struct SimpleCommand<H = HereDoc> {
     pub assigns: Vec<Assign>,
     pub words: Vec<Word>,
-    pub redirs: Vec<Redir<H>>,
+    pub redirs: Rc<Vec<Redir<H>>>,
 }
 
 impl<H> SimpleCommand<H> {
@@ -1858,7 +1858,7 @@ mod tests {
         let mut command = SimpleCommand {
             assigns: vec![],
             words: vec![],
-            redirs: vec![],
+            redirs: vec![].into(),
         };
         assert_eq!(command.to_string(), "");
 
@@ -1878,7 +1878,7 @@ mod tests {
         command.words.push(Word::from_str("foo").unwrap());
         assert_eq!(command.to_string(), "name=value hello=world echo foo");
 
-        command.redirs.push(Redir {
+        Rc::make_mut(&mut command.redirs).push(Redir {
             fd: None,
             body: RedirBody::from(HereDoc {
                 delimiter: Word::from_str("END").unwrap(),
@@ -1894,7 +1894,7 @@ mod tests {
         command.words.clear();
         assert_eq!(command.to_string(), "<<END");
 
-        command.redirs.push(Redir {
+        Rc::make_mut(&mut command.redirs).push(Redir {
             fd: Some(Fd(1)),
             body: RedirBody::from(HereDoc {
                 delimiter: Word::from_str("here").unwrap(),

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -871,6 +871,16 @@ pub enum RedirBody<H = HereDoc> {
     // TODO process redirection
 }
 
+impl RedirBody<HereDoc> {
+    /// Returns the operand word of the redirection.
+    pub fn operand(&self) -> &Word {
+        match self {
+            RedirBody::Normal { operand, .. } => operand,
+            RedirBody::HereDoc(here_doc) => &here_doc.delimiter,
+        }
+    }
+}
+
 impl<H: fmt::Display> fmt::Display for RedirBody<H> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
This pull request implements the `<` redirection for external utility in simple command.

- [x] Expand filename
- [x] Open file
- [x] Handle file opening error
- [x] Move FD
- [x] Call redirection function in simple command

----

- [x] `System::open`
- [x] Wrap `SimpleCommand::redirs` in `Rc`
    - Needed to perform redirections in a subshell