### PR TITLE
Multi-line source code attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ name = "yash-syntax"
 version = "0.1.0"
 dependencies = [
  "annotate-snippets",
+ "assert_matches",
  "async-trait",
  "futures-executor",
  "futures-util",

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -120,9 +120,9 @@ mod tests {
         assert_eq!(alias.name, "foo");
         assert_eq!(alias.replacement, "bar baz");
         assert_eq!(alias.global, false);
-        assert_eq!(alias.origin.line.value, "foo=bar baz");
-        assert_eq!(alias.origin.line.number.get(), 1);
-        assert_eq!(alias.origin.line.source, Source::Unknown);
+        assert_eq!(alias.origin.code.value, "foo=bar baz");
+        assert_eq!(alias.origin.code.number.get(), 1);
+        assert_eq!(alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.column.get(), 1);
     }
 
@@ -140,27 +140,27 @@ mod tests {
         assert_eq!(abc.name, "abc");
         assert_eq!(abc.replacement, "xyz");
         assert_eq!(abc.global, false);
-        assert_eq!(abc.origin.line.value, "abc=xyz");
-        assert_eq!(abc.origin.line.number.get(), 1);
-        assert_eq!(abc.origin.line.source, Source::Unknown);
+        assert_eq!(abc.origin.code.value, "abc=xyz");
+        assert_eq!(abc.origin.code.number.get(), 1);
+        assert_eq!(abc.origin.code.source, Source::Unknown);
         assert_eq!(abc.origin.column.get(), 1);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
         assert_eq!(yes.replacement, "no");
         assert_eq!(yes.global, false);
-        assert_eq!(yes.origin.line.value, "yes=no");
-        assert_eq!(yes.origin.line.number.get(), 1);
-        assert_eq!(yes.origin.line.source, Source::Unknown);
+        assert_eq!(yes.origin.code.value, "yes=no");
+        assert_eq!(yes.origin.code.number.get(), 1);
+        assert_eq!(yes.origin.code.source, Source::Unknown);
         assert_eq!(yes.origin.column.get(), 1);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
         assert_eq!(ls.replacement, "ls --color");
         assert_eq!(ls.global, false);
-        assert_eq!(ls.origin.line.value, "ls=ls --color");
-        assert_eq!(ls.origin.line.number.get(), 1);
-        assert_eq!(ls.origin.line.source, Source::Unknown);
+        assert_eq!(ls.origin.code.value, "ls=ls --color");
+        assert_eq!(ls.origin.code.number.get(), 1);
+        assert_eq!(ls.origin.code.source, Source::Unknown);
         assert_eq!(ls.origin.column.get(), 1);
     }
 

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(*alias.origin.code.value.borrow(), "foo=bar baz");
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
-        assert_eq!(alias.origin.column.get(), 1);
+        assert_eq!(alias.origin.index.get(), 1);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(*abc.origin.code.value.borrow(), "abc=xyz");
         assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
-        assert_eq!(abc.origin.column.get(), 1);
+        assert_eq!(abc.origin.index.get(), 1);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(*yes.origin.code.value.borrow(), "yes=no");
         assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
-        assert_eq!(yes.origin.column.get(), 1);
+        assert_eq!(yes.origin.index.get(), 1);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(*ls.origin.code.value.borrow(), "ls=ls --color");
         assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
-        assert_eq!(ls.origin.column.get(), 1);
+        assert_eq!(ls.origin.index.get(), 1);
     }
 
     #[test]

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(alias.replacement, "bar baz");
         assert_eq!(alias.global, false);
         assert_eq!(alias.origin.code.value, "foo=bar baz");
-        assert_eq!(alias.origin.code.number.get(), 1);
+        assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.column.get(), 1);
     }
@@ -141,7 +141,7 @@ mod tests {
         assert_eq!(abc.replacement, "xyz");
         assert_eq!(abc.global, false);
         assert_eq!(abc.origin.code.value, "abc=xyz");
-        assert_eq!(abc.origin.code.number.get(), 1);
+        assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
         assert_eq!(abc.origin.column.get(), 1);
 
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(yes.replacement, "no");
         assert_eq!(yes.global, false);
         assert_eq!(yes.origin.code.value, "yes=no");
-        assert_eq!(yes.origin.code.number.get(), 1);
+        assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
         assert_eq!(yes.origin.column.get(), 1);
 
@@ -159,7 +159,7 @@ mod tests {
         assert_eq!(ls.replacement, "ls --color");
         assert_eq!(ls.global, false);
         assert_eq!(ls.origin.code.value, "ls=ls --color");
-        assert_eq!(ls.origin.code.number.get(), 1);
+        assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
         assert_eq!(ls.origin.column.get(), 1);
     }

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(alias.name, "foo");
         assert_eq!(alias.replacement, "bar baz");
         assert_eq!(alias.global, false);
-        assert_eq!(alias.origin.code.value, "foo=bar baz");
+        assert_eq!(*alias.origin.code.value.borrow(), "foo=bar baz");
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.column.get(), 1);
@@ -140,7 +140,7 @@ mod tests {
         assert_eq!(abc.name, "abc");
         assert_eq!(abc.replacement, "xyz");
         assert_eq!(abc.global, false);
-        assert_eq!(abc.origin.code.value, "abc=xyz");
+        assert_eq!(*abc.origin.code.value.borrow(), "abc=xyz");
         assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
         assert_eq!(abc.origin.column.get(), 1);
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(yes.name, "yes");
         assert_eq!(yes.replacement, "no");
         assert_eq!(yes.global, false);
-        assert_eq!(yes.origin.code.value, "yes=no");
+        assert_eq!(*yes.origin.code.value.borrow(), "yes=no");
         assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
         assert_eq!(yes.origin.column.get(), 1);
@@ -158,7 +158,7 @@ mod tests {
         assert_eq!(ls.name, "ls");
         assert_eq!(ls.replacement, "ls --color");
         assert_eq!(ls.global, false);
-        assert_eq!(ls.origin.code.value, "ls=ls --color");
+        assert_eq!(*ls.origin.code.value.borrow(), "ls=ls --color");
         assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
         assert_eq!(ls.origin.column.get(), 1);

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(*alias.origin.code.value.borrow(), "foo=bar baz");
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
-        assert_eq!(alias.origin.index.get(), 1);
+        assert_eq!(alias.origin.index, 0);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(*abc.origin.code.value.borrow(), "abc=xyz");
         assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
-        assert_eq!(abc.origin.index.get(), 1);
+        assert_eq!(abc.origin.index, 0);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(*yes.origin.code.value.borrow(), "yes=no");
         assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
-        assert_eq!(yes.origin.index.get(), 1);
+        assert_eq!(yes.origin.index, 0);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(*ls.origin.code.value.borrow(), "ls=ls --color");
         assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
-        assert_eq!(ls.origin.index.get(), 1);
+        assert_eq!(ls.origin.index, 0);
     }
 
     #[test]

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -329,7 +329,7 @@ impl<'a> From<&'a Error<'_>> for Message<'a> {
         let mut a = vec![Annotation {
             r#type: AnnotationType::Error,
             label: field.value.as_str().into(),
-            location: field.origin.clone(),
+            location: &field.origin,
         }];
 
         field.origin.code.source.complement_annotations(&mut a);

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -326,11 +326,11 @@ impl<'a> From<&'a Error<'_>> for Message<'a> {
     fn from(error: &'a Error<'_>) -> Self {
         let field = error.field();
 
-        let mut a = vec![Annotation {
-            r#type: AnnotationType::Error,
-            label: field.value.as_str().into(),
-            location: &field.origin,
-        }];
+        let mut a = vec![Annotation::new(
+            AnnotationType::Error,
+            field.value.as_str().into(),
+            &field.origin,
+        )];
 
         field.origin.code.source.complement_annotations(&mut a);
 

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -332,7 +332,7 @@ impl<'a> From<&'a Error<'_>> for Message<'a> {
             location: field.origin.clone(),
         }];
 
-        field.origin.line.source.complement_annotations(&mut a);
+        field.origin.code.source.complement_annotations(&mut a);
 
         Message {
             r#type: AnnotationType::Error,
@@ -707,7 +707,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.line.value, "-abar");
+            assert_eq!(field.origin.code.value, "-abar");
         });
         assert_eq!(operands, []);
 
@@ -717,12 +717,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.line.value, "-a1");
+            assert_eq!(field.origin.code.value, "-a1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.line.value, "-a2");
+            assert_eq!(field.origin.code.value, "-a2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -739,7 +739,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.line.value, "bar");
+            assert_eq!(field.origin.code.value, "bar");
         });
         assert_eq!(operands, []);
 
@@ -749,12 +749,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.line.value, "1");
+            assert_eq!(field.origin.code.value, "1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.line.value, "2");
+            assert_eq!(field.origin.code.value, "2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -783,7 +783,7 @@ mod tests {
         assert_eq!(options[2].spec.get_short(), Some('c'));
         assert_matches!(options[2].argument, Some(ref field) => {
             assert_eq!(field.value, "def");
-            assert_eq!(field.origin.line.value, "-abcdef");
+            assert_eq!(field.origin.code.value, "-abcdef");
         });
         assert_eq!(operands, []);
     }
@@ -800,7 +800,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "");
+            assert_eq!(field.origin.code.value, "");
         });
         assert_eq!(operands, []);
     }
@@ -937,7 +937,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "--option=");
+            assert_eq!(field.origin.code.value, "--option=");
         });
         assert_eq!(operands, []);
 
@@ -948,12 +948,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.line.value, "--option=x");
+            assert_eq!(field.origin.code.value, "--option=x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.line.value, "--option=value");
+            assert_eq!(field.origin.code.value, "--option=value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -971,7 +971,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.line.value, "");
+            assert_eq!(field.origin.code.value, "");
         });
         assert_eq!(operands, []);
 
@@ -982,12 +982,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.line.value, "x");
+            assert_eq!(field.origin.code.value, "x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.line.value, "value");
+            assert_eq!(field.origin.code.value, "value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -1005,12 +1005,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "argument");
-            assert_eq!(field.origin.line.value, "argument");
+            assert_eq!(field.origin.code.value, "argument");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "--");
-            assert_eq!(field.origin.line.value, "--");
+            assert_eq!(field.origin.code.value, "--");
         });
         assert_eq!(operands, Field::dummies(["operand"]));
     }

--- a/yash-builtin/src/common/arg.rs
+++ b/yash-builtin/src/common/arg.rs
@@ -707,7 +707,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.code.value, "-abar");
+            assert_eq!(*field.origin.code.value.borrow(), "-abar");
         });
         assert_eq!(operands, []);
 
@@ -717,12 +717,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.code.value, "-a1");
+            assert_eq!(*field.origin.code.value.borrow(), "-a1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.code.value, "-a2");
+            assert_eq!(*field.origin.code.value.borrow(), "-a2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -739,7 +739,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "bar");
-            assert_eq!(field.origin.code.value, "bar");
+            assert_eq!(*field.origin.code.value.borrow(), "bar");
         });
         assert_eq!(operands, []);
 
@@ -749,12 +749,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "1");
-            assert_eq!(field.origin.code.value, "1");
+            assert_eq!(*field.origin.code.value.borrow(), "1");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "2");
-            assert_eq!(field.origin.code.value, "2");
+            assert_eq!(*field.origin.code.value.borrow(), "2");
         });
         assert_eq!(operands, Field::dummies(["3"]));
     }
@@ -783,7 +783,7 @@ mod tests {
         assert_eq!(options[2].spec.get_short(), Some('c'));
         assert_matches!(options[2].argument, Some(ref field) => {
             assert_eq!(field.value, "def");
-            assert_eq!(field.origin.code.value, "-abcdef");
+            assert_eq!(*field.origin.code.value.borrow(), "-abcdef");
         });
         assert_eq!(operands, []);
     }
@@ -800,7 +800,7 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.code.value, "");
+            assert_eq!(*field.origin.code.value.borrow(), "");
         });
         assert_eq!(operands, []);
     }
@@ -937,7 +937,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.code.value, "--option=");
+            assert_eq!(*field.origin.code.value.borrow(), "--option=");
         });
         assert_eq!(operands, []);
 
@@ -948,12 +948,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.code.value, "--option=x");
+            assert_eq!(*field.origin.code.value.borrow(), "--option=x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.code.value, "--option=value");
+            assert_eq!(*field.origin.code.value.borrow(), "--option=value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -971,7 +971,7 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "");
-            assert_eq!(field.origin.code.value, "");
+            assert_eq!(*field.origin.code.value.borrow(), "");
         });
         assert_eq!(operands, []);
 
@@ -982,12 +982,12 @@ mod tests {
         assert_eq!(options[0].spec.get_long(), Some("option"));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "x");
-            assert_eq!(field.origin.code.value, "x");
+            assert_eq!(*field.origin.code.value.borrow(), "x");
         });
         assert_eq!(options[1].spec.get_long(), Some("option"));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "value");
-            assert_eq!(field.origin.code.value, "value");
+            assert_eq!(*field.origin.code.value.borrow(), "value");
         });
         assert_eq!(operands, Field::dummies(["argument"]));
     }
@@ -1005,12 +1005,12 @@ mod tests {
         assert_eq!(options[0].spec.get_short(), Some('a'));
         assert_matches!(options[0].argument, Some(ref field) => {
             assert_eq!(field.value, "argument");
-            assert_eq!(field.origin.code.value, "argument");
+            assert_eq!(*field.origin.code.value.borrow(), "argument");
         });
         assert_eq!(options[1].spec.get_short(), Some('a'));
         assert_matches!(options[1].argument, Some(ref field) => {
             assert_eq!(field.value, "--");
-            assert_eq!(field.origin.code.value, "--");
+            assert_eq!(*field.origin.code.value.borrow(), "--");
         });
         assert_eq!(operands, Field::dummies(["operand"]));
     }

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -107,15 +107,7 @@ impl Input for Stdin {
 
                 Err(errno) => {
                     let code = Rc::new(to_code(bytes, number));
-                    let index = code
-                        .value
-                        .borrow()
-                        .chars()
-                        .count()
-                        .try_into()
-                        .unwrap_or(u64::MAX)
-                        .saturating_add(1);
-                    let index = unsafe { NonZeroU64::new_unchecked(index) };
+                    let index = code.value.borrow().chars().count();
                     let location = Location { code, index };
                     let error = std::io::Error::from_raw_os_error(errno as i32);
                     return Err((location, error));

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use std::num::NonZeroU64;
 use std::rc::Rc;
 use std::slice::from_mut;
-use yash_syntax::source::Line;
+use yash_syntax::source::Code;
 use yash_syntax::source::Location;
 use yash_syntax::source::Source;
 
@@ -73,11 +73,11 @@ impl Input for Stdin {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
-        fn to_line(bytes: Vec<u8>, number: NonZeroU64) -> Line {
+        fn to_code(bytes: Vec<u8>, number: NonZeroU64) -> Code {
             // TODO Maybe we should report invalid UTF-8 bytes rather than ignoring them
             let value = String::from_utf8(bytes)
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).to_string());
-            Line {
+            Code {
                 value,
                 number,
                 source: Source::Stdin,
@@ -105,7 +105,7 @@ impl Input for Stdin {
                 }
 
                 Err(errno) => {
-                    let line = Rc::new(to_line(bytes, number));
+                    let line = Rc::new(to_code(bytes, number));
                     let column = line
                         .value
                         .chars()
@@ -121,7 +121,7 @@ impl Input for Stdin {
             }
         }
 
-        Ok(to_line(bytes, number))
+        Ok(to_code(bytes, number))
     }
 }
 

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -107,7 +107,7 @@ impl Input for Stdin {
 
                 Err(errno) => {
                     let code = Rc::new(to_code(bytes, number));
-                    let column = code
+                    let index = code
                         .value
                         .borrow()
                         .chars()
@@ -115,8 +115,8 @@ impl Input for Stdin {
                         .try_into()
                         .unwrap_or(u64::MAX)
                         .saturating_add(1);
-                    let column = unsafe { NonZeroU64::new_unchecked(column) };
-                    let location = Location { code, column };
+                    let index = unsafe { NonZeroU64::new_unchecked(index) };
+                    let location = Location { code, index };
                     let error = std::io::Error::from_raw_os_error(errno as i32);
                     return Err((location, error));
                 }

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -23,7 +23,6 @@
 use crate::io::Fd;
 use crate::system::SharedSystem;
 use async_trait::async_trait;
-use std::num::NonZeroU64;
 use std::slice::from_mut;
 
 #[doc(no_inline)]
@@ -41,26 +40,12 @@ pub use yash_syntax::input::*;
 #[derive(Clone, Debug)]
 pub struct Stdin {
     system: SharedSystem,
-    line_number: NonZeroU64,
 }
 
 impl Stdin {
     /// Creates a new `Stdin` instance.
     pub fn new(system: SharedSystem) -> Self {
-        Stdin {
-            system,
-            line_number: NonZeroU64::new(1).unwrap(),
-        }
-    }
-
-    /// Returns the current line number.
-    pub fn line_number(&self) -> NonZeroU64 {
-        self.line_number
-    }
-
-    /// Overwrites the current line number.
-    pub fn set_line_number(&mut self, line_number: NonZeroU64) {
-        self.line_number = line_number;
+        Stdin { system }
     }
 }
 
@@ -80,10 +65,6 @@ impl Input for Stdin {
                     assert_eq!(count, 1);
                     bytes.push(byte);
                     if byte == b'\n' {
-                        // TODO self.line_number = self.line_number.saturating_add(1);
-                        self.line_number = unsafe {
-                            NonZeroU64::new_unchecked(self.line_number.get().saturating_add(1))
-                        };
                         break;
                     }
                 }

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -73,13 +73,13 @@ impl Input for Stdin {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
-        fn to_code(bytes: Vec<u8>, number: NonZeroU64) -> Code {
+        fn to_code(bytes: Vec<u8>, start_line_number: NonZeroU64) -> Code {
             // TODO Maybe we should report invalid UTF-8 bytes rather than ignoring them
             let value = String::from_utf8(bytes)
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).to_string());
             Code {
                 value,
-                number,
+                start_line_number,
                 source: Source::Stdin,
             }
         }
@@ -140,7 +140,7 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -157,11 +157,11 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "echo ok\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -178,19 +178,19 @@ mod tests {
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "#!/bin/sh\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "echo ok\n");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "exit");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Stdin);
         let line = block_on(stdin.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Stdin);
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
         let (location, error) = block_on(stdin.next_line(&Context)).unwrap_err();
         assert_eq!(location.code.value, "");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Stdin);
         assert_eq!(error.raw_os_error(), Some(Errno::EBADF as i32));
     }

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -115,7 +115,7 @@ impl Input for Stdin {
             }
         }
 
-        Ok(to_code(bytes, number))
+        Ok(to_code(bytes, number).value.into_inner())
     }
 }
 
@@ -133,9 +133,7 @@ mod tests {
         let mut stdin = Stdin::new(system);
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "");
-        assert_eq!(line.start_line_number.get(), 1);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "");
     }
 
     #[test]
@@ -150,13 +148,9 @@ mod tests {
         let mut stdin = Stdin::new(system);
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "echo ok\n");
-        assert_eq!(line.start_line_number.get(), 1);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "echo ok\n");
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "");
-        assert_eq!(line.start_line_number.get(), 2);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "");
     }
 
     #[test]
@@ -171,21 +165,13 @@ mod tests {
         let mut stdin = Stdin::new(system);
 
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "#!/bin/sh\n");
-        assert_eq!(line.start_line_number.get(), 1);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "#!/bin/sh\n");
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "echo ok\n");
-        assert_eq!(line.start_line_number.get(), 2);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "echo ok\n");
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "exit");
-        assert_eq!(line.start_line_number.get(), 3);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "exit");
         let line = block_on(stdin.next_line(&Context)).unwrap();
-        assert_eq!(*line.value.borrow(), "");
-        assert_eq!(line.start_line_number.get(), 3);
-        assert_eq!(line.source, Source::Stdin);
+        assert_eq!(line, "");
     }
 
     #[test]

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -105,8 +105,8 @@ impl Input for Stdin {
                 }
 
                 Err(errno) => {
-                    let line = Rc::new(to_code(bytes, number));
-                    let column = line
+                    let code = Rc::new(to_code(bytes, number));
+                    let column = code
                         .value
                         .chars()
                         .count()
@@ -114,7 +114,7 @@ impl Input for Stdin {
                         .unwrap_or(u64::MAX)
                         .saturating_add(1);
                     let column = unsafe { NonZeroU64::new_unchecked(column) };
-                    let location = Location { line, column };
+                    let location = Location { code, column };
                     let error = std::io::Error::from_raw_os_error(errno as i32);
                     return Err((location, error));
                 }
@@ -202,9 +202,9 @@ mod tests {
         let mut stdin = Stdin::new(system);
 
         let (location, error) = block_on(stdin.next_line(&Context)).unwrap_err();
-        assert_eq!(location.line.value, "");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Stdin);
+        assert_eq!(location.code.value, "");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Stdin);
         assert_eq!(error.raw_os_error(), Some(Errno::EBADF as i32));
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -129,8 +129,8 @@ mod tests {
             assert_eq!(roe.read_only_location, location);
             assert_eq!(roe.new_value.value, Value::Scalar("new".into()));
         });
-        assert_eq!(e.location.line.value, "v=new");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "v=new");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -131,6 +131,6 @@ mod tests {
         });
         assert_eq!(*e.location.code.value.borrow(), "v=new");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -131,6 +131,6 @@ mod tests {
         });
         assert_eq!(*e.location.code.value.borrow(), "v=new");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -129,7 +129,7 @@ mod tests {
             assert_eq!(roe.read_only_location, location);
             assert_eq!(roe.new_value.value, Value::Scalar("new".into()));
         });
