### PR TITLE
Multi-line source code attribution

### DIFF
--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -120,9 +120,9 @@ mod tests {
         assert_eq!(alias.name, "foo");
         assert_eq!(alias.replacement, "bar baz");
         assert_eq!(alias.global, false);
-        assert_eq!(alias.origin.line.value, "foo=bar baz");
-        assert_eq!(alias.origin.line.number.get(), 1);
-        assert_eq!(alias.origin.line.source, Source::Unknown);
+        assert_eq!(alias.origin.code.value, "foo=bar baz");
+        assert_eq!(alias.origin.code.number.get(), 1);
+        assert_eq!(alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.column.get(), 1);
     }
 
@@ -140,27 +140,27 @@ mod tests {
         assert_eq!(abc.name, "abc");
         assert_eq!(abc.replacement, "xyz");
         assert_eq!(abc.global, false);
-        assert_eq!(abc.origin.line.value, "abc=xyz");
-        assert_eq!(abc.origin.line.number.get(), 1);
-        assert_eq!(abc.origin.line.source, Source::Unknown);
+        assert_eq!(abc.origin.code.value, "abc=xyz");
+        assert_eq!(abc.origin.code.number.get(), 1);
+        assert_eq!(abc.origin.code.source, Source::Unknown);
         assert_eq!(abc.origin.column.get(), 1);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
         assert_eq!(yes.replacement, "no");
         assert_eq!(yes.global, false);
-        assert_eq!(yes.origin.line.value, "yes=no");
-        assert_eq!(yes.origin.line.number.get(), 1);
-        assert_eq!(yes.origin.line.source, Source::Unknown);
+        assert_eq!(yes.origin.code.value, "yes=no");
+        assert_eq!(yes.origin.code.number.get(), 1);
+        assert_eq!(yes.origin.code.source, Source::Unknown);
         assert_eq!(yes.origin.column.get(), 1);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
         assert_eq!(ls.replacement, "ls --color");
         assert_eq!(ls.global, false);
-        assert_eq!(ls.origin.line.value, "ls=ls --color");
-        assert_eq!(ls.origin.line.number.get(), 1);
-        assert_eq!(ls.origin.line.source, Source::Unknown);
+        assert_eq!(ls.origin.code.value, "ls=ls --color");
+        assert_eq!(ls.origin.code.number.get(), 1);
+        assert_eq!(ls.origin.code.source, Source::Unknown);
         assert_eq!(ls.origin.column.get(), 1);
     }
 

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(alias.replacement, "bar baz");
         assert_eq!(alias.global, false);
         assert_eq!(alias.origin.code.value, "foo=bar baz");
-        assert_eq!(alias.origin.code.number.get(), 1);
+        assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.column.get(), 1);
     }
@@ -141,7 +141,7 @@ mod tests {
         assert_eq!(abc.replacement, "xyz");
         assert_eq!(abc.global, false);
         assert_eq!(abc.origin.code.value, "abc=xyz");
-        assert_eq!(abc.origin.code.number.get(), 1);
+        assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
         assert_eq!(abc.origin.column.get(), 1);
 
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(yes.replacement, "no");
         assert_eq!(yes.global, false);
         assert_eq!(yes.origin.code.value, "yes=no");
-        assert_eq!(yes.origin.code.number.get(), 1);
+        assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
         assert_eq!(yes.origin.column.get(), 1);
 
@@ -159,7 +159,7 @@ mod tests {
         assert_eq!(ls.replacement, "ls --color");
         assert_eq!(ls.global, false);
         assert_eq!(ls.origin.code.value, "ls=ls --color");
-        assert_eq!(ls.origin.code.number.get(), 1);
+        assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
         assert_eq!(ls.origin.column.get(), 1);
     }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -332,7 +332,7 @@ impl<'a> From<&'a Error<'_>> for Message<'a> {
             location: field.origin.clone(),
         }];
 
-        field.origin.line.source.complement_annotations(&mut a);
+        field.origin.code.source.complement_annotations(&mut a);
 
         Message {
             r#type: AnnotationType::Error,
@@ -707,7 +707,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.line.value, "-abar");
+            assert_eq!(field.origin.code.value, "-abar");
         });
         assert_eq!(operands, []);
 
@@ -717,12 +717,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.line.value, "-a1");
+            assert_eq!(field.origin.code.value, "-a1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.line.value, "-a2");
+            assert_eq!(field.origin.code.value, "-a2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -739,7 +739,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.line.value, "bar");
+            assert_eq!(field.origin.code.value, "bar");
         });
         assert_eq!(operands, []);
 
@@ -749,12 +749,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.line.value, "1");
+            assert_eq!(field.origin.code.value, "1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.line.value, "2");
+            assert_eq!(field.origin.code.value, "2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -783,7 +783,7 @@ mod tests {
         assert_eq!(options[2].spec.get_short(), Some('c'));
         assert_matches!(options[2].argument, Some(ref field) => {
             assert_eq!(field.value, "def");
-            assert_eq!(field.origin.line.value, "-abcdef");
+            assert_eq!(field.origin.code.value, "-abcdef");
         });
         assert_eq!(operands, []);
     }
@@ -800,7 +800,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "");
+            assert_eq!(field.origin.code.value, "");
         });
         assert_eq!(operands, []);
     }
@@ -937,7 +937,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "--option=");
+            assert_eq!(field.origin.code.value, "--option=");
         });
         assert_eq!(operands, []);
 
@@ -948,12 +948,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.line.value, "--option=x");
+            assert_eq!(field.origin.code.value, "--option=x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.line.value, "--option=value");
+            assert_eq!(field.origin.code.value, "--option=value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -971,7 +971,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "");
+            assert_eq!(field.origin.code.value, "");
         });
         assert_eq!(operands, []);
 
@@ -982,12 +982,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.line.value, "x");
+            assert_eq!(field.origin.code.value, "x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.line.value, "value");
+            assert_eq!(field.origin.code.value, "value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -1005,12 +1005,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "argument");
-            assert_eq!(field.origin.line.value, "argument");
+            assert_eq!(field.origin.code.value, "argument");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "--");
-            assert_eq!(field.origin.line.value, "--");
+            assert_eq!(field.origin.code.value, "--");
         });
         assert_eq!(operands, Field::dummies(["operand"]));
     }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -50,6 +50,7 @@
 //! ```
 
 use std::iter::Peekable;
