### PR TITLE
Remove System::wait_sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "annotate-snippets",
  "async-trait",
  "futures-executor",
+ "futures-util",
  "yash-builtin",
  "yash-env",
  "yash-semantics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
 name = "yash-env"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "either",
  "futures-executor",

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -23,5 +23,6 @@ nix = "0.22.0"
 yash-syntax = { path = "../yash-syntax", version = "0.1.0" }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 futures-executor = "0.3.15"
 futures-util = { version = "0.3.15", features = ["channel"] }

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -323,21 +323,6 @@ pub trait System: Debug {
     /// immediately.
     fn wait(&mut self) -> nix::Result<nix::sys::wait::WaitStatus>;
 
-    /// Reports updated status of a child process.
-    ///
-    /// This is a thin wrapper around the `waitpid` system call. Users of `Env`
-    /// should not call it directly. Use dedicated job-managing functions
-    /// instead.
-    ///
-    /// This function is a temporary API that performs synchronous wait by
-    /// blocking in the function or by returning a future you need to await.
-    /// Eventually, a new function that only polls the state of children will
-    /// substitute this function.
-    #[deprecated]
-    fn wait_sync(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = nix::Result<nix::sys::wait::WaitStatus>>>>;
-
     // TODO Consider passing raw pointers for optimization
     /// Replaces the current process with an external utility.
     ///

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -195,7 +195,30 @@ pub trait System: Debug {
     ///
     /// This is an abstract wrapper around the `sigaction` system call. It
     /// returns the previous handler if successful.
+    ///
+    /// When you set the handler to `SignalHandling::Catch`, signals sent to
+    /// this process are accumulated in the `System` instance and made available
+    /// from [`caught_signals`](Self::caught_signals).
     fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> nix::Result<SignalHandling>;
+
+    /// Returns signals this process has caught, if any.
+    ///
+    /// To catch a signal, you must set the signal handler to
+    /// [`SignalHandling::Catch`] by calling [`sigaction`](Self::sigaction)
+    /// first. Once the handler is ready, signals sent to the process are
+    /// accumulated in the `System`. You call `caught_signals` to obtain a list
+    /// of caught signals thus far.
+    ///
+    /// This function clears the internal list of caught signals, so a next call
+    /// will return an empty list unless another signal is caught since the
+    /// first call. Because the list size is limited, you should call this
+    /// function periodically before the list gets full, in which case further
+    /// caught signals are silently ignored.
+    ///
+    /// Note that signals become pending if sent while blocked by
+    /// [`sigmask`](Self::sigmask). They must be unblocked so that they are
+    /// caught and made available from this function.
+    fn caught_signals(&mut self) -> Vec<Signal>;
 
     // TODO timespec
     /// Waits for a next event.

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -191,7 +191,6 @@ pub trait System: Debug {
     ) -> nix::Result<()>;
 
     // TODO timespec
-    // TODO sigmask
     /// Waits for a next event.
     ///
     /// This function blocks the calling thread until one of the following
@@ -199,16 +198,25 @@ pub trait System: Debug {
     ///
     /// - An FD in `readers` becomes ready for reading.
     /// - An FD in `writers` becomes ready for writing.
+    /// - A signal handler catches a signal.
     ///
-    /// When this function returns, FDs that are not ready for reading and
-    /// writing are removed from `readers` and `writers`, respectively. The
+    /// When this function returns an `Ok`, FDs that are not ready for reading
+    /// and writing are removed from `readers` and `writers`, respectively. The
     /// return value will be the number of FDs left in `readers` and `writers`.
     ///
     /// If `readers` and `writers` contain an FD that is not open for reading
     /// and writing, respectively, this function will fail with `EBADF`. In this
     /// case, you should remove the FD from `readers` and `writers` and try
     /// again.
-    fn select(&mut self, readers: &mut FdSet, writers: &mut FdSet) -> nix::Result<c_int>;
+    ///
+    /// If `signal_mask` is `Some` signal set, the signal blocking mask is set
+    /// to it while waiting and restored when the function returns.
+    fn select(
+        &mut self,
+        readers: &mut FdSet,
+        writers: &mut FdSet,
+        signal_mask: Option<&SigSet>,
+    ) -> nix::Result<c_int>;
 
     /// Creates a new child process.
     ///

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -53,6 +53,8 @@ use async_trait::async_trait;
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
+use nix::sys::signal::SigSet;
+use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::Mode;
 use nix::unistd::Pid;
 use std::collections::HashMap;
@@ -177,6 +179,16 @@ pub trait System: Debug {
     /// to support concurrent I/O in an `async` function context and ensure the
     /// whole `buffer` is written.
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize>;
+
+    /// Gets and/or sets the signal blocking mask.
+    ///
+    /// This is a thin wrapper around the `sigprocmask` system call.
+    fn sigmask(
+        &mut self,
+        how: SigmaskHow,
+        set: Option<&SigSet>,
+        oldset: Option<&mut SigSet>,
+    ) -> nix::Result<()>;
 
     // TODO timespec
     // TODO sigmask

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -183,7 +183,16 @@ pub trait System: Debug {
 
     /// Gets and/or sets the signal blocking mask.
     ///
-    /// This is a thin wrapper around the `sigprocmask` system call.
+    /// This is a low-level function used internally by
+    /// [`SharedSystem::set_signal_handling`]. You should not call this function
+    /// directly, or you will disrupt the behavior of `SharedSystem`. The
+    /// description below applies if you want to do everything yourself without
+    /// depending on `SharedSystem`.
+    ///
+    /// This is a thin wrapper around the `sigprocmask` system call. If `set` is
+    /// `Some`, this function updates the signal blocking mask according to
+    /// `how`. If `oldset` is `Some`, this function sets the previous mask to
+    /// it.
     fn sigmask(
         &mut self,
         how: SigmaskHow,
@@ -193,8 +202,14 @@ pub trait System: Debug {
 
     /// Gets and sets the handler for a signal.
     ///
-    /// This is an abstract wrapper around the `sigaction` system call. It
-    /// returns the previous handler if successful.
+    /// This is a low-level function used internally by
+    /// [`SharedSystem::set_signal_handling`]. You should not call this function
+    /// directly, or you will disrupt the behavior of `SharedSystem`. The
+    /// description below applies if you want to do everything yourself without
+    /// depending on `SharedSystem`.
+    ///
+    /// This is an abstract wrapper around the `sigaction` system call. This
+    /// function returns the previous handler if successful.
     ///
     /// When you set the handler to `SignalHandling::Catch`, signals sent to
     /// this process are accumulated in the `System` instance and made available
@@ -202,6 +217,12 @@ pub trait System: Debug {
     fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> nix::Result<SignalHandling>;
 
     /// Returns signals this process has caught, if any.
+    ///
+    /// This is a low-level function used internally by
+    /// [`SharedSystem::select`]. You should not call this function directly, or
+    /// you will disrupt the behavior of `SharedSystem`. The description below
+    /// applies if you want to do everything yourself without depending on
+    /// `SharedSystem`.
     ///
     /// To catch a signal, you must set the signal handler to
     /// [`SignalHandling::Catch`] by calling [`sigaction`](Self::sigaction)
@@ -222,6 +243,12 @@ pub trait System: Debug {
 
     // TODO timespec
     /// Waits for a next event.
+    ///
+    /// This is a low-level function used internally by
+    /// [`SharedSystem::select`]. You should not call this function directly, or
+    /// you will disrupt the behavior of `SharedSystem`. The description below
+    /// applies if you want to do everything yourself without depending on
+    /// `SharedSystem`.
     ///
     /// This function blocks the calling thread until one of the following
     /// condition is met:

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -149,8 +149,13 @@ impl System for RealSystem {
         nix::sys::signal::sigprocmask(how, set, oldset)
     }
 
-    fn select(&mut self, readers: &mut FdSet, writers: &mut FdSet) -> nix::Result<c_int> {
-        nix::sys::select::pselect(None, readers, writers, None, None, None)
+    fn select(
+        &mut self,
+        readers: &mut FdSet,
+        writers: &mut FdSet,
+        signal_mask: Option<&SigSet>,
+    ) -> nix::Result<c_int> {
+        nix::sys::select::pselect(None, readers, writers, None, None, signal_mask)
     }
 
     /// Creates a new child process.

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -262,20 +262,6 @@ impl System for RealSystem {
         nix::sys::wait::waitpid(None, options.into())
     }
 
-    /// Reports updated status of a child process.
-    ///
-    /// This implementation blocks inside the function and returns a future that
-    /// will immediately return a `Ready`.
-    fn wait_sync(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = nix::Result<nix::sys::wait::WaitStatus>>>> {
-        use nix::sys::wait::WaitPidFlag;
-        let options = WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED;
-        // TODO Should set WNOHANG too
-        let result = nix::sys::wait::waitpid(None, options.into());
-        Box::pin(std::future::ready(result))
-    }
-
     fn execve(
         &mut self,
         path: &CStr,

--- a/yash-env/src/real_system.rs
+++ b/yash-env/src/real_system.rs
@@ -25,6 +25,8 @@ use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::libc::{S_IFMT, S_IFREG};
 use nix::sys::select::FdSet;
+use nix::sys::signal::SigSet;
+use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::stat;
 use nix::sys::stat::Mode;
 use nix::unistd::access;
@@ -136,6 +138,15 @@ impl System for RealSystem {
                 return result;
             }
         }
+    }
+
+    fn sigmask(
+        &mut self,
+        how: SigmaskHow,
+        set: Option<&SigSet>,
+        oldset: Option<&mut SigSet>,
+    ) -> nix::Result<()> {
+        nix::sys::signal::sigprocmask(how, set, oldset)
     }
 
     fn select(&mut self, readers: &mut FdSet, writers: &mut FdSet) -> nix::Result<c_int> {

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -238,8 +238,13 @@ impl System for SharedSystem {
     ) -> nix::Result<()> {
         self.0.borrow_mut().sigmask(how, set, oldset)
     }
-    fn select(&mut self, readers: &mut FdSet, writers: &mut FdSet) -> nix::Result<c_int> {
-        (**self.0.borrow_mut()).select(readers, writers)
+    fn select(
+        &mut self,
+        readers: &mut FdSet,
+        writers: &mut FdSet,
+        signal_mask: Option<&SigSet>,
+    ) -> nix::Result<c_int> {
+        (**self.0.borrow_mut()).select(readers, writers, signal_mask)
     }
     unsafe fn new_child_process(&mut self) -> nix::Result<Box<dyn ChildProcess>> {
         self.0.borrow_mut().new_child_process()
@@ -303,7 +308,7 @@ impl SelectSystem {
     pub fn select(&mut self) -> nix::Result<()> {
         let mut readers = self.io.readers();
         let mut writers = self.io.writers();
-        match self.system.select(&mut readers, &mut writers) {
+        match self.system.select(&mut readers, &mut writers, None) {
             Ok(_) => {
                 self.io.wake(readers, writers);
                 Ok(())

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -24,6 +24,8 @@ use futures_util::task::Poll;
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
+use nix::sys::signal::SigSet;
+use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::Mode;
 use nix::sys::wait::WaitStatus;
 use std::cell::RefCell;
@@ -227,6 +229,14 @@ impl System for SharedSystem {
     }
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize> {
         self.0.borrow_mut().write(fd, buffer)
+    }
+    fn sigmask(
+        &mut self,
+        how: SigmaskHow,
+        set: Option<&SigSet>,
+        oldset: Option<&mut SigSet>,
+    ) -> nix::Result<()> {
+        self.0.borrow_mut().sigmask(how, set, oldset)
     }
     fn select(&mut self, readers: &mut FdSet, writers: &mut FdSet) -> nix::Result<c_int> {
         (**self.0.borrow_mut()).select(readers, writers)

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -243,6 +243,9 @@ impl System for SharedSystem {
     fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> nix::Result<SignalHandling> {
         self.0.borrow_mut().sigaction(signal, action)
     }
+    fn caught_signals(&mut self) -> Vec<Signal> {
+        self.0.borrow_mut().caught_signals()
+    }
     fn select(
         &mut self,
         readers: &mut FdSet,

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -34,11 +34,9 @@ use std::cell::RefCell;
 use std::convert::Infallible;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::future::Future;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::os::raw::c_int;
-use std::pin::Pin;
 use std::rc::Rc;
 use std::rc::Weak;
 use std::task::Waker;
@@ -296,10 +294,6 @@ impl System for SharedSystem {
     }
     fn wait(&mut self) -> nix::Result<WaitStatus> {
         self.0.borrow_mut().wait()
-    }
-    fn wait_sync(&mut self) -> Pin<Box<dyn Future<Output = nix::Result<WaitStatus>>>> {
-        #[allow(deprecated)]
-        self.0.borrow_mut().wait_sync()
     }
     fn execve(
         &mut self,

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -18,6 +18,7 @@
 
 use crate::io::Fd;
 use crate::ChildProcess;
+use crate::SignalHandling;
 use crate::System;
 use futures_util::future::poll_fn;
 use futures_util::task::Poll;
@@ -26,6 +27,7 @@ use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
 use nix::sys::signal::SigSet;
 use nix::sys::signal::SigmaskHow;
+use nix::sys::signal::Signal;
 use nix::sys::stat::Mode;
 use nix::sys::wait::WaitStatus;
 use std::cell::RefCell;
@@ -237,6 +239,9 @@ impl System for SharedSystem {
         oldset: Option<&mut SigSet>,
     ) -> nix::Result<()> {
         self.0.borrow_mut().sigmask(how, set, oldset)
+    }
+    fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> nix::Result<SignalHandling> {
+        self.0.borrow_mut().sigaction(signal, action)
     }
     fn select(
         &mut self,

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -342,12 +342,12 @@ impl SelectSystem {
 /// TODO Elaborate
 #[derive(Clone, Debug, Default)]
 struct AsyncIo {
-    readers: Vec<Awaiter>,
-    writers: Vec<Awaiter>,
+    readers: Vec<FdAwaiter>,
+    writers: Vec<FdAwaiter>,
 }
 
 #[derive(Clone, Debug)]
-struct Awaiter {
+struct FdAwaiter {
     fd: Fd,
     waker: Waker,
 }
@@ -384,12 +384,12 @@ impl AsyncIo {
 
     /// Adds an awaiter for reading.
     pub fn wait_for_reading(&mut self, fd: Fd, waker: Waker) {
-        self.readers.push(Awaiter { fd, waker });
+        self.readers.push(FdAwaiter { fd, waker });
     }
 
     /// Adds an awaiter for writing.
     pub fn wait_for_writing(&mut self, fd: Fd, waker: Waker) {
-        self.writers.push(Awaiter { fd, waker });
+        self.writers.push(FdAwaiter { fd, waker });
     }
 
     /// Wakes awaiters that are ready for reading/writing.

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -50,6 +50,7 @@ pub use self::process::*;
 use crate::io::Fd;
 use crate::ChildProcess;
 use crate::Env;
+use crate::SignalHandling;
 use crate::System;
 use async_trait::async_trait;
 use nix::errno::Errno;
@@ -57,6 +58,7 @@ use nix::fcntl::OFlag;
 use nix::sys::select::FdSet;
 use nix::sys::signal::SigSet;
 use nix::sys::signal::SigmaskHow;
+use nix::sys::signal::Signal;
 use nix::sys::wait::WaitStatus;
 use nix::unistd::Pid;
 use std::cell::Ref;
@@ -327,6 +329,11 @@ impl System for VirtualSystem {
             process.block_signals(how, set)
         }
         Ok(())
+    }
+
+    fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> nix::Result<SignalHandling> {
+        let mut process = self.current_process_mut();
+        Ok(process.set_signal_handling(signal, action))
     }
 
     /// Waits for a next event.

--- a/yash-env/src/virtual_system.rs
+++ b/yash-env/src/virtual_system.rs
@@ -336,6 +336,10 @@ impl System for VirtualSystem {
         Ok(process.set_signal_handling(signal, action))
     }
 
+    fn caught_signals(&mut self) -> Vec<Signal> {
+        std::mem::take(&mut self.current_process_mut().caught_signals)
+    }
+
     /// Waits for a next event.
     ///
     /// The `VirtualSystem` implementation for this method does not actually

--- a/yash-env/src/virtual_system/process.rs
+++ b/yash-env/src/virtual_system/process.rs
@@ -316,25 +316,6 @@ impl Process {
         }
     }
 
-    /// Performs [`SharedSystem::select`](crate::SharedSystem::select) for this
-    /// process.
-    ///
-    /// If this process is a child process created from another process in the
-    /// system, this function calls `SharedSystem::select` to wake tasks that
-    /// are ready to resume in the process.
-    ///
-    /// For the initial process created when creating a new
-    /// [`VirtualSystem`](crate::VirtualSystem), this function does nothing. To
-    /// `select` on the initial process, directly call `SharedSystem::select`
-    /// for the [`Env`](crate::Env) controlling the process.
-    pub fn select(&self) -> nix::Result<()> {
-        if let Some(system) = Weak::upgrade(&self.selector) {
-            system.borrow_mut().select()
-        } else {
-            Ok(())
-        }
-    }
-
     /// Returns the arguments to the last call to
     /// [`execve`](crate::VirtualSystem::execve) on this process.
     #[inline(always)]

--- a/yash-env/src/virtual_system/process.rs
+++ b/yash-env/src/virtual_system/process.rs
@@ -237,6 +237,14 @@ impl Process {
         &self.blocked_signals
     }
 
+    /// Returns the currently pending signals.
+    ///
+    /// A signal is pending when it has been raised but not yet delivered
+    /// because it is being blocked.
+    pub fn pending_signals(&self) -> &SigSet {
+        &self.pending_signals
+    }
+
     /// Updates the signal blocking mask for this process.
     ///
     /// If this function unblocks a signal, any pending signal is delivered.

--- a/yash-env/src/virtual_system/process.rs
+++ b/yash-env/src/virtual_system/process.rs
@@ -64,6 +64,9 @@ pub struct Process {
     /// Set of blocked signals.
     blocked_signals: SigSet,
 
+    /// List of signals that have been delivered and caught.
+    pub(crate) caught_signals: Vec<Signal>,
+
     /// Weak reference to the `SelectSystem` for this process.
     ///
     /// This weak reference is empty for the initial process of a
@@ -104,6 +107,7 @@ impl Process {
             state_awaiters: Some(Vec::new()),
             signal_handlings: HashMap::new(),
             blocked_signals: SigSet::empty(),
+            caught_signals: Vec::new(),
             selector: Weak::new(),
             last_exec: None,
         }

--- a/yash-semantics/src/command_impl/pipeline.rs
+++ b/yash-semantics/src/command_impl/pipeline.rs
@@ -250,6 +250,7 @@ mod tests {
     use std::rc::Rc;
     use yash_env::exec::Divert;
     use yash_env::exec::ExitStatus;
+    use yash_env::virtual_system::SystemState;
     use yash_env::VirtualSystem;
 
     #[test]
@@ -326,7 +327,7 @@ mod tests {
             let poll = task.as_mut().poll(context);
             if poll.is_pending() {
                 shared_system.select().unwrap();
-                state.borrow().select_all();
+                SystemState::select_all(&state);
             }
             poll
         }));
@@ -356,7 +357,7 @@ mod tests {
             let poll = task.as_mut().poll(context);
             if poll.is_pending() {
                 shared_system.select().unwrap();
-                state.borrow().select_all();
+                SystemState::select_all(&state);
             }
             poll
         }));

--- a/yash/Cargo.toml
+++ b/yash/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 async-trait = "0.1.50"
 futures-executor = "0.3.15"
+futures-util = "0.3.15"
 yash-builtin = { path = "../yash-builtin", version = "0.1.0" }
 yash-env = { path = "../yash-env", version = "0.1.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.1.0" }


### PR DESCRIPTION
Closes #88.

As a single-threaded program, asynchronous tasks have to avoid blocking the running thread directly to allow other tasks to run concurrently. This pull request removes `System::wait_sync` which blocks the current thread. `SharedSystem::select` now blocks the thread while waiting for child processes to finish.

- [x] Implement `System::sigmask`
- [x] Extend `System::select` to allow modifying signal mask
- [x] Implement `System::sigaction`
- [x] Implement `System::caught_signal`
- [x] Implement `Process::raise_signal` in the virtual system
- [x] Send `SIGCHLD` when a child process exits in the virtual system
    - The implementation in this pull request does not support sending `SIGCHLD` to a parent on all kinds of process state change.
- [x] Implement `VirtualSystem::wait`
- [x] Retain signal awaiters (`Waker`s) in `AsyncSignal`
- [x] Implement `SharedSystem::set_signal_handling` and `SharedSystem::wait_for_signal`
- [x] Implement `Env::wait_for_subshell`
- [x] Migrate existing implementation to the new functions
- [x] Remove `System::wait_sync` and its implementors
- [x] Consider removing `Process::state_awaiters` from the virtual system.
    - We should only need to remember whether the latest process status has been `wait`ed for or not.
- [x] Restore the signal mask before `exec`ing an external utility
