### PR TITLE
Run traps after running command

### DIFF
--- a/yash-semantics/src/command_impl.rs
+++ b/yash-semantics/src/command_impl.rs
@@ -24,8 +24,9 @@ mod pipeline;
 mod simple_command;
 
 use super::Command;
+use crate::run_traps_for_caught_signals;
 use async_trait::async_trait;
-use std::ops::ControlFlow::Continue;
+use std::ops::ControlFlow::{Break, Continue};
 use yash_env::exec::Result;
 use yash_env::Env;
 use yash_syntax::syntax;
@@ -33,12 +34,23 @@ use yash_syntax::syntax;
 #[async_trait(?Send)]
 impl Command for syntax::Command {
     /// Executes the command.
+    ///
+    /// After executing the command body, this function [runs
+    /// traps](run_traps_for_caught_signals) if any caught signals are pending.
     async fn execute(&self, env: &mut Env) -> Result {
         use syntax::Command::*;
-        match self {
+        let main_result = match self {
             Simple(command) => command.execute(env).await,
             Compound(command) => command.execute(env).await,
             Function(definition) => definition.execute(env).await,
+        };
+
+        let trap_result = run_traps_for_caught_signals(env).await;
+
+        match (main_result, trap_result) {
+            (_, Continue(())) => main_result,
+            (Continue(()), _) => trap_result,
+            (Break(main_divert), Break(trap_divert)) => Break(main_divert.max(trap_divert)),
         }
     }
 }
@@ -61,11 +73,53 @@ impl Command for syntax::List {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
     use futures_executor::block_on;
-    use std::ops::ControlFlow::Break;
     use yash_env::exec::Divert;
     use yash_env::exec::ExitStatus;
+    use yash_env::trap::Signal;
+    use yash_env::trap::Trap;
+    use yash_env::VirtualSystem;
+    use yash_syntax::source::Location;
+
+    #[test]
+    fn command_handles_traps() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Box::new(system.clone()));
+        env.builtins.insert("echo", echo_builtin());
+        env.traps
+            .set_trap(
+                &mut env.system,
+                Signal::SIGUSR1,
+                Trap::Command("echo USR1".into()),
+                Location::dummy(""),
+                false,
+            )
+            .unwrap();
+        system
+            .state
+            .borrow_mut()
+            .processes
+            .get_mut(&system.process_id)
+            .unwrap()
+            .raise_signal(Signal::SIGUSR1);
+        let command: syntax::Command = "echo main".parse().unwrap();
+        let result = block_on(command.execute(&mut env));
+        assert_eq!(result, Continue(()));
+        assert_eq!(env.exit_status, ExitStatus::SUCCESS);
+        assert_eq!(
+            system
+                .state
+                .borrow()
+                .file_system
+                .get("/dev/stdout")
+                .unwrap()
+                .borrow()
+                .content,
+            b"main\nUSR1\n"
+        );
+    }
 
     #[test]
     fn list_execute_no_divert() {


### PR DESCRIPTION
This pull request reverts part of #114 to change the timing of running traps. Instead of after each simple command, traps are now run after each (any kind of) command. This should allow more opportunities for running traps.