### PR TITLE
Argument syntax parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
 name = "yash-builtin"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "futures-executor",
  "futures-util",

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -22,5 +22,6 @@ yash-quote = { path = "../yash-quote", version = "0.1.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.1.0" }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 futures-util = "0.3.18"
 futures-executor = "0.3.18"

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -21,6 +21,8 @@ use yash_env::io::Fd;
 use yash_env::semantics::ExitStatus;
 use yash_env::system::Errno;
 
+pub mod arg;
+
 /// Part of the execution environment that allows printing to the standard
 /// output.
 #[async_trait(?Send)]

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -141,29 +141,29 @@ pub struct Error {}
 /// argument and the field does not include one, the following field is consumed
 /// as the argument.
 ///
-/// This function returns `true` if consumed one or more fields.
+/// This function returns `Ok(true)` if consumed one or more fields.
 fn parse_short_options<'a, I: Iterator<Item = Field>>(
     option_specs: &'a [OptionSpec],
     arguments: &mut Peekable<I>,
     option_occurrences: &mut Vec<OptionOccurrence<'a>>,
-) -> bool {
+) -> Result<bool, Error> {
     let argument = match arguments.peek() {
         Some(argument) => argument,
-        None => return false,
+        None => return Ok(false),
     };
 
     let mut chars = argument.value.chars();
     if chars.next() != Some('-') {
         // argument.value not starting with a hyphen
-        return false;
+        return Ok(false);
     }
     if chars.as_str().is_empty() {
         // argument.value == "-"
-        return false;
+        return Ok(false);
     }
     if chars.as_str() == "-" {
         // argument.value == "--"
-        return false;
+        return Ok(false);
     }
 
     while let Some(c) = chars.next() {
@@ -188,13 +188,13 @@ fn parse_short_options<'a, I: Iterator<Item = Field>>(
                         Some(argument)
                     };
                     option_occurrences.push(OptionOccurrence { spec, argument });
-                    return true;
+                    return Ok(true);
                 }
             };
         }
     }
     drop(arguments.next());
-    true
+    Ok(true)
 }
 
 /// Parses command-line arguments into options and operands.
@@ -210,7 +210,7 @@ pub fn parse_arguments(
     let mut arguments = arguments.into_iter().skip(1).peekable();
 
     let mut option_occurrences = vec![];
-    while parse_short_options(option_specs, &mut arguments, &mut option_occurrences) {}
+    while parse_short_options(option_specs, &mut arguments, &mut option_occurrences)? {}
 
     arguments.next_if(|argument| argument.value == "--");
 

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -203,6 +203,7 @@ pub struct OptionOccurrence<'a> {
 
 /// Error in command line parsing
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Error<'a> {
     /// Short option that is not defined in the option specs
     UnknownShortOption(char, Field),

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -304,6 +304,16 @@ mod tests {
         assert_eq!(operands, Field::dummies(["-a", "--", "-a"]));
     }
 
-    // TODO options_are_not_recognized_after_operand (depending mode)
+    #[test]
+    fn options_are_not_recognized_after_operand_by_default() {
+        let specs = &[OptionSpec::new().short('x'), OptionSpec::new().short('y')];
+
+        let arguments = Field::dummies(["foo", "-x", "bar", "-y", "baz"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 1, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('x'));
+        assert_eq!(operands, Field::dummies(["bar", "-y", "baz"]));
+    }
+
     // TODO options_are_recognized_after_operand (depending mode)
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -49,8 +49,9 @@
 //! assert_eq!(operands, Field::dummies(["-a", "foo"]));
 //! ```
 
-#[doc(no_inline)]
 use std::iter::Peekable;
+
+#[doc(no_inline)]
 pub use yash_env::semantics::Field;
 
 /// Specification for an options's argument

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -98,13 +98,14 @@ fn parse_short_options<'a>(
         return false;
     }
 
+    let mut found = false;
     for c in i {
         if let Some(spec) = option_specs.iter().find(|spec| spec.get_short() == Some(c)) {
+            found = true;
             option_occurrences.push(OptionOccurrence { spec });
         }
     }
-    // TODO Return false if no options were found
-    true
+    found
 }
 
 /// Parses command-line arguments into options and operands.