-        assert_eq!(e.location.code.value, "v=new");
+        assert_eq!(*e.location.code.value.borrow(), "v=new");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
     }

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(roe.new_value.value, Value::Scalar("new".into()));
         });
         assert_eq!(e.location.code.value, "v=new");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -158,7 +158,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
             a.push(Annotation {
@@ -793,13 +793,13 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let new_value = Variable {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -794,7 +794,7 @@ mod tests {
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
-            value: "".to_string(),
+            value: "".to_string().into(),
             start_line_number: number,
             source: Source::Unknown,
         });

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -795,7 +795,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -152,20 +152,20 @@ pub struct Error {
 
 impl<'a> From<&'a Error> for Message<'a> {
     fn from(e: &'a Error) -> Self {
-        let mut a = vec![Annotation {
-            r#type: AnnotationType::Error,
-            label: e.cause.label(),
-            location: &e.location,
-        }];
+        let mut a = vec![Annotation::new(
+            AnnotationType::Error,
+            e.cause.label(),
+            &e.location,
+        )];
 
         e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
-            a.push(Annotation {
-                r#type: AnnotationType::Info,
-                label: label.into(),
+            a.push(Annotation::new(
+                AnnotationType::Info,
+                label.into(),
                 location,
-            });
+            ));
         }
 
         Message {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -800,7 +800,7 @@ mod tests {
         });
         let location = Location {
             code,
-            column: number,
+            index: number,
         };
         let new_value = Variable {
             value: Value::Scalar("value".into()),

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -722,7 +722,7 @@ mod tests {
     use std::num::NonZeroU64;
     use std::rc::Rc;
     use yash_env::variable::Value;
-    use yash_syntax::source::Line;
+    use yash_syntax::source::Code;
     use yash_syntax::source::Source;
 
     #[derive(Debug)]
@@ -793,7 +793,7 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -155,7 +155,7 @@ impl<'a> From<&'a Error> for Message<'a> {
         let mut a = vec![Annotation {
             r#type: AnnotationType::Error,
             label: e.cause.label(),
-            location: e.location.clone(),
+            location: &e.location,
         }];
 
         e.location.code.source.complement_annotations(&mut a);
@@ -164,7 +164,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             a.push(Annotation {
                 r#type: AnnotationType::Info,
                 label: label.into(),
-                location: location.clone(),
+                location,
             });
         }
 
@@ -822,13 +822,13 @@ mod tests {
         assert_eq!(message.annotations.len(), 2);
         assert_eq!(message.annotations[0].r#type, AnnotationType::Error);
         assert_eq!(message.annotations[0].label, "variable `var` is read-only");
-        assert_eq!(message.annotations[0].location, error.location);
+        assert_eq!(message.annotations[0].location, &error.location);
         assert_eq!(message.annotations[1].r#type, AnnotationType::Info);
         assert_eq!(
             message.annotations[1].label,
             "the variable was made read-only here"
         );
-        assert_eq!(message.annotations[1].location, Location::dummy("ROL"));
+        assert_eq!(message.annotations[1].location, &Location::dummy("ROL"));
     }
 
     #[test]

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -792,16 +792,12 @@ mod tests {
 
     #[test]
     fn from_error_for_message() {
-        let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string().into(),
-            start_line_number: number,
+            start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location {
-            code,
-            index: number,
-        };
+        let location = Location { code, index: 0 };
         let new_value = Variable {
             value: Value::Scalar("value".into()),
             last_assigned_location: Some(Location::dummy("assigned")),

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -75,11 +75,7 @@ pub async fn print_error(
     label: Cow<'_, str>,
     location: &Location,
 ) {
-    let mut a = vec![Annotation {
-        r#type: AnnotationType::Error,
-        label,
-        location,
-    }];
+    let mut a = vec![Annotation::new(AnnotationType::Error, label, location)];
     location.code.source.complement_annotations(&mut a);
     let message = Message {
         r#type: AnnotationType::Error,

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn print_error(
     let mut a = vec![Annotation {
         r#type: AnnotationType::Error,
         label,
-        location: location.clone(),
+        location,
     }];
     location.code.source.complement_annotations(&mut a);
     let message = Message {

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -80,7 +80,7 @@ pub async fn print_error(
         label,
         location: location.clone(),
     }];
-    location.line.source.complement_annotations(&mut a);
+    location.code.source.complement_annotations(&mut a);
     let message = Message {
         r#type: AnnotationType::Error,
         title,

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -163,11 +163,11 @@ impl From<crate::expansion::Error> for Error {
 
 impl<'a> From<&'a Error> for Message<'a> {
     fn from(e: &'a Error) -> Self {
-        let mut a = vec![Annotation {
-            r#type: AnnotationType::Error,
-            label: e.cause.label(),
-            location: &e.location,
-        }];
+        let mut a = vec![Annotation::new(
+            AnnotationType::Error,
+            e.cause.label(),
+            &e.location,
+        )];
 
         e.location.code.source.complement_annotations(&mut a);
 

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -169,7 +169,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         Message {
             r#type: AnnotationType::Error,

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -166,7 +166,7 @@ impl<'a> From<&'a Error> for Message<'a> {
         let mut a = vec![Annotation {
             r#type: AnnotationType::Error,
             label: e.cause.label(),
-            location: e.location.clone(),
+            location: &e.location,
         }];
 
         e.location.code.source.complement_annotations(&mut a);

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -65,6 +65,9 @@ pub async fn read_eval_loop(env: &mut Env, lexer: &mut Lexer<'_>) -> Result {
     let mut executed = false;
 
     loop {
+        if !lexer.pending() {
+            lexer.flush();
+        }
         let mut parser = Parser::new(lexer, &env.aliases);
         match parser.command_line().await {
             Ok(Some(command)) => {

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Items in the `source` module:
+    - `Line` renamed to `Code`
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Removed
 
 - `Code::enumerate`
+- `Lines`
+- `lines`
 
 ## [0.1.0] - 2021-12-11
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `source` module:
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
+    - `Location`'s field `column` renamed to `index`
     - `Code`'s field `value` wrapped in the `RefCell`
     - `Annotation`'s field `location` changed to a reference
     - `Annotation`'s field `code` added

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Annotation`'s field `location` changed to a reference
     - `Annotation`'s field `code` added
     - `Annotation`'s method `new` added
+- Items in the `input` module:
+    - `Result` redefined as `Result<String, Error>` (previously `Result<Code, Error>`)
 - `Lexer::new` now requiring the `start_line_number` and `source` parameters
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `source` module:
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
+    - `Code`'s field `value` wrapped in the `RefCell`
     - `Annotation`'s field `location` changed to a reference
     - `Annotation`'s field `code` added
     - `Annotation`'s method `new` added

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ????-??-??
 
+Previously, source code attribution attached to ASTs was line-oriented. The
+attribution now contains a whole fragment of code corresponding to a complete
+command.
+
 ### Added
 
 - `source_chars`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `input` module:
     - `Result` redefined as `Result<String, Error>` (previously `Result<Code, Error>`)
     - `Error` redefined as `std::io::Error` (previously `(Location, std::io::Error)`)
+    - `Memory::new` no longer taking a `Source` parameter
 - `Lexer::new` now requiring the `start_line_number` and `source` parameters
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Annotation`'s field `location` changed to a reference
     - `Annotation`'s field `code` added
     - `Annotation`'s method `new` added
+- `Lexer::new` now requiring the `start_line_number` and `source` parameters
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Annotation`'s method `new` added
 - Items in the `input` module:
     - `Result` redefined as `Result<String, Error>` (previously `Result<Code, Error>`)
+    - `Error` redefined as `std::io::Error` (previously `(Location, std::io::Error)`)
 - `Lexer::new` now requiring the `start_line_number` and `source` parameters
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ????-??-??
 
+### Added
+
+- `Lexer::pending`
+- `Lexer::flush`
+
 ### Changed
 
 - Items in the `source` module:

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `futures-util` 0.3.18 → 0.3.19
     - `itertools` 0.10.1 → 0.10.3
 
+## Removed
+
+- `Code::enumerate`
+
 ## [0.1.0] - 2021-12-11
 
 ### Added

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
     - `Annotation`'s field `location` changed to a reference
+    - `Annotation`'s field `code` added
+    - `Annotation`'s method `new` added
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Items in the `source` module:
     - `Line` renamed to `Code`
+    - `Location`'s field `line` renamed to `code`
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `source` module:
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
+    - `Annotation`'s field `location` changed to a reference
 - Dependency versions
     - `async-trait` 0.1.50 → 0.1.52
     - `futures-util` 0.3.18 → 0.3.19

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items in the `source` module:
     - `Line` renamed to `Code`
     - `Location`'s field `line` renamed to `code`
-    - `Location`'s field `column` renamed to `index`
+    - `Location`'s field `column` replaced with `index`
     - `Code`'s field `value` wrapped in the `RefCell`
     - `Annotation`'s field `location` changed to a reference
     - `Annotation`'s field `code` added

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `source_chars`
 - `Lexer::pending`
 - `Lexer::flush`
 

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -20,4 +20,5 @@ futures-util = "0.3.19"
 itertools = "0.10.3"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 futures-executor = "0.3.19"

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -16,7 +16,6 @@
 
 //! Methods about passing [source](crate::source) code to the [parser](crate::parser).
 
-use crate::source::Source;
 use async_trait::async_trait;
 
 /// Current state in which source code is read.
@@ -62,8 +61,7 @@ pub struct Memory<'a> {
 
 impl Memory<'_> {
     /// Creates a new `Memory` that reads the given string.
-    pub fn new(code: &str, _source: Source) -> Memory<'_> {
-        // FIXME Remove the source parameter
+    pub fn new(code: &str) -> Memory<'_> {
         let lines = code.split_inclusive('\n');
         Memory { lines }
     }
@@ -79,12 +77,11 @@ impl Input for Memory<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source::Source;
     use futures_executor::block_on;
 
     #[test]
     fn memory_empty_source() {
-        let mut input = Memory::new("", Source::Unknown);
+        let mut input = Memory::new("");
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line, "");
@@ -92,7 +89,7 @@ mod tests {
 
     #[test]
     fn memory_one_line() {
-        let mut input = Memory::new("one\n", Source::Unknown);
+        let mut input = Memory::new("one\n");
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line, "one\n");
@@ -103,7 +100,7 @@ mod tests {
 
     #[test]
     fn memory_three_lines() {
-        let mut input = Memory::new("one\ntwo\nthree", Source::Unknown);
+        let mut input = Memory::new("one\ntwo\nthree");
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line, "one\n");

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -17,7 +17,7 @@
 //! Methods about passing [source](crate::source) code to the [parser](crate::parser).
 
 use crate::source::lines;
-use crate::source::Line;
+use crate::source::Code;
 use crate::source::Lines;
 use crate::source::Location;
 use crate::source::Source;
@@ -37,7 +37,7 @@ pub struct Context;
 pub type Error = (Location, std::io::Error);
 
 /// Result of the [Input] function.
-pub type Result = std::result::Result<Line, Error>;
+pub type Result = std::result::Result<Code, Error>;
 
 /// Line-oriented source code reader.
 ///
@@ -46,7 +46,7 @@ pub type Result = std::result::Result<Line, Error>;
 pub trait Input {
     /// Reads a next line of the source code.
     ///
-    /// The input function is line-oriented; that is, this function returns a [`Line`] that is
+    /// The input function is line-oriented; that is, this function returns a [`Code`] that is
     /// terminated by a newline unless the end of input (EOF) is reached, in which case the
     /// remaining characters up to the EOF must be returned without a trailing newline. If there
     /// are no more characters at all, the returned line is empty.
@@ -71,7 +71,7 @@ impl Memory<'_> {
         Memory { lines }
     }
 
-    fn next_line_sync(&mut self, _: &Context) -> Line {
+    fn next_line_sync(&mut self, _: &Context) -> Code {
         self.lines.next_or_empty()
     }
 }

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -94,7 +94,7 @@ mod tests {
         let mut input = Memory::new("", Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "");
+        assert_eq!(*line.value.borrow(), "");
         assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
     }
@@ -104,12 +104,12 @@ mod tests {
         let mut input = Memory::new("one\n", Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "one\n");
+        assert_eq!(*line.value.borrow(), "one\n");
         assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "");
+        assert_eq!(*line.value.borrow(), "");
         assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
     }
@@ -119,22 +119,22 @@ mod tests {
         let mut input = Memory::new("one\ntwo\nthree", Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "one\n");
+        assert_eq!(*line.value.borrow(), "one\n");
         assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "two\n");
+        assert_eq!(*line.value.borrow(), "two\n");
         assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "three");
+        assert_eq!(*line.value.borrow(), "three");
         assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
-        assert_eq!(line.value, "");
+        assert_eq!(*line.value.borrow(), "");
         assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
     }

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
     }
 
@@ -105,12 +105,12 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "one\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
     }
 
@@ -120,22 +120,22 @@ mod tests {
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "one\n");
-        assert_eq!(line.number.get(), 1);
+        assert_eq!(line.start_line_number.get(), 1);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "two\n");
-        assert_eq!(line.number.get(), 2);
+        assert_eq!(line.start_line_number.get(), 2);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "three");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
 
         let line = block_on(input.next_line(&Context)).unwrap();
         assert_eq!(line.value, "");
-        assert_eq!(line.number.get(), 3);
+        assert_eq!(line.start_line_number.get(), 3);
         assert_eq!(line.source, Source::Unknown);
     }
 }

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -16,7 +16,6 @@
 
 //! Methods about passing [source](crate::source) code to the [parser](crate::parser).
 
-use crate::source::Location;
 use crate::source::Source;
 use async_trait::async_trait;
 
@@ -31,7 +30,7 @@ use async_trait::async_trait;
 pub struct Context;
 
 /// Error returned by the [Input] function.
-pub type Error = (Location, std::io::Error);
+pub type Error = std::io::Error;
 
 /// Result of the [Input] function.
 pub type Result = std::result::Result<String, Error>;

--- a/yash-syntax/src/parser.rs
+++ b/yash-syntax/src/parser.rs
@@ -38,8 +38,10 @@
 //! let input = Box::new(Memory::new("echo $?", Source::Unknown));
 //!
 //! // Next, create a lexer.
+//! # use std::num::NonZeroU64;
 //! # use yash_syntax::parser::lex::Lexer;
-//! let mut lexer = Lexer::new(input);
+//! let line = NonZeroU64::new(1).unwrap();
+//! let mut lexer = Lexer::new(input, line, Source::Unknown);
 //!
 //! // Then, create a new parser borrowing the lexer.
 //! # use yash_syntax::parser::Parser;

--- a/yash-syntax/src/parser.rs
+++ b/yash-syntax/src/parser.rs
@@ -35,7 +35,7 @@
 //! use yash_syntax::input::Memory;
 //! use yash_syntax::source::Source;
 //! # // TODO demonstrate with a Source other than Unknown
-//! let input = Box::new(Memory::new("echo $?", Source::Unknown));
+//! let input = Box::new(Memory::new("echo $?"));
 //!
 //! // Next, create a lexer.
 //! # use std::num::NonZeroU64;

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -132,6 +132,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo &&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 }

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -129,7 +129,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingPipeline(AndOr::AndThen))
         );
-        assert_eq!(e.location.code.value, "foo &&");
+        assert_eq!(*e.location.code.value.borrow(), "foo &&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -130,7 +130,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingPipeline(AndOr::AndThen))
         );
         assert_eq!(e.location.code.value, "foo &&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -132,6 +132,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo &&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 }

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -129,9 +129,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingPipeline(AndOr::AndThen))
         );
-        assert_eq!(e.location.line.value, "foo &&");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo &&");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -315,7 +315,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
         assert_eq!(e.location.code.value, ")");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -329,7 +329,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EsacAsPattern));
         assert_eq!(e.location.code.value, "(esac)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -343,7 +343,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidPattern));
         assert_eq!(e.location.code.value, "(&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -357,7 +357,7 @@ mod tests {
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
         assert_eq!(e.location.code.value, "(foo| |");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -374,7 +374,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::UnclosedPatternList)
         );
         assert_eq!(e.location.code.value, "(foo bar");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
@@ -582,7 +582,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingCaseSubject));
         assert_eq!(e.location.code.value, " case  ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -596,7 +596,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidCaseSubject));
         assert_eq!(e.location.code.value, " case ; ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -610,14 +610,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingIn { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " case x esac");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " case x esac");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
@@ -631,14 +631,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedCase { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "case x in a) }");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "case x in a) }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -314,9 +314,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
-        assert_eq!(e.location.line.value, ")");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, ")");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -328,9 +328,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EsacAsPattern));
-        assert_eq!(e.location.line.value, "(esac)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(esac)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -342,9 +342,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidPattern));
-        assert_eq!(e.location.line.value, "(&");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(&");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -356,9 +356,9 @@ mod tests {
 
         let e = block_on(parser.case_item()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingPattern));
-        assert_eq!(e.location.line.value, "(foo| |");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(foo| |");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -373,9 +373,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedPatternList)
         );
-        assert_eq!(e.location.line.value, "(foo bar");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(foo bar");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
 
@@ -581,9 +581,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingCaseSubject));
-        assert_eq!(e.location.line.value, " case  ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case  ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -595,9 +595,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidCaseSubject));
-        assert_eq!(e.location.line.value, " case ; ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case ; ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -609,16 +609,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingIn { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " case x esac");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " case x esac");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " case x esac");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " case x esac");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 
@@ -630,16 +630,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedCase { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "case x in a) }");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "case x in a) }");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not a MissingIn: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "case x in a) }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "case x in a) }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), ")");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(esac)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -346,7 +346,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo| |");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo bar");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 6);
+        assert_eq!(e.location.index.get(), 6);
     }
 
     #[test]
@@ -571,7 +571,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case  ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 8);
+        assert_eq!(e.location.index.get(), 8);
     }
 
     #[test]
@@ -585,7 +585,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 
     #[test]
@@ -600,12 +600,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " case x esac");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " case x esac");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 9);
+        assert_eq!(e.location.index.get(), 9);
     }
 
     #[test]
@@ -620,11 +620,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "case x in a) }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "case x in a) }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 14);
+        assert_eq!(e.location.index.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), ")");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(esac)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -346,7 +346,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo| |");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo bar");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 6);
+        assert_eq!(e.location.index, 5);
     }
 
     #[test]
@@ -571,7 +571,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case  ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 8);
+        assert_eq!(e.location.index, 7);
     }
 
     #[test]
@@ -585,7 +585,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]
@@ -600,12 +600,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " case x esac");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " case x esac");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 9);
+        assert_eq!(e.location.index, 8);
     }
 
     #[test]
@@ -620,11 +620,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "case x in a) }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "case x in a) }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 14);
+        assert_eq!(e.location.index, 13);
     }
 }

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -158,12 +158,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " do not close ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " do not close ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 15);
+        assert_eq!(e.location.index, 14);
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "do done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -153,16 +153,16 @@ mod tests {
 
         let e = block_on(parser.do_clause()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " do not close ");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " do not close ");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " do not close ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " do not close ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 15);
     }
 
@@ -174,9 +174,9 @@ mod tests {
 
         let e = block_on(parser.do_clause()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyDoClause));
-        assert_eq!(e.location.line.value, "do done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "do done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -154,14 +154,14 @@ mod tests {
         let e = block_on(parser.do_clause()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " do not close ");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " do not close ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 15);
     }
@@ -175,7 +175,7 @@ mod tests {
         let e = block_on(parser.do_clause()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyDoClause));
         assert_eq!(e.location.code.value, "do done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -158,12 +158,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " do not close ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " do not close ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 15);
+        assert_eq!(e.location.index.get(), 15);
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "do done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -186,7 +186,7 @@ impl<'a, 'b> Parser<'a, 'b> {
         if !self.aliases.is_empty() {
             if let Token(_) = token.id {
                 if let Some(name) = token.word.to_string_if_literal() {
-                    if !token.word.location.line.source.is_alias_for(&name) {
+                    if !token.word.location.code.source.is_alias_for(&name) {
                         if let Some(alias) = self.aliases.get(&name as &str) {
                             if is_command_name
                                 || alias.0.global
@@ -736,7 +736,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.line.number.get(), 1);
+            assert_eq!(location.code.number.get(), 1);
             assert_eq!(location.column.get(), 1);
         })
     }
@@ -764,7 +764,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.line.number.get(), 2);
+            assert_eq!(location.code.number.get(), 2);
             assert_eq!(location.column.get(), 1);
         })
     }

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -737,7 +737,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         })
     }
 
@@ -765,7 +765,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 2);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         })
     }
 

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -736,7 +736,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.column.get(), 1);
         })
     }
@@ -764,7 +764,7 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.column.get(), 1);
         })
     }

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -764,8 +764,8 @@ mod tests {
             assert!(parser.take_read_here_docs().is_empty());
 
             let location = lexer.location().await.unwrap();
-            assert_eq!(location.code.start_line_number.get(), 2);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.code.start_line_number.get(), 1);
+            assert_eq!(location.index, 4);
         })
     }
 

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -737,7 +737,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         })
     }
 
@@ -765,7 +765,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 2);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         })
     }
 

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -458,7 +458,7 @@ impl<'a> From<&'a Error> for Message<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source::Line;
+    use crate::source::Code;
     use crate::source::Source;
     use std::num::NonZeroU64;
     use std::rc::Rc;
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn display_for_error() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -430,7 +430,7 @@ impl<'a> From<&'a Error> for Message<'a> {
             location: e.location.clone(),
         }];
 
-        e.location.line.source.complement_annotations(&mut a);
+        e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
             a.push(Annotation {
@@ -466,13 +466,13 @@ mod tests {
     #[test]
     fn display_for_error() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let error = Error {
@@ -488,13 +488,13 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number,
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: number,
         };
         let error = Error {

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -473,7 +473,7 @@ mod tests {
         });
         let location = Location {
             code,
-            column: number,
+            index: number,
         };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),
@@ -495,7 +495,7 @@ mod tests {
         });
         let location = Location {
             code,
-            column: number,
+            index: number,
         };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -427,7 +427,7 @@ impl<'a> From<&'a Error> for Message<'a> {
         let mut a = vec![Annotation {
             r#type: AnnotationType::Error,
             label: e.cause.label().into(),
-            location: e.location.clone(),
+            location: &e.location,
         }];
 
         e.location.code.source.complement_annotations(&mut a);
@@ -436,14 +436,14 @@ impl<'a> From<&'a Error> for Message<'a> {
             a.push(Annotation {
                 r#type: AnnotationType::Info,
                 label: label.into(),
-                location: location.clone(),
+                location,
             });
         }
         if let ErrorCause::Syntax(SyntaxError::BangAfterBar) = &e.cause {
             a.push(Annotation {
                 r#type: AnnotationType::Help,
                 label: "surround this in a grouping: `{ ! ...; }`".into(),
-                location: e.location.clone(),
+                location: &e.location,
             })
         }
 
@@ -510,6 +510,6 @@ mod tests {
         assert_eq!(message.annotations.len(), 1);
         assert_eq!(message.annotations[0].r#type, AnnotationType::Error);
         assert_eq!(message.annotations[0].label, "expected a delimiter word");
-        assert_eq!(message.annotations[0].location, error.location);
+        assert_eq!(message.annotations[0].location, &error.location);
     }
 }

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -468,7 +468,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {
@@ -490,7 +490,7 @@ mod tests {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string(),
-            number,
+            start_line_number: number,
             source: Source::Unknown,
         });
         let location = Location {

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -424,27 +424,27 @@ impl fmt::Display for Error {
 
 impl<'a> From<&'a Error> for Message<'a> {
     fn from(e: &'a Error) -> Self {
-        let mut a = vec![Annotation {
-            r#type: AnnotationType::Error,
-            label: e.cause.label().into(),
-            location: &e.location,
-        }];
+        let mut a = vec![Annotation::new(
+            AnnotationType::Error,
+            e.cause.label().into(),
+            &e.location,
+        )];
 
         e.location.code.source.complement_annotations(&mut a);
 
         if let Some((location, label)) = e.cause.related_location() {
-            a.push(Annotation {
-                r#type: AnnotationType::Info,
-                label: label.into(),
+            a.push(Annotation::new(
+                AnnotationType::Info,
+                label.into(),
                 location,
-            });
+            ));
         }
         if let ErrorCause::Syntax(SyntaxError::BangAfterBar) = &e.cause {
-            a.push(Annotation {
-                r#type: AnnotationType::Help,
-                label: "surround this in a grouping: `{ ! ...; }`".into(),
-                location: &e.location,
-            })
+            a.push(Annotation::new(
+                AnnotationType::Help,
+                "surround this in a grouping: `{ ! ...; }`".into(),
+                &e.location,
+            ));
         }
 
         Message {

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -467,7 +467,7 @@ mod tests {
     fn display_for_error() {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
-            value: "".to_string(),
+            value: "".to_string().into(),
             start_line_number: number,
             source: Source::Unknown,
         });
@@ -489,7 +489,7 @@ mod tests {
     fn from_error_for_message() {
         let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
-            value: "".to_string(),
+            value: "".to_string().into(),
             start_line_number: number,
             source: Source::Unknown,
         });

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -465,16 +465,12 @@ mod tests {
 
     #[test]
     fn display_for_error() {
-        let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string().into(),
-            start_line_number: number,
+            start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location {
-            code,
-            index: number,
-        };
+        let location = Location { code, index: 0 };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),
             location,
@@ -487,16 +483,12 @@ mod tests {
 
     #[test]
     fn from_error_for_message() {
-        let number = NonZeroU64::new(1).unwrap();
         let code = Rc::new(Code {
             value: "".to_string().into(),
-            start_line_number: number,
+            start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location {
-            code,
-            index: number,
-        };
+        let location = Location { code, index: 0 };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),
             location,

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 6);
+        assert_eq!(e.location.index, 5);
     }
 
     #[test]
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "for; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]
@@ -485,12 +485,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "FOR if do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index.get(), 5);
+            assert_eq!(original.index, 4);
             assert_eq!(alias.name, "if");
         });
     }
@@ -507,12 +507,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "for X\n");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 
     #[test]
@@ -542,12 +542,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "for_A_in_a_b if c; do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index.get(), 14);
+            assert_eq!(original.index, 13);
             assert_eq!(alias.name, "if");
         });
     }
@@ -564,11 +564,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " for X; ! do :; done");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " for X; ! do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 9);
+        assert_eq!(e.location.index, 8);
     }
 }

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -423,9 +423,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, " for ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
 
@@ -437,9 +437,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, " for\n");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for\n");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -451,9 +451,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
-        assert_eq!(e.location.line.value, "for; do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "for; do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -482,17 +482,17 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
-        assert_eq!(e.location.line.value, "&");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "&");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
-        if let Source::Alias { original, alias } = &e.location.line.source {
-            assert_eq!(original.line.value, "FOR if do :; done");
-            assert_eq!(original.line.number.get(), 1);
-            assert_eq!(original.line.source, Source::Unknown);
+        if let Source::Alias { original, alias } = &e.location.code.source {
+            assert_eq!(original.code.value, "FOR if do :; done");
+            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 5);
             assert_eq!(alias.name, "if");
         } else {
-            panic!("Not an alias: {:?}", e.location.line.source);
+            panic!("Not an alias: {:?}", e.location.code.source);
         }
     }
 
@@ -504,16 +504,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
-            assert_eq!(opening_location.line.value, "for X\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "for X\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "; do :; done");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "; do :; done");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -542,17 +542,17 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
-        assert_eq!(e.location.line.value, "&");
-        assert_eq!(e.location.line.number.get(), 1);
+        assert_eq!(e.location.code.value, "&");
+        assert_eq!(e.location.code.number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
-        if let Source::Alias { original, alias } = &e.location.line.source {
-            assert_eq!(original.line.value, "for_A_in_a_b if c; do :; done");
-            assert_eq!(original.line.number.get(), 1);
-            assert_eq!(original.line.source, Source::Unknown);
+        if let Source::Alias { original, alias } = &e.location.code.source {
+            assert_eq!(original.code.value, "for_A_in_a_b if c; do :; done");
+            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 14);
             assert_eq!(alias.name, "if");
         } else {
-            panic!("Not an alias: {:?}", e.location.line.source);
+            panic!("Not an alias: {:?}", e.location.code.source);
         }
     }
 
@@ -564,16 +564,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
-            assert_eq!(opening_location.line.value, " for X; ! do :; done");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " for X; ! do :; done");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " for X; ! do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " for X; ! do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 }

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -504,15 +504,15 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_matches!(&e.cause,
             ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "for X\n");
+            assert_eq!(*opening_location.code.value.borrow(), "for X\n; do :; done");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.index, 0);
         });
-        assert_eq!(*e.location.code.value.borrow(), "; do :; done");
-        assert_eq!(e.location.code.start_line_number.get(), 2);
+        assert_eq!(*e.location.code.value.borrow(), "for X\n; do :; done");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 6);
+        assert_eq!(e.location.index.get(), 6);
     }
 
     #[test]
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "for; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -485,12 +485,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "FOR if do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.column.get(), 5);
+            assert_eq!(original.index.get(), 5);
             assert_eq!(alias.name, "if");
         });
     }
@@ -507,12 +507,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "for X\n");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 
     #[test]
@@ -542,12 +542,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "for_A_in_a_b if c; do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.column.get(), 14);
+            assert_eq!(original.index.get(), 14);
             assert_eq!(alias.name, "if");
         });
     }
@@ -564,11 +564,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " for X; ! do :; done");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " for X; ! do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 9);
+        assert_eq!(e.location.index.get(), 9);
     }
 }

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -424,7 +424,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, " for ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 6);
     }
@@ -438,7 +438,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, " for\n");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -452,7 +452,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MissingForName));
         assert_eq!(e.location.code.value, "for; do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -483,11 +483,11 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
         assert_eq!(e.location.code.value, "&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
         if let Source::Alias { original, alias } = &e.location.code.source {
             assert_eq!(original.code.value, "FOR if do :; done");
-            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 5);
             assert_eq!(alias.name, "if");
@@ -505,14 +505,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
             assert_eq!(opening_location.code.value, "for X\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "; do :; done");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -543,11 +543,11 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
         assert_eq!(e.location.code.value, "&");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.column.get(), 1);
         if let Source::Alias { original, alias } = &e.location.code.source {
             assert_eq!(original.code.value, "for_A_in_a_b if c; do :; done");
-            assert_eq!(original.code.number.get(), 1);
+            assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
             assert_eq!(original.column.get(), 14);
             assert_eq!(alias.name, "if");
@@ -565,14 +565,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::MissingForBody { opening_location }) = &e.cause {
             assert_eq!(opening_location.code.value, " for X; ! do :; done");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Not MissingForBody: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " for X; ! do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ) ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "() foo ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -326,6 +326,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "()b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -161,9 +161,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::UnmatchedParenthesis)
         );
-        assert_eq!(e.location.line.value, "( ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -183,9 +183,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingFunctionBody)
         );
-        assert_eq!(e.location.line.value, "( ) ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( ) ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -205,9 +205,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.line.value, "() foo ; ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "() foo ; ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -326,9 +326,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.line.value, "()b");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "()b");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -100,6 +100,7 @@ mod tests {
     use crate::alias::{AliasSet, HashEntry};
     use crate::source::Location;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -161,7 +162,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::UnmatchedParenthesis)
         );
-        assert_eq!(e.location.code.value, "( ");
+        assert_eq!(*e.location.code.value.borrow(), "( ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
@@ -183,7 +184,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingFunctionBody)
         );
-        assert_eq!(e.location.code.value, "( ) ");
+        assert_eq!(*e.location.code.value.borrow(), "( ) ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
@@ -205,7 +206,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.code.value, "() foo ; ");
+        assert_eq!(*e.location.code.value.borrow(), "() foo ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
@@ -242,13 +243,11 @@ mod tests {
             parser.short_function_definition(c).await.unwrap()
         });
         let result = result.fill(&mut std::iter::empty()).unwrap();
-        if let Command::Function(f) = result {
+        assert_matches!(result, Command::Function(f) => {
             assert_eq!(f.has_keyword, false);
             assert_eq!(f.name.to_string(), "f");
             assert_eq!(f.body.to_string(), "(:)");
-        } else {
-            panic!("Not a function definition: {:?}", result);
-        }
+        });
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, EndOfInput);
@@ -285,13 +284,11 @@ mod tests {
             parser.short_function_definition(c).await.unwrap()
         });
         let result = result.fill(&mut std::iter::empty()).unwrap();
-        if let Command::Function(f) = result {
+        assert_matches!(result, Command::Function(f) => {
             assert_eq!(f.has_keyword, false);
             assert_eq!(f.name.to_string(), "f");
             assert_eq!(f.body.to_string(), "(:)");
-        } else {
-            panic!("Not a function definition: {:?}", result);
-        }
+        });
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, EndOfInput);
@@ -326,7 +323,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
-        assert_eq!(e.location.code.value, "()b");
+        assert_eq!(*e.location.code.value.borrow(), "()b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ) ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "() foo ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]
@@ -326,6 +326,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "()b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -162,7 +162,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::UnmatchedParenthesis)
         );
         assert_eq!(e.location.code.value, "( ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -184,7 +184,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingFunctionBody)
         );
         assert_eq!(e.location.code.value, "( ) ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -206,7 +206,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
         assert_eq!(e.location.code.value, "() foo ; ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -327,7 +327,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::InvalidFunctionBody)
         );
         assert_eq!(e.location.code.value, "()b");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -144,12 +144,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " { oh no ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " { oh no ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 10);
+        assert_eq!(e.location.index, 9);
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{ }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 
     #[test]
@@ -242,12 +242,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " ( oh no");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " ( oh no");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 9);
+        assert_eq!(e.location.index, 8);
     }
 
     #[test]
@@ -261,6 +261,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -99,6 +99,7 @@ mod tests {
     use crate::alias::{AliasSet, HashEntry};
     use crate::source::Location;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -138,15 +139,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, " { oh no ");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), " { oh no ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
-        } else {
-            panic!("Wrong error cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, " { oh no ");
+        });
+        assert_eq!(*e.location.code.value.borrow(), " { oh no ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 10);
@@ -160,7 +160,7 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyGrouping));
-        assert_eq!(e.location.code.value, "{ }");
+        assert_eq!(*e.location.code.value.borrow(), "{ }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
@@ -237,15 +237,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, " ( oh no");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), " ( oh no");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
-        } else {
-            panic!("Wrong error cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, " ( oh no");
+        });
+        assert_eq!(*e.location.code.value.borrow(), " ( oh no");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
@@ -259,7 +258,7 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptySubshell));
-        assert_eq!(e.location.code.value, "( )");
+        assert_eq!(*e.location.code.value.borrow(), "( )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -140,14 +140,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " { oh no ");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " { oh no ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 10);
     }
@@ -161,7 +161,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyGrouping));
         assert_eq!(e.location.code.value, "{ }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -239,14 +239,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, " ( oh no");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, " ( oh no");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
@@ -260,7 +260,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptySubshell));
         assert_eq!(e.location.code.value, "( )");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -139,16 +139,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedGrouping { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " { oh no ");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " { oh no ");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " { oh no ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " { oh no ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 10);
     }
 
@@ -160,9 +160,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyGrouping));
-        assert_eq!(e.location.line.value, "{ }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{ }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -238,16 +238,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSubshell { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, " ( oh no");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, " ( oh no");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, " ( oh no");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " ( oh no");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 
@@ -259,9 +259,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptySubshell));
-        assert_eq!(e.location.line.value, "( )");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( )");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -144,12 +144,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " { oh no ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " { oh no ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 10);
+        assert_eq!(e.location.index.get(), 10);
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{ }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 
     #[test]
@@ -242,12 +242,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " ( oh no");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " ( oh no");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 9);
+        assert_eq!(e.location.index.get(), 9);
     }
 
     #[test]
@@ -261,6 +261,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -298,12 +298,12 @@ mod tests {
             assert_eq!(*if_location.code.value.borrow(), " if :; fi");
             assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
-            assert_eq!(if_location.index.get(), 2);
+            assert_eq!(if_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), " if :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 8);
+        assert_eq!(e.location.index, 7);
     }
 
     #[test]
@@ -318,12 +318,12 @@ mod tests {
             assert_eq!(*elif_location.code.value.borrow(), "if a; then b; elif c; fi");
             assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
-            assert_eq!(elif_location.index.get(), 15);
+            assert_eq!(elif_location.index, 14);
         });
         assert_eq!(*e.location.code.value.borrow(), "if a; then b; elif c; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 23);
+        assert_eq!(e.location.index, 22);
     }
 
     #[test]
@@ -338,12 +338,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "  if :; then :; }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 3);
+            assert_eq!(opening_location.index, 2);
         });
         assert_eq!(*e.location.code.value.borrow(), "  if :; then :; }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 17);
+        assert_eq!(e.location.index, 16);
     }
 
     #[test]
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "   if then :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 12);
+        assert_eq!(e.location.index, 11);
     }
 
     #[test]
@@ -388,7 +388,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 20);
+        assert_eq!(e.location.index, 19);
     }
 
     #[test]
@@ -405,7 +405,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 28);
+        assert_eq!(e.location.index, 27);
     }
 
     #[test]
@@ -419,6 +419,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then :; else fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 20);
+        assert_eq!(e.location.index, 19);
     }
 }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -295,14 +295,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) = e.cause {
             assert_eq!(if_location.code.value, " if :; fi");
-            assert_eq!(if_location.code.number.get(), 1);
+            assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
             assert_eq!(if_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, " if :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -316,14 +316,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) = e.cause {
             assert_eq!(elif_location.code.value, "if a; then b; elif c; fi");
-            assert_eq!(elif_location.code.number.get(), 1);
+            assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
             assert_eq!(elif_location.column.get(), 15);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, "if a; then b; elif c; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 23);
     }
@@ -337,14 +337,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "  if :; then :; }");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 3);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
         assert_eq!(e.location.code.value, "  if :; then :; }");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 17);
     }
@@ -358,7 +358,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfCondition));
         assert_eq!(e.location.code.value, "   if then :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -372,7 +372,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfBody));
         assert_eq!(e.location.code.value, "if :; then fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 12);
     }
@@ -386,7 +386,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifCondition));
         assert_eq!(e.location.code.value, "if :; then :; elif then :; fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
@@ -400,7 +400,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifBody));
         assert_eq!(e.location.code.value, "if :; then :; elif :; then fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 28);
     }
@@ -414,7 +414,7 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElse));
         assert_eq!(e.location.code.value, "if :; then :; else fi");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -142,6 +142,7 @@ mod tests {
     use super::super::lex::TokenId::EndOfInput;
     use super::*;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -293,15 +294,13 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) = e.cause {
-            assert_eq!(if_location.code.value, " if :; fi");
+        assert_matches!(e.cause, ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) => {
+            assert_eq!(*if_location.code.value.borrow(), " if :; fi");
             assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
             assert_eq!(if_location.column.get(), 2);
-        } else {
-            panic!("Wrong error cause: {:?}", e);
-        }
-        assert_eq!(e.location.code.value, " if :; fi");
+        });
+        assert_eq!(*e.location.code.value.borrow(), " if :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
@@ -314,15 +313,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) = e.cause {
-            assert_eq!(elif_location.code.value, "if a; then b; elif c; fi");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) => {
+            assert_eq!(*elif_location.code.value.borrow(), "if a; then b; elif c; fi");
             assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
             assert_eq!(elif_location.column.get(), 15);
-        } else {
-            panic!("Wrong error cause: {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "if a; then b; elif c; fi");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "if a; then b; elif c; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 23);
@@ -335,15 +333,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "  if :; then :; }");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "  if :; then :; }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 3);
-        } else {
-            panic!("Wrong error cause: {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "  if :; then :; }");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "  if :; then :; }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 17);
@@ -357,7 +354,7 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfCondition));
-        assert_eq!(e.location.code.value, "   if then :; fi");
+        assert_eq!(*e.location.code.value.borrow(), "   if then :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
@@ -371,7 +368,7 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfBody));
-        assert_eq!(e.location.code.value, "if :; then fi");
+        assert_eq!(*e.location.code.value.borrow(), "if :; then fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 12);
@@ -385,7 +382,10 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifCondition));
-        assert_eq!(e.location.code.value, "if :; then :; elif then :; fi");
+        assert_eq!(
+            *e.location.code.value.borrow(),
+            "if :; then :; elif then :; fi"
+        );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
@@ -399,7 +399,10 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifBody));
-        assert_eq!(e.location.code.value, "if :; then :; elif :; then fi");
+        assert_eq!(
+            *e.location.code.value.borrow(),
+            "if :; then :; elif :; then fi"
+        );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 28);
@@ -413,7 +416,7 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElse));
-        assert_eq!(e.location.code.value, "if :; then :; else fi");
+        assert_eq!(*e.location.code.value.borrow(), "if :; then :; else fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -294,16 +294,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::IfMissingThen { if_location }) = e.cause {
-            assert_eq!(if_location.line.value, " if :; fi");
-            assert_eq!(if_location.line.number.get(), 1);
-            assert_eq!(if_location.line.source, Source::Unknown);
+            assert_eq!(if_location.code.value, " if :; fi");
+            assert_eq!(if_location.code.number.get(), 1);
+            assert_eq!(if_location.code.source, Source::Unknown);
             assert_eq!(if_location.column.get(), 2);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, " if :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " if :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -315,16 +315,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::ElifMissingThen { elif_location }) = e.cause {
-            assert_eq!(elif_location.line.value, "if a; then b; elif c; fi");
-            assert_eq!(elif_location.line.number.get(), 1);
-            assert_eq!(elif_location.line.source, Source::Unknown);
+            assert_eq!(elif_location.code.value, "if a; then b; elif c; fi");
+            assert_eq!(elif_location.code.number.get(), 1);
+            assert_eq!(elif_location.code.source, Source::Unknown);
             assert_eq!(elif_location.column.get(), 15);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, "if a; then b; elif c; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if a; then b; elif c; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 23);
     }
 
@@ -336,16 +336,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedIf { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "  if :; then :; }");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "  if :; then :; }");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 3);
         } else {
             panic!("Wrong error cause: {:?}", e);
         }
-        assert_eq!(e.location.line.value, "  if :; then :; }");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  if :; then :; }");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 17);
     }
 
@@ -357,9 +357,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfCondition));
-        assert_eq!(e.location.line.value, "   if then :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "   if then :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -371,9 +371,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyIfBody));
-        assert_eq!(e.location.line.value, "if :; then fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 12);
     }
 
@@ -385,9 +385,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifCondition));
-        assert_eq!(e.location.line.value, "if :; then :; elif then :; fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; elif then :; fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
 
@@ -399,9 +399,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElifBody));
-        assert_eq!(e.location.line.value, "if :; then :; elif :; then fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; elif :; then fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 28);
     }
 
@@ -413,9 +413,9 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyElse));
-        assert_eq!(e.location.line.value, "if :; then :; else fi");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "if :; then :; else fi");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 20);
     }
 }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -298,12 +298,12 @@ mod tests {
             assert_eq!(*if_location.code.value.borrow(), " if :; fi");
             assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
-            assert_eq!(if_location.column.get(), 2);
+            assert_eq!(if_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), " if :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 8);
+        assert_eq!(e.location.index.get(), 8);
     }
 
     #[test]
@@ -318,12 +318,12 @@ mod tests {
             assert_eq!(*elif_location.code.value.borrow(), "if a; then b; elif c; fi");
             assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
-            assert_eq!(elif_location.column.get(), 15);
+            assert_eq!(elif_location.index.get(), 15);
         });
         assert_eq!(*e.location.code.value.borrow(), "if a; then b; elif c; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 23);
+        assert_eq!(e.location.index.get(), 23);
     }
 
     #[test]
@@ -338,12 +338,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "  if :; then :; }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 3);
+            assert_eq!(opening_location.index.get(), 3);
         });
         assert_eq!(*e.location.code.value.borrow(), "  if :; then :; }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 17);
+        assert_eq!(e.location.index.get(), 17);
     }
 
     #[test]
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "   if then :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 12);
+        assert_eq!(e.location.index.get(), 12);
     }
 
     #[test]
@@ -388,7 +388,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 20);
+        assert_eq!(e.location.index.get(), 20);
     }
 
     #[test]
@@ -405,7 +405,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 28);
+        assert_eq!(e.location.index.get(), 28);
     }
 
     #[test]
@@ -419,6 +419,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then :; else fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 20);
+        assert_eq!(e.location.index.get(), 20);
     }
 }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -98,6 +98,7 @@ mod tests {
     use crate::source::Source;
     use crate::syntax::Backslashed;
     use crate::syntax::Literal;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -108,15 +109,13 @@ mod tests {
         let result = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap();
-        if let TextUnit::Arith { content, location } = result {
+        assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(content.0, []);
-            assert_eq!(location.code.value, "X");
+            assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not an arithmetic expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
@@ -129,7 +128,7 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.code.value, "Y");
+        assert_eq!(*location.code.value.borrow(), "Y");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
@@ -145,15 +144,13 @@ mod tests {
         let result = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap();
-        if let TextUnit::Arith { content, location } = result {
+        assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(content.0, []);
-            assert_eq!(location.code.value, "X");
+            assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not an arithmetic expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
@@ -166,7 +163,7 @@ mod tests {
         let result = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap();
-        if let TextUnit::Arith { content, location } = result {
+        assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(
                 content.0,
                 [
@@ -177,13 +174,11 @@ mod tests {
                     Backslashed('$')
                 ]
             );
-            assert_eq!(location.code.value, "X");
+            assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not an arithmetic expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
@@ -194,15 +189,14 @@ mod tests {
         let location = Location::dummy("Z");
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "Z");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("unexpected error cause {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "((1");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "((1");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
@@ -214,15 +208,14 @@ mod tests {
         let location = Location::dummy("Z");
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "Z");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("unexpected error cause {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "((1)");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "((1)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
@@ -236,7 +229,7 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.code.value, "Z");
+        assert_eq!(*location.code.value.borrow(), "Z");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -110,9 +110,9 @@ mod tests {
             .unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -129,9 +129,9 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.line.value, "Y");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "Y");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
@@ -147,9 +147,9 @@ mod tests {
             .unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -177,9 +177,9 @@ mod tests {
                     Backslashed('$')
                 ]
             );
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not an arithmetic expansion: {:?}", result);
@@ -195,16 +195,16 @@ mod tests {
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "((1");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "((1");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -215,16 +215,16 @@ mod tests {
 
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "((1)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "((1)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -236,9 +236,9 @@ mod tests {
         let location = block_on(lexer.arithmetic_expansion(location))
             .unwrap()
             .unwrap_err();
-        assert_eq!(location.line.value, "Z");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "Z");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(lexer.index(), 0);

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -111,7 +111,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -130,7 +130,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(location.code.value, "Y");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
@@ -148,7 +148,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content.0, []);
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -178,7 +178,7 @@ mod tests {
                 ]
             );
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -196,14 +196,14 @@ mod tests {
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "((1");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -216,14 +216,14 @@ mod tests {
         let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "((1)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -237,7 +237,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(location.code.value, "Z");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -114,7 +114,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -131,7 +131,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Y");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
     }
@@ -149,7 +149,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -177,7 +177,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -194,12 +194,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]
@@ -213,12 +213,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Z");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
 
         assert_eq!(lexer.index(), 0);
     }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -114,7 +114,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -131,7 +131,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Y");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
     }
@@ -149,7 +149,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -177,7 +177,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -194,12 +194,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -213,12 +213,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Z");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
 
         assert_eq!(lexer.index(), 0);
     }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -110,7 +110,7 @@ mod tests {
         let result = block_on(lexer.backquote()).unwrap().unwrap();
         assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(content, []);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -134,7 +134,7 @@ mod tests {
                     BackquoteUnit::Literal('o')
                 ]
             );
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -163,7 +163,7 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -177,7 +177,7 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.backquote()).unwrap().unwrap();
-        if let TextUnit::Backquote { content, location } = result {
+        assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(
                 content,
                 [
@@ -193,10 +193,8 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.index.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+            assert_eq!(location.index, 0);
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -209,15 +207,13 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.backquote()).unwrap().unwrap();
-        if let TextUnit::Backquote { content, location } = result {
+        assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(
                 content,
                 [BackquoteUnit::Literal('a'), BackquoteUnit::Literal('b')]
             );
-            assert_eq!(location.index.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+            assert_eq!(location.index, 0);
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -235,12 +231,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "`");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -255,11 +251,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`foo");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "`foo");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -236,16 +236,16 @@ mod tests {
         };
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "`");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "`");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "`");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "`");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -258,16 +258,16 @@ mod tests {
         };
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "`foo");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "`foo");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "`foo");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "`foo");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -110,7 +110,7 @@ mod tests {
         let result = block_on(lexer.backquote()).unwrap().unwrap();
         assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(content, []);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -134,7 +134,7 @@ mod tests {
                     BackquoteUnit::Literal('o')
                 ]
             );
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -163,7 +163,7 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -193,7 +193,7 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         } else {
             panic!("Not a backquote: {:?}", result);
         }
@@ -214,7 +214,7 @@ mod tests {
                 content,
                 [BackquoteUnit::Literal('a'), BackquoteUnit::Literal('b')]
             );
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         } else {
             panic!("Not a backquote: {:?}", result);
         }
@@ -235,12 +235,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "`");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -255,11 +255,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`foo");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "`foo");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -86,6 +86,7 @@ mod tests {
     use crate::parser::error::ErrorCause;
     use crate::parser::lex::Lexer;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -107,12 +108,10 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.backquote()).unwrap().unwrap();
-        if let TextUnit::Backquote { content, location } = result {
+        assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(content, []);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -125,7 +124,7 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.backquote()).unwrap().unwrap();
-        if let TextUnit::Backquote { content, location } = result {
+        assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(
                 content,
                 [
@@ -136,9 +135,7 @@ mod tests {
                 ]
             );
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -151,7 +148,7 @@ mod tests {
             context: WordContext::Text,
         };
         let result = block_on(lexer.backquote()).unwrap().unwrap();
-        if let TextUnit::Backquote { content, location } = result {
+        assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(
                 content,
                 [
@@ -167,9 +164,7 @@ mod tests {
                 ]
             );
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -235,15 +230,14 @@ mod tests {
             context: WordContext::Word,
         };
         let e = block_on(lexer.backquote()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "`");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "`");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("unexpected error cause {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "`");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "`");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
@@ -257,15 +251,13 @@ mod tests {
             context: WordContext::Word,
         };
         let e = block_on(lexer.backquote()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "`foo");
+        assert_matches!(e.cause, ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "`foo");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("unexpected error cause {:?}", e);
-        }
-        assert_eq!(e.location.code.value, "`foo");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "`foo");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -237,14 +237,14 @@ mod tests {
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "`");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "`");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -259,14 +259,14 @@ mod tests {
         let e = block_on(lexer.backquote()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedBackquote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "`foo");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "`foo");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "$");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
     }
 
     #[test]
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{};");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{_;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
         assert_eq!(*e.location.code.value.borrow(), "{#x+};");
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -167,7 +167,7 @@ mod tests {
 
     fn assert_opening_location(location: &Location) {
         assert_eq!(location.code.value, "$");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
     }
@@ -256,7 +256,7 @@ mod tests {
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
         assert_eq!(e.location.code.value, "{};");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -277,7 +277,7 @@ mod tests {
             panic!("Unexpected cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "{;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -298,7 +298,7 @@ mod tests {
             panic!("Unexpected cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "{_;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -163,10 +163,11 @@ mod tests {
     use crate::syntax::SwitchType;
     use crate::syntax::TrimLength;
     use crate::syntax::TrimSide;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     fn assert_opening_location(location: &Location) {
-        assert_eq!(location.code.value, "$");
+        assert_eq!(*location.code.value.borrow(), "$");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
@@ -255,7 +256,7 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
-        assert_eq!(e.location.code.value, "{};");
+        assert_eq!(*e.location.code.value.borrow(), "{};");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
@@ -271,12 +272,11 @@ mod tests {
         let location = Location::dummy("$");
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) = e.cause {
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
             assert_opening_location(&opening_location);
-        } else {
-            panic!("Unexpected cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "{;");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "{;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
@@ -292,12 +292,11 @@ mod tests {
         let location = Location::dummy("$");
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) = e.cause {
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
             assert_opening_location(&opening_location);
-        } else {
-            panic!("Unexpected cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "{_;");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "{_;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
@@ -386,13 +385,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "x");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -410,13 +407,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "foo");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.to_string(), "'!'");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -434,13 +429,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -458,13 +451,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "-");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -482,13 +473,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -506,13 +495,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -530,13 +517,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Switch(switch) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.to_string(), "");
-        } else {
-            panic!("Not a switch: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -554,13 +539,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Trim(trim) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Longest);
             assert_eq!(trim.pattern.to_string(), "");
-        } else {
-            panic!("Not a modifier: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -578,13 +561,11 @@ mod tests {
 
         let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
         assert_eq!(result.name, "#");
-        if let Modifier::Trim(trim) = result.modifier {
+        assert_matches!(result.modifier, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Suffix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.to_string(), "");
-        } else {
-            panic!("Not a modifier: {:?}", result.modifier);
-        }
+        });
         // TODO assert about other result members
         assert_opening_location(&result.location);
 
@@ -602,7 +583,7 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
-        assert_eq!(e.location.code.value, "{#x+};");
+        assert_eq!(*e.location.code.value.borrow(), "{#x+};");
         assert_eq!(e.location.column.get(), 4);
     }
 

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "$");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
     }
 
     #[test]
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{};");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{_;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
         assert_eq!(*e.location.code.value.borrow(), "{#x+};");
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -166,9 +166,9 @@ mod tests {
     use futures_executor::block_on;
 
     fn assert_opening_location(location: &Location) {
-        assert_eq!(location.line.value, "$");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "$");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -255,9 +255,9 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
-        assert_eq!(e.location.line.value, "{};");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{};");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -276,9 +276,9 @@ mod tests {
         } else {
             panic!("Unexpected cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "{;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -297,9 +297,9 @@ mod tests {
         } else {
             panic!("Unexpected cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "{_;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "{_;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -602,7 +602,7 @@ mod tests {
 
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
-        assert_eq!(e.location.line.value, "{#x+};");
+        assert_eq!(e.location.code.value, "{#x+};");
         assert_eq!(e.location.column.get(), 4);
     }
 

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -75,7 +75,7 @@ mod tests {
             .unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "X");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
@@ -85,7 +85,7 @@ mod tests {
 
         let next = block_on(lexer.location()).unwrap();
         assert_eq!(next.code.value, "( foo bar )baz");
-        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 12);
     }
@@ -100,7 +100,7 @@ mod tests {
 
         let next = block_on(lexer.location()).unwrap();
         assert_eq!(next.code.value, " foo bar )baz");
-        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 1);
     }
@@ -115,14 +115,14 @@ mod tests {
             e.cause
         {
             assert_eq!(opening_location.code.value, "Z");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "( foo bar baz");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -78,7 +78,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
             assert_eq!(content, " foo bar ");
         });
 
@@ -86,7 +86,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), "( foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.column.get(), 12);
+        assert_eq!(next.index.get(), 12);
     }
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), " foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.column.get(), 1);
+        assert_eq!(next.index.get(), 1);
     }
 
     #[test]
@@ -115,11 +115,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "( foo bar baz");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 14);
+        assert_eq!(e.location.index.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -74,9 +74,9 @@ mod tests {
             .unwrap()
             .unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "X");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "X");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
         } else {
@@ -84,9 +84,9 @@ mod tests {
         }
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(next.line.value, "( foo bar )baz");
-        assert_eq!(next.line.number.get(), 1);
-        assert_eq!(next.line.source, Source::Unknown);
+        assert_eq!(next.code.value, "( foo bar )baz");
+        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 12);
     }
 
@@ -99,9 +99,9 @@ mod tests {
         assert_eq!(result, None);
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(next.line.value, " foo bar )baz");
-        assert_eq!(next.line.number.get(), 1);
-        assert_eq!(next.line.source, Source::Unknown);
+        assert_eq!(next.code.value, " foo bar )baz");
+        assert_eq!(next.code.number.get(), 1);
+        assert_eq!(next.code.source, Source::Unknown);
         assert_eq!(next.column.get(), 1);
     }
 
@@ -114,16 +114,16 @@ mod tests {
         if let ErrorCause::Syntax(SyntaxError::UnclosedCommandSubstitution { opening_location }) =
             e.cause
         {
-            assert_eq!(opening_location.line.value, "Z");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "Z");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "( foo bar baz");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "( foo bar baz");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 14);
     }
 }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -78,7 +78,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
             assert_eq!(content, " foo bar ");
         });
 
@@ -86,7 +86,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), "( foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.index.get(), 12);
+        assert_eq!(next.index, 11);
     }
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), " foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.index.get(), 1);
+        assert_eq!(next.index, 0);
     }
 
     #[test]