+use std::rc::Rc;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
@@ -327,9 +328,10 @@ impl<'a> From<&'a Error<'_>> for Message<'a> {
         let field = error.field();
 
         let mut a = vec![Annotation {
+            code: Rc::new(&*field.origin.code),
+            column: field.origin.column,
             r#type: AnnotationType::Error,
             label: field.value.as_str().into(),
-            location: field.origin.clone(),
         }];
 
         field.origin.code.source.complement_annotations(&mut a);

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use std::num::NonZeroU64;
 use std::rc::Rc;
 use std::slice::from_mut;
-use yash_syntax::source::Line;
+use yash_syntax::source::Code;
 use yash_syntax::source::Location;
 use yash_syntax::source::Source;
 
@@ -73,11 +73,11 @@ impl Input for Stdin {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
-        fn to_line(bytes: Vec<u8>, number: NonZeroU64) -> Line {
+        fn to_code(bytes: Vec<u8>, number: NonZeroU64) -> Code {
             // TODO Maybe we should report invalid UTF-8 bytes rather than ignoring them
             let value = String::from_utf8(bytes)
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).to_string());
-            Line {
+            Code {
                 value,
                 number,
                 source: Source::Stdin,
@@ -105,7 +105,7 @@ impl Input for Stdin {
                 }
 
                 Err(errno) => {
-                    let line = Rc::new(to_line(bytes, number));
+                    let line = Rc::new(to_code(bytes, number));
                     let column = line
                         .value
                         .chars()
@@ -121,7 +121,7 @@ impl Input for Stdin {
             }
         }
 
-        Ok(to_line(bytes, number))
+        Ok(to_code(bytes, number))
     }
 }
 

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -73,13 +73,13 @@ impl Input for Stdin {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
-        fn to_code(bytes: Vec<u8>, number: NonZeroU64) -> Code {
+        fn to_code(bytes: Vec<u8>, start_line_number: NonZeroU64) -> Code {
             // TODO Maybe we should report invalid UTF-8 bytes rather than ignoring them
             let value = String::from_utf8(bytes)
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).to_string());
             Code {
                 value,
-                number,
+                start_line_number,
                 source: Source::Stdin,
             }
         }
@@ -140,7 +140,7 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -157,11 +157,11 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "echo ok\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -178,19 +178,19 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "#!/bin/sh\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "echo ok\n");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "exit");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
         let (location, error) = block_on(stdin.next_line(&Context)).unwrap_err();
         assert_eq!(location.code.value, "");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Stdin);
         assert_eq!(error.raw_os_error(), Some(Errno::EBADF as i32));
     }

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -105,8 +105,8 @@ impl Input for Stdin {
                 }
 
                 Err(errno) => {
-                    let line = Rc::new(to_code(bytes, number));
-                    let column = line
+                    let code = Rc::new(to_code(bytes, number));
+                    let column = code
                         .value
                         .chars()
                         .count()
@@ -114,7 +114,7 @@ impl Input for Stdin {
                         .unwrap_or(u64::MAX)
                         .saturating_add(1);
                     let column = unsafe { NonZeroU64::new_unchecked(column) };
-                    let location = Location { line, column };
+                    let location = Location { code, column };
                     let error = std::io::Error::from_raw_os_error(errno as i32);
                     return Err((location, error));
                 }
@@ -202,9 +202,9 @@ mod tests {
         let mut stdin = Stdin::new(system);
 
         let (location, error) = block_on(stdin.next_line(&Context)).unwrap_err();
-        assert_eq!(location.line.value, "");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Stdin);
+        assert_eq!(location.code.value, "");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Stdin);
         assert_eq!(error.raw_os_error(), Some(Errno::EBADF as i32));
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -129,8 +129,8 @@ mod tests {
             assert_eq!(roe.read_only_location, location);
             assert_eq!(roe.new_value.value, Value::Scalar("new".into()));
         });
-        assert_eq!(e.location.line.value, "v=new");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "v=new");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(roe.new_value.value, Value::Scalar("new".into()));
         });
         assert_eq!(e.location.code.value, "v=new");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -158,7 +158,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
             a.push(Annotation {
@@ -793,13 +793,13 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let new_value = Variable {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -795,7 +795,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -722,7 +722,7 @@ mod tests {
     use std::num::NonZeroU64;
     use std::rc::Rc;
     use yash_env::variable::Value;
-    use yash_syntax::source::Line;
+    use yash_syntax::source::Code;
     use yash_syntax::source::Source;
 
     #[derive(Debug)]
@@ -793,7 +793,7 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -38,6 +38,7 @@ use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::snippet::Snippet;
 use async_trait::async_trait;
 use std::borrow::Cow;
+use std::rc::Rc;
 use yash_env::io::Fd;
 use yash_env::Env;
 use yash_syntax::source::pretty::Annotation;
@@ -76,9 +77,10 @@ pub async fn print_error(
     location: &Location,
 ) {
     let mut a = vec![Annotation {
+        code: Rc::new(&*location.code),
+        column: location.column,
         r#type: AnnotationType::Error,
         label,
-        location: location.clone(),
     }];
     location.code.source.complement_annotations(&mut a);
     let message = Message {

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -80,7 +80,7 @@ pub async fn print_error(
         label,
         location: location.clone(),
     }];
-    location.line.source.complement_annotations(&mut a);
+    location.code.source.complement_annotations(&mut a);
     let message = Message {
         r#type: AnnotationType::Error,
         title,

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -63,6 +63,7 @@ use std::ffi::CString;
 use std::ffi::NulError;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::rc::Rc;
 use yash_env::io::Fd;
 use yash_env::semantics::Field;
 use yash_env::system::Errno;
@@ -164,9 +165,10 @@ impl From<crate::expansion::Error> for Error {
 impl<'a> From<&'a Error> for Message<'a> {
     fn from(e: &'a Error) -> Self {
         let mut a = vec![Annotation {
+            code: Rc::new(&*e.location.code),
+            column: e.location.column,
             r#type: AnnotationType::Error,
             label: e.cause.label(),
-            location: e.location.clone(),
         }];
 
         e.location.code.source.complement_annotations(&mut a);
@@ -421,7 +423,6 @@ mod tests {
     use futures_executor::block_on;
     use std::cell::RefCell;
     use std::path::PathBuf;
-    use std::rc::Rc;
     use yash_env::system::r#virtual::INode;
     use yash_env::Env;
     use yash_env::VirtualSystem;

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -169,7 +169,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         Message {
             r#type: AnnotationType::Error,

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Items in the `source` module:
+    - `Line` renamed to `Code`
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `source` module:
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
+    - `Annotation`'s field `location` replaced with `code` and `column`
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Items in the `source` module:
     - `Line` renamed to `Code`
+    - `Location`'s field `line` renamed to `code`
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -17,7 +17,7 @@
 //! Methods about passing [source](crate::source) code to the [parser](crate::parser).
 
 use crate::source::lines;
-use crate::source::Line;
+use crate::source::Code;
 use crate::source::Lines;
 use crate::source::Location;
 use crate::source::Source;
@@ -37,7 +37,7 @@ pub struct Context;
 pub type Error = (Location, std::io::Error);
 
 /// Result of the [Input] function.
-pub type Result = std::result::Result<Line, Error>;
+pub type Result = std::result::Result<Code, Error>;
 
 /// Line-oriented source code reader.
 ///
@@ -46,7 +46,7 @@ pub type Result = std::result::Result<Line, Error>;
 pub trait Input {
     /// Reads a next line of the source code.
     ///
-    /// The input function is line-oriented; that is, this function returns a [`Line`] that is
+    /// The input function is line-oriented; that is, this function returns a [`Code`] that is
     /// terminated by a newline unless the end of input (EOF) is reached, in which case the
     /// remaining characters up to the EOF must be returned without a trailing newline. If there
     /// are no more characters at all, the returned line is empty.
@@ -71,7 +71,7 @@ impl Memory<'_> {
         Memory { lines }
     }
 
-    fn next_line_sync(&mut self, _: &Context) -> Line {
+    fn next_line_sync(&mut self, _: &Context) -> Code {
         self.lines.next_or_empty()
     }
 }

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
     }
 
@@ -105,12 +105,12 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "one\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
     }
 
@@ -120,22 +120,22 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "one\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "two\n");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "three");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
     }
 }

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -130,7 +130,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingPipeline(AndOr::AndThen))
         );
         assert_eq!(e.location.code.value, "foo &&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -129,9 +129,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingPipeline(AndOr::AndThen))
         );
-        assert_eq!(e.location.line.value, "foo &&");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo &&");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -315,7 +315,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
         assert_eq!(e.location.code.value, ")");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -329,7 +329,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EsacAsPattern));
         assert_eq!(e.location.code.value, "(esac)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -343,7 +343,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidPattern));
         assert_eq!(e.location.code.value, "(&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -357,7 +357,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
         assert_eq!(e.location.code.value, "(foo| |");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -374,7 +374,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::UnclosedPatternList)
         );
         assert_eq!(e.location.code.value, "(foo bar");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
@@ -582,7 +582,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingCaseSubject));
         assert_eq!(e.location.code.value, " case  ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -596,7 +596,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidCaseSubject));
         assert_eq!(e.location.code.value, " case ; ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -610,14 +610,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingIn { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " case x esac");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " case x esac");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
@@ -631,14 +631,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedCase { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "case x in a) }");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "case x in a) }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -314,9 +314,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
-        assert_eq!(e.location.line.value, ")");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, ")");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -328,9 +328,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EsacAsPattern));
-        assert_eq!(e.location.line.value, "(esac)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(esac)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -342,9 +342,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidPattern));
-        assert_eq!(e.location.line.value, "(&");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(&");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -356,9 +356,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
-        assert_eq!(e.location.line.value, "(foo| |");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(foo| |");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -373,9 +373,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedPatternList)
         );
-        assert_eq!(e.location.line.value, "(foo bar");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(foo bar");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
 
@@ -581,9 +581,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingCaseSubject));
-        assert_eq!(e.location.line.value, " case  ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case  ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -595,9 +595,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidCaseSubject));
-        assert_eq!(e.location.line.value, " case ; ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case ; ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -609,16 +609,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingIn { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " case x esac");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " case x esac");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " case x esac");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case x esac");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 
@@ -630,16 +630,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedCase { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "case x in a) }");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "case x in a) }");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "case x in a) }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "case x in a) }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -153,16 +153,16 @@ mod tests {
 
         let e = block_on(parser.do_clause()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " do not close ");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " do not close ");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " do not close ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " do not close ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 15);
     }
 