@@ -275,6 +276,22 @@ mod tests {
         assert_eq!(operands, []);
     }
 
-    // TODO single_hyphen_argument_is_not_option
+    #[test]
+    fn single_hyphen_argument_is_not_option() {
+        let specs = &[OptionSpec::new().short('a')];
+
+        let arguments = Field::dummies(["foo", "-"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies(["-"]));
+
+        let arguments = Field::dummies(["foo", "-", "-"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies(["-", "-"]));
+    }
+
     // TODO options_are_not_recognized_after_separator
+    // TODO options_are_not_recognized_after_operand (depending mode)
+    // TODO options_are_recognized_after_operand (depending mode)
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -303,17 +303,13 @@ fn parse_long_option<'a, I: Iterator<Item = Field>>(
         None => return Ok(None),
     };
 
-    let mut argument = match equal {
-        Some(index) => {
-            let mut argument = arguments.next().unwrap();
-            argument.value.drain(..index + 3);
-            Some(argument)
-        }
-        None => {
-            drop(arguments.next());
-            None
-        }
-    };
+    let argument = arguments.next().unwrap();
+
+    let mut argument = equal.map(|index| {
+        let mut argument = argument;
+        argument.value.drain(..index + 3); // Remove "--", name, and "="
+        argument
+    });
 
     match (spec.get_argument(), &argument) {
         (OptionArgumentSpec::None, None) => (),

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -489,6 +489,28 @@ mod tests {
 
     // TODO empty_argument_to_short_option
 
+    #[test]
+    fn option_argument_that_looks_like_separator() {
+        let specs = &[OptionSpec::new()
+            .short('a')
+            .argument(OptionArgumentSpec::Required)];
+
+        let arguments = Field::dummies(["foo", "-a", "argument", "-a", "--", "--", "operand"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 2, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('a'));
+        assert_matches!(options[0].argument, Some(ref field) => {
+            assert_eq!(field.value, "argument");
+            assert_eq!(field.origin.line.value, "argument");
+        });
+        assert_eq!(options[1].spec.get_short(), Some('a'));
+        assert_matches!(options[1].argument, Some(ref field) => {
+            assert_eq!(field.value, "--");
+            assert_eq!(field.origin.line.value, "--");
+        });
+        assert_eq!(operands, Field::dummies(["operand"]));
+    }
+
     // TODO options_are_recognized_after_operand (depending mode)
 
     // TODO missing_argument_to_short_option

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -53,8 +53,11 @@ pub struct Error {}
 pub fn parse_arguments(
     _option_specs: &[OptionSpec],
     _mode: Mode,
-    arguments: Vec<Field>,
+    mut arguments: Vec<Field>,
 ) -> Result<(Vec<ParsedOption>, Vec<Field>), Error> {
+    if !arguments.is_empty() {
+        arguments.remove(0);
+    }
     Ok((vec![], arguments))
 }
 
@@ -67,5 +70,23 @@ mod tests {
         let (options, operands) = parse_arguments(&[], Mode::default(), vec![]).unwrap();
         assert_eq!(options, []);
         assert_eq!(operands, []);
+    }
+
+    #[test]
+    fn only_operands() {
+        let arguments = Field::dummies(["foo"]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, []);
+
+        let arguments = Field::dummies(["foo", ""]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies([""]));
+
+        let arguments = Field::dummies(["foo", "bar", "", "baz"]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies(["bar", "", "baz"]));
     }
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -154,14 +154,20 @@ fn parse_short_options<'a, I: Iterator<Item = Field>>(
 
     let mut chars = argument.value.chars();
     if chars.next() != Some('-') {
+        // argument.value not starting with a hyphen
+        return false;
+    }
+    if chars.as_str().is_empty() {
+        // argument.value == "-"
+        return false;
+    }
+    if chars.as_str() == "-" {
+        // argument.value == "--"
         return false;
     }
 
-    let mut found = false;
     while let Some(c) = chars.next() {
         if let Some(spec) = option_specs.iter().find(|spec| spec.get_short() == Some(c)) {
-            found = true;
-
             match spec.get_argument() {
                 OptionArgumentSpec::None => {
                     let argument = None;
@@ -187,10 +193,8 @@ fn parse_short_options<'a, I: Iterator<Item = Field>>(
             };
         }
     }
-    if found {
-        arguments.next();
-    }
-    found
+    drop(arguments.next());
+    true
 }
 
 /// Parses command-line arguments into options and operands.

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -98,7 +98,7 @@ fn parse_short_options<'a>(
         return false;
     }
 
-    if let Some(c) = i.next() {
+    for c in i {
         if let Some(spec) = option_specs.iter().find(|spec| spec.get_short() == Some(c)) {
             option_occurrences.push(OptionOccurrence { spec });
         }
@@ -255,7 +255,25 @@ mod tests {
         assert_eq!(operands, []);
     }
 
-    // TODO multiple_occurrences_of_short_options_in_single_argument
+    #[test]
+    fn multiple_occurrences_of_short_options_in_single_argument() {
+        let specs = &[OptionSpec::new().short('p'), OptionSpec::new().short('q')];
+
+        let arguments = Field::dummies(["command", "-pq", "!"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 2, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('p'));
+        assert_eq!(options[1].spec.get_short(), Some('q'));
+        assert_eq!(operands, Field::dummies(["!"]));
+
+        let arguments = Field::dummies(["command", "-qpq"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 3, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('q'));
+        assert_eq!(options[1].spec.get_short(), Some('p'));
+        assert_eq!(options[2].spec.get_short(), Some('q'));
+        assert_eq!(operands, []);
+    }
 
     // TODO single_hyphen_argument_is_not_option
     // TODO options_are_not_recognized_after_separator

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -1,0 +1,52 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command-line argument parser
+//!
+//! This module provides functionalities for parsing command-line arguments into
+//! options and operands.
+//!
+//! This module's parser can parse command lines that adhere to POSIX Utility
+//! Syntax Guidelines and support non-standard syntax extensions such as long
+//! options and options after operands.
+//!
+//! # Example
+//!
+//! TODO
+
+#[doc(no_inline)]
+pub use yash_env::semantics::Field;
+
+/// TODO
+pub struct OptionSpec {}
+
+/// TODO
+pub struct Mode {}
+
+/// TODO
+pub struct ParsedOption {}
+
+/// TODO
+pub struct Error {}
+
+/// Parses command-line arguments into options and operands.
+pub fn parse_arguments(
+    _option_specs: &[OptionSpec],
+    _mode: Mode,
+    _arguments: Vec<Field>,
+) -> Result<(Vec<ParsedOption>, Vec<Field>), Error> {
+    todo!()
+}

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -487,7 +487,22 @@ mod tests {
         assert_eq!(operands, []);
     }
 
-    // TODO empty_argument_to_short_option
+    #[test]
+    fn empty_argument_to_short_option() {
+        let specs = &[OptionSpec::new()
+            .short('a')
+            .argument(OptionArgumentSpec::Required)];
+
+        let arguments = Field::dummies(["foo", "-a", ""]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 1, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('a'));
+        assert_matches!(options[0].argument, Some(ref field) => {
+            assert_eq!(field.value, "");
+            assert_eq!(field.origin.line.value, "");
+        });
+        assert_eq!(operands, []);
+    }
 
     #[test]
     fn option_argument_that_looks_like_separator() {

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -34,19 +34,38 @@ pub use yash_env::semantics::Field;
 pub struct OptionSpec {}
 
 /// TODO
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
 pub struct Mode {}
 
 /// TODO
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParsedOption {}
 
 /// TODO
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {}
 
+/// TODO impl std::error::Error for Error
+
 /// Parses command-line arguments into options and operands.
+///
+/// The first argument is always dropped.
 pub fn parse_arguments(
     _option_specs: &[OptionSpec],
     _mode: Mode,
-    _arguments: Vec<Field>,
+    arguments: Vec<Field>,
 ) -> Result<(Vec<ParsedOption>, Vec<Field>), Error> {
-    todo!()
+    Ok((vec![], arguments))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_arguments() {
+        let (options, operands) = parse_arguments(&[], Mode::default(), vec![]).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, []);
+    }
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -458,7 +458,35 @@ mod tests {
         assert_eq!(operands, Field::dummies(["3"]));
     }
 
-    // TODO argument_taking_option_adjacent_to_another_option
+    #[test]
+    fn argument_taking_option_adjacent_to_another_option() {
+        let specs = &[
+            OptionSpec::new()
+                .short('a')
+                .argument(OptionArgumentSpec::None),
+            OptionSpec::new()
+                .short('b')
+                .argument(OptionArgumentSpec::None),
+            OptionSpec::new()
+                .short('c')
+                .argument(OptionArgumentSpec::Required),
+        ];
+
+        let arguments = Field::dummies(["foo", "-abcdef"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 3, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('a'));
+        assert_eq!(options[0].argument, None);
+        assert_eq!(options[1].spec.get_short(), Some('b'));
+        assert_eq!(options[1].argument, None);
+        assert_eq!(options[2].spec.get_short(), Some('c'));
+        assert_matches!(options[2].argument, Some(ref field) => {
+            assert_eq!(field.value, "def");
+            assert_eq!(field.origin.line.value, "-abcdef");
+        });
+        assert_eq!(operands, []);
+    }
+
     // TODO empty_argument_to_short_option
 
     // TODO options_are_recognized_after_operand (depending mode)

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -643,6 +643,27 @@ mod tests {
     }
 
     #[test]
+    fn mixed_occurrences_of_various_option_specs() {
+        let specs = &[
+            OptionSpec::new().short('a'),
+            OptionSpec::new().short('b').long("bar"),
+            OptionSpec::new().long("baz"),
+        ];
+
+        let arguments = Field::dummies(["foo", "-ba", "--baz", "--bar", "--", "-a"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 4, "{:?}", options);
+        assert_eq!(options[0].spec, &OptionSpec::new().short('b').long("bar"));
+        assert_eq!(options[1].spec, &OptionSpec::new().short('a'));
+        assert_eq!(options[2].spec, &OptionSpec::new().long("baz"));
+        assert_eq!(options[3].spec, &OptionSpec::new().short('b').long("bar"));
+        assert_eq!(operands, Field::dummies(["-a"]));
+    }
+
+    // TODO abbreviated_long_option
+    // TODO exact_match_is_not_ambiguous_error
+
+    #[test]
     fn option_argument_that_looks_like_separator() {
         let specs = &[OptionSpec::new()
             .short('a')
@@ -667,4 +688,5 @@ mod tests {
     // TODO options_are_recognized_after_operand (depending mode)
 
     // TODO missing_argument_to_short_option
+    // TODO ambiguous_long_option
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -121,11 +121,6 @@ pub fn parse_arguments(
     if !arguments.is_empty() {
         arguments.remove(0);
     }
-    if let Some(argument) = arguments.first() {
-        if argument.value == "--" {
-            arguments.remove(0);
-        }
-    }
 
     let mut option_occurrences = vec![];
     while let Some(argument) = arguments.first() {
@@ -135,6 +130,13 @@ pub fn parse_arguments(
             break;
         }
     }
+
+    if let Some(argument) = arguments.first() {
+        if argument.value == "--" {
+            arguments.remove(0);
+        }
+    }
+
     Ok((option_occurrences, arguments))
 }
 
@@ -291,7 +293,17 @@ mod tests {
         assert_eq!(operands, Field::dummies(["-", "-"]));
     }
 
-    // TODO options_are_not_recognized_after_separator
+    #[test]
+    fn options_are_not_recognized_after_separator() {
+        let specs = &[OptionSpec::new().short('a')];
+
+        let arguments = Field::dummies(["foo", "-a", "--", "-a", "--", "-a"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options.len(), 1, "{:?}", options);
+        assert_eq!(options[0].spec.get_short(), Some('a'));
+        assert_eq!(operands, Field::dummies(["-a", "--", "-a"]));
+    }
+
     // TODO options_are_not_recognized_after_operand (depending mode)
     // TODO options_are_recognized_after_operand (depending mode)
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -58,6 +58,11 @@ pub fn parse_arguments(
     if !arguments.is_empty() {
         arguments.remove(0);
     }
+    if let Some(argument) = arguments.first() {
+        if argument.value == "--" {
+            arguments.remove(0);
+        }
+    }
     Ok((vec![], arguments))
 }
 
@@ -89,4 +94,24 @@ mod tests {
         assert_eq!(options, []);
         assert_eq!(operands, Field::dummies(["bar", "", "baz"]));
     }
+
+    #[test]
+    fn operands_following_separator() {
+        let arguments = Field::dummies(["command", "--"]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, []);
+
+        let arguments = Field::dummies(["command", "--", "1"]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies(["1"]));
+
+        let arguments = Field::dummies(["command", "--", "a", "", "z"]);
+        let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies(["a", "", "z"]));
+    }
+
+    // TODO options_are_not_recognized_after_separator
 }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -30,8 +30,43 @@
 #[doc(no_inline)]
 pub use yash_env::semantics::Field;
 
-/// TODO
-pub struct OptionSpec {}
+/// Specification of an option
+///
+/// This structure may contain the following properties:
+///
+/// - Short option name (a single character)
+/// - Long option name (a string)
+/// - Whether this option takes an argument
+///
+/// All of these are optional, but either or both of the short and long names
+/// should be set for the option spec to have meaningful effect.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OptionSpec {
+    short: Option<char>,
+}
+
+impl OptionSpec {
+    /// Creates a new empty option spec.
+    pub const fn new() -> Self {
+        OptionSpec { short: None }
+    }
+
+    /// Returns the short option name.
+    pub const fn get_short(&self) -> Option<char> {
+        self.short
+    }
+
+    /// Gives a short name for this option.
+    pub fn set_short(&mut self, name: char) {
+        self.short = Some(name);
+    }
+
+    /// Chained version of [`set_short`](Self::set_short)
+    pub const fn short(mut self, name: char) -> Self {
+        self.short = Some(name);
+        self
+    }
+}
 
 /// TODO
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
@@ -111,6 +146,21 @@ mod tests {
         let (options, operands) = parse_arguments(&[], Mode::default(), arguments).unwrap();
         assert_eq!(options, []);
         assert_eq!(operands, Field::dummies(["a", "", "z"]));
+    }
+
+    #[test]
+    fn non_occurring_short_option() {
+        let specs = &[OptionSpec::new().short('a')];
+
+        let arguments = Field::dummies(["foo"]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, []);
+
+        let arguments = Field::dummies(["foo", ""]);
+        let (options, operands) = parse_arguments(specs, Mode::default(), arguments).unwrap();
+        assert_eq!(options, []);
+        assert_eq!(operands, Field::dummies([""]));
     }
 
     // TODO options_are_not_recognized_after_separator


### PR DESCRIPTION
This pull request implements basic part of #122.

- Short and long options
- Argument-taking options
- Separator (`--`)
- Errors