@@ -115,11 +115,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "( foo bar baz");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 14);
+        assert_eq!(e.location.index, 13);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -164,7 +164,7 @@ impl<'a> LexerCore<'a> {
                         } else {
                             // Completely empty source
                             Location {
-                                line: Rc::new(line),
+                                code: Rc::new(line),
                                 column: NonZeroU64::new(1).unwrap(),
                             }
                         };
@@ -280,7 +280,7 @@ impl<'a> LexerCore<'a> {
         fn is_same_alias(alias: &Alias, sc: Option<&SourceChar>) -> bool {
             match sc {
                 None => false,
-                Some(sc) => sc.location.line.source.is_alias_for(&alias.name),
+                Some(sc) => sc.location.code.source.is_alias_for(&alias.name),
             }
         }
 
@@ -291,7 +291,7 @@ impl<'a> LexerCore<'a> {
                 return false;
             }
 
-            if let Source::Alias { ref alias, .. } = sc.location.line.source {
+            if let Source::Alias { ref alias, .. } = sc.location.code.source {
                 #[allow(clippy::collapsible_if)]
                 if ends_with_blank(&alias.replacement) {
                     if !is_same_alias(alias, self.source.get(index + 1)) {
@@ -673,9 +673,9 @@ mod tests {
         let mut lexer = LexerCore::new(Box::new(input));
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
-            assert_eq!(location.line.value, "");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not end-of-input: {:?}", result);
@@ -708,9 +708,9 @@ mod tests {
         } else {
             panic!("expected IoError, but actually {}", e.cause)
         }
-        assert_eq!(e.location.line.value, "line");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "line");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -722,18 +722,18 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
         }
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
@@ -743,9 +743,9 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, '\n');
-            assert_eq!(c.location.line.value, "a\n");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a\n");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         } else {
             panic!("Not a char: {:?}", result);
@@ -755,9 +755,9 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'b');
-            assert_eq!(c.location.line.value, "b");
-            assert_eq!(c.location.line.number.get(), 2);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "b");
+            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
             panic!("Not a char: {:?}", result);
@@ -766,9 +766,9 @@ mod tests {
 
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
-            assert_eq!(location.line.value, "b");
-            assert_eq!(location.line.number.get(), 2);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "b");
+            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
             panic!("Not end-of-input: {:?}", result);
@@ -848,9 +848,9 @@ mod tests {
             let result = lexer.peek_char().await;
             if let Ok(PeekChar::Char(c)) = result {
                 assert_eq!(c.value, 'a');
-                assert_eq!(c.location.line.value, "abc");
-                assert_eq!(c.location.line.number.get(), 1);
-                assert_eq!(c.location.line.source, Source::Unknown);
+                assert_eq!(c.location.code.value, "abc");
+                assert_eq!(c.location.code.number.get(), 1);
+                assert_eq!(c.location.code.source, Source::Unknown);
                 assert_eq!(c.location.column.get(), 1);
             } else {
                 panic!("Not a char: {:?}", result);
@@ -917,20 +917,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'l');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -940,20 +940,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'e');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -963,20 +963,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'x');
-            assert_eq!(c.location.line.value, "lex");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "lex");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, "a b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, "a b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 3);
             lexer.consume_char();