@@ -174,9 +174,9 @@ mod tests {
 
         let e = block_on(parser.do_clause()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyDoClause));
-        assert_eq!(e.location.line.value, "do done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "do done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -154,14 +154,14 @@ mod tests {
         let e = block_on(parser.do_clause()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " do not close ");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " do not close ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 15);
     }
@@ -175,7 +175,7 @@ mod tests {
         let e = block_on(parser.do_clause()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyDoClause));
         assert_eq!(e.location.code.value, "do done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -186,7 +186,7 @@ impl<'a, 'b> Parser<'a, 'b> {
         if !self.aliases.is_empty() {
             if let Token(_) = token.id {
                 if let Some(name) = token.word.to_string_if_literal() {
-                    if !token.word.location.line.source.is_alias_for(&name) {
+                    if !token.word.location.code.source.is_alias_for(&name) {
                         if let Some(alias) = self.aliases.get(&name as &str) {
                             if is_command_name
                                 || alias.0.global
@@ -736,7 +736,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.line.number.get(), 1);
+            assert_eq!(location.code.number.get(), 1);
             assert_eq!(location.column.get(), 1);
         })
     }
@@ -764,7 +764,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.line.number.get(), 2);
+            assert_eq!(location.code.number.get(), 2);
             assert_eq!(location.column.get(), 1);
         })
     }

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -736,7 +736,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.column.get(), 1);
         })
     }
@@ -764,7 +764,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.column.get(), 1);
         })
     }

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -458,7 +458,7 @@ impl<'a> From<&'a Error> for Message<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source::Line;
+    use crate::source::Code;
     use crate::source::Source;
     use std::num::NonZeroU64;
     use std::rc::Rc;
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn display_for_error() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -430,7 +430,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
             a.push(Annotation {
@@ -466,13 +466,13 @@ mod tests {
     #[test]
     fn display_for_error() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let error = Error {
@@ -488,13 +488,13 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let error = Error {

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -468,7 +468,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {
@@ -490,7 +490,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -423,9 +423,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, " for ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
 
@@ -437,9 +437,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, " for\n");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for\n");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -451,9 +451,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, "for; do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "for; do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -482,17 +482,17 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
-        assert_eq!(e.location.line.value, "&");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "&");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
-        if let Source::Alias { original, alias } = &e.location.line.source {
-            assert_eq!(original.line.value, "FOR if do :; done");
-            assert_eq!(original.line.number.get(), 1);
-            assert_eq!(original.line.source, Source::Unknown);
+        if let Source::Alias { original, alias } = &e.location.code.source {
+            assert_eq!(original.code.value, "FOR if do :; done");
+            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 5);
             assert_eq!(alias.name, "if");
         } else {
-            panic!("Not an alias: {:?}", e.location.line.source);
+            panic!("Not an alias: {:?}", e.location.code.source);
         }
     }
 
@@ -504,16 +504,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
-            assert_eq!(opening_location.line.value, "for X\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "for X\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "; do :; done");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "; do :; done");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -542,17 +542,17 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
-        assert_eq!(e.location.line.value, "&");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "&");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
-        if let Source::Alias { original, alias } = &e.location.line.source {
-            assert_eq!(original.line.value, "for_A_in_a_b if c; do :; done");
-            assert_eq!(original.line.number.get(), 1);
-            assert_eq!(original.line.source, Source::Unknown);
+        if let Source::Alias { original, alias } = &e.location.code.source {
+            assert_eq!(original.code.value, "for_A_in_a_b if c; do :; done");
+            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 14);
             assert_eq!(alias.name, "if");
         } else {
-            panic!("Not an alias: {:?}", e.location.line.source);
+            panic!("Not an alias: {:?}", e.location.code.source);
         }
     }
 
@@ -564,16 +564,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
-            assert_eq!(opening_location.line.value, " for X; ! do :; done");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " for X; ! do :; done");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " for X; ! do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for X; ! do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 }

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -424,7 +424,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, " for ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
@@ -438,7 +438,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, " for\n");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -452,7 +452,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, "for; do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -483,11 +483,11 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
         assert_eq!(e.location.code.value, "&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
         if let Source::Alias { original, alias } = &e.location.code.source {
             assert_eq!(original.code.value, "FOR if do :; done");
-            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 5);
             assert_eq!(alias.name, "if");
@@ -505,14 +505,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
             assert_eq!(opening_location.code.value, "for X\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "; do :; done");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -543,11 +543,11 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
         assert_eq!(e.location.code.value, "&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
         if let Source::Alias { original, alias } = &e.location.code.source {
             assert_eq!(original.code.value, "for_A_in_a_b if c; do :; done");
-            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 14);
             assert_eq!(alias.name, "if");
@@ -565,14 +565,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
             assert_eq!(opening_location.code.value, " for X; ! do :; done");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " for X; ! do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -161,9 +161,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::UnmatchedParenthesis)
         );
-        assert_eq!(e.location.line.value, "( ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -183,9 +183,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingFunctionBody)
         );
-        assert_eq!(e.location.line.value, "( ) ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( ) ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -205,9 +205,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.line.value, "() foo ; ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "() foo ; ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -326,9 +326,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.line.value, "()b");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "()b");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -162,7 +162,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::UnmatchedParenthesis)
         );
         assert_eq!(e.location.code.value, "( ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -184,7 +184,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingFunctionBody)
         );
         assert_eq!(e.location.code.value, "( ) ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -206,7 +206,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
         assert_eq!(e.location.code.value, "() foo ; ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -327,7 +327,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
         assert_eq!(e.location.code.value, "()b");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -140,14 +140,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " { oh no ");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " { oh no ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 10);
     }
@@ -161,7 +161,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyGrouping));
         assert_eq!(e.location.code.value, "{ }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -239,14 +239,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " ( oh no");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " ( oh no");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
@@ -260,7 +260,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptySubshell));
         assert_eq!(e.location.code.value, "( )");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -139,16 +139,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " { oh no ");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " { oh no ");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " { oh no ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " { oh no ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 10);
     }
 
