### PR TITLE
File redirections

### DIFF
--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -245,6 +245,9 @@ impl System for VirtualSystem {
             if option.contains(OFlag::O_EXCL) {
                 return Err(Errno::EEXIST);
             }
+            if option.contains(OFlag::O_TRUNC) {
+                inode.borrow_mut().content.clear();
+            }
             Rc::clone(inode)
         } else {
             if !option.contains(OFlag::O_CREAT) {

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -124,6 +124,7 @@ impl VirtualSystem {
                     offset: 0,
                     is_readable: true,
                     is_writable: true,
+                    is_appending: true,
                 })),
                 cloexec: false,
             };
@@ -275,6 +276,7 @@ impl System for VirtualSystem {
             offset: 0,
             is_readable,
             is_writable,
+            is_appending: option.contains(OFlag::O_APPEND),
         }));
         let body = FdBody {
             open_file_description,
@@ -746,6 +748,69 @@ mod tests {
             nix::sys::stat::Mode::empty(),
         );
         assert_eq!(second, Err(Errno::EEXIST));
+    }
+
+    #[test]
+    fn open_truncating() {
+        let mut system = VirtualSystem::new();
+        let fd = system
+            .open(
+                &CString::new("file").unwrap(),
+                OFlag::O_WRONLY | OFlag::O_CREAT,
+                nix::sys::stat::Mode::all(),
+            )
+            .unwrap();
+        system.write(fd, &[1, 2, 3]).unwrap();
+
+        let result = system.open(
+            &CString::new("file").unwrap(),
+            OFlag::O_WRONLY | OFlag::O_TRUNC,
+            nix::sys::stat::Mode::empty(),
+        );
+        assert_eq!(result, Ok(Fd(4)));
+
+        let reader = system
+            .open(
+                &CString::new("file").unwrap(),
+                OFlag::O_RDONLY,
+                nix::sys::stat::Mode::empty(),
+            )
+            .unwrap();
+        let count = system.read(reader, &mut [0; 1]).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn open_appending() {
+        let mut system = VirtualSystem::new();
+        let fd = system
+            .open(
+                &CString::new("file").unwrap(),
+                OFlag::O_WRONLY | OFlag::O_CREAT,
+                nix::sys::stat::Mode::all(),
+            )
+            .unwrap();
+        system.write(fd, &[1, 2, 3]).unwrap();
+
+        let result = system.open(
+            &CString::new("file").unwrap(),
+            OFlag::O_WRONLY | OFlag::O_APPEND,
+            nix::sys::stat::Mode::empty(),
+        );
+        assert_eq!(result, Ok(Fd(4)));
+        system.write(Fd(4), &[4, 5, 6]).unwrap();
+
+        let reader = system
+            .open(
+                &CString::new("file").unwrap(),
+                OFlag::O_RDONLY,
+                nix::sys::stat::Mode::empty(),
+            )
+            .unwrap();
+        let mut buffer = [0; 7];
+        let count = system.read(reader, &mut buffer).unwrap();
+        assert_eq!(count, 6);
+        assert_eq!(buffer, [1, 2, 3, 4, 5, 6, 0]);
     }
 
     #[test]

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -16,6 +16,41 @@
 
 //! Redirection semantics.
 //!
+//! # Effect of redirections
+//!
+//! A [redirection](Redir) modifies its [target file
+//! descriptor](Redir::fd_or_default) on the basis of its [body](RedirBody).
+//!
+//! If the body is `Normal`, the operand word is [expanded](crate::expansion)
+//! first. Then, the [operator](RedirOp) defines the next behavior:
+//!
+//! - `FileIn`: Opens a file for reading, regarding the expanded field as a
+//!   pathname.
+//! - `FileInOut`: Likewise, opens a file for reading and writing.
+//! - `FileOut`, `FileClobber`: Likewise, opens a file for writing and clears
+//!   the file content.  Creates an empty regular file if the file does not
+//!   exist.
+//! - `FileAppend`: Likewise, opens a file for appending.
+//!   Creates an empty regular file if the file does not exist.
+//! - `FdIn`: Copies a file descriptor, regarding the expanded field as a
+//!   non-negative decimal integer denoting a readable file descriptor to copy
+//!   from. Closes the target file descriptor if the field is a single hyphen
+//!   (`-`) instead.
+//! - `FdOut`: Likewise, copies or closes a file descriptor, but the source file
+//!   descriptor must be writable instead of readable.
+//! - `Pipe`: Opens a pipe, regarding the expanded field as a
+//!   non-negative decimal integer denoting a file descriptor to become the
+//!   reading end of the pipe. The target file descriptor will be the writing
+//!   end.
+//! - `String`: Opens a readable file descriptor from which you can read the
+//!   expanded field followed by a newline character.
+//!
+//! TODO `noclobber` option
+//!
+//! If the body is `HereDoc`, (TODO Elaborate).
+//!
+//! # Performing redirections
+//!
 //! To perform redirections, you need to wrap an [`Env`] in a [`RedirEnv`]
 //! first. Then, you call [`RedirEnv::perform_redir`] to affect the target file
 //! descriptor. When you drop the `RedirEnv`, it undoes the effect to the file


### PR DESCRIPTION
Implements `>`, `>|`, `>>`, and `<>` redirections. (`<` was implemented in #86)

The `clobber` shell option is not yet supported in this pull request, so the `>` redirection behaves the same as the `>|` redirection.

- [x] `>`
- [x] `>|`
- [x] `>>`
- [x] `<>`