@@ -986,9 +986,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, "a b");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "a b");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
         });
@@ -1018,20 +1018,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'x');
-            assert_eq!(c.location.line.value, "x\n");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "x\n");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -1041,20 +1041,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, '\n');
-            assert_eq!(c.location.line.value, "x\n");
-            assert_eq!(c.location.line.number.get(), 1);
+            assert_eq!(c.location.code.value, "x\n");
+            assert_eq!(c.location.code.number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -1064,20 +1064,20 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, 'y');
-            assert_eq!(c.location.line.value, "y");
-            assert_eq!(c.location.line.number.get(), 2);
+            assert_eq!(c.location.code.value, "y");
+            assert_eq!(c.location.code.number.get(), 2);
             if let Source::Alias {
                 original,
                 alias: alias2,
-            } = &c.location.line.source
+            } = &c.location.code.source
             {
-                assert_eq!(original.line.value, " foo b");
-                assert_eq!(original.line.number.get(), 1);
-                assert_eq!(original.line.source, Source::Unknown);
+                assert_eq!(original.code.value, " foo b");
+                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
             } else {
-                panic!("Wrong source: {:?}", c.location.line.source);
+                panic!("Wrong source: {:?}", c.location.code.source);
             }
             assert_eq!(c.location.column.get(), 1);
             lexer.consume_char();
@@ -1087,9 +1087,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, " foo b");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, " foo b");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 5);
             lexer.consume_char();
         });
@@ -1117,9 +1117,9 @@ mod tests {
                 other => panic!("Not a char: {:?}", other),
             };
             assert_eq!(c.value, ' ');
-            assert_eq!(c.location.line.value, "x ");
-            assert_eq!(c.location.line.number.get(), 1);
-            assert_eq!(c.location.line.source, Source::Unknown);
+            assert_eq!(c.location.code.value, "x ");
+            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         });
     }
@@ -1229,9 +1229,9 @@ mod tests {
         .unwrap();
         assert_eq!(called, 1);
         assert_eq!(c.value, 'w');
-        assert_eq!(c.location.line.value, "word\n");
-        assert_eq!(c.location.line.number.get(), 1);
-        assert_eq!(c.location.line.source, Source::Unknown);
+        assert_eq!(c.location.code.value, "word\n");
+        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 1);
 
         let mut called = 0;
@@ -1262,9 +1262,9 @@ mod tests {
         .unwrap();
         assert_eq!(called, 1);
         assert_eq!(c.value, 'o');
-        assert_eq!(c.location.line.value, "word\n");
-        assert_eq!(c.location.line.number.get(), 1);
-        assert_eq!(c.location.line.source, Source::Unknown);
+        assert_eq!(c.location.code.value, "word\n");
+        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 2);
 
         block_on(lexer.consume_char_if(|c| {
@@ -1308,9 +1308,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<< )");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<< )");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -24,6 +24,7 @@ use crate::input::Input;
 use crate::input::Memory;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
+use crate::source::source_chars;
 use crate::source::Code;
 use crate::source::Location;
 use crate::source::Source;
@@ -172,13 +173,7 @@ impl<'a> LexerCore<'a> {
                         // Successful read
                         self.raw_code.value.borrow_mut().push_str(&line);
                         self.source
-                            .extend(line.chars().enumerate().map(|(i, value)| SourceChar {
-                                value,
-                                location: Location {
-                                    code: Rc::clone(&self.raw_code),
-                                    index: self.index + i,
-                                },
-                            }))
+                            .extend(source_chars(&line, &self.raw_code, self.index));
                     }
                 }
                 Err(io_error) => {
@@ -303,17 +298,7 @@ impl<'a> LexerCore<'a> {
             start_line_number: NonZeroU64::new(1).unwrap(),
             source,
         });
-        let repl = alias
-            .replacement
-            .chars()
-            .enumerate()
-            .map(|(index, value)| SourceChar {
-                value,
-                location: Location {
-                    code: Rc::clone(&code),
-                    index,
-                },
-            });
+        let repl = source_chars(&alias.replacement, &code, 0);
 
         self.source.splice(begin..end, repl);
         self.index = begin;

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -165,7 +165,7 @@ impl<'a> LexerCore<'a> {
                             // Completely empty source
                             Location {
                                 code: Rc::new(line),
-                                column: NonZeroU64::new(1).unwrap(),
+                                index: NonZeroU64::new(1).unwrap(),
                             }
                         };
                         self.state = InputState::EndOfInput(location);
@@ -677,7 +677,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
     }
 
@@ -708,7 +708,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "line");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 
     #[test]
@@ -722,14 +722,14 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.column.get(), 1);
+            assert_eq!(c.location.index.get(), 1);
         });
         assert_matches!(result, Ok(PeekChar::Char(c)) => {
             assert_eq!(c.value, 'a');
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.column.get(), 1);
+            assert_eq!(c.location.index.get(), 1);
         });
         lexer.consume_char();
 
@@ -739,7 +739,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.column.get(), 2);
+            assert_eq!(c.location.index.get(), 2);
         });
         lexer.consume_char();
 
@@ -749,7 +749,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "b");
             assert_eq!(c.location.code.start_line_number.get(), 2);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.column.get(), 1);
+            assert_eq!(c.location.index.get(), 1);
         });
         lexer.consume_char();
 
@@ -758,7 +758,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "b");
             assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 2);
+            assert_eq!(location.index.get(), 2);
         });
     }
 
@@ -829,7 +829,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "abc");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.column.get(), 1);
+                assert_eq!(c.location.index.get(), 1);
             });
         });
     }
@@ -897,10 +897,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 1);
+                    assert_eq!(original.index.get(), 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 1);
+                assert_eq!(c.location.index.get(), 1);
             });
             lexer.consume_char();
 
@@ -913,10 +913,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 1);
+                    assert_eq!(original.index.get(), 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 2);
+                assert_eq!(c.location.index.get(), 2);
             });
             lexer.consume_char();
 
@@ -929,10 +929,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 1);
+                    assert_eq!(original.index.get(), 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 3);
+                assert_eq!(c.location.index.get(), 3);
             });
             lexer.consume_char();
 
@@ -941,7 +941,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "a b");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.column.get(), 2);
+                assert_eq!(c.location.index.get(), 2);
             });
             lexer.consume_char();
         });
@@ -975,10 +975,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 2);
+                    assert_eq!(original.index.get(), 2);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 1);
+                assert_eq!(c.location.index.get(), 1);
             });
             lexer.consume_char();
 
@@ -991,10 +991,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 2);
+                    assert_eq!(original.index.get(), 2);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 2);
+                assert_eq!(c.location.index.get(), 2);
             });
             lexer.consume_char();
 
@@ -1006,10 +1006,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.column.get(), 2);
+                    assert_eq!(original.index.get(), 2);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.column.get(), 1);
+                assert_eq!(c.location.index.get(), 1);
             });
             lexer.consume_char();
 
@@ -1018,7 +1018,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), " foo b");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.column.get(), 5);
+                assert_eq!(c.location.index.get(), 5);
             });
             lexer.consume_char();
         });
@@ -1046,7 +1046,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "x ");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.column.get(), 2);
+                assert_eq!(c.location.index.get(), 2);
             });
         });
     }