@@ -160,9 +160,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyGrouping));
-        assert_eq!(e.location.line.value, "{ }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{ }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -238,16 +238,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " ( oh no");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " ( oh no");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " ( oh no");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " ( oh no");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 
@@ -259,9 +259,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptySubshell));
-        assert_eq!(e.location.line.value, "( )");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( )");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -295,14 +295,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) = e.cause {
             assert_eq!(if_location.code.value, " if :; fi");
-            assert_eq!(if_location.code.number.get(), 1);
+            assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
             assert_eq!(if_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, " if :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -316,14 +316,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) = e.cause {
             assert_eq!(elif_location.code.value, "if a; then b; elif c; fi");
-            assert_eq!(elif_location.code.number.get(), 1);
+            assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
             assert_eq!(elif_location.column.get(), 15);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, "if a; then b; elif c; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 23);
     }
@@ -337,14 +337,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "  if :; then :; }");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 3);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, "  if :; then :; }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 17);
     }
@@ -358,7 +358,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfCondition));
         assert_eq!(e.location.code.value, "   if then :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -372,7 +372,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfBody));
         assert_eq!(e.location.code.value, "if :; then fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 12);
     }
@@ -386,7 +386,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifCondition));
         assert_eq!(e.location.code.value, "if :; then :; elif then :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
@@ -400,7 +400,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifBody));
         assert_eq!(e.location.code.value, "if :; then :; elif :; then fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 28);
     }
@@ -414,7 +414,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElse));
         assert_eq!(e.location.code.value, "if :; then :; else fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -294,16 +294,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) = e.cause {
-            assert_eq!(if_location.line.value, " if :; fi");
-            assert_eq!(if_location.line.number.get(), 1);
-            assert_eq!(if_location.line.source, Source::Unknown);
+            assert_eq!(if_location.code.value, " if :; fi");
+            assert_eq!(if_location.code.number.get(), 1);
+            assert_eq!(if_location.code.source, Source::Unknown);
             assert_eq!(if_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, " if :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " if :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -315,16 +315,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) = e.cause {
-            assert_eq!(elif_location.line.value, "if a; then b; elif c; fi");
-            assert_eq!(elif_location.line.number.get(), 1);
-            assert_eq!(elif_location.line.source, Source::Unknown);
+            assert_eq!(elif_location.code.value, "if a; then b; elif c; fi");
+            assert_eq!(elif_location.code.number.get(), 1);
+            assert_eq!(elif_location.code.source, Source::Unknown);
             assert_eq!(elif_location.column.get(), 15);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, "if a; then b; elif c; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if a; then b; elif c; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 23);
     }
 
@@ -336,16 +336,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "  if :; then :; }");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "  if :; then :; }");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 3);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, "  if :; then :; }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  if :; then :; }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 17);
     }
 
@@ -357,9 +357,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfCondition));
-        assert_eq!(e.location.line.value, "   if then :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "   if then :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -371,9 +371,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfBody));
-        assert_eq!(e.location.line.value, "if :; then fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 12);
     }
 
@@ -385,9 +385,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifCondition));
-        assert_eq!(e.location.line.value, "if :; then :; elif then :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; elif then :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
 
@@ -399,9 +399,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifBody));
-        assert_eq!(e.location.line.value, "if :; then :; elif :; then fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; elif :; then fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 28);
     }
 
@@ -413,9 +413,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElse));
-        assert_eq!(e.location.line.value, "if :; then :; else fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; else fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
 }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -110,9 +110,9 @@ mod tests {
             .unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -129,9 +129,9 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.line.value, "Y");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "Y");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
