### PR TITLE
Special handling for printing traps in subshells

### DIFF
--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -41,15 +41,15 @@ pub trait Env: Stdout + Stderr {
     /// Returns an iterator for currently configured trap actions.
     fn iter(&self) -> Iter;
 
-    /// Returns the currently configured trap action for a signal.
+    /// Returns the trap action for a signal.
     ///
-    /// This function returns an optional pair of a trap action and the location
-    /// specified when setting the trap. The result is `None` if no trap has
-    /// been set for the signal.
+    /// This function returns a pair of optional trap states. The first is the
+    /// currently configured trap action, and the second is the action set
+    /// before entering the current subshell environment.
     ///
     /// This function does not reflect the initial signal actions the shell
     /// inherited on startup.
-    fn get_trap(&self, signal: Signal) -> Option<&TrapState>;
+    fn get_trap(&self, signal: Signal) -> (Option<&TrapState>, Option<&TrapState>);
 
     /// Sets a trap action for a signal.
     ///
@@ -79,7 +79,7 @@ impl Env for yash_env::Env {
         self.traps.iter()
     }
 
-    fn get_trap(&self, signal: Signal) -> Option<&TrapState> {
+    fn get_trap(&self, signal: Signal) -> (Option<&TrapState>, Option<&TrapState>) {
         self.traps.get_trap(signal)
     }
 

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -98,7 +98,12 @@ impl Env for yash_env::Env {
 /// Prints the currently configured traps.
 pub async fn print_traps<E: Env>(env: &mut E) -> Result {
     let mut output = String::new();
-    for (&signal, trap) in env.iter() {
+    for (&signal, current, parent) in env.iter() {
+        let trap = match (current, parent) {
+            (Some(trap), _) => trap,
+            (None, Some(trap)) => trap,
+            (None, None) => continue,
+        };
         let command = match &trap.action {
             Trap::Default => continue,
             Trap::Ignore => "",
@@ -276,5 +281,24 @@ mod tests {
         assert_ne!(file.content, []);
     }
 
-    // TODO printing_traps_in_subshell
+    #[test]
+    fn printing_traps_in_subshell() {
+        let system = Box::new(VirtualSystem::new());
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(system);
+        let args = Field::dummies(["trap", "echo", "INT"]);
+        let _ = builtin_body(&mut env, args).now_or_never().unwrap();
+        let args = Field::dummies(["trap", "", "TERM"]);
+        let _ = builtin_body(&mut env, args).now_or_never().unwrap();
+        env.traps.enter_subshell(&mut env.system);
+        let args = Field::dummies(["trap"]);
+
+        let result = block_on(builtin_body(&mut env, args));
+        assert_eq!(result, (ExitStatus::SUCCESS, Continue(())));
+        let state = state.borrow();
+        let file = state.file_system.get("/dev/stdout").unwrap().borrow();
+        assert_eq!(file.content, b"trap -- echo INT\ntrap -- '' TERM\n");
+    }
+
+    // TODO printing_traps_after_setting_in_subshell
 }

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -126,9 +126,16 @@ impl From<&UserSignalState> for SignalHandling {
     }
 }
 
+/// Whole configuration for a signal.
 #[derive(Clone, Debug)]
 struct SignalState {
+    /// User signal state that is effective in the current environment.
     current_user_state: UserSignalState,
+
+    /// User signal state that was effective in the parent environment.
+    parent_user_state: Option<UserSignalState>,
+
+    /// Whether the internal handler has been installed in the current environment.
     internal_handler_enabled: bool,
 }
 
@@ -232,6 +239,7 @@ impl TrapSet {
                     if initial_handling == SignalHandling::Ignore {
                         vacant.insert(SignalState {
                             current_user_state: UserSignalState::InitiallyIgnored,
+                            parent_user_state: None,
                             internal_handler_enabled: false,
                         });
                         return Err(SetTrapError::InitiallyIgnored);
@@ -257,6 +265,7 @@ impl TrapSet {
 
         let state = SignalState {
             current_user_state: UserSignalState::Trap(state),
+            parent_user_state: None,
             internal_handler_enabled: false,
         };
         #[allow(clippy::drop_ref)]
@@ -355,6 +364,7 @@ impl TrapSet {
                 };
                 vacant.insert(SignalState {
                     current_user_state,
+                    parent_user_state: None,
                     internal_handler_enabled: true,
                 });
             }


### PR DESCRIPTION
This pull request implements the following part of the trap built-in semantics from the POSIX standard:

> If the command is executed in a subshell, the implementation does not perform the optional check described above for a command substitution containing only a single trap command, and no trap commands with operands have been executed since entry to the subshell, the list shall contain the commands that were associated with each condition immediately before the subshell environment was entered. Otherwise, the list shall contain the commands currently associated with each condition.

- [x] Define the parent signal state in the data structure.
- [x] Return the parent state from TrapSet::get_trap
- [x] Return the parent state from the iterator
- [x] Remember parent states on fork
- [x] Print parent states in the trap built-in
- [x] Remove parent states before setting a trap
- [x] Implement behavior for nested subshells
- [x] Resolve remaining todos