@@ -1159,7 +1159,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.column.get(), 1);
+        assert_eq!(c.location.index.get(), 1);
 
         let mut called = 0;
         let r = block_on(lexer.consume_char_if(|c| {
@@ -1192,7 +1192,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.column.get(), 2);
+        assert_eq!(c.location.index.get(), 2);
 
         block_on(lexer.consume_char_if(|c| {
             assert_eq!(c, 'r');
@@ -1238,6 +1238,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -390,7 +390,7 @@ impl<'a> Lexer<'a> {
     #[must_use]
     pub fn from_memory(code: &'a str, source: Source) -> Lexer<'a> {
         let line = NonZeroU64::new(1).unwrap();
-        Lexer::new(Box::new(Memory::new(code, source.clone())), line, source)
+        Lexer::new(Box::new(Memory::new(code)), line, source)
     }
 
     /// Disables line continuation recognition onward.
@@ -731,7 +731,7 @@ mod tests {
 
     #[test]
     fn lexer_core_peek_char_empty_source() {
-        let input = Memory::new("", Source::Unknown);
+        let input = Memory::new("");
         let line = NonZeroU64::new(32).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         let result = block_on(lexer.peek_char());
@@ -774,7 +774,7 @@ mod tests {
 
     #[test]
     fn lexer_core_consume_char_success() {
-        let input = Memory::new("a\nb", Source::Unknown);
+        let input = Memory::new("a\nb");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
 
@@ -827,7 +827,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "A character must have been peeked before being consumed: index=0")]
     fn lexer_core_consume_char_panic() {
-        let input = Memory::new("a", Source::Unknown);
+        let input = Memory::new("a");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         lexer.consume_char();
@@ -835,7 +835,7 @@ mod tests {
 
     #[test]
     fn lexer_core_peek_char_at() {
-        let input = Memory::new("a\nb", Source::Unknown);
+        let input = Memory::new("a\nb");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
 
@@ -854,7 +854,7 @@ mod tests {
 
     #[test]
     fn lexer_core_index() {
-        let input = Memory::new("a\nb", Source::Unknown);
+        let input = Memory::new("a\nb");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
 
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn lexer_core_rewind_success() {
-        let input = Memory::new("abc", Source::Unknown);
+        let input = Memory::new("abc");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         lexer.rewind(0);
@@ -903,7 +903,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "The new index 1 must not be larger than the current index 0")]
     fn lexer_core_rewind_invalid_index() {
-        let input = Memory::new("abc", Source::Unknown);
+        let input = Memory::new("abc");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         lexer.rewind(1);
@@ -911,7 +911,7 @@ mod tests {
 
     #[test]
     fn lexer_core_source_string() {
-        let input = Memory::new("ab\ncd", Source::Unknown);
+        let input = Memory::new("ab\ncd");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         block_on(async {
@@ -928,7 +928,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "begin index 0 should be less than end index 0")]
     fn lexer_core_substitute_alias_with_invalid_index() {
-        let input = Memory::new("a b", Source::Unknown);
+        let input = Memory::new("a b");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         let alias = Rc::new(Alias {
@@ -942,7 +942,7 @@ mod tests {
 
     #[test]
     fn lexer_core_substitute_alias_single_line_replacement() {
-        let input = Memory::new("a b", Source::Unknown);
+        let input = Memory::new("a b");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         let alias = Rc::new(Alias {
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn lexer_core_substitute_alias_multi_line_replacement() {
-        let input = Memory::new(" foo b", Source::Unknown);
+        let input = Memory::new(" foo b");
         let line = NonZeroU64::new(1).unwrap();
         let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
         let alias = Rc::new(Alias {
@@ -1098,7 +1098,7 @@ mod tests {
     #[test]
     fn lexer_core_substitute_alias_empty_replacement() {
         block_on(async {
-            let input = Memory::new("x ", Source::Unknown);
+            let input = Memory::new("x ");
             let line = NonZeroU64::new(1).unwrap();
             let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
             let alias = Rc::new(Alias {
@@ -1132,16 +1132,17 @@ mod tests {
             global: false,
             origin: Location::dummy("origin"),
         });
-        let input = Memory::new("a", Source::Alias { original, alias });
+        let source = Source::Alias { original, alias };
+        let input = Memory::new("a");
         let line = NonZeroU64::new(1).unwrap();
-        let lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
+        let lexer = LexerCore::new(Box::new(input), line, source);
         assert!(!lexer.is_after_blank_ending_alias(0));
     }
 
     #[test]
     fn lexer_core_is_after_blank_ending_alias_not_blank_ending() {
         block_on(async {
-            let input = Memory::new("a x", Source::Unknown);
+            let input = Memory::new("a x");
             let line = NonZeroU64::new(1).unwrap();
             let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
             let alias = Rc::new(Alias {
@@ -1166,7 +1167,7 @@ mod tests {
     #[test]
     fn lexer_core_is_after_blank_ending_alias_blank_ending() {
         block_on(async {
-            let input = Memory::new("a x", Source::Unknown);
+            let input = Memory::new("a x");
             let line = NonZeroU64::new(1).unwrap();
             let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
             let alias = Rc::new(Alias {

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -674,7 +674,7 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
             assert_eq!(location.code.value, "");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -709,7 +709,7 @@ mod tests {
             panic!("expected IoError, but actually {}", e.cause)
         }
         assert_eq!(e.location.code.value, "line");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -723,7 +723,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -732,7 +732,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'a');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -744,7 +744,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, '\n');
             assert_eq!(c.location.code.value, "a\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         } else {
@@ -756,7 +756,7 @@ mod tests {
         if let Ok(PeekChar::Char(c)) = result {
             assert_eq!(c.value, 'b');
             assert_eq!(c.location.code.value, "b");
-            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.start_line_number.get(), 2);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 1);
         } else {
@@ -767,7 +767,7 @@ mod tests {
         let result = block_on(lexer.peek_char());
         if let Ok(PeekChar::EndOfInput(location)) = result {
             assert_eq!(location.code.value, "b");
-            assert_eq!(location.code.number.get(), 2);
+            assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
@@ -849,7 +849,7 @@ mod tests {
             if let Ok(PeekChar::Char(c)) = result {
                 assert_eq!(c.value, 'a');
                 assert_eq!(c.location.code.value, "abc");
-                assert_eq!(c.location.code.number.get(), 1);
+                assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
                 assert_eq!(c.location.column.get(), 1);
             } else {
@@ -918,14 +918,14 @@ mod tests {
             };
             assert_eq!(c.value, 'l');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -941,14 +941,14 @@ mod tests {
             };
             assert_eq!(c.value, 'e');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -964,14 +964,14 @@ mod tests {
             };
             assert_eq!(c.value, 'x');
             assert_eq!(c.location.code.value, "lex");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, "a b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 1);
                 assert_eq!(alias2, &alias);
@@ -987,7 +987,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, "a b");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
             lexer.consume_char();
@@ -1019,14 +1019,14 @@ mod tests {
             };
             assert_eq!(c.value, 'x');
             assert_eq!(c.location.code.value, "x\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1042,14 +1042,14 @@ mod tests {
             };
             assert_eq!(c.value, '\n');
             assert_eq!(c.location.code.value, "x\n");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1065,14 +1065,14 @@ mod tests {
             };
             assert_eq!(c.value, 'y');
             assert_eq!(c.location.code.value, "y");
-            assert_eq!(c.location.code.number.get(), 2);
+            assert_eq!(c.location.code.start_line_number.get(), 2);
             if let Source::Alias {
                 original,
                 alias: alias2,
             } = &c.location.code.source
             {
                 assert_eq!(original.code.value, " foo b");
-                assert_eq!(original.code.number.get(), 1);
+                assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
                 assert_eq!(original.column.get(), 2);
                 assert_eq!(alias2, &alias);
@@ -1088,7 +1088,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, " foo b");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 5);
             lexer.consume_char();
@@ -1118,7 +1118,7 @@ mod tests {
             };
             assert_eq!(c.value, ' ');
             assert_eq!(c.location.code.value, "x ");
-            assert_eq!(c.location.code.number.get(), 1);
+            assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
             assert_eq!(c.location.column.get(), 2);
         });
@@ -1230,7 +1230,7 @@ mod tests {
         assert_eq!(called, 1);
         assert_eq!(c.value, 'w');
         assert_eq!(c.location.code.value, "word\n");
-        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 1);
 
@@ -1263,7 +1263,7 @@ mod tests {
         assert_eq!(called, 1);
         assert_eq!(c.value, 'o');
         assert_eq!(c.location.code.value, "word\n");
-        assert_eq!(c.location.code.number.get(), 1);
+        assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
         assert_eq!(c.location.column.get(), 2);
 
@@ -1309,7 +1309,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<< )");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -31,7 +31,6 @@ use crate::source::SourceChar;
 use crate::syntax::Word;
 use std::fmt;
 use std::future::Future;
-use std::num::NonZeroU64;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -165,7 +164,7 @@ impl<'a> LexerCore<'a> {
                             // Completely empty source
                             Location {
                                 code: Rc::new(line),
-                                index: NonZeroU64::new(1).unwrap(),
+                                index: 0,
                             }
                         };
                         self.state = InputState::EndOfInput(location);
@@ -677,7 +676,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
     }
 
@@ -708,7 +707,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "line");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 
     #[test]
@@ -722,14 +721,14 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index.get(), 1);
+            assert_eq!(c.location.index, 0);
         });
         assert_matches!(result, Ok(PeekChar::Char(c)) => {
             assert_eq!(c.value, 'a');
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index.get(), 1);
+            assert_eq!(c.location.index, 0);
         });
         lexer.consume_char();
 
@@ -739,7 +738,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index.get(), 2);
+            assert_eq!(c.location.index, 1);
         });
         lexer.consume_char();
 
@@ -749,7 +748,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "b");
             assert_eq!(c.location.code.start_line_number.get(), 2);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index.get(), 1);
+            assert_eq!(c.location.index, 0);
         });
         lexer.consume_char();
 
@@ -758,7 +757,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "b");
             assert_eq!(location.code.start_line_number.get(), 2);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 2);
+            assert_eq!(location.index, 1);
         });
     }
 
@@ -829,7 +828,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "abc");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index.get(), 1);
+                assert_eq!(c.location.index, 0);
             });
         });
     }
@@ -897,10 +896,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 1);
+                    assert_eq!(original.index, 0);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 1);
+                assert_eq!(c.location.index, 0);
             });
             lexer.consume_char();
 
@@ -913,10 +912,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 1);
+                    assert_eq!(original.index, 0);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 2);
+                assert_eq!(c.location.index, 1);
             });
             lexer.consume_char();
 
@@ -929,10 +928,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 1);
+                    assert_eq!(original.index, 0);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 3);
+                assert_eq!(c.location.index, 2);
             });
             lexer.consume_char();
 
@@ -941,7 +940,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "a b");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index.get(), 2);
+                assert_eq!(c.location.index, 1);
             });
             lexer.consume_char();
         });
@@ -975,10 +974,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 2);
+                    assert_eq!(original.index, 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 1);
+                assert_eq!(c.location.index, 0);
             });
             lexer.consume_char();
 
@@ -991,10 +990,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 2);
+                    assert_eq!(original.index, 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 2);
+                assert_eq!(c.location.index, 1);
             });
             lexer.consume_char();
 
@@ -1006,10 +1005,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number.get(), 1);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index.get(), 2);
+                    assert_eq!(original.index, 1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index.get(), 1);
+                assert_eq!(c.location.index, 0);
             });
             lexer.consume_char();
 
@@ -1018,7 +1017,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), " foo b");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index.get(), 5);
+                assert_eq!(c.location.index, 4);
             });
             lexer.consume_char();
         });
@@ -1046,7 +1045,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "x ");
                 assert_eq!(c.location.code.start_line_number.get(), 1);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index.get(), 2);
+                assert_eq!(c.location.index, 1);
             });
         });
     }
@@ -1159,7 +1158,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.index.get(), 1);
+        assert_eq!(c.location.index, 0);
 
         let mut called = 0;
         let r = block_on(lexer.consume_char_if(|c| {
@@ -1192,7 +1191,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.index.get(), 2);
+        assert_eq!(c.location.index, 1);
 
         block_on(lexer.consume_char_if(|c| {
             assert_eq!(c, 'r');
@@ -1238,6 +1237,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -129,9 +129,9 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "0");
-            assert_eq!(location.line.value, "$0");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$0");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a raw parameter: {:?}", result);
@@ -148,9 +148,9 @@ mod tests {
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "$()");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$()");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, "");
         } else {
@@ -165,9 +165,9 @@ mod tests {
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.line.value, "$( foo bar )");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$( foo bar )");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
         } else {
@@ -186,9 +186,9 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content, Text(vec![Literal('1')]));
-            assert_eq!(location.line.value, "$((1))");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$((1))");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("unexpected result {:?}", result);

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -130,7 +130,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "0");
             assert_eq!(location.code.value, "$0");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -149,7 +149,7 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "$()");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, "");
@@ -166,7 +166,7 @@ mod tests {
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
         if let TextUnit::CommandSubst { location, content } = result {
             assert_eq!(location.code.value, "$( foo bar )");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
@@ -187,7 +187,7 @@ mod tests {
         if let TextUnit::Arith { content, location } = result {
             assert_eq!(content, Text(vec![Literal('1')]));
             assert_eq!(location.code.value, "$((1))");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -69,6 +69,7 @@ mod tests {
     use crate::source::Source;
     use crate::syntax::Literal;
     use crate::syntax::Text;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -127,15 +128,13 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        if let TextUnit::RawParam { name, location } = result {
+        assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "0");
-            assert_eq!(location.code.value, "$0");
+            assert_eq!(*location.code.value.borrow(), "$0");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a raw parameter: {:?}", result);
-        }
+        });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
 
@@ -147,15 +146,13 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.code.value, "$()");
+        assert_matches!(result, TextUnit::CommandSubst { location, content } => {
+            assert_eq!(*location.code.value.borrow(), "$()");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, "");
-        } else {
-            panic!("unexpected result {:?}", result);
-        }
+        });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
 
         let mut lexer = Lexer::from_memory("$( foo bar )", Source::Unknown);
@@ -164,15 +161,13 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        if let TextUnit::CommandSubst { location, content } = result {
-            assert_eq!(location.code.value, "$( foo bar )");
+        assert_matches!(result, TextUnit::CommandSubst { location, content } => {
+            assert_eq!(*location.code.value.borrow(), "$( foo bar )");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
             assert_eq!(content, " foo bar ");
-        } else {
-            panic!("unexpected result {:?}", result);
-        }
+        });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
 
@@ -184,15 +179,13 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        if let TextUnit::Arith { content, location } = result {
+        assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(content, Text(vec![Literal('1')]));
-            assert_eq!(location.code.value, "$((1))");
+            assert_eq!(*location.code.value.borrow(), "$((1))");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("unexpected result {:?}", result);
-        }
+        });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
 
@@ -204,11 +197,9 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        if let TextUnit::RawParam { name, .. } = result {
+        assert_matches!(result, TextUnit::RawParam { name, .. } => {
             assert_eq!(name, "0");
-        } else {
-            panic!("Not a raw parameter: {:?}", result);
-        }
+        });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
 }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -133,7 +133,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$0");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -150,7 +150,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$()");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
             assert_eq!(content, "");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -165,7 +165,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$( foo bar )");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
             assert_eq!(content, " foo bar ");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -184,7 +184,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$((1))");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -133,7 +133,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$0");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -150,7 +150,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$()");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
             assert_eq!(content, "");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -165,7 +165,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$( foo bar )");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
             assert_eq!(content, " foo bar ");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -184,7 +184,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$((1))");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -169,8 +169,9 @@ mod tests {
         assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.start_line_number.get(), 2);
-        assert_eq!(location.index, 0);
+        assert_eq!(*location.code.value.borrow(), "END\nX");
+        assert_eq!(location.code.start_line_number.get(), 1);
+        assert_eq!(location.index, 4);
     }
 
     #[test]
@@ -184,8 +185,9 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "content\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.index, 0);
+        assert_eq!(*location.code.value.borrow(), "content\nFOO\nX");
+        assert_eq!(location.code.start_line_number.get(), 1);
+        assert_eq!(location.index, 12);
     }
 
     #[test]
@@ -199,8 +201,9 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.start_line_number.get(), 6);
-        assert_eq!(location.index, 0);
+        assert_eq!(*location.code.value.borrow(), "foo\n\tBAR\n\nbaz\nBAR\nX");
+        assert_eq!(location.code.start_line_number.get(), 1);
+        assert_eq!(location.index, 18);
     }
 
     #[test]
@@ -279,8 +282,9 @@ END
         assert_eq!(heredoc.content.to_string(), "foo\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.index, 0);
+        assert_eq!(*location.code.value.borrow(), "\t\t\tfoo\n\tBAR\n\n");
+        assert_eq!(location.code.start_line_number.get(), 1);
+        assert_eq!(location.index, 12);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 2);
+        assert_eq!(location.code.start_line_number.get(), 2);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "content\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 3);
+        assert_eq!(location.code.start_line_number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 6);
+        assert_eq!(location.code.start_line_number.get(), 6);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -278,7 +278,7 @@ END
         assert_eq!(heredoc.content.to_string(), "foo\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.code.number.get(), 3);
+        assert_eq!(location.code.start_line_number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -292,14 +292,14 @@ END
             e.cause
         {
             assert_eq!(redir_op_location.code.value, "END");
-            assert_eq!(redir_op_location.code.number.get(), 1);
+            assert_eq!(redir_op_location.code.start_line_number.get(), 1);
             assert_eq!(redir_op_location.code.source, Source::Unknown);
             assert_eq!(redir_op_location.column.get(), 1);
         } else {
             panic!("Not UnclosedHereDocContent: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -170,7 +170,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 2);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
     }
 
     #[test]
@@ -185,7 +185,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 6);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
     }
 
     #[test]
@@ -280,7 +280,7 @@ END
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
     }
 
     #[test]
@@ -294,11 +294,11 @@ END
             assert_eq!(*redir_op_location.code.value.borrow(), "END");
             assert_eq!(redir_op_location.code.start_line_number.get(), 1);
             assert_eq!(redir_op_location.code.source, Source::Unknown);
-            assert_eq!(redir_op_location.index.get(), 1);
+            assert_eq!(redir_op_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -170,7 +170,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 2);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
     }
 
     #[test]
@@ -185,7 +185,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 6);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
     }
 
     #[test]
@@ -280,7 +280,7 @@ END
 
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(location.code.start_line_number.get(), 3);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
     }
 
     #[test]
@@ -294,11 +294,11 @@ END
             assert_eq!(*redir_op_location.code.value.borrow(), "END");
             assert_eq!(redir_op_location.code.start_line_number.get(), 1);
             assert_eq!(redir_op_location.code.source, Source::Unknown);
-            assert_eq!(redir_op_location.column.get(), 1);
+            assert_eq!(redir_op_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(heredoc.content.0, []);
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 2);
+        assert_eq!(location.code.number.get(), 2);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "content\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 3);
+        assert_eq!(location.code.number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(heredoc.content.to_string(), "foo\n\tBAR\n\nbaz\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 6);
+        assert_eq!(location.code.number.get(), 6);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -278,7 +278,7 @@ END
         assert_eq!(heredoc.content.to_string(), "foo\n");
 
         let location = block_on(lexer.location()).unwrap();
-        assert_eq!(location.line.number.get(), 3);
+        assert_eq!(location.code.number.get(), 3);
         assert_eq!(location.column.get(), 1);
     }
 
@@ -291,16 +291,16 @@ END
         if let ErrorCause::Syntax(SyntaxError::UnclosedHereDocContent { redir_op_location }) =
             e.cause
         {
-            assert_eq!(redir_op_location.line.value, "END");
-            assert_eq!(redir_op_location.line.number.get(), 1);
-            assert_eq!(redir_op_location.line.source, Source::Unknown);
+            assert_eq!(redir_op_location.code.value, "END");
+            assert_eq!(redir_op_location.code.number.get(), 1);
+            assert_eq!(redir_op_location.code.source, Source::Unknown);
             assert_eq!(redir_op_location.column.get(), 1);
         } else {
             panic!("Not UnclosedHereDocContent: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -198,7 +198,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "+}");
-            assert_eq!(switch.word.location.index.get(), 2);
+            assert_eq!(switch.word.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -226,7 +226,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "+a  z}");
-            assert_eq!(switch.word.location.index.get(), 2);
+            assert_eq!(switch.word.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -246,7 +246,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
-            assert_eq!(switch.word.location.index.get(), 3);
+            assert_eq!(switch.word.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -266,7 +266,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "-}");
-            assert_eq!(switch.word.location.index.get(), 2);
+            assert_eq!(switch.word.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -294,7 +294,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":-cool}");
-            assert_eq!(switch.word.location.index.get(), 3);
+            assert_eq!(switch.word.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -314,7 +314,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
-            assert_eq!(switch.word.location.index.get(), 3);
+            assert_eq!(switch.word.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -341,7 +341,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "=Yes}");
-            assert_eq!(switch.word.location.index.get(), 2);
+            assert_eq!(switch.word.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -361,7 +361,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "?}");
-            assert_eq!(switch.word.location.index.get(), 2);
+            assert_eq!(switch.word.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -387,7 +387,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":?No}");
-            assert_eq!(switch.word.location.index.get(), 3);
+            assert_eq!(switch.word.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -438,7 +438,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index.get(), 2);
+            assert_eq!(trim.pattern.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -458,7 +458,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index.get(), 2);
+            assert_eq!(trim.pattern.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -481,7 +481,7 @@ mod tests {
                 assert_eq!(units[..], [TextUnit::Literal('?')]);
             });
             assert_eq!(*trim.pattern.location.code.value.borrow(), r#"##"?"}"#);
-            assert_eq!(trim.pattern.location.index.get(), 3);
+            assert_eq!(trim.pattern.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -504,7 +504,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), r"%\%}");
-            assert_eq!(trim.pattern.location.index.get(), 2);
+            assert_eq!(trim.pattern.location.index, 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -527,7 +527,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), "%%%}");
-            assert_eq!(trim.pattern.location.index.get(), 3);
+            assert_eq!(trim.pattern.location.index, 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -558,7 +558,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":");
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -572,7 +572,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":x}");
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -586,6 +586,6 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":#}");
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -198,7 +198,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "+}");
-            assert_eq!(switch.word.location.column.get(), 2);
+            assert_eq!(switch.word.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -226,7 +226,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "+a  z}");
-            assert_eq!(switch.word.location.column.get(), 2);
+            assert_eq!(switch.word.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -246,7 +246,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
-            assert_eq!(switch.word.location.column.get(), 3);
+            assert_eq!(switch.word.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -266,7 +266,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "-}");
-            assert_eq!(switch.word.location.column.get(), 2);
+            assert_eq!(switch.word.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -294,7 +294,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":-cool}");
-            assert_eq!(switch.word.location.column.get(), 3);
+            assert_eq!(switch.word.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -314,7 +314,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
-            assert_eq!(switch.word.location.column.get(), 3);
+            assert_eq!(switch.word.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -341,7 +341,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "=Yes}");
-            assert_eq!(switch.word.location.column.get(), 2);
+            assert_eq!(switch.word.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -361,7 +361,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "?}");
-            assert_eq!(switch.word.location.column.get(), 2);
+            assert_eq!(switch.word.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -387,7 +387,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":?No}");
-            assert_eq!(switch.word.location.column.get(), 3);
+            assert_eq!(switch.word.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -438,7 +438,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.column.get(), 2);
+            assert_eq!(trim.pattern.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -458,7 +458,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.column.get(), 2);
+            assert_eq!(trim.pattern.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -481,7 +481,7 @@ mod tests {
                 assert_eq!(units[..], [TextUnit::Literal('?')]);
             });
             assert_eq!(*trim.pattern.location.code.value.borrow(), r#"##"?"}"#);
-            assert_eq!(trim.pattern.location.column.get(), 3);
+            assert_eq!(trim.pattern.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -504,7 +504,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), r"%\%}");
-            assert_eq!(trim.pattern.location.column.get(), 2);
+            assert_eq!(trim.pattern.location.index.get(), 2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -527,7 +527,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), "%%%}");
-            assert_eq!(trim.pattern.location.column.get(), 3);
+            assert_eq!(trim.pattern.location.index.get(), 3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -558,7 +558,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":");
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -572,7 +572,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":x}");
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -586,6 +586,6 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":#}");
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -155,6 +155,7 @@ mod tests {
     use crate::syntax::Text;
     use crate::syntax::TextUnit;
     use crate::syntax::WordUnit;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -192,15 +193,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.code.value, "+}");