@@ -147,9 +147,9 @@ mod tests {
             .unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -177,9 +177,9 @@ mod tests {
                     Backslashed('$')
                 ]
             );
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -195,16 +195,16 @@ mod tests {
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "((1");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "((1");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -215,16 +215,16 @@ mod tests {
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "((1)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "((1)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -236,9 +236,9 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.line.value, "Z");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "Z");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(lexer.index(), 0);

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -111,7 +111,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -130,7 +130,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(location.code.value, "Y");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
@@ -148,7 +148,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -178,7 +178,7 @@ mod tests {
                 ]
             );
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -196,14 +196,14 @@ mod tests {
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "((1");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -216,14 +216,14 @@ mod tests {
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "((1)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -237,7 +237,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(location.code.value, "Z");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -236,16 +236,16 @@ mod tests {
         };
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "`");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "`");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "`");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "`");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -258,16 +258,16 @@ mod tests {
         };
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "`foo");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "`foo");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "`foo");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "`foo");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -237,14 +237,14 @@ mod tests {
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "`");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "`");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -259,14 +259,14 @@ mod tests {
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "`foo");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "`foo");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -167,7 +167,7 @@ mod tests {
 
     fn assert_opening_location(location: &Location) {
         assert_eq!(location.code.value, "$");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
     }
@@ -256,7 +256,7 @@ mod tests {
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
         assert_eq!(e.location.code.value, "{};");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -277,7 +277,7 @@ mod tests {
             panic!("Unexpected cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "{;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -298,7 +298,7 @@ mod tests {
             panic!("Unexpected cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "{_;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -166,9 +166,9 @@ mod tests {
     use futures_executor::block_on;
 
     fn assert_opening_location(location: &Location) {
-        assert_eq!(location.line.value, "$");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "$");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -255,9 +255,9 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
-        assert_eq!(e.location.line.value, "{};");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{};");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -276,9 +276,9 @@ mod tests {
         } else {
             panic!("Unexpected cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "{;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -297,9 +297,9 @@ mod tests {
         } else {
             panic!("Unexpected cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "{_;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{_;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -602,7 +602,7 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
-        assert_eq!(e.location.line.value, "{#x+};");
+        assert_eq!(e.location.code.value, "{#x+};");
         assert_eq!(e.location.column.get(), 4);
     }
 

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -75,7 +75,7 @@ mod tests {
             .unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
@@ -85,7 +85,7 @@ mod tests {
 
         let next = block_on(lexer.location()).unwrap();
         assert_eq!(next.code.value, "( foo bar )baz");
-        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 12);
     }
@@ -100,7 +100,7 @@ mod tests {
 
         let next = block_on(lexer.location()).unwrap();
         assert_eq!(next.code.value, " foo bar )baz");
-        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 1);
     }
@@ -115,14 +115,14 @@ mod tests {
             e.cause
         {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "( foo bar baz");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -74,9 +74,9 @@ mod tests {
             .unwrap()
             .unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
         } else {
@@ -84,9 +84,9 @@ mod tests {
         }
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(next.line.value, "( foo bar )baz");
-        assert_eq!(next.line.number.get(), 1);
-        assert_eq!(next.line.source, Source::Unknown);
+        assert_eq!(next.code.value, "( foo bar )baz");
+        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 12);
     }
 
@@ -99,9 +99,9 @@ mod tests {
         assert_eq!(result, None);
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(next.line.value, " foo bar )baz");
-        assert_eq!(next.line.number.get(), 1);
-        assert_eq!(next.line.source, Source::Unknown);
+        assert_eq!(next.code.value, " foo bar )baz");
+        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 1);
     }
 
@@ -114,16 +114,16 @@ mod tests {
         if let ErrorCause::Syntax(SyntaxError::UnclosedCommandSubstitution { opening_location }) =
             e.cause
         {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "( foo bar baz");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( foo bar baz");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -164,7 +164,7 @@ impl<'a> LexerCore<'a> {
                         } else {
                             // Completely empty source
                             Location {
-                                line: Rc::new(line),
+                                code: Rc::new(line),
                                 column: NonZeroU64::new(1).unwrap(),
                             }
                         };
@@ -280,7 +280,7 @@ impl<'a> LexerCore<'a> {
         fn is_same_alias(alias: &Alias, sc: Option<&SourceChar>) -> bool {
             match sc {
                 None => false,
-                Some(sc) => sc.location.line.source.is_alias_for(&alias.name),
+                Some(sc) => sc.location.code.source.is_alias_for(&alias.name),
             }
         }
 
@@ -291,7 +291,7 @@ impl<'a> LexerCore<'a> {
                 return false;
             }
 
-            if let Source::Alias { ref alias, .. } = sc.location.line.source {
+            if let Source::Alias { ref alias, .. } = sc.location.code.source {
                 #[allow(clippy::collapsible_if)]
                 if ends_with_blank(&alias.replacement) {
                     if !is_same_alias(alias, self.source.get(index + 1)) {
@@ -673,9 +673,9 @@ mod tests {
         let mut lexer = LexerCore::new(Box::new(input));
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
-            assert_eq!(location.line.value, "");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not end-of-input: {:?}", result);
@@ -708,9 +708,9 @@ mod tests {
         } else {
             panic!("expected IoError, but actually {}", e.cause)
         }
-        assert_eq!(e.location.line.value, "line");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "line");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -722,18 +722,18 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
         }
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
@@ -743,9 +743,9 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, '\n');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         } else {
             panic!("Not a char: {:?}", result);
@@ -755,9 +755,9 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'b');
-            assert_eq!(c.location.line.value, "b");
-            assert_eq!(c.location.line.number.get(), 2);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "b");
+            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
@@ -766,9 +766,9 @@ mod tests {
 
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
-            assert_eq!(location.line.value, "b");
-            assert_eq!(location.line.number.get(), 2);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "b");
+            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
             panic!("Not end-of-input: {:?}", result);
@@ -848,9 +848,9 @@ mod tests {
             let result = lexer.peek_char().await;
             if let Ok(PeekChar::Char(c)) = result {
                 assert_eq!(c.value, 'a');
-                assert_eq!(c.location.line.value, "abc");
-                assert_eq!(c.location.line.number.get(), 1);
-                assert_eq!(c.location.line.source, Source::Unknown);
+                assert_eq!(c.location.code.value, "abc");
+                assert_eq!(c.location.code.number.get(), 1);
+                assert_eq!(c.location.code.source, Source::Unknown);
                 assert_eq!(c.location.column.get(), 1);
             } else {
                 panic!("Not a char: {:?}", result);
@@ -917,20 +917,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'l');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -940,20 +940,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'e');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -963,20 +963,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'x');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 3);
             lexer.consume_char();
@@ -986,9 +986,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, "a b");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a b");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
         });
@@ -1018,20 +1018,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'x');
-            assert_eq!(c.location.line.value, "x\n");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "x\n");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -1041,20 +1041,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, '\n');
-            assert_eq!(c.location.line.value, "x\n");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "x\n");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -1064,20 +1064,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'y');
-            assert_eq!(c.location.line.value, "y");
-            assert_eq!(c.location.line.number.get(), 2);
+            assert_eq!(c.location.code.value, "y");
+            assert_eq!(c.location.code.number.get(), 2);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -1087,9 +1087,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, " foo b");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, " foo b");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 5);
             lexer.consume_char();
         });
@@ -1117,9 +1117,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, "x ");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "x ");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         });
     }
@@ -1229,9 +1229,9 @@ mod tests {
         .unwrap();
         assert_eq!(called, 1);
         assert_eq!(c.value, 'w');
-        assert_eq!(c.location.line.value, "word\n");
-        assert_eq!(c.location.line.number.get(), 1);
-        assert_eq!(c.location.line.source, Source::Unknown);
+        assert_eq!(c.location.code.value, "word\n");
+        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 1);
 
         let mut called = 0;
@@ -1262,9 +1262,9 @@ mod tests {
         .unwrap();
         assert_eq!(called, 1);
         assert_eq!(c.value, 'o');
-        assert_eq!(c.location.line.value, "word\n");
-        assert_eq!(c.location.line.number.get(), 1);
-        assert_eq!(c.location.line.source, Source::Unknown);
+        assert_eq!(c.location.code.value, "word\n");
+        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 2);
 
         block_on(lexer.consume_char_if(|c| {
@@ -1308,9 +1308,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<< )");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<< )");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -674,7 +674,7 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
             assert_eq!(location.code.value, "");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -709,7 +709,7 @@ mod tests {
             panic!("expected IoError, but actually {}", e.cause)
         }
         assert_eq!(e.location.code.value, "line");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -723,7 +723,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -732,7 +732,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -744,7 +744,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, '\n');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         } else {
@@ -756,7 +756,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'b');
             assert_eq!(c.location.code.value, "b");
-            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.start_line_number.get(), 2);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -767,7 +767,7 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
             assert_eq!(location.code.value, "b");
-            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
@@ -849,7 +849,7 @@ mod tests {
             if let Ok(PeekChar::Char(c)) = result {
                 assert_eq!(c.value, 'a');
                 assert_eq!(c.location.code.value, "abc");
-                assert_eq!(c.location.code.number.get(), 1);
+                assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
                 assert_eq!(c.location.column.get(), 1);
             } else {
@@ -918,14 +918,14 @@ mod tests {
             };
             assert_eq!(c.value, 'l');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -941,14 +941,14 @@ mod tests {
             };
             assert_eq!(c.value, 'e');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -964,14 +964,14 @@ mod tests {
             };
             assert_eq!(c.value, 'x');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -987,7 +987,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, "a b");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -1019,14 +1019,14 @@ mod tests {
             };
             assert_eq!(c.value, 'x');
             assert_eq!(c.location.code.value, "x\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1042,14 +1042,14 @@ mod tests {
             };
             assert_eq!(c.value, '\n');
             assert_eq!(c.location.code.value, "x\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1065,14 +1065,14 @@ mod tests {
             };
             assert_eq!(c.value, 'y');
             assert_eq!(c.location.code.value, "y");
-            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.start_line_number.get(), 2);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1088,7 +1088,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, " foo b");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 5);
             lexer.consume_char();
@@ -1118,7 +1118,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, "x ");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         });
@@ -1230,7 +1230,7 @@ mod tests {
         assert_eq!(called, 1);
         assert_eq!(c.value, 'w');
         assert_eq!(c.location.code.value, "word\n");
-        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 1);
 
@@ -1263,7 +1263,7 @@ mod tests {
         assert_eq!(called, 1);
         assert_eq!(c.value, 'o');
         assert_eq!(c.location.code.value, "word\n");
-        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 2);
 
@@ -1309,7 +1309,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<< )");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -129,9 +129,9 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "0");
-            assert_eq!(location.line.value, "$0");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$0");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a raw parameter: {:?}", result);
@@ -148,9 +148,9 @@ mod tests {
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "$()");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$()");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, "");
         } else {
@@ -165,9 +165,9 @@ mod tests {
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "$( foo bar )");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$( foo bar )");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
         } else {
@@ -186,9 +186,9 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content, Text(vec![Literal('1')]));
-            assert_eq!(location.line.value, "$((1))");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$((1))");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("unexpected result {:?}", result);

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -130,7 +130,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "0");
             assert_eq!(location.code.value, "$0");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -149,7 +149,7 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "$()");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, "");
@@ -166,7 +166,7 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "$( foo bar )");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
@@ -187,7 +187,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content, Text(vec![Literal('1')]));
             assert_eq!(location.code.value, "$((1))");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 2);
+        assert_eq!(location.code.start_line_number.get(), 2);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "content\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 3);
+        assert_eq!(location.code.start_line_number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 6);
+        assert_eq!(location.code.start_line_number.get(), 6);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -278,7 +278,7 @@ END
         assert_eq!(heredoc.content.to_string(), "foo\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 3);
+        assert_eq!(location.code.start_line_number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -292,14 +292,14 @@ END
             e.cause
         {
             assert_eq!(redir_op_location.code.value, "END");
-            assert_eq!(redir_op_location.code.number.get(), 1);
+            assert_eq!(redir_op_location.code.start_line_number.get(), 1);
             assert_eq!(redir_op_location.code.source, Source::Unknown);
             assert_eq!(redir_op_location.column.get(), 1);
         } else {
             panic!("Not UnclosedHereDocContent: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 2);
+        assert_eq!(location.code.number.get(), 2);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "content\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 3);
+        assert_eq!(location.code.number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 6);
+        assert_eq!(location.code.number.get(), 6);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -278,7 +278,7 @@ END
         assert_eq!(heredoc.content.to_string(), "foo\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 3);
+        assert_eq!(location.code.number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -291,16 +291,16 @@ END
         if let ErrorCause::Syntax(SyntaxError::UnclosedHereDocContent { redir_op_location }) =
             e.cause
         {
-            assert_eq!(redir_op_location.line.value, "END");
-            assert_eq!(redir_op_location.line.number.get(), 1);
-            assert_eq!(redir_op_location.line.source, Source::Unknown);
+            assert_eq!(redir_op_location.code.value, "END");
+            assert_eq!(redir_op_location.code.number.get(), 1);
+            assert_eq!(redir_op_location.code.source, Source::Unknown);
             assert_eq!(redir_op_location.column.get(), 1);
         } else {
             panic!("Not UnclosedHereDocContent: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "+}");
+            assert_eq!(switch.word.location.code.value, "+}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -226,7 +226,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('z')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, "+a  z}");
+            assert_eq!(switch.word.location.code.value, "+a  z}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -248,7 +248,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, ":+}");
+            assert_eq!(switch.word.location.code.value, ":+}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -270,7 +270,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "-}");
+            assert_eq!(switch.word.location.code.value, "-}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -300,7 +300,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('l')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, ":-cool}");
+            assert_eq!(switch.word.location.code.value, ":-cool}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -322,7 +322,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, ":=}");
+            assert_eq!(switch.word.location.code.value, ":=}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -351,7 +351,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('s')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, "=Yes}");
+            assert_eq!(switch.word.location.code.value, "=Yes}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -373,7 +373,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "?}");
+            assert_eq!(switch.word.location.code.value, "?}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -401,7 +401,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('o')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, ":?No}");
+            assert_eq!(switch.word.location.code.value, ":?No}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -458,7 +458,7 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.line.value, "#'*'}");
+            assert_eq!(trim.pattern.location.code.value, "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -480,7 +480,7 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.line.value, "#'*'}");
+            assert_eq!(trim.pattern.location.code.value, "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -507,7 +507,7 @@ mod tests {
             } else {
                 panic!("Not a double quote: {:?}", trim.pattern);
             }
-            assert_eq!(trim.pattern.location.line.value, r#"##"?"}"#);
+            assert_eq!(trim.pattern.location.code.value, r#"##"?"}"#);
             assert_eq!(trim.pattern.location.column.get(), 3);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -532,7 +532,7 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
-            assert_eq!(trim.pattern.location.line.value, r"%\%}");
+            assert_eq!(trim.pattern.location.code.value, r"%\%}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -557,7 +557,7 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
-            assert_eq!(trim.pattern.location.line.value, "%%%}");
+            assert_eq!(trim.pattern.location.code.value, "%%%}");
             assert_eq!(trim.pattern.location.column.get(), 3);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -592,7 +592,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":");
+        assert_eq!(e.location.code.value, ":");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":x}");
+        assert_eq!(e.location.code.value, ":x}");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -620,7 +620,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":#}");
+        assert_eq!(e.location.code.value, ":#}");
         assert_eq!(e.location.column.get(), 2);
     }
 }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
         assert_eq!(t.word.location.code.value, "<<-");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
@@ -421,7 +421,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<<>");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -438,7 +438,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<<");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<\\\n");
-        assert_eq!(t.word.location.code.number.get(), 3);
+        assert_eq!(t.word.location.code.start_line_number.get(), 3);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -491,7 +491,7 @@ mod tests {
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
         assert_eq!(t.word.location.code.value, "\n");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -403,9 +403,9 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
-        assert_eq!(t.word.location.line.value, "<<-");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<-");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
@@ -420,9 +420,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<<>");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<>");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -437,9 +437,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<<");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -454,9 +454,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<\\\n");
-        assert_eq!(t.word.location.line.number.get(), 3);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<\\\n");
+        assert_eq!(t.word.location.code.number.get(), 3);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -490,9 +490,9 @@ mod tests {
 
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
-        assert_eq!(t.word.location.line.value, "\n");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "\n");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -371,7 +371,7 @@ mod tests {
     use crate::input::Context;
     use crate::input::Input;
     use crate::source::lines;
-    use crate::source::Line;
+    use crate::source::Code;
     use crate::source::Source;
     use crate::syntax::TextUnit;
     use crate::syntax::WordUnit;
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn lexer_operator_should_not_peek_beyond_newline() {
-        struct OneLineInput(Option<Line>);
+        struct OneLineInput(Option<Code>);
         #[async_trait::async_trait(?Send)]
         impl Input for OneLineInput {
             async fn next_line(&mut self, _: &Context) -> crate::input::Result {

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -93,7 +93,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "@");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -112,7 +112,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "1");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -131,7 +131,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "az_AZ_019");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -150,7 +150,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "abc");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -167,7 +167,7 @@ mod tests {
 
         let location = block_on(lexer.raw_param(location)).unwrap().unwrap_err();
         assert_eq!(location.code.value, "X");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -92,9 +92,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "@");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -111,9 +111,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "1");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -130,9 +130,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "az_AZ_019");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -149,9 +149,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "abc");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -166,9 +166,9 @@ mod tests {
         let location = Location::dummy("X");
 
         let location = block_on(lexer.raw_param(location)).unwrap().unwrap_err();
-        assert_eq!(location.line.value, "X");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "X");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -604,16 +604,16 @@ mod tests {
         let mut lexer = Lexer::from_memory("x(()", Source::Unknown);
         let e = block_on(lexer.text_with_parentheses(|_| false, |_| false)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedParen { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "x(()");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "x(()");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "x(()");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "x(()");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -605,14 +605,14 @@ mod tests {
         let e = block_on(lexer.text_with_parentheses(|_| false, |_| false)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedParen { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "x(()");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "x(()");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -101,7 +101,7 @@ mod tests {
 
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.location.code.value, "");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::EndOfInput);
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
         assert_eq!(t.word.location.code.value, "abc ");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Token(None));
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
         assert_eq!(t.word.location.code.value, "12<");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
         assert_eq!(t.word.location.code.value, "0>>");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