+            assert_eq!(*switch.word.location.code.value.borrow(), "+}");
             assert_eq!(switch.word.location.column.get(), 2);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -214,7 +213,7 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(
@@ -226,11 +225,9 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('z')),
                 ]
             );
-            assert_eq!(switch.word.location.code.value, "+a  z}");
+            assert_eq!(*switch.word.location.code.value.borrow(), "+a  z}");
             assert_eq!(switch.word.location.column.get(), 2);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -244,15 +241,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.code.value, ":+}");
+            assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
             assert_eq!(switch.word.location.column.get(), 3);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -266,15 +261,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.code.value, "-}");
+            assert_eq!(*switch.word.location.code.value.borrow(), "-}");
             assert_eq!(switch.word.location.column.get(), 2);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -288,7 +281,7 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(
@@ -300,11 +293,9 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('l')),
                 ]
             );
-            assert_eq!(switch.word.location.code.value, ":-cool}");
+            assert_eq!(*switch.word.location.code.value.borrow(), ":-cool}");
             assert_eq!(switch.word.location.column.get(), 3);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -318,15 +309,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.code.value, ":=}");
+            assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
             assert_eq!(switch.word.location.column.get(), 3);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -340,7 +329,7 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(
@@ -351,11 +340,9 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('s')),
                 ]
             );
-            assert_eq!(switch.word.location.code.value, "=Yes}");
+            assert_eq!(*switch.word.location.code.value.borrow(), "=Yes}");
             assert_eq!(switch.word.location.column.get(), 2);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -369,15 +356,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.code.value, "?}");
+            assert_eq!(*switch.word.location.code.value.borrow(), "?}");
             assert_eq!(switch.word.location.column.get(), 2);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -391,7 +376,7 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(
@@ -401,11 +386,9 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('o')),
                 ]
             );
-            assert_eq!(switch.word.location.code.value, ":?No}");
+            assert_eq!(*switch.word.location.code.value.borrow(), ":?No}");
             assert_eq!(switch.word.location.column.get(), 3);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -419,11 +402,9 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(switch.word.units, [WordUnit::Tilde("".to_string())]);
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
     }
 
     #[test]
@@ -435,14 +416,12 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Switch(switch) = result {
+        assert_matches!(result, Modifier::Switch(switch) => {
             assert_eq!(
                 switch.word.units,
                 [WordUnit::Unquoted(TextUnit::Literal('~'))]
             );
-        } else {
-            panic!("Not a switch: {:?}", result);
-        }
+        });
     }
 
     #[test]
@@ -454,15 +433,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.code.value, "#'*'}");
+            assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -476,15 +453,13 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.code.value, "#'*'}");
+            assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -498,20 +473,16 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Longest);
             assert_eq!(trim.pattern.units.len(), 1, "{:?}", trim.pattern);
-            if let WordUnit::DoubleQuote(Text(units)) = &trim.pattern.units[0] {
+            assert_matches!(&trim.pattern.units[0], WordUnit::DoubleQuote(Text(units)) => {
                 assert_eq!(units[..], [TextUnit::Literal('?')]);
-            } else {
-                panic!("Not a double quote: {:?}", trim.pattern);
-            }
-            assert_eq!(trim.pattern.location.code.value, r#"##"?"}"#);
+            });
+            assert_eq!(*trim.pattern.location.code.value.borrow(), r#"##"?"}"#);
             assert_eq!(trim.pattern.location.column.get(), 3);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -525,18 +496,16 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Suffix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
-            assert_eq!(trim.pattern.location.code.value, r"%\%}");
+            assert_eq!(*trim.pattern.location.code.value.borrow(), r"%\%}");
             assert_eq!(trim.pattern.location.column.get(), 2);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -550,18 +519,16 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Suffix);
             assert_eq!(trim.length, TrimLength::Longest);
             assert_eq!(
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
-            assert_eq!(trim.pattern.location.code.value, "%%%}");
+            assert_eq!(*trim.pattern.location.code.value.borrow(), "%%%}");
             assert_eq!(trim.pattern.location.column.get(), 3);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
     }
@@ -575,11 +542,9 @@ mod tests {
         };
 
         let result = block_on(lexer.suffix_modifier()).unwrap();
-        if let Modifier::Trim(trim) = result {
+        assert_matches!(result, Modifier::Trim(trim) => {
             assert_eq!(trim.pattern.units, [WordUnit::Tilde("".to_string())]);
-        } else {
-            panic!("Not a trim: {:?}", result);
-        }
+        });
     }
 
     #[test]
@@ -592,7 +557,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.code.value, ":");
+        assert_eq!(*e.location.code.value.borrow(), ":");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -606,7 +571,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.code.value, ":x}");
+        assert_eq!(*e.location.code.value.borrow(), ":x}");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -620,7 +585,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.code.value, ":#}");
+        assert_eq!(*e.location.code.value.borrow(), ":#}");
         assert_eq!(e.location.column.get(), 2);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "+}");
+            assert_eq!(switch.word.location.code.value, "+}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -226,7 +226,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('z')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, "+a  z}");
+            assert_eq!(switch.word.location.code.value, "+a  z}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -248,7 +248,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, ":+}");
+            assert_eq!(switch.word.location.code.value, ":+}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -270,7 +270,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "-}");
+            assert_eq!(switch.word.location.code.value, "-}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -300,7 +300,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('l')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, ":-cool}");
+            assert_eq!(switch.word.location.code.value, ":-cool}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -322,7 +322,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, ":=}");
+            assert_eq!(switch.word.location.code.value, ":=}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -351,7 +351,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('s')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, "=Yes}");
+            assert_eq!(switch.word.location.code.value, "=Yes}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -373,7 +373,7 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(switch.word.location.line.value, "?}");
+            assert_eq!(switch.word.location.code.value, "?}");
             assert_eq!(switch.word.location.column.get(), 2);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -401,7 +401,7 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('o')),
                 ]
             );
-            assert_eq!(switch.word.location.line.value, ":?No}");
+            assert_eq!(switch.word.location.code.value, ":?No}");
             assert_eq!(switch.word.location.column.get(), 3);
         } else {
             panic!("Not a switch: {:?}", result);
@@ -458,7 +458,7 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.line.value, "#'*'}");
+            assert_eq!(trim.pattern.location.code.value, "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -480,7 +480,7 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(trim.pattern.location.line.value, "#'*'}");
+            assert_eq!(trim.pattern.location.code.value, "#'*'}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -507,7 +507,7 @@ mod tests {
             } else {
                 panic!("Not a double quote: {:?}", trim.pattern);
             }
-            assert_eq!(trim.pattern.location.line.value, r#"##"?"}"#);
+            assert_eq!(trim.pattern.location.code.value, r#"##"?"}"#);
             assert_eq!(trim.pattern.location.column.get(), 3);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -532,7 +532,7 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
-            assert_eq!(trim.pattern.location.line.value, r"%\%}");
+            assert_eq!(trim.pattern.location.code.value, r"%\%}");
             assert_eq!(trim.pattern.location.column.get(), 2);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -557,7 +557,7 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
-            assert_eq!(trim.pattern.location.line.value, "%%%}");
+            assert_eq!(trim.pattern.location.code.value, "%%%}");
             assert_eq!(trim.pattern.location.column.get(), 3);
         } else {
             panic!("Not a trim: {:?}", result);
@@ -592,7 +592,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":");
+        assert_eq!(e.location.code.value, ":");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":x}");
+        assert_eq!(e.location.code.value, ":x}");
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -620,7 +620,7 @@ mod tests {
 
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
-        assert_eq!(e.location.line.value, ":#}");
+        assert_eq!(e.location.code.value, ":#}");
         assert_eq!(e.location.column.get(), 2);
     }
 }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
         assert_eq!(t.word.location.code.value, "<<-");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
@@ -421,7 +421,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<<>");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -438,7 +438,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<<");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.location.code.value, "<\\\n");
-        assert_eq!(t.word.location.code.number.get(), 3);
+        assert_eq!(t.word.location.code.start_line_number.get(), 3);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
@@ -491,7 +491,7 @@ mod tests {
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
         assert_eq!(t.word.location.code.value, "\n");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -370,8 +370,6 @@ mod tests {
     use super::*;
     use crate::input::Context;
     use crate::input::Input;
-    use crate::source::lines;
-    use crate::source::Code;
     use crate::source::Source;
     use crate::syntax::TextUnit;
     use crate::syntax::WordUnit;
@@ -455,10 +453,10 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(*t.word.location.code.value.borrow(), "<\\\n");
-        assert_eq!(t.word.location.code.start_line_number.get(), 3);
+        assert_eq!(*t.word.location.code.value.borrow(), "\\\n\\\n<\\\n<\\\n>");
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.index, 4);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -474,7 +472,7 @@ mod tests {
 
     #[test]
     fn lexer_operator_should_not_peek_beyond_newline() {
-        struct OneLineInput(Option<Code>);
+        struct OneLineInput(Option<String>);
         #[async_trait::async_trait(?Send)]
         impl Input for OneLineInput {
             async fn next_line(&mut self, _: &Context) -> crate::input::Result {
@@ -486,10 +484,9 @@ mod tests {
             }
         }
 
-        let line = lines("\n", Source::Unknown).next().unwrap();
         let line_number = NonZeroU64::new(1).unwrap();
         let mut lexer = Lexer::new(
-            Box::new(OneLineInput(Some(line))),
+            Box::new(OneLineInput(Some("\n".to_owned()))),
             line_number,
             Source::Unknown,
         );

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -376,6 +376,7 @@ mod tests {
     use crate::syntax::TextUnit;
     use crate::syntax::WordUnit;
     use futures_executor::block_on;
+    use std::num::NonZeroU64;
 
     fn ensure_sorted(trie: &Trie) {
         assert!(
@@ -486,7 +487,12 @@ mod tests {
         }
 
         let line = lines("\n", Source::Unknown).next().unwrap();
-        let mut lexer = Lexer::new(Box::new(OneLineInput(Some(line))));
+        let line_number = NonZeroU64::new(1).unwrap();
+        let mut lexer = Lexer::new(
+            Box::new(OneLineInput(Some(line))),
+            line_number,
+            Source::Unknown,
+        );
 
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -403,7 +403,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
-        assert_eq!(t.word.location.code.value, "<<-");
+        assert_eq!(*t.word.location.code.value.borrow(), "<<-");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -420,7 +420,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.code.value, "<<>");
+        assert_eq!(*t.word.location.code.value.borrow(), "<<>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -437,7 +437,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.code.value, "<<");
+        assert_eq!(*t.word.location.code.value.borrow(), "<<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -454,7 +454,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.code.value, "<\\\n");
+        assert_eq!(*t.word.location.code.value.borrow(), "<\\\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 3);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -490,7 +490,7 @@ mod tests {
 
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
-        assert_eq!(t.word.location.code.value, "\n");
+        assert_eq!(*t.word.location.code.value.borrow(), "\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -403,9 +403,9 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
-        assert_eq!(t.word.location.line.value, "<<-");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<-");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
@@ -420,9 +420,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<<>");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<>");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -437,9 +437,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<<");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<<");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -454,9 +454,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(t.word.location.line.value, "<\\\n");
-        assert_eq!(t.word.location.line.number.get(), 3);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "<\\\n");
+        assert_eq!(t.word.location.code.number.get(), 3);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
@@ -490,9 +490,9 @@ mod tests {
 
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
-        assert_eq!(t.word.location.line.value, "\n");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "\n");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -371,7 +371,7 @@ mod tests {
     use crate::input::Context;
     use crate::input::Input;
     use crate::source::lines;
-    use crate::source::Line;
+    use crate::source::Code;
     use crate::source::Source;
     use crate::syntax::TextUnit;
     use crate::syntax::WordUnit;
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn lexer_operator_should_not_peek_beyond_newline() {
-        struct OneLineInput(Option<Line>);
+        struct OneLineInput(Option<Code>);
         #[async_trait::async_trait(?Send)]
         impl Input for OneLineInput {
             async fn next_line(&mut self, _: &Context) -> crate::input::Result {

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<-");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -423,10 +423,10 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
-        assert_eq!(block_on(lexer.location()).unwrap().column.get(), 3);
+        assert_eq!(block_on(lexer.location()).unwrap().index.get(), 3);
     }
 
     #[test]
@@ -440,7 +440,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<\\\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 3);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }
 }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<-");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -423,10 +423,10 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
-        assert_eq!(block_on(lexer.location()).unwrap().index.get(), 3);
+        assert_eq!(block_on(lexer.location()).unwrap().index, 2);
     }
 
     #[test]
@@ -440,7 +440,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<\\\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 3);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }
 }

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -96,7 +96,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -113,7 +113,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('2')));
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
@@ -147,7 +147,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "X");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 1);
+        assert_eq!(location.index.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -93,7 +93,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "@");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -112,7 +112,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "1");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -131,7 +131,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "az_AZ_019");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -150,7 +150,7 @@ mod tests {
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "abc");
             assert_eq!(location.code.value, "$");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
@@ -167,7 +167,7 @@ mod tests {
 
         let location = block_on(lexer.raw_param(location)).unwrap().unwrap_err();
         assert_eq!(location.code.value, "X");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -92,9 +92,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "@");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -111,9 +111,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "1");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -130,9 +130,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "az_AZ_019");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -149,9 +149,9 @@ mod tests {
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
         if let TextUnit::RawParam { name, location } = result {
             assert_eq!(name, "abc");
-            assert_eq!(location.line.value, "$");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, "$");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
         } else {
             panic!("Not a parameter expansion: {:?}", result);
@@ -166,9 +166,9 @@ mod tests {
         let location = Location::dummy("X");
 
         let location = block_on(lexer.raw_param(location)).unwrap().unwrap_err();
-        assert_eq!(location.line.value, "X");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "X");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -96,7 +96,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -113,7 +113,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('2')));
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
@@ -147,7 +147,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "X");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 1);
+        assert_eq!(location.index, 0);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -82,6 +82,7 @@ impl Lexer<'_> {
 mod tests {
     use super::*;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -90,15 +91,13 @@ mod tests {
         let location = Location::dummy("$");
 
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
-        if let TextUnit::RawParam { name, location } = result {
+        assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "@");
-            assert_eq!(location.code.value, "$");
+            assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a parameter expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
@@ -109,15 +108,13 @@ mod tests {
         let location = Location::dummy("$");
 
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
-        if let TextUnit::RawParam { name, location } = result {
+        assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "1");
-            assert_eq!(location.code.value, "$");
+            assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a parameter expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('2')));
     }
@@ -128,15 +125,13 @@ mod tests {
         let location = Location::dummy("$");
 
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
-        if let TextUnit::RawParam { name, location } = result {
+        assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "az_AZ_019");
-            assert_eq!(location.code.value, "$");
+            assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a parameter expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
@@ -147,15 +142,13 @@ mod tests {
         let location = Location::dummy("$");
 
         let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
-        if let TextUnit::RawParam { name, location } = result {
+        assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "abc");
-            assert_eq!(location.code.value, "$");
+            assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a parameter expansion: {:?}", result);
-        }
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
     }
@@ -166,7 +159,7 @@ mod tests {
         let location = Location::dummy("X");
 
         let location = block_on(lexer.raw_param(location)).unwrap().unwrap_err();
-        assert_eq!(location.code.value, "X");
+        assert_eq!(*location.code.value.borrow(), "X");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 1);

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -604,16 +604,16 @@ mod tests {
         let mut lexer = Lexer::from_memory("x(()", Source::Unknown);
         let e = block_on(lexer.text_with_parentheses(|_| false, |_| false)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedParen { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "x(()");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "x(()");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "x(()");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "x(()");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -356,7 +356,7 @@ mod tests {
         .unwrap();
         assert_matches!(result, CommandSubst { content, location } => {
             assert_eq!(content, "");
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -377,7 +377,7 @@ mod tests {
         .unwrap();
         assert_matches!(result, Backquote { content, location } => {
             assert_eq!(content, [BackquoteUnit::Backslashed('"')]);
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -401,7 +401,7 @@ mod tests {
                 content,
                 [BackquoteUnit::Literal('\\'), BackquoteUnit::Literal('"')]
             );
-            assert_eq!(location.index.get(), 1);
+            assert_eq!(location.index, 0);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -599,11 +599,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "x(()");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 2);
+            assert_eq!(opening_location.index, 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "x(()");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -605,14 +605,14 @@ mod tests {
         let e = block_on(lexer.text_with_parentheses(|_| false, |_| false)).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedParen { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "x(()");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 2);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "x(()");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -354,12 +354,10 @@ mod tests {
         ))
         .unwrap()
         .unwrap();
-        if let CommandSubst { content, location } = result {
+        assert_matches!(result, CommandSubst { content, location } => {
             assert_eq!(content, "");
-            assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("unexpected result {:?}", result);
-        }
+            assert_eq!(location.index.get(), 1);
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -377,12 +375,10 @@ mod tests {
         ))
         .unwrap()
         .unwrap();
-        if let Backquote { content, location } = result {
+        assert_matches!(result, Backquote { content, location } => {
             assert_eq!(content, [BackquoteUnit::Backslashed('"')]);
-            assert_eq!(location.column.get(), 1);
-        } else {
-            panic!("Not a backquote: {:?}", result);
-        }
+            assert_eq!(location.index.get(), 1);
+        });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -405,7 +401,7 @@ mod tests {
                 content,
                 [BackquoteUnit::Literal('\\'), BackquoteUnit::Literal('"')]
             );
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -603,11 +599,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "x(()");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 2);
+            assert_eq!(opening_location.index.get(), 2);
         });
         assert_eq!(*e.location.code.value.borrow(), "x(()");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 }

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -101,7 +101,7 @@ mod tests {
 
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.location.code.value, "");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::EndOfInput);
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
         assert_eq!(t.word.location.code.value, "abc ");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Token(None));
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
         assert_eq!(t.word.location.code.value, "12<");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
         assert_eq!(t.word.location.code.value, "0>>");
-        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
@@ -185,7 +185,7 @@ mod tests {
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
             assert_eq!(t.word.location.code.value, " a  ");
-            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 2);
             assert_eq!(t.id, TokenId::Token(None));
@@ -194,7 +194,7 @@ mod tests {
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
             assert_eq!(t.word.location.code.value, " a  ");
-            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 5);
             assert_eq!(t.id, TokenId::EndOfInput);

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
     }
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "abc ");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
 
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "12<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
@@ -170,11 +170,11 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "0>>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index.get(), 1);
+        assert_eq!(t.word.location.index, 0);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
-        assert_eq!(block_on(lexer.location()).unwrap().index.get(), 2);
+        assert_eq!(block_on(lexer.location()).unwrap().index, 1);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index.get(), 2);
+            assert_eq!(t.word.location.index, 1);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index.get(), 5);
+            assert_eq!(t.word.location.index, 4);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);
         });

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -100,9 +100,9 @@ mod tests {
         let mut lexer = Lexer::from_memory("", Source::Unknown);
 
         let t = block_on(lexer.token()).unwrap();
-        assert_eq!(t.word.location.line.value, "");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
@@ -117,9 +117,9 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('a')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
-        assert_eq!(t.word.location.line.value, "abc ");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "abc ");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
@@ -150,9 +150,9 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
-        assert_eq!(t.word.location.line.value, "12<");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "12<");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
@@ -167,9 +167,9 @@ mod tests {
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
-        assert_eq!(t.word.location.line.value, "0>>");
-        assert_eq!(t.word.location.line.number.get(), 1);
-        assert_eq!(t.word.location.line.source, Source::Unknown);
+        assert_eq!(t.word.location.code.value, "0>>");
+        assert_eq!(t.word.location.code.number.get(), 1);
+        assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
@@ -184,18 +184,18 @@ mod tests {
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.line.value, " a  ");
-            assert_eq!(t.word.location.line.number.get(), 1);
-            assert_eq!(t.word.location.line.source, Source::Unknown);
+            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 2);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.line.value, " a  ");
-            assert_eq!(t.word.location.line.number.get(), 1);
-            assert_eq!(t.word.location.line.source, Source::Unknown);
+            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(t.word.location.code.number.get(), 1);
+            assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 5);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
     }
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "abc ");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
 
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "12<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
@@ -170,11 +170,11 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "0>>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.column.get(), 1);
+        assert_eq!(t.word.location.index.get(), 1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
-        assert_eq!(block_on(lexer.location()).unwrap().column.get(), 2);
+        assert_eq!(block_on(lexer.location()).unwrap().index.get(), 2);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.column.get(), 2);
+            assert_eq!(t.word.location.index.get(), 2);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.column.get(), 5);
+            assert_eq!(t.word.location.index.get(), 5);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);
         });

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -100,7 +100,7 @@ mod tests {
         let mut lexer = Lexer::from_memory("", Source::Unknown);
 
         let t = block_on(lexer.token()).unwrap();
-        assert_eq!(t.word.location.code.value, "");
+        assert_eq!(*t.word.location.code.value.borrow(), "");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -117,7 +117,7 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('a')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
-        assert_eq!(t.word.location.code.value, "abc ");
+        assert_eq!(*t.word.location.code.value.borrow(), "abc ");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
-        assert_eq!(t.word.location.code.value, "12<");
+        assert_eq!(*t.word.location.code.value.borrow(), "12<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -167,7 +167,7 @@ mod tests {
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
-        assert_eq!(t.word.location.code.value, "0>>");
+        assert_eq!(*t.word.location.code.value.borrow(), "0>>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
         assert_eq!(t.word.location.column.get(), 1);
@@ -184,7 +184,7 @@ mod tests {
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 2);
@@ -193,7 +193,7 @@ mod tests {
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(t.word.location.code.value, " a  ");
+            assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
             assert_eq!(t.word.location.column.get(), 5);

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -191,7 +191,7 @@ mod tests {
                 .unwrap();
         if let Unquoted(CommandSubst { content, location }) = result {
             assert_eq!(content, "");
-            assert_eq!(location.column.get(), 1);
+            assert_eq!(location.index.get(), 1);
         } else {
             panic!("unexpected result {:?}", result);
         }
@@ -347,12 +347,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "'abc\n");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "def\\");
         assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -470,12 +470,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "\"abc\n");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "def");
         assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -494,7 +494,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), r"0$(:)X\#");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.column.get(), 2);
+            assert_eq!(location.index.get(), 2);
         });
         assert_eq!(word.units[2], WordUnit::Unquoted(TextUnit::Literal('X')));
         assert_eq!(
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(*word.location.code.value.borrow(), r"0$(:)X\#");
         assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
-        assert_eq!(word.location.column.get(), 1);
+        assert_eq!(word.location.index.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -521,7 +521,7 @@ mod tests {
         assert_eq!(*word.location.code.value.borrow(), "");
         assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
-        assert_eq!(word.location.column.get(), 1);
+        assert_eq!(word.location.index.get(), 1);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -334,15 +334,15 @@ mod tests {
             .unwrap_err();
         assert_matches!(e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedSingleQuote { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "'abc\n");
+            assert_eq!(*opening_location.code.value.borrow(), "'abc\ndef\\");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.index, 0);
         });
-        assert_eq!(*e.location.code.value.borrow(), "def\\");
-        assert_eq!(e.location.code.start_line_number.get(), 2);
+        assert_eq!(*e.location.code.value.borrow(), "'abc\ndef\\");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.index, 9);
     }
 
     #[test]
@@ -449,15 +449,15 @@ mod tests {
             .unwrap_err();
         assert_matches!(e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedDoubleQuote { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "\"abc\n");
+            assert_eq!(*opening_location.code.value.borrow(), "\"abc\ndef");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.index, 0);
         });
-        assert_eq!(*e.location.code.value.borrow(), "def");
-        assert_eq!(e.location.code.start_line_number.get(), 2);
+        assert_eq!(*e.location.code.value.borrow(), "\"abc\ndef");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.index, 8);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -342,16 +342,16 @@ mod tests {
         let e = block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSingleQuote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "'abc\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "'abc\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "def\\");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "def\\");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -466,16 +466,16 @@ mod tests {
         let e = block_on(lexer.word_unit(|c| panic!("unexpected call to is_delimiter({:?})", c)))
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoubleQuote { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "\"abc\n");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "\"abc\n");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
-        assert_eq!(e.location.line.value, "def");
-        assert_eq!(e.location.line.number.get(), 2);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "def");
+        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -492,9 +492,9 @@ mod tests {
         assert_eq!(word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
         if let WordUnit::Unquoted(TextUnit::CommandSubst { content, location }) = &word.units[1] {
             assert_eq!(content, ":");
-            assert_eq!(location.line.value, r"0$(:)X\#");
-            assert_eq!(location.line.number.get(), 1);
-            assert_eq!(location.line.source, Source::Unknown);
+            assert_eq!(location.code.value, r"0$(:)X\#");
+            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
             panic!("unexpected word unit: {:?}", word.units[1]);
@@ -504,9 +504,9 @@ mod tests {
             word.units[3],
             WordUnit::Unquoted(TextUnit::Backslashed('#'))
         );
-        assert_eq!(word.location.line.value, r"0$(:)X\#");
-        assert_eq!(word.location.line.number.get(), 1);
-        assert_eq!(word.location.line.source, Source::Unknown);
+        assert_eq!(word.location.code.value, r"0$(:)X\#");
+        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -521,9 +521,9 @@ mod tests {
         };
         let word = block_on(lexer.word(|_| panic!("unexpected call to is_delimiter"))).unwrap();
         assert_eq!(word.units, []);
-        assert_eq!(word.location.line.value, "");
-        assert_eq!(word.location.line.number.get(), 1);
-        assert_eq!(word.location.line.source, Source::Unknown);
+        assert_eq!(word.location.code.value, "");
+        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
     }
 

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -343,14 +343,14 @@ mod tests {
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedSingleQuote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "'abc\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "def\\");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -467,14 +467,14 @@ mod tests {
             .unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedDoubleQuote { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "\"abc\n");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("unexpected error cause {:?}", e);
         }
         assert_eq!(e.location.code.value, "def");
-        assert_eq!(e.location.code.number.get(), 2);
+        assert_eq!(e.location.code.start_line_number.get(), 2);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -493,7 +493,7 @@ mod tests {
         if let WordUnit::Unquoted(TextUnit::CommandSubst { content, location }) = &word.units[1] {
             assert_eq!(content, ":");
             assert_eq!(location.code.value, r"0$(:)X\#");
-            assert_eq!(location.code.number.get(), 1);
+            assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
             assert_eq!(location.column.get(), 2);
         } else {
@@ -505,7 +505,7 @@ mod tests {
             WordUnit::Unquoted(TextUnit::Backslashed('#'))
         );
         assert_eq!(word.location.code.value, r"0$(:)X\#");
-        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
 
@@ -522,7 +522,7 @@ mod tests {
         let word = block_on(lexer.word(|_| panic!("unexpected call to is_delimiter"))).unwrap();
         assert_eq!(word.units, []);
         assert_eq!(word.location.code.value, "");
-        assert_eq!(word.location.code.number.get(), 1);
+        assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
         assert_eq!(word.location.column.get(), 1);
     }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -228,9 +228,9 @@ mod tests {
         assert_eq!(list.0.len(), 3);
 
         let location = list.0[0].async_flag.as_ref().unwrap();
-        assert_eq!(location.line.value, "foo & bar ; baz&");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
@@ -238,9 +238,9 @@ mod tests {
         assert_eq!(list.0[1].and_or.to_string(), "bar");
 
         let location = list.0[2].async_flag.as_ref().unwrap();
-        assert_eq!(location.line.value, "foo & bar ; baz&");
-        assert_eq!(location.line.number.get(), 1);
-        assert_eq!(location.line.source, Source::Unknown);
+        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
@@ -322,9 +322,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocContent)
         );
-        assert_eq!(e.location.line.value, "<<END");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<<END");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -336,9 +336,9 @@ mod tests {
 
         let e = block_on(parser.command_line()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::UnexpectedToken));
-        assert_eq!(e.location.line.value, "foo)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(list.0.len(), 3);
 
         let location = list.0[0].async_flag.as_ref().unwrap();
-        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 5);
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(list.0[1].and_or.to_string(), "bar");
 
         let location = list.0[2].async_flag.as_ref().unwrap();
-        assert_eq!(location.code.value, "foo & bar ; baz&");
+        assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 16);
@@ -322,7 +322,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocContent)
         );
-        assert_eq!(e.location.code.value, "<<END");
+        assert_eq!(*e.location.code.value.borrow(), "<<END");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
@@ -336,7 +336,7 @@ mod tests {
 
         let e = block_on(parser.command_line()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::UnexpectedToken));
-        assert_eq!(e.location.code.value, "foo)");
+        assert_eq!(*e.location.code.value.borrow(), "foo)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -229,7 +229,7 @@ mod tests {
 
         let location = list.0[0].async_flag.as_ref().unwrap();
         assert_eq!(location.code.value, "foo & bar ; baz&");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
@@ -239,7 +239,7 @@ mod tests {
 
         let location = list.0[2].async_flag.as_ref().unwrap();
         assert_eq!(location.code.value, "foo & bar ; baz&");
-        assert_eq!(location.code.number.get(), 1);
+        assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
         assert_eq!(location.column.get(), 16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
@@ -323,7 +323,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocContent)
         );
         assert_eq!(e.location.code.value, "<<END");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -337,7 +337,7 @@ mod tests {
         let e = block_on(parser.command_line()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::UnexpectedToken));
         assert_eq!(e.location.code.value, "foo)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 5);
+        assert_eq!(location.index, 4);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
         assert_eq!(list.0[1].async_flag, None);
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index.get(), 16);
+        assert_eq!(location.index, 15);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
 
@@ -325,7 +325,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<END");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 
     #[test]
@@ -339,6 +339,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 }

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 5);
+        assert_eq!(location.index.get(), 5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
         assert_eq!(list.0[1].async_flag, None);
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.column.get(), 16);
+        assert_eq!(location.index.get(), 16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
 
@@ -325,7 +325,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<END");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 
     #[test]
@@ -339,6 +339,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 }

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -170,9 +170,9 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::DoubleNegation));
-        assert_eq!(e.location.line.value, " !  !");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " !  !");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -187,9 +187,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBang)
         );
-        assert_eq!(e.location.line.value, "!\n");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "!\n");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
 
@@ -204,9 +204,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBar)
         );
-        assert_eq!(e.location.line.value, "foo | ;");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo | ;");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 
@@ -218,9 +218,9 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::BangAfterBar));
-        assert_eq!(e.location.line.value, "foo | !");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "foo | !");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
 

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -170,7 +170,7 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::DoubleNegation));
-        assert_eq!(e.location.code.value, " !  !");
+        assert_eq!(*e.location.code.value.borrow(), " !  !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
@@ -187,7 +187,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBang)
         );
-        assert_eq!(e.location.code.value, "!\n");
+        assert_eq!(*e.location.code.value.borrow(), "!\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
@@ -204,7 +204,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBar)
         );
-        assert_eq!(e.location.code.value, "foo | ;");
+        assert_eq!(*e.location.code.value.borrow(), "foo | ;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
@@ -218,7 +218,7 @@ mod tests {
 
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::BangAfterBar));
-        assert_eq!(e.location.code.value, "foo | !");
+        assert_eq!(*e.location.code.value.borrow(), "foo | !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " !  !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "!\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 2);
+        assert_eq!(e.location.index, 1);
     }
 
     #[test]
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | ;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 7);
+        assert_eq!(e.location.index, 6);
     }
 
     #[test]

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -171,7 +171,7 @@ mod tests {
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::DoubleNegation));
         assert_eq!(e.location.code.value, " !  !");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -188,7 +188,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBang)
         );
         assert_eq!(e.location.code.value, "!\n");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 2);
     }
@@ -205,7 +205,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingCommandAfterBar)
         );
         assert_eq!(e.location.code.value, "foo | ;");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }
@@ -219,7 +219,7 @@ mod tests {
         let e = block_on(parser.pipeline()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::BangAfterBar));
         assert_eq!(e.location.code.value, "foo | !");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 7);
     }

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " !  !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "!\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 2);
+        assert_eq!(e.location.index.get(), 2);
     }
 
     #[test]
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | ;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 7);
+        assert_eq!(e.location.index.get(), 7);
     }
 
     #[test]

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -365,7 +365,7 @@ mod tests {
             e.location.code.value,
             "9999999999999999999999999999999999999999< x"
         );
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
@@ -391,7 +391,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
         assert_eq!(e.location.code.value, " < >");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -408,7 +408,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
         assert_eq!(e.location.code.value, "  < ");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -425,7 +425,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<< <<");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
@@ -442,7 +442,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
         assert_eq!(e.location.code.value, "<<");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -362,11 +362,11 @@ mod tests {
         let e = block_on(parser.redirection()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::FdOutOfRange));
         assert_eq!(
-            e.location.line.value,
+            e.location.code.value,
             "9999999999999999999999999999999999999999< x"
         );
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 1);
     }
 
@@ -390,9 +390,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.line.value, " < >");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " < >");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -407,9 +407,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.line.value, "  < ");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  < ");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -424,9 +424,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<< <<");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<< <<");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
     }
 
@@ -441,9 +441,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.line.value, "<<");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "<<");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -367,7 +367,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 1);
+        assert_eq!(e.location.index, 0);
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " < >");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  < ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< <<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 4);
+        assert_eq!(e.location.index, 3);
     }
 
     #[test]
@@ -444,6 +444,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -367,7 +367,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 1);
+        assert_eq!(e.location.index.get(), 1);
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " < >");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  < ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< <<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 4);
+        assert_eq!(e.location.index.get(), 4);
     }
 
     #[test]
@@ -444,6 +444,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -362,7 +362,7 @@ mod tests {
         let e = block_on(parser.redirection()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::FdOutOfRange));
         assert_eq!(
-            e.location.code.value,
+            *e.location.code.value.borrow(),
             "9999999999999999999999999999999999999999< x"
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
@@ -390,7 +390,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.code.value, " < >");
+        assert_eq!(*e.location.code.value.borrow(), " < >");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
@@ -407,7 +407,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingRedirOperand)
         );
-        assert_eq!(e.location.code.value, "  < ");
+        assert_eq!(*e.location.code.value.borrow(), "  < ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
@@ -424,7 +424,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.code.value, "<< <<");
+        assert_eq!(*e.location.code.value.borrow(), "<< <<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 4);
@@ -441,7 +441,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::MissingHereDocDelimiter)
         );
-        assert_eq!(e.location.code.value, "<<");
+        assert_eq!(*e.location.code.value.borrow(), "<<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -232,14 +232,14 @@ mod tests {
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "(a b");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "(a b");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
@@ -252,14 +252,14 @@ mod tests {
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "(a;b)");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "(a;b)");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "my");
         assert_eq!(sc.assigns[0].value.to_string(), "assignment");
         assert_eq!(sc.assigns[0].location.code.value, "my=assignment");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
     }
@@ -315,19 +315,19 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
         assert_eq!(sc.assigns[0].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
         assert_eq!(sc.assigns[1].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[1].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[1].location.column.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
         assert_eq!(sc.assigns[2].location.code.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[2].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[2].location.column.get(), 8);
     }
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
         assert_eq!(sc.assigns[0].location.code.value, "a= ()");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
@@ -579,7 +579,7 @@ mod tests {
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b");
         assert_eq!(sc.assigns[0].location.code.value, "a=b()");
-        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -231,16 +231,16 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "(a b");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "(a b");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "(a b");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(a b");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
     }
 
@@ -251,16 +251,16 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "(a;b)");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "(a;b)");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Unexpected cause {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "(a;b)");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "(a;b)");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
     }
 
@@ -296,9 +296,9 @@ mod tests {
         assert_eq!(sc.assigns.len(), 1);
         assert_eq!(sc.assigns[0].name, "my");
         assert_eq!(sc.assigns[0].value.to_string(), "assignment");
-        assert_eq!(sc.assigns[0].location.line.value, "my=assignment");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "my=assignment");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
     }
 
@@ -314,21 +314,21 @@ mod tests {
         assert_eq!(sc.assigns.len(), 3);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
-        assert_eq!(sc.assigns[1].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[1].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[1].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[1].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[1].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[1].location.column.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
-        assert_eq!(sc.assigns[2].location.line.value, "a= b=! c=X");
-        assert_eq!(sc.assigns[2].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[2].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[2].location.code.value, "a= b=! c=X");
+        assert_eq!(sc.assigns[2].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[2].location.column.get(), 8);
     }
 
@@ -557,9 +557,9 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.line.value, "a= ()");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a= ()");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();
@@ -578,9 +578,9 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b");
-        assert_eq!(sc.assigns[0].location.line.value, "a=b()");
-        assert_eq!(sc.assigns[0].location.line.number.get(), 1);
-        assert_eq!(sc.assigns[0].location.line.source, Source::Unknown);
+        assert_eq!(sc.assigns[0].location.code.value, "a=b()");
+        assert_eq!(sc.assigns[0].location.code.number.get(), 1);
+        assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -171,6 +171,7 @@ mod tests {
     use crate::source::Source;
     use crate::syntax::RedirBody;
     use crate::syntax::RedirOp;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -230,15 +231,14 @@ mod tests {
         let aliases = Default::default();
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "(a b");
+        assert_matches!(e.cause,
+             ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "(a b");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("Unexpected cause {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "(a b");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "(a b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 5);
@@ -250,15 +250,14 @@ mod tests {
         let aliases = Default::default();
         let mut parser = Parser::new(&mut lexer, &aliases);
         let e = block_on(parser.array_values()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "(a;b)");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedArrayValue { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "(a;b)");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("Unexpected cause {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "(a;b)");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "(a;b)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 3);
@@ -296,7 +295,7 @@ mod tests {
         assert_eq!(sc.assigns.len(), 1);
         assert_eq!(sc.assigns[0].name, "my");
         assert_eq!(sc.assigns[0].value.to_string(), "assignment");
-        assert_eq!(sc.assigns[0].location.code.value, "my=assignment");
+        assert_eq!(*sc.assigns[0].location.code.value.borrow(), "my=assignment");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
@@ -314,19 +313,19 @@ mod tests {
         assert_eq!(sc.assigns.len(), 3);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.code.value, "a= b=! c=X");
+        assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
-        assert_eq!(sc.assigns[1].location.code.value, "a= b=! c=X");
+        assert_eq!(*sc.assigns[1].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[1].location.column.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
-        assert_eq!(sc.assigns[2].location.code.value, "a= b=! c=X");
+        assert_eq!(*sc.assigns[2].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[2].location.column.get(), 8);
@@ -557,7 +556,7 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "");
-        assert_eq!(sc.assigns[0].location.code.value, "a= ()");
+        assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= ()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);
@@ -578,7 +577,7 @@ mod tests {
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b");
-        assert_eq!(sc.assigns[0].location.code.value, "a=b()");
+        assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a=b()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
         assert_eq!(sc.assigns[0].location.column.get(), 1);

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -236,12 +236,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a b");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 5);
+        assert_eq!(e.location.index, 4);
     }
 
     #[test]
@@ -255,12 +255,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a;b)");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a;b)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 3);
+        assert_eq!(e.location.index, 2);
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "my=assignment");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index.get(), 1);
+        assert_eq!(sc.assigns[0].location.index, 0);
     }
 
     #[test]
@@ -316,19 +316,19 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index.get(), 1);
+        assert_eq!(sc.assigns[0].location.index, 0);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
         assert_eq!(*sc.assigns[1].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[1].location.index.get(), 4);
+        assert_eq!(sc.assigns[1].location.index, 3);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
         assert_eq!(*sc.assigns[2].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[2].location.index.get(), 8);
+        assert_eq!(sc.assigns[2].location.index, 7);
     }
 
     #[test]
@@ -559,7 +559,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= ()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index.get(), 1);
+        assert_eq!(sc.assigns[0].location.index, 0);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));
@@ -580,7 +580,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a=b()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index.get(), 1);
+        assert_eq!(sc.assigns[0].location.index, 0);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -236,12 +236,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a b");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 5);
+        assert_eq!(e.location.index.get(), 5);
     }
 
     #[test]
@@ -255,12 +255,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a;b)");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a;b)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 3);
+        assert_eq!(e.location.index.get(), 3);
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "my=assignment");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.column.get(), 1);
+        assert_eq!(sc.assigns[0].location.index.get(), 1);
     }
 
     #[test]
@@ -316,19 +316,19 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.column.get(), 1);
+        assert_eq!(sc.assigns[0].location.index.get(), 1);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
         assert_eq!(*sc.assigns[1].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[1].location.column.get(), 4);
+        assert_eq!(sc.assigns[1].location.index.get(), 4);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
         assert_eq!(*sc.assigns[2].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[2].location.column.get(), 8);
+        assert_eq!(sc.assigns[2].location.index.get(), 8);
     }
 
     #[test]
@@ -559,7 +559,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= ()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.column.get(), 1);
+        assert_eq!(sc.assigns[0].location.index.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));
@@ -580,7 +580,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a=b()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.column.get(), 1);
+        assert_eq!(sc.assigns[0].location.index.get(), 1);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -156,12 +156,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "while :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "while :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 8);
+        assert_eq!(e.location.index, 7);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " while do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 8);
+        assert_eq!(e.location.index, 7);
     }
 
     #[test]
@@ -258,12 +258,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "until :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index.get(), 1);
+            assert_eq!(opening_location.index, 0);
         });
         assert_eq!(*e.location.code.value.borrow(), "until :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 8);
+        assert_eq!(e.location.index, 7);
     }
 
     #[test]
@@ -280,7 +280,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  until do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index.get(), 9);
+        assert_eq!(e.location.index, 8);
     }
 
     #[test]

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -152,14 +152,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "while :");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "while :");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -176,7 +176,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::EmptyWhileCondition)
         );
         assert_eq!(e.location.code.value, " while do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -255,14 +255,14 @@ mod tests {
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) = e.cause {
             assert_eq!(opening_location.code.value, "until :");
-            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
         assert_eq!(e.location.code.value, "until :");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
@@ -279,7 +279,7 @@ mod tests {
             ErrorCause::Syntax(SyntaxError::EmptyUntilCondition)
         );
         assert_eq!(e.location.code.value, "  until do :; done");
-        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -151,16 +151,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "while :");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "while :");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "while :");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "while :");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -175,9 +175,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyWhileCondition)
         );