@@ -185,7 +185,7 @@ mod tests {
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
             assert_eq!(t.word.location.code.value, " a  ");
-            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 2);
             assert_eq!(t.id, TokenId::Token(None));
@@ -194,7 +194,7 @@ mod tests {
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
             assert_eq!(t.word.location.code.value, " a  ");
-            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 5);
             assert_eq!(t.id, TokenId::EndOfInput);

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -100,9 +100,9 @@ mod tests {
         let mut lexer = Lexer::from_memory("", Source::Unknown);
 
         let t = block_on(lexer.token()).unwrap();
-        assert_eq!(t.word.location.line.value, "");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
@@ -117,9 +117,9 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('a')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
-        assert_eq!(t.word.location.line.value, "abc ");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "abc ");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
@@ -150,9 +150,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
-        assert_eq!(t.word.location.line.value, "12<");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "12<");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
@@ -167,9 +167,9 @@ mod tests {
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
-        assert_eq!(t.word.location.line.value, "0>>");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "0>>");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
@@ -184,18 +184,18 @@ mod tests {
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.line.value, " a  ");
-            assert_eq!(t.word.location.line.number.get(), 1);
-            assert_eq!(t.word.location.line.source, Source::Unknown);
+            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 2);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.line.value, " a  ");
-            assert_eq!(t.word.location.line.number.get(), 1);
-            assert_eq!(t.word.location.line.source, Source::Unknown);
+            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 5);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -342,16 +342,16 @@ mod tests {
         let e = block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSingleQuote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "'abc\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "'abc\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "def\\");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "def\\");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -466,16 +466,16 @@ mod tests {
         let e = block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoubleQuote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "\"abc\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "\"abc\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "def");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "def");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -492,9 +492,9 @@ mod tests {
         assert_eq!(word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
         if let WordUnit::Unquoted(TextUnit::CommandSubst { content, location }) = &word.units[1] {
             assert_eq!(content, ":");
-            assert_eq!(location.line.value, r"0$(:)X\#");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, r"0$(:)X\#");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
             panic!("unexpected word unit: {:?}", word.units[1]);
@@ -504,9 +504,9 @@ mod tests {
             word.units[3],
             WordUnit::Unquoted(TextUnit::Backslashed('#'))
         );
-        assert_eq!(word.location.line.value, r"0$(:)X\#");
-        assert_eq!(word.location.line.number.get(), 1);
-        assert_eq!(word.location.line.source, Source::Unknown);
+        assert_eq!(word.location.code.value, r"0$(:)X\#");
+        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -521,9 +521,9 @@ mod tests {
         };
         let word = block_on(lexer.word(|_| panic!("unexpected call to is_delimiter"))).unwrap();
         assert_eq!(word.units, []);
-        assert_eq!(word.location.line.value, "");
-        assert_eq!(word.location.line.number.get(), 1);
-        assert_eq!(word.location.line.source, Source::Unknown);
+        assert_eq!(word.location.code.value, "");
+        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
     }
 

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -343,14 +343,14 @@ mod tests {
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSingleQuote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "'abc\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "def\\");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -467,14 +467,14 @@ mod tests {
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoubleQuote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "\"abc\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "def");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -493,7 +493,7 @@ mod tests {
         if let WordUnit::Unquoted(TextUnit::CommandSubst { content, location }) = &word.units[1] {
             assert_eq!(content, ":");
             assert_eq!(location.code.value, r"0$(:)X\#");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
@@ -505,7 +505,7 @@ mod tests {
             WordUnit::Unquoted(TextUnit::Backslashed('#'))
         );
         assert_eq!(word.location.code.value, r"0$(:)X\#");
-        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
 
@@ -522,7 +522,7 @@ mod tests {
         let word = block_on(lexer.word(|_| panic!("unexpected call to is_delimiter"))).unwrap();
         assert_eq!(word.units, []);
         assert_eq!(word.location.code.value, "");
-        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
     }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -228,9 +228,9 @@ mod tests {
         assert_eq!(list.0.len(), 3);
 
         let location = list.0[0].async_flag.as_ref().unwrap();
-        assert_eq!(location.line.value, "foo & bar ; baz&");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
@@ -238,9 +238,9 @@ mod tests {
         assert_eq!(list.0[1].and_or.to_string(), "bar");
 
         let location = list.0[2].async_flag.as_ref().unwrap();
-        assert_eq!(location.line.value, "foo & bar ; baz&");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
@@ -322,9 +322,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocContent)
         );
-        assert_eq!(e.location.line.value, "<<END");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<<END");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -336,9 +336,9 @@ mod tests {
 
         let e = block_on(parser.command_line()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::UnexpectedToken));
-        assert_eq!(e.location.line.value, "foo)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -229,7 +229,7 @@ mod tests {
 
         let location = list.0[0].async_flag.as_ref().unwrap();
         assert_eq!(location.code.value, "foo & bar ; baz&");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
@@ -239,7 +239,7 @@ mod tests {
 
         let location = list.0[2].async_flag.as_ref().unwrap();
         assert_eq!(location.code.value, "foo & bar ; baz&");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
@@ -323,7 +323,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocContent)
         );
         assert_eq!(e.location.code.value, "<<END");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -337,7 +337,7 @@ mod tests {
         let e = block_on(parser.command_line()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::UnexpectedToken));
         assert_eq!(e.location.code.value, "foo)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -170,9 +170,9 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::DoubleNegation));
-        assert_eq!(e.location.line.value, " !  !");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " !  !");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -187,9 +187,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBang)
         );
-        assert_eq!(e.location.line.value, "!\n");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "!\n");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -204,9 +204,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBar)
         );
-        assert_eq!(e.location.line.value, "foo | ;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo | ;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -218,9 +218,9 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::BangAfterBar));
-        assert_eq!(e.location.line.value, "foo | !");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo | !");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -171,7 +171,7 @@ mod tests {
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::DoubleNegation));
         assert_eq!(e.location.code.value, " !  !");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -188,7 +188,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBang)
         );
         assert_eq!(e.location.code.value, "!\n");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -205,7 +205,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBar)
         );
         assert_eq!(e.location.code.value, "foo | ;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -219,7 +219,7 @@ mod tests {
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::BangAfterBar));
         assert_eq!(e.location.code.value, "foo | !");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -365,7 +365,7 @@ mod tests {
             e.location.code.value,
             "9999999999999999999999999999999999999999< x"
         );
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -391,7 +391,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
         assert_eq!(e.location.code.value, " < >");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -408,7 +408,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
         assert_eq!(e.location.code.value, "  < ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -425,7 +425,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<< <<");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -442,7 +442,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<<");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -362,11 +362,11 @@ mod tests {
         let e = block_on(parser.redirection()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::FdOutOfRange));
         assert_eq!(
-            e.location.line.value,
+            e.location.code.value,
             "9999999999999999999999999999999999999999< x"
         );
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -390,9 +390,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.line.value, " < >");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " < >");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -407,9 +407,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.line.value, "  < ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  < ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -424,9 +424,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<< <<");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<< <<");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -441,9 +441,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<<");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<<");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -232,14 +232,14 @@ mod tests {
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "(a b");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "(a b");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -252,14 +252,14 @@ mod tests {
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "(a;b)");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "(a;b)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "my");
         assert_eq!(sc.assigns[0].value.to_string(), "assignment");
         assert_eq!(sc.assigns[0].location.code.value, "my=assignment");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
     }