-        assert_eq!(e.location.line.value, " while do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, " while do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -254,16 +254,16 @@ mod tests {
 
         let e = block_on(parser.compound_command()).unwrap_err();
         if let ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.line.value, "until :");
-            assert_eq!(opening_location.line.number.get(), 1);
-            assert_eq!(opening_location.line.source, Source::Unknown);
+            assert_eq!(opening_location.code.value, "until :");
+            assert_eq!(opening_location.code.number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
         } else {
             panic!("Wrong error cause: {:?}", e.cause);
         }
-        assert_eq!(e.location.line.value, "until :");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "until :");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
     }
 
@@ -278,9 +278,9 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyUntilCondition)
         );
-        assert_eq!(e.location.line.value, "  until do :; done");
-        assert_eq!(e.location.line.number.get(), 1);
-        assert_eq!(e.location.line.source, Source::Unknown);
+        assert_eq!(e.location.code.value, "  until do :; done");
+        assert_eq!(e.location.code.number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);
     }
 

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -156,12 +156,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "while :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "while :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 8);
+        assert_eq!(e.location.index.get(), 8);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " while do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 8);
+        assert_eq!(e.location.index.get(), 8);
     }
 
     #[test]
@@ -258,12 +258,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "until :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.column.get(), 1);
+            assert_eq!(opening_location.index.get(), 1);
         });
         assert_eq!(*e.location.code.value.borrow(), "until :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 8);
+        assert_eq!(e.location.index.get(), 8);
     }
 
     #[test]
@@ -280,7 +280,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  until do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.column.get(), 9);
+        assert_eq!(e.location.index.get(), 9);
     }
 
     #[test]

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -103,6 +103,7 @@ mod tests {
     use crate::alias::{AliasSet, HashEntry};
     use crate::source::Location;
     use crate::source::Source;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
 
     #[test]
@@ -150,15 +151,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "while :");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedWhileClause { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "while :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("Wrong error cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "while :");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "while :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
@@ -175,7 +175,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyWhileCondition)
         );
-        assert_eq!(e.location.code.value, " while do :; done");
+        assert_eq!(*e.location.code.value.borrow(), " while do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
@@ -253,15 +253,14 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
 
         let e = block_on(parser.compound_command()).unwrap_err();
-        if let ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) = e.cause {
-            assert_eq!(opening_location.code.value, "until :");
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedUntilClause { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "until :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
             assert_eq!(opening_location.column.get(), 1);
-        } else {
-            panic!("Wrong error cause: {:?}", e.cause);
-        }
-        assert_eq!(e.location.code.value, "until :");
+        });
+        assert_eq!(*e.location.code.value.borrow(), "until :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 8);
@@ -278,7 +277,7 @@ mod tests {
             e.cause,
             ErrorCause::Syntax(SyntaxError::EmptyUntilCondition)
         );
-        assert_eq!(e.location.code.value, "  until do :; done");
+        assert_eq!(*e.location.code.value.borrow(), "  until do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.column.get(), 9);

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -220,6 +220,44 @@ pub fn lines(code: &str, source: Source) -> Lines<'_> {
     }
 }
 
+/// Creates an iterator of [source char](SourceChar)s from a string.
+///
+/// `index_offset` will be the `index` of the first source char's location. For
+/// each succeeding char, the `index` will be incremented by one.
+///
+/// ```
+/// # use yash_syntax::source::{Code, Source, source_chars};
+/// # use std::cell::RefCell;
+/// # use std::num::NonZeroU64;
+/// # use std::rc::Rc;
+/// let s = "abc";
+/// let code = Rc::new(Code {
+///     value: RefCell::new(s.to_string()),
+///     start_line_number: NonZeroU64::new(1).unwrap(),
+///     source: Source::Unknown,
+/// });
+/// let chars: Vec<_> = source_chars(s, &code, 10).collect();
+/// assert_eq!(chars[0].value, 'a');
+/// assert_eq!(chars[0].location.code, code);
+/// assert_eq!(chars[0].location.index, 10);
+/// assert_eq!(chars[1].value, 'b');
+/// assert_eq!(chars[1].location.code, code);
+/// assert_eq!(chars[1].location.index, 11);
+/// ```
+pub fn source_chars<'a>(
+    s: &'a str,
+    code: &'a Rc<Code>,
+    index_offset: usize,
+) -> impl Iterator<Item = SourceChar> + 'a {
+    s.chars().enumerate().map(move |(i, value)| SourceChar {
+        value,
+        location: Location {
+            code: Rc::clone(code),
+            index: index_offset + i,
+        },
+    })
+}
+
 /// Position of a character in source code.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Location {

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -16,7 +16,11 @@
 
 //! Source code that is passed to the parser.
 //!
-//! TODO Elaborate
+//! This module contains items representing information about the source code
+//! from which ASTs originate. [`Source`] identifies the origin of source code
+//! fragments contained in [`Code`]. A [`Location`] specifies a particular
+//! character in a `Code` instance. You can use the [`pretty`] submodule to
+//! format messages describing source code locations.
 
 pub mod pretty;
 
@@ -133,7 +137,8 @@ impl Source {
 
 /// Source code fragment
 ///
-/// TODO Elaborate
+/// An instance of `Code` contains a block of the source code that was parsed to
+/// produce an AST.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Code {
     /// Content of the code, usually terminated by a newline.

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -229,14 +229,14 @@ pub struct Location {
     /// Character position in the code. Counted from 1.
     ///
     /// Characters are counted in the number of Unicode scalar values, not bytes.
-    pub column: NonZeroU64,
+    pub index: NonZeroU64,
 }
 
 impl Location {
     /// Creates a dummy location.
     ///
     /// The returned location has [unknown](Source::Unknown) source and the
-    /// given source code value. The line and column numbers are 1.
+    /// given source code value. The `start_line_number` and `index` are 1.
     ///
     /// This function is mainly for use in testing.
     #[inline]
@@ -251,16 +251,16 @@ impl Location {
             });
             Location {
                 code,
-                column: number,
+                index: number,
             }
         }
         with_line(value.into())
     }
 
-    /// Increases the column number
+    /// Increases the `index` by `count`.
     pub fn advance(&mut self, count: u64) {
-        let column = self.column.get().checked_add(count).unwrap();
-        self.column = NonZeroU64::new(column).unwrap();
+        let index = self.index.get().checked_add(count).unwrap();
+        self.index = NonZeroU64::new(index).unwrap();
     }
 }
 
@@ -275,19 +275,15 @@ pub struct SourceChar {
 
 impl Code {
     /// Creates an iterator of `SourceChar`.
-    ///
-    /// The character columns are counted from 1.
     #[allow(clippy::needless_lifetimes)] // This lifetime is actually needed.
     pub fn enumerate<'a>(self: &'a Rc<Self>) -> impl Iterator<Item = SourceChar> + 'a {
         // We do need to collect the iterator to release the borrow.
         #[allow(clippy::needless_collect)]
         let chars = self.value.borrow().chars().collect::<Vec<char>>();
         chars.into_iter().zip(1u64..).map(move |(value, i)| {
-            let column = NonZeroU64::new(i).unwrap();
-            let location = Location {
-                code: self.clone(),
-                column,
-            };
+            let code = self.clone();
+            let index = NonZeroU64::new(i).unwrap();
+            let location = Location { code, index };
             SourceChar { value, location }
         })
     }
@@ -382,20 +378,20 @@ mod tests {
     #[test]
     fn location_advance() {
         let code = Rc::new(lines("line\n", Source::Unknown).next().unwrap());
-        let column = NonZeroU64::new(1).unwrap();
+        let index = NonZeroU64::new(1).unwrap();
         let mut location = Location {
             code: code.clone(),
-            column,
+            index,
         };
 
         location.advance(1);
-        assert_eq!(location.column.get(), 2);
+        assert_eq!(location.index.get(), 2);
         location.advance(2);
-        assert_eq!(location.column.get(), 4);
+        assert_eq!(location.index.get(), 4);
 
         // The advance function does not check the line length.
         location.advance(5);
-        assert_eq!(location.column.get(), 9);
+        assert_eq!(location.index.get(), 9);
 
         assert!(Rc::ptr_eq(&location.code, &code));
     }
@@ -417,23 +413,23 @@ mod tests {
         let chars = code.enumerate().collect::<Vec<SourceChar>>();
         assert_eq!(chars.len(), 3);
         assert_eq!(chars[0].value, 'f');
-        assert_eq!(chars[0].location.column.get(), 1);
+        assert_eq!(chars[0].location.index.get(), 1);
         assert!(Rc::ptr_eq(&chars[0].location.code, &code));
         assert_eq!(chars[1].value, 'o');
-        assert_eq!(chars[1].location.column.get(), 2);
+        assert_eq!(chars[1].location.index.get(), 2);
         assert!(Rc::ptr_eq(&chars[1].location.code, &code));
         assert_eq!(chars[2].value, 'o');
-        assert_eq!(chars[2].location.column.get(), 3);
+        assert_eq!(chars[2].location.index.get(), 3);
         assert!(Rc::ptr_eq(&chars[2].location.code, &code));
 
         let code = make_code("hello", 4);
         let chars = code.enumerate().collect::<Vec<SourceChar>>();
         assert_eq!(chars.len(), 5);
         assert_eq!(chars[0].value, 'h');
-        assert_eq!(chars[0].location.column.get(), 1);
+        assert_eq!(chars[0].location.index.get(), 1);
         assert!(Rc::ptr_eq(&chars[0].location.code, &code));
         assert_eq!(chars[4].value, 'o');
-        assert_eq!(chars[4].location.column.get(), 5);
+        assert_eq!(chars[4].location.index.get(), 5);
         assert!(Rc::ptr_eq(&chars[4].location.code, &code));
     }
 }

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -32,6 +32,7 @@
 
 use super::Location;
 use std::borrow::Cow;
+use std::cell::Ref;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -81,7 +82,7 @@ impl<'a> Annotation<'a> {
             r#type,
             label,
             location,
-            code: Rc::new(location.code.value.as_str()),
+            code: Rc::new(Ref::map(location.code.value.borrow(), String::as_str)),
         }
     }
 }
@@ -261,7 +262,7 @@ mod annotate_snippets_support {
         use std::rc::Rc;
 
         let code = Rc::new(Code {
-            value: "".to_string(),
+            value: "".to_string().into(),
             start_line_number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
@@ -321,7 +322,7 @@ mod annotate_snippets_support {
             origin: Location::dummy("my origin"),
         });
         let code = Rc::new(Code {
-            value: "substitution".to_string(),
+            value: "substitution".to_string().into(),
             start_line_number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -185,11 +185,10 @@ mod annotate_snippets_support {
                     .try_into()
                     .unwrap_or(usize::MAX);
                 let value = &annotation.code;
-                let index = &annotation.location.index;
-                let index = index.get().try_into().unwrap_or(usize::MAX);
-                let index = index.min(value.chars().count()).max(1);
+                let index = annotation.location.index;
+                let index = index.min(value.chars().count().saturating_sub(1));
                 let annotation = snippet::SourceAnnotation {
-                    range: (index - 1, index),
+                    range: (index, index + 1),
                     label: &annotation.label,
                     annotation_type: annotation.r#type.into(),
                 };
@@ -266,10 +265,7 @@ mod annotate_snippets_support {
             start_line_number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location {
-            code,
-            index: NonZeroU64::new(42).unwrap(),
-        };
+        let location = Location { code, index: 42 };
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "".into(),
@@ -281,10 +277,8 @@ mod annotate_snippets_support {
 
     #[test]
     fn from_message_non_default_range() {
-        use std::num::NonZeroU64;
-
         let mut location = Location::dummy("my location");
-        location.index = NonZeroU64::new(7).unwrap();
+        location.index = 6;
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "".into(),
@@ -296,10 +290,8 @@ mod annotate_snippets_support {
 
     #[test]
     fn from_message_range_overflow() {
-        use std::num::NonZeroU64;
-
         let mut location = Location::dummy("my location");
-        location.index = NonZeroU64::new(12).unwrap();
+        location.index = 11;
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "".into(),
@@ -326,10 +318,7 @@ mod annotate_snippets_support {
             start_line_number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });
-        let location = Location {
-            code,
-            index: NonZeroU64::new(5).unwrap(),
-        };
+        let location = Location { code, index: 4 };
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "my title".into(),
@@ -383,11 +372,9 @@ mod annotate_snippets_support {
 
     #[test]
     fn from_message_two_annotations_same_slice() {
-        use std::num::NonZeroU64;
-
         let location_1 = Location::dummy("my location");
         let location_3 = Location {
-            index: NonZeroU64::new(3).unwrap(),
+            index: 2,
             ..location_1.clone()
         };
         let message = Message {

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -225,7 +225,7 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
         use std::rc::Rc;
 
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "".to_string(),
             number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
@@ -297,7 +297,7 @@ mod annotate_snippets_support {
             global: false,
             origin: Location::dummy("my origin"),
         });
-        let line = Rc::new(Line {
+        let line = Rc::new(Code {
             value: "substitution".to_string(),
             number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -96,13 +96,13 @@ impl super::Source {
                     label: format!("alias `{}` was substituted here", alias.name).into(),
                     location: original.clone(),
                 }));
-                original.line.source.complement_annotations(result);
+                original.code.source.complement_annotations(result);
                 result.extend(std::iter::once(Annotation {
                     r#type: AnnotationType::Info,
                     label: format!("alias `{}` was defined here", alias.name).into(),
                     location: alias.origin.clone(),
                 }));
-                alias.origin.line.source.complement_annotations(result);
+                alias.origin.code.source.complement_annotations(result);
             }
         }
     }
@@ -147,27 +147,27 @@ mod annotate_snippets_support {
 
             let mut lines = vec![];
             for annotation in &message.annotations {
-                let line = &annotation.location.line;
-                let line_start = line.number.get().try_into().unwrap_or(usize::MAX);
+                let code = &annotation.location.code;
+                let line_start = code.number.get().try_into().unwrap_or(usize::MAX);
                 let column = &annotation.location.column;
                 let column = column.get().try_into().unwrap_or(usize::MAX);
-                let column = column.min(line.value.chars().count()).max(1);
+                let column = column.min(code.value.chars().count()).max(1);
                 let annotation = snippet::SourceAnnotation {
                     range: (column - 1, column),
                     label: &annotation.label,
                     annotation_type: annotation.r#type.into(),
                 };
-                if let Some(i) = lines.iter().position(|l| l == line) {
+                if let Some(i) = lines.iter().position(|l| l == code) {
                     snippet.slices[i].annotations.push(annotation);
                 } else {
                     snippet.slices.push(snippet::Slice {
-                        source: &line.value,
+                        source: &code.value,
                         line_start,
-                        origin: Some(line.source.label()),
+                        origin: Some(code.source.label()),
                         fold: true,
                         annotations: vec![annotation],
                     });
-                    lines.push(line.clone());
+                    lines.push(code.clone());
                 }
             }
 
@@ -225,13 +225,13 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
         use std::rc::Rc;
 
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "".to_string(),
             number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
         let location = Location {
-            line,
+            code,
             column: NonZeroU64::new(42).unwrap(),
         };
         let message = Message {
@@ -297,13 +297,13 @@ mod annotate_snippets_support {
             global: false,
             origin: Location::dummy("my origin"),
         });
-        let line = Rc::new(Code {
+        let code = Rc::new(Code {
             value: "substitution".to_string(),
             number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });
         let location = Location {
-            line,
+            code,
             column: NonZeroU64::new(5).unwrap(),
         };
         let message = Message {

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -183,9 +183,10 @@ mod annotate_snippets_support {
                     .get()
                     .try_into()
                     .unwrap_or(usize::MAX);
+                let value = &annotation.code;
                 let column = &annotation.location.column;
                 let column = column.get().try_into().unwrap_or(usize::MAX);
-                let column = column.min(code.value.chars().count()).max(1);
+                let column = column.min(value.chars().count()).max(1);
                 let annotation = snippet::SourceAnnotation {
                     range: (column - 1, column),
                     label: &annotation.label,
@@ -195,7 +196,7 @@ mod annotate_snippets_support {
                     snippet.slices[i].annotations.push(annotation);
                 } else {
                     snippet.slices.push(snippet::Slice {
-                        source: &code.value,
+                        source: value,
                         line_start,
                         origin: Some(code.source.label()),
                         fold: true,

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -185,11 +185,11 @@ mod annotate_snippets_support {
                     .try_into()
                     .unwrap_or(usize::MAX);
                 let value = &annotation.code;
-                let column = &annotation.location.column;
-                let column = column.get().try_into().unwrap_or(usize::MAX);
-                let column = column.min(value.chars().count()).max(1);
+                let index = &annotation.location.index;
+                let index = index.get().try_into().unwrap_or(usize::MAX);
+                let index = index.min(value.chars().count()).max(1);
                 let annotation = snippet::SourceAnnotation {
-                    range: (column - 1, column),
+                    range: (index - 1, index),
                     label: &annotation.label,
                     annotation_type: annotation.r#type.into(),
                 };
@@ -268,7 +268,7 @@ mod annotate_snippets_support {
         });
         let location = Location {
             code,
-            column: NonZeroU64::new(42).unwrap(),
+            index: NonZeroU64::new(42).unwrap(),
         };
         let message = Message {
             r#type: AnnotationType::Warning,
@@ -284,7 +284,7 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
 
         let mut location = Location::dummy("my location");
-        location.column = NonZeroU64::new(7).unwrap();
+        location.index = NonZeroU64::new(7).unwrap();
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "".into(),
@@ -299,7 +299,7 @@ mod annotate_snippets_support {
         use std::num::NonZeroU64;
 
         let mut location = Location::dummy("my location");
-        location.column = NonZeroU64::new(12).unwrap();
+        location.index = NonZeroU64::new(12).unwrap();
         let message = Message {
             r#type: AnnotationType::Warning,
             title: "".into(),
@@ -328,7 +328,7 @@ mod annotate_snippets_support {
         });
         let location = Location {
             code,
-            column: NonZeroU64::new(5).unwrap(),
+            index: NonZeroU64::new(5).unwrap(),
         };
         let message = Message {
             r#type: AnnotationType::Warning,
@@ -387,7 +387,7 @@ mod annotate_snippets_support {
 
         let location_1 = Location::dummy("my location");
         let location_3 = Location {
-            column: NonZeroU64::new(3).unwrap(),
+            index: NonZeroU64::new(3).unwrap(),
             ..location_1.clone()
         };
         let message = Message {

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -148,7 +148,11 @@ mod annotate_snippets_support {
             let mut lines = vec![];
             for annotation in &message.annotations {
                 let code = &annotation.location.code;
-                let line_start = code.number.get().try_into().unwrap_or(usize::MAX);
+                let line_start = code
+                    .start_line_number
+                    .get()
+                    .try_into()
+                    .unwrap_or(usize::MAX);
                 let column = &annotation.location.column;
                 let column = column.get().try_into().unwrap_or(usize::MAX);
                 let column = column.min(code.value.chars().count()).max(1);
@@ -227,7 +231,7 @@ mod annotate_snippets_support {
 
         let code = Rc::new(Code {
             value: "".to_string(),
-            number: NonZeroU64::new(128).unwrap(),
+            start_line_number: NonZeroU64::new(128).unwrap(),
             source: Source::Unknown,
         });
         let location = Location {
@@ -299,7 +303,7 @@ mod annotate_snippets_support {
         });
         let code = Rc::new(Code {
             value: "substitution".to_string(),
-            number: NonZeroU64::new(10).unwrap(),
+            start_line_number: NonZeroU64::new(10).unwrap(),
             source: Source::Alias { original, alias },
         });
         let location = Location {

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -64,7 +64,7 @@
 //! use yash_syntax::source::Source;
 //! # use yash_syntax::syntax::Word;
 //! let word: Word = "foo".parse().unwrap();
-//! assert_eq!(word.location.line.source, Source::Unknown);
+//! assert_eq!(word.location.code.source, Source::Unknown);
 //! ```
 //!
 //! To include substantial source information in the AST, you need to prepare a

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -25,6 +25,7 @@ pub use yash_syntax::{alias, parser, source, syntax};
 
 // TODO Allow user to select input source
 async fn parse_and_print(mut env: yash_env::Env) -> i32 {
+    use std::num::NonZeroU64;
     use std::ops::ControlFlow::Break;
     use yash_env::input::Stdin;
     use yash_env::variable::Scope;
@@ -44,7 +45,9 @@ async fn parse_and_print(mut env: yash_env::Env) -> i32 {
         env.variables.assign(Scope::Global, name, value).unwrap();
     }
 
-    let mut lexer = parser::lex::Lexer::new(Box::new(Stdin::new(env.system.clone())));
+    let input = Box::new(Stdin::new(env.system.clone()));
+    let line = NonZeroU64::new(1).unwrap();
+    let mut lexer = parser::lex::Lexer::new(input, line, source::Source::Stdin);
     let result = semantics::read_eval_loop(&mut env, &mut lexer).await;
     if let Break(divert) = result {
         if let Some(exit_status) = divert.exit_status() {


### PR DESCRIPTION
Currently, error messages printed by the `annotate-snippets` crate only shows one line of relevant code. To make messages contain the whole code fragment, we need to reorganize data structures about source code attribution.

(This PR is a rework of #128 and #129, which didn't seem to work)

- [x] Rename the structure
- [x] Rename `Location::line` to `Location::code`
- [x] Rename `number` to `start_line_number`
- [x] Change `Annotation::location` to a reference
- [x] Add `Annotation::code: Rc<dyn Deref<Target = str>>`
- [x] Wrap `Code::value` in `RefCell`
- [x] Rename `Location::column` to `index`
- [x] Count `Location::index` starting from 0 rather than 1
- [x] Share `Code` among lines containing a single command
- [x] Reset `LexerCore::raw_code` on each complete command
- [x] Reconsider the signature (and optimize the implementation) of `Code::enumerate`
- [x] Consider removing `lines`
- [x] (Other FIXMEs)
- [x] (Documentation: rustdoc & changelog)
    - `Code`
    - `source`