@@ -315,19 +315,19 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
         assert_eq!(sc.assigns[0].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
         assert_eq!(sc.assigns[1].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[1].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[1].location.column.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
         assert_eq!(sc.assigns[2].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[2].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[2].location.column.get(), 8);
     }
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
         assert_eq!(sc.assigns[0].location.code.value, "a= ()");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
@@ -579,7 +579,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b");
         assert_eq!(sc.assigns[0].location.code.value, "a=b()");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -231,16 +231,16 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "(a b");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "(a b");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "(a b");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(a b");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -251,16 +251,16 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "(a;b)");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "(a;b)");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "(a;b)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(a;b)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -296,9 +296,9 @@ mod tests {
         assert_eq!(sc.assigns.len(), 1);
         assert_eq!(sc.assigns[0].name, "my");
         assert_eq!(sc.assigns[0].value.to_string(), "assignment");
-        assert_eq!(sc.assigns[0].location.line.value, "my=assignment");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "my=assignment");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
     }
 
@@ -314,21 +314,21 @@ mod tests {
         assert_eq!(sc.assigns.len(), 3);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
-        assert_eq!(sc.assigns[1].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[1].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[1].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[1].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[1].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[1].location.column.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
-        assert_eq!(sc.assigns[2].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[2].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[2].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[2].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[2].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[2].location.column.get(), 8);
     }
 
@@ -557,9 +557,9 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.line.value, "a= ()");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a= ()");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();
@@ -578,9 +578,9 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b");
-        assert_eq!(sc.assigns[0].location.line.value, "a=b()");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a=b()");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -152,14 +152,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "while :");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "while :");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -176,7 +176,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::EmptyWhileCondition)
         );
         assert_eq!(e.location.code.value, " while do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -255,14 +255,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "until :");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "until :");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -279,7 +279,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::EmptyUntilCondition)
         );
         assert_eq!(e.location.code.value, "  until do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -151,16 +151,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "while :");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "while :");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "while :");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "while :");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -175,9 +175,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyWhileCondition)
         );
-        assert_eq!(e.location.line.value, " while do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " while do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -254,16 +254,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "until :");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "until :");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "until :");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "until :");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -278,9 +278,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyUntilCondition)
         );
-        assert_eq!(e.location.line.value, "  until do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  until do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -225,7 +225,7 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
         use std::rc::Rc;
 
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
@@ -297,7 +297,7 @@ mod annotate_snippets_support {
             global: false,
             origin: Location::dummy("my origin"),
         });
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "substitution".to_string(),
             number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -96,13 +96,13 @@ impl super::Source {
                     label: format!("alias `{}` was substituted here", alias.name).into(),
                     location: original.clone(),
                 }));
-                original.line.source.complement_annotations(result);
+                original.code.source.complement_annotations(result);
                 result.extend(std::iter::once(Annotation {
                     r#type: AnnotationType::Info,
                     label: format!("alias `{}` was defined here", alias.name).into(),
                     location: alias.origin.clone(),
                 }));
-                alias.origin.line.source.complement_annotations(result);
+                alias.origin.code.source.complement_annotations(result);
             }
         }
     }
@@ -147,27 +147,27 @@ mod annotate_snippets_support {
 
             let mut lines = vec![];
             for annotation in &message.annotations {
-                let line = &annotation.location.line;
-                let line_start = line.number.get().try_into().unwrap_or(usize::MAX);
+                let code = &annotation.location.code;
+                let line_start = code.number.get().try_into().unwrap_or(usize::MAX);
                 let column = &annotation.location.column;
                 let column = column.get().try_into().unwrap_or(usize::MAX);
-                let column = column.min(line.value.chars().count()).max(1);
+                let column = column.min(code.value.chars().count()).max(1);
                 let annotation = snippet::SourceAnnotation {
                     range: (column - 1, column),
                     label: &annotation.label,
                     annotation_type: annotation.r#type.into(),
                 };
-                if let Some(i) = lines.iter().position(|l| l == line) {
+                if let Some(i) = lines.iter().position(|l| l == code) {
                     snippet.slices[i].annotations.push(annotation);
                 } else {
                     snippet.slices.push(snippet::Slice {
-                        source: &line.value,
+                        source: &code.value,
                         line_start,
-                        origin: Some(line.source.label()),
+                        origin: Some(code.source.label()),
                         fold: true,
                         annotations: vec![annotation],
                     });
-                    lines.push(line.clone());
+                    lines.push(code.clone());
                 }
             }
 
@@ -225,13 +225,13 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
         use std::rc::Rc;
 
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: NonZeroU64::new(42).unwrap(),
         };
         let message = Message {
@@ -297,13 +297,13 @@ mod annotate_snippets_support {
             global: false,
             origin: Location::dummy("my origin"),
         });
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "substitution".to_string(),
             number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });
         let location = Location {
-            line,
+            code,
             column: NonZeroU64::new(5).unwrap(),
         };
         let message = Message {

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -148,7 +148,11 @@ mod annotate_snippets_support {
             let mut lines = vec![];
             for annotation in &message.annotations {
                 let code = &annotation.location.code;
-                let line_start = code.number.get().try_into().unwrap_or(usize::MAX);
+                let line_start = code
+                    .start_line_number
+                    .get()
+                    .try_into()
+                    .unwrap_or(usize::MAX);
                 let column = &annotation.location.column;
                 let column = column.get().try_into().unwrap_or(usize::MAX);
                 let column = column.min(code.value.chars().count()).max(1);
@@ -227,7 +231,7 @@ mod annotate_snippets_support {
 
         let code = Rc::new(Code {
             value: "".to_string(),
-            number: NonZeroU64::new(128).unwrap(),
+            start_line_number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
         let location = Location {
@@ -299,7 +303,7 @@ mod annotate_snippets_support {
         });
         let code = Rc::new(Code {
             value: "substitution".to_string(),
-            number: NonZeroU64::new(10).unwrap(),
+            start_line_number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });
         let location = Location {

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -64,7 +64,7 @@
 //! use yash_syntax::source::Source;
 //! # use yash_syntax::syntax::Word;
 //! let word: Word = "foo".parse().unwrap();
-//! assert_eq!(word.location.line.source, Source::Unknown);
+//! assert_eq!(word.location.code.source, Source::Unknown);
 //! ```
 //!
 //! To include substantial source information in the AST, you need to prepare a


### PR DESCRIPTION
Currently, error messages printed by the `annotate-snippets` crate only shows one line of relevant code. To make messages contain the whole code fragment, we need to reorganize data structures about source code attribution.

(This PR is a rework of #128, which didn't seem to work)

- [x] Rename the structure
- [x] Rename `Location::line` to `Location::code`
- [x] Rename `number` to `start_line_number`
- [x] Remove `location` from `Annotation` and add `code` and `column`
    - `code: Rc<dyn Deref<Target = Code>>`
- [ ] Wrap `Location::code` in `RefCell`
- [ ] Share `Code` among lines containing a single command
- [ ] Reconsider the signature (and optimize the implementation) of `Code::enumerate`
- [ ] (Other FIXMEs)
- [ ] (Documentation: rustdoc & changelog)
