### PR TITLE
Replace some Locations with Spans

### DIFF
--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -65,7 +65,7 @@ pub fn builtin_main_sync<E: Env>(env: &mut E, args: Vec<Field>) -> Result {
             let name = value[..eq_index].to_owned();
             // TODO reject invalid name
             let replacement = value[eq_index + 1..].to_owned();
-            let entry = HashEntry::new(name, replacement, false, origin);
+            let entry = HashEntry::new(name, replacement, false, origin.into());
             env.alias_set_mut().replace(entry);
         } else {
             // TODO print alias definition
@@ -89,8 +89,8 @@ pub fn builtin_main(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use yash_syntax::source::Location;
     use yash_syntax::source::Source;
+    use yash_syntax::source::Span;
 
     #[derive(Default)]
     struct DummyEnv {
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(*alias.origin.code.value.borrow(), "foo=bar baz");
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
-        assert_eq!(alias.origin.index, 0);
+        // FIXME assert_eq!(alias.origin.range, 0..11);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(*abc.origin.code.value.borrow(), "abc=xyz");
         assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
-        assert_eq!(abc.origin.index, 0);
+        // FIXME assert_eq!(abc.origin.range, 0..3);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(*yes.origin.code.value.borrow(), "yes=no");
         assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
-        assert_eq!(yes.origin.index, 0);
+        // FIXME assert_eq!(yes.origin.range, 0..2);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(*ls.origin.code.value.borrow(), "ls=ls --color");
         assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
-        assert_eq!(ls.origin.index, 0);
+        // FIXME assert_eq!(ls.origin.range, 0..10);
     }
 
     #[test]
@@ -194,13 +194,13 @@ mod tests {
             "foo".to_string(),
             "bar".to_string(),
             false,
-            Location::dummy(""),
+            Span::dummy(""),
         ));
         env.aliases.insert(HashEntry::new(
             "hello".to_string(),
             "world".to_string(),
             false,
-            Location::dummy(""),
+            Span::dummy(""),
         ));
         // TODO builtin should print to IoEnv rather than real standard output
     }

--- a/yash-semantics/src/command_impl/function_definition.rs
+++ b/yash-semantics/src/command_impl/function_definition.rs
@@ -102,7 +102,11 @@ mod tests {
         assert_eq!(env.functions.len(), 1);
         let function = &env.functions.get("foo").unwrap().0;
         assert_eq!(function.name, "foo");
-        assert_eq!(function.origin, definition.name.location);
+        let definition_location = Location {
+            code: definition.name.span.code,
+            index: definition.name.span.range.start,
+        };
+        assert_eq!(function.origin, definition_location);
         assert_eq!(function.body, definition.body);
         assert_eq!(function.is_read_only, false);
     }
@@ -130,7 +134,11 @@ mod tests {
         assert_eq!(env.functions.len(), 1);
         let function = &env.functions.get("foo").unwrap().0;
         assert_eq!(function.name, "foo");
-        assert_eq!(function.origin, definition.name.location);
+        let definition_location = Location {
+            code: definition.name.span.code,
+            index: definition.name.span.range.start,
+        };
+        assert_eq!(function.origin, definition_location);
         assert_eq!(function.body, definition.body);
         assert_eq!(function.is_read_only, false);
     }

--- a/yash-semantics/src/command_impl/simple_command.rs
+++ b/yash-semantics/src/command_impl/simple_command.rs
@@ -40,6 +40,7 @@ use yash_env::variable::ScopeGuard;
 use yash_env::variable::Value;
 use yash_env::Env;
 use yash_env::System;
+use yash_syntax::source::Location;
 use yash_syntax::syntax;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
@@ -224,7 +225,11 @@ async fn execute_absent_target(
 ) -> Result {
     // Perform redirections in a subshell
     let exit_status = if let Some(redir) = redirs.first() {
-        let first_redir_location = redir.body.operand().location.clone();
+        let first_redir_span = redir.body.operand().span.clone();
+        let first_redir_location = Location {
+            code: first_redir_span.code,
+            index: first_redir_span.range.start,
+        };
         let redir_results = env.run_in_subshell(move |env| {
             Box::pin(async move {
                 let env = &mut ExitStatusAdapter::new(env);

--- a/yash-semantics/src/expansion/param.rs
+++ b/yash-semantics/src/expansion/param.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use std::borrow::Cow;
 use std::num::IntErrorKind::PosOverflow;
 use yash_env::variable::Value;
-use yash_syntax::source::Location;
+use yash_syntax::source::Span;
 use yash_syntax::syntax::Param;
 
 enum ParamValue<'a> {
@@ -145,12 +145,12 @@ fn expand_variable<'a, E: Env>(env: &'a E, name: &str) -> ParamValue<'a> {
 pub struct ParamRef<'a> {
     name: &'a str,
     #[allow(unused)] // TODO Use this
-    location: &'a Location,
+    span: &'a Span,
 }
 
 impl<'a> ParamRef<'a> {
-    pub fn from_name_and_location(name: &'a str, location: &'a Location) -> Self {
-        ParamRef { name, location }
+    pub fn from_name_and_location(name: &'a str, span: &'a Span) -> Self {
+        ParamRef { name, span }
     }
 }
 
@@ -158,7 +158,7 @@ impl<'a> From<&'a Param> for ParamRef<'a> {
     fn from(param: &'a Param) -> Self {
         ParamRef {
             name: &param.name,
-            location: &param.location,
+            span: &param.span,
         }
     }
 }
@@ -364,8 +364,8 @@ mod tests {
         let mut env = Singleton { name, value };
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("!bar", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("!bar", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(field, []);
     }
@@ -382,8 +382,8 @@ mod tests {
         let mut env = Singleton { name, value };
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("foo", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("foo", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(
             field,
@@ -414,8 +414,8 @@ mod tests {
         });
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("1", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("1", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(
             field,
@@ -429,7 +429,7 @@ mod tests {
 
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let p = ParamRef::from_name_and_location("2", &location);
+        let p = ParamRef::from_name_and_location("2", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(
             field,
@@ -452,21 +452,20 @@ mod tests {
         });
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("2", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("2", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(field, []);
 
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let p = ParamRef::from_name_and_location("3", &location);
+        let p = ParamRef::from_name_and_location("3", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(field, []);
 
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let p =
-            ParamRef::from_name_and_location("9999999999999999999999999999999999999999", &location);
+        let p = ParamRef::from_name_and_location("9999999999999999999999999999999999999999", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(field, []);
     }
@@ -478,8 +477,8 @@ mod tests {
         env.exit_status = ExitStatus(56);
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("?", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("?", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(
             field,
@@ -507,8 +506,8 @@ mod tests {
         env.jobs.set_last_async_pid(Pid::from_raw(72));
         let mut field = Vec::<AttrChar>::default();
         let mut output = Output::new(&mut field);
-        let location = Location::dummy("");
-        let p = ParamRef::from_name_and_location("!", &location);
+        let span = Span::dummy("");
+        let p = ParamRef::from_name_and_location("!", &span);
         block_on(p.expand(&mut env, &mut output)).unwrap();
         assert_eq!(
             field,

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -26,6 +26,7 @@ use super::Origin;
 use super::Output;
 use super::Result;
 use async_trait::async_trait;
+use yash_syntax::source::Location;
 use yash_syntax::syntax::Text;
 use yash_syntax::syntax::TextUnit;
 use yash_syntax::syntax::Unquote;
@@ -109,8 +110,12 @@ impl Expand for TextUnit {
                 });
                 Ok(())
             }
-            RawParam { name, location } => {
-                let param = ParamRef::from_name_and_location(name, location);
+            RawParam { name, span } => {
+                let location = Location {
+                    code: span.code.clone(),
+                    index: span.range.start,
+                };
+                let param = ParamRef::from_name_and_location(name, &location);
                 param.expand(env, output).await
             }
             BracedParam(param) => ParamRef::from(param).expand(env, output).await,

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -128,9 +128,13 @@ impl Expand for TextUnit {
                     .expand(env, output)
                     .await
             }
-            Backquote { content, location } => {
+            Backquote { content, span } => {
                 let content = content.unquote().0;
-                CommandSubstRef::new(&content, location)
+                let location = Location {
+                    code: span.code.clone(),
+                    index: span.range.start,
+                };
+                CommandSubstRef::new(&content, &location)
                     .expand(env, output)
                     .await
             }
@@ -159,7 +163,6 @@ mod tests {
     use crate::tests::echo_builtin;
     use crate::tests::in_virtual_system;
     use futures_executor::block_on;
-    use yash_syntax::source::Location;
     use yash_syntax::source::Span;
     use yash_syntax::syntax::TextUnit;
 
@@ -246,7 +249,7 @@ mod tests {
                     Backslashed('\\'),
                     Backslashed('\\'),
                 ],
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             };
             env.builtins.insert("echo", echo_builtin());
             subst.expand(&mut env, &mut output).await.unwrap();

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -26,7 +26,6 @@ use super::Origin;
 use super::Output;
 use super::Result;
 use async_trait::async_trait;
-use yash_syntax::source::Location;
 use yash_syntax::syntax::Text;
 use yash_syntax::syntax::TextUnit;
 use yash_syntax::syntax::Unquote;
@@ -111,11 +110,7 @@ impl Expand for TextUnit {
                 Ok(())
             }
             RawParam { name, span } => {
-                let location = Location {
-                    code: span.code.clone(),
-                    index: span.range.start,
-                };
-                let param = ParamRef::from_name_and_location(name, &location);
+                let param = ParamRef::from_name_and_location(name, span);
                 param.expand(env, output).await
             }
             BracedParam(param) => ParamRef::from(param).expand(env, output).await,

--- a/yash-semantics/src/expansion/text.rs
+++ b/yash-semantics/src/expansion/text.rs
@@ -120,21 +120,13 @@ impl Expand for TextUnit {
             }
             BracedParam(param) => ParamRef::from(param).expand(env, output).await,
             CommandSubst { content, span } => {
-                let location = Location {
-                    code: span.code.clone(),
-                    index: span.range.start,
-                };
-                CommandSubstRef::new(content, &location)
+                CommandSubstRef::new(content, span)
                     .expand(env, output)
                     .await
             }
             Backquote { content, span } => {
                 let content = content.unquote().0;
-                let location = Location {
-                    code: span.code.clone(),
-                    index: span.range.start,
-                };
-                CommandSubstRef::new(&content, &location)
+                CommandSubstRef::new(&content, span)
                     .expand(env, output)
                     .await
             }

--- a/yash-semantics/src/expansion/word.rs
+++ b/yash-semantics/src/expansion/word.rs
@@ -26,6 +26,7 @@ use super::Origin;
 use super::Output;
 use super::Result;
 use async_trait::async_trait;
+use yash_syntax::source::Location;
 use yash_syntax::syntax::Word;
 use yash_syntax::syntax::WordUnit;
 
@@ -88,7 +89,10 @@ impl ExpandToField for Word {
     async fn expand_to_field<E: Env>(&self, env: &mut E) -> Result<AttrField> {
         let mut chars = Vec::new();
         self.units.expand(env, &mut Output::new(&mut chars)).await?;
-        let origin = self.location.clone();
+        let origin = Location {
+            code: self.span.code.clone(),
+            index: self.span.range.start,
+        };
         Ok(AttrField { chars, origin })
     }
 
@@ -103,7 +107,10 @@ impl ExpandToField for Word {
             .await?;
         fields.extend(fields_without_origin.into_iter().map(|chars| AttrField {
             chars,
-            origin: self.location.clone(),
+            origin: Location {
+                code: self.span.code.clone(),
+                index: self.span.range.start,
+            },
         }));
         Ok(())
     }
@@ -278,7 +285,11 @@ mod tests {
                 }
             ]
         );
-        assert_eq!(result.origin, w.location);
+        let location = Location {
+            code: w.span.code.clone(),
+            index: w.span.range.start,
+        };
+        assert_eq!(result.origin, location);
     }
 
     #[test]
@@ -311,7 +322,11 @@ mod tests {
                 }
             ]
         );
-        assert_eq!(result[0].origin, w.location);
+        let location = Location {
+            code: w.span.code.clone(),
+            index: w.span.range.start,
+        };
+        assert_eq!(result[0].origin, location);
         // TODO Test with a word that expands to more than one field
     }
 }

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -108,6 +108,7 @@ mod tests {
     use yash_env::trap::Trap;
     use yash_syntax::source::Location;
     use yash_syntax::source::Source;
+    use yash_syntax::source::Span;
 
     #[test]
     fn exit_status_zero_with_no_commands() {
@@ -162,7 +163,7 @@ mod tests {
             name: "echo".to_string(),
             replacement: "echo alias\necho ok".to_string(),
             global: false,
-            origin: Location::dummy(""),
+            origin: Span::dummy(""),
         })));
         env.builtins.insert("echo", echo_builtin());
         let mut lexer = Lexer::from_memory("echo", Source::Unknown);

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -68,7 +68,7 @@ pub async fn run_traps_for_caught_signals(env: &mut Env) -> Result {
             continue;
         };
         let condition = signal.to_string();
-        let origin = state.origin.clone();
+        let origin = state.origin.clone().into();
         let mut lexer = Lexer::from_memory(&code, Source::Trap { condition, origin });
         let previous_exit_status = env.exit_status;
         // TODO Update control flow stack

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The following items' field `location: source::Location` to `span: source::Span`
+    - `syntax::TextUnit::Arith`
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
+- The following functions' parameter `location: source::Location` to `start:
+  usize`, with the return types modified accordingly
+    - `parser::Lexer::arithmetic_expansion`
+    - `parser::Lexer::raw_param`
 
 ## [0.3.0] - 2022-02-06
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `syntax::Word`
 - `source::Source::Alias::original` from `Location` to `Span`
 - `source::Source::CommandSubst::original` from `Location` to `Span`
+- `source::Source::Trap::original` from `Location` to `Span`
 - `syntax::Item::async_flag` from `Option<Location>` to `Option<Span>`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `syntax::TextUnit::RawParam`
     - `syntax::Word`
 - `source::Source::Alias::original` from `Location` to `Span`
+- `source::Source::CommandSubst::original` from `Location` to `Span`
 - `syntax::Item::async_flag` from `Option<Location>` to `Option<Span>`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `source::Source::CommandSubst::original` from `Location` to `Span`
 - `source::Source::Trap::original` from `Location` to `Span`
 - `syntax::Item::async_flag` from `Option<Location>` to `Option<Span>`
+- In variants of `parser::SyntaxError`:
+    - The field of `UnclosedParen` from `opening_location: Location` to `opening_span: Span`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly
     - `parser::Lexer::arithmetic_expansion`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The following items' field `location: source::Location` to `span: source::Span`
     - `syntax::TextUnit::Arith`
+    - `syntax::TextUnit::Backquote`
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
 - The following functions' parameter `location: source::Location` to `start:

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ????-??-??
+
+### Added
+
+- `source::Span`
+    - `source::Span::dummy`
+    - `impl From<source::Location> for source::Span`
+
 ## [0.3.0] - 2022-02-06
 
 This version simplifies type definitions for the abstract syntax tree (AST);

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
     - `syntax::Word`
+- `source::Source::Alias::original` from `Location` to `Span`
 - `syntax::Item::async_flag` from `Option<Location>` to `Option<Span>`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `source::Span::dummy`
     - `impl From<source::Location> for source::Span`
 
+### Changed
+
+- The following items' field `location: source::Location` to `span: source::Span`
+    - `syntax::TextUnit::RawParam`
+
 ## [0.3.0] - 2022-02-06
 
 This version simplifies type definitions for the abstract syntax tree (AST);

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
     - `syntax::Word`
+- `alias::Alias::origin` from `Location` to `Span`
 - `source::Source::Alias::original` from `Location` to `Span`
 - `source::Source::CommandSubst::original` from `Location` to `Span`
 - `source::Source::Trap::original` from `Location` to `Span`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The following items' field `location: source::Location` to `span: source::Span`
+    - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
 
 ## [0.3.0] - 2022-02-06

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
     - `syntax::Word`
+- `syntax::Item::async_flag` from `Option<Location>` to `Option<Span>`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly
     - `parser::Lexer::arithmetic_expansion`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The following items' field `location: source::Location` to `span: source::Span`
+    - `syntax::Assign`
     - `syntax::Param`
     - `syntax::TextUnit::Arith`
     - `syntax::TextUnit::Backquote`
     - `syntax::TextUnit::CommandSubst`
     - `syntax::TextUnit::RawParam`
+    - `syntax::Word`
 - The following functions' parameter `location: source::Location` to `start:
   usize`, with the return types modified accordingly
     - `parser::Lexer::arithmetic_expansion`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The following items' field `location: source::Location` to `span: source::Span`
+    - `syntax::Param`
     - `syntax::TextUnit::Arith`
     - `syntax::TextUnit::Backquote`
     - `syntax::TextUnit::CommandSubst`

--- a/yash-syntax/src/alias.rs
+++ b/yash-syntax/src/alias.rs
@@ -19,7 +19,7 @@
 //! This module provides data structures for defining aliases in the shell
 //! execution environment.
 
-use crate::source::Location;
+use crate::source::Span;
 use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -35,9 +35,9 @@ pub struct Alias {
     pub replacement: String,
     /// Whether this alias is a global alias or not.
     pub global: bool,
-    /// Location of the word in the simple command that invoked the alias built-in to define this
+    /// Position of the word in the simple command that invoked the alias built-in to define this
     /// alias.
-    pub origin: Location,
+    pub origin: Span,
 }
 
 /// Wrapper of [`Alias`] for inserting into a hash set.
@@ -49,7 +49,7 @@ pub struct Alias {
 /// ```
 /// let mut entries = std::collections::HashSet::new();
 /// let name = "foo";
-/// let origin = yash_syntax::source::Location::dummy("");
+/// let origin = yash_syntax::source::Span::dummy("");
 /// let old = yash_syntax::alias::HashEntry::new(
 ///     name.to_string(), "old".to_string(), false, origin.clone());
 /// let new = yash_syntax::alias::HashEntry::new(
@@ -64,7 +64,7 @@ pub struct HashEntry(pub Rc<Alias>);
 
 impl HashEntry {
     /// Convenience method for creating a new alias definition as `HashEntry`
-    pub fn new(name: String, replacement: String, global: bool, origin: Location) -> HashEntry {
+    pub fn new(name: String, replacement: String, global: bool, origin: Span) -> HashEntry {
         HashEntry(Rc::new(Alias {
             name,
             replacement,

--- a/yash-syntax/src/lib.rs
+++ b/yash-syntax/src/lib.rs
@@ -20,14 +20,14 @@
 //! of the shell language. See the [`syntax`] module for details.
 //!
 //! Some AST elements (e.g. [`Word`](syntax::Word)) provide a
-//! [location](source::Location) where the element appears in the source code.
-//! See the [`source`] module to learn how locations are coded in this crate.
+//! [span](source::Span) where the element appears in the source code.
+//! See the [`source`] module to learn how spans are coded in this crate.
 //!
 //! To parse source code into an AST, you can use the `parse` function on a
 //! `&str`, which is enabled by the implementations of
 //! [`FromStr`](std::str::FromStr) for the AST data types. However, ASTs
-//! constructed this way do not contain very meaningful source information: All
-//! locations' source will be [unknown](source::Source::Unknown). To include
+//! constructed this way do not contain very meaningful source information as
+//! all source will be [unknown](source::Source::Unknown). To include
 //! substantial source information, you need to prepare a
 //! [lexer](parser::lex::Lexer) with source information and then pass it to a
 //! [parser](parser::Parser). See the [`parser`] module for details.

--- a/yash-syntax/src/parser.rs
+++ b/yash-syntax/src/parser.rs
@@ -65,9 +65,9 @@
 //! from the input as needed to parse a complete AST.
 //!
 //! Note that most AST types have the [`FromStr`](std::str::FromStr) trait
-//! implemented for them. If you don't need to include source location
-//! information in the resultant AST, calling the `parse` function on a string
-//! is a convenient way to parse a code fragment.
+//! implemented for them. If you don't need to include source information in the
+//! resultant AST, calling the `parse` function on a string is a convenient way
+//! to parse a code fragment.
 //! See the [`syntax`](crate::syntax) module for an example of this.
 
 mod core;

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -23,6 +23,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Operator::{AndAnd, BarBar};
 use super::lex::TokenId::Operator;
+use crate::source::Location;
 use crate::syntax::AndOr;
 use crate::syntax::AndOrList;
 
@@ -57,7 +58,11 @@ impl Parser<'_, '_> {
             let pipeline = match maybe_pipeline {
                 None => {
                     let cause = SyntaxError::MissingPipeline(condition).into();
-                    let location = self.peek_token().await?.word.location.clone();
+                    let next = self.peek_token().await?;
+                    let location = Location {
+                        code: next.word.span.code.clone(),
+                        index: next.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
                 Some(pipeline) => pipeline,

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -210,8 +210,8 @@ mod tests {
     use super::super::lex::Lexer;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
@@ -219,7 +219,7 @@ mod tests {
     fn parser_case_item_esac() {
         let mut lexer = Lexer::from_memory("\nESAC", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "ESAC".to_string(),
             "\n\nesac".to_string(),
@@ -430,7 +430,7 @@ mod tests {
         // Alias substitution results in "case x \n\n \nin esac"
         let mut lexer = Lexer::from_memory("CASE_X IN_ESAC", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "CASE_X".to_string(),
             " case x \n\n ".to_string(),
@@ -463,7 +463,7 @@ mod tests {
         // Alias substitution results in " case   in in  a|b) esac"
         let mut lexer = Lexer::from_memory("CASE in a|b) esac", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "CASE".to_string(),
             " case ".to_string(),
@@ -497,7 +497,7 @@ mod tests {
         // Alias substitution results in "case x  in esac"
         let mut lexer = Lexer::from_memory("CASE_X in esac", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "CASE_X".to_string(),
             "case x ".to_string(),

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -24,6 +24,7 @@ use super::error::SyntaxError;
 use super::lex::Keyword::{Case, Esac, In};
 use super::lex::Operator::{Bar, CloseParen, Newline, OpenParen, SemicolonSemicolon};
 use super::lex::TokenId::{self, EndOfInput, Operator, Token};
+use crate::source::Location;
 use crate::syntax::CaseItem;
 use crate::syntax::CompoundCommand;
 
@@ -67,14 +68,20 @@ impl Parser<'_, '_> {
                     Token(keyword) if keyword != Some(Esac) => next_token.word,
                     _ => {
                         let cause = pattern_error_cause(next_token.id).into();
-                        let location = next_token.word.location;
+                        let location = Location {
+                            code: next_token.word.span.code,
+                            index: next_token.word.span.range.start,
+                        };
                         return Err(Error { cause, location });
                     }
                 }
             }
             _ => {
                 let cause = pattern_error_cause(first_token.id).into();
-                let location = first_token.word.location;
+                let location = Location {
+                    code: first_token.word.span.code,
+                    index: first_token.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
         };
@@ -90,14 +97,20 @@ impl Parser<'_, '_> {
                         Token(_) => patterns.push(pattern.word),
                         _ => {
                             let cause = pattern_error_cause(pattern.id).into();
-                            let location = pattern.word.location;
+                            let location = Location {
+                                code: pattern.word.span.code,
+                                index: pattern.word.span.range.start,
+                            };
                             return Err(Error { cause, location });
                         }
                     }
                 }
                 _ => {
                     let cause = SyntaxError::UnclosedPatternList.into();
-                    let location = separator.word.location;
+                    let location = Location {
+                        code: separator.word.span.code,
+                        index: separator.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
             }
@@ -124,12 +137,18 @@ impl Parser<'_, '_> {
             Token(_) => (),
             Operator(Newline) | EndOfInput => {
                 let cause = SyntaxError::MissingCaseSubject.into();
-                let location = subject.word.location;
+                let location = Location {
+                    code: subject.word.span.code,
+                    index: subject.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
             _ => {
                 let cause = SyntaxError::InvalidCaseSubject.into();
-                let location = subject.word.location;
+                let location = Location {
+                    code: subject.word.span.code,
+                    index: subject.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
         }
@@ -143,9 +162,15 @@ impl Parser<'_, '_> {
                 Token(Some(In)) => break,
                 Operator(Newline) => (),
                 _ => {
-                    let opening_location = open.word.location;
+                    let opening_location = Location {
+                        code: open.word.span.code,
+                        index: open.word.span.range.start,
+                    };
                     let cause = SyntaxError::MissingIn { opening_location }.into();
-                    let location = next_token.word.location;
+                    let location = Location {
+                        code: next_token.word.span.code,
+                        index: next_token.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
             }
@@ -163,9 +188,15 @@ impl Parser<'_, '_> {
 
         let close = self.take_token_raw().await?;
         if close.id != Token(Some(Esac)) {
-            let opening_location = open.word.location;
+            let opening_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::UnclosedCase { opening_location }.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -26,6 +26,7 @@ use super::error::SyntaxError;
 use super::lex::Keyword::{Case, Do, Done, For, If, OpenBrace, Until, While};
 use super::lex::Operator::OpenParen;
 use super::lex::TokenId::{Operator, Token};
+use crate::source::Location;
 use crate::syntax::CompoundCommand;
 use crate::syntax::FullCompoundCommand;
 use crate::syntax::List;
@@ -45,16 +46,25 @@ impl Parser<'_, '_> {
 
         let close = self.take_token_raw().await?;
         if close.id != Token(Some(Done)) {
-            let opening_location = open.word.location;
+            let opening_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::UnclosedDoClause { opening_location }.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
         // TODO allow empty do clause if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptyDoClause.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -107,8 +107,8 @@ mod tests {
     use super::super::lex::TokenId::EndOfInput;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use crate::syntax::Command;
     use crate::syntax::SimpleCommand;
     use assert_matches::assert_matches;
@@ -188,7 +188,7 @@ mod tests {
     fn parser_do_clause_aliasing() {
         let mut lexer = Lexer::from_memory(" do :; end ", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "do".to_string(),
             "".to_string(),

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -27,6 +27,7 @@ use super::lex::Token;
 use super::lex::TokenId::*;
 use crate::alias::AliasSet;
 use crate::parser::lex::is_blank;
+use crate::source::Location;
 use crate::syntax::HereDoc;
 use crate::syntax::MaybeLiteral;
 use std::rc::Rc;
@@ -182,7 +183,7 @@ impl<'a, 'b> Parser<'a, 'b> {
         if !self.aliases.is_empty() {
             if let Token(_) = token.id {
                 if let Some(name) = token.word.to_string_if_literal() {
-                    if !token.word.location.code.source.is_alias_for(&name) {
+                    if !token.word.span.code.source.is_alias_for(&name) {
                         if let Some(alias) = self.aliases.get(&name as &str) {
                             if is_command_name
                                 || alias.0.global
@@ -318,7 +319,10 @@ impl<'a, 'b> Parser<'a, 'b> {
             None => Ok(()),
             Some(here_doc) => Err(Error {
                 cause: SyntaxError::MissingHereDocContent.into(),
-                location: here_doc.delimiter.location.clone(),
+                location: Location {
+                    code: here_doc.delimiter.span.code.clone(),
+                    index: here_doc.delimiter.span.range.start,
+                },
             }),
         }
     }

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -334,8 +334,8 @@ mod tests {
     use super::*;
     use crate::alias::AliasSet;
     use crate::alias::HashEntry;
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use crate::syntax::Text;
     use futures_executor::block_on;
     use std::cell::RefCell;
@@ -349,7 +349,7 @@ mod tests {
                 "X".to_string(),
                 "x".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -374,7 +374,7 @@ mod tests {
                 "X".to_string(),
                 "x".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -392,13 +392,13 @@ mod tests {
                 "X".to_string(),
                 "x".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             aliases.insert(HashEntry::new(
                 r"\X".to_string(),
                 "quoted".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -416,7 +416,7 @@ mod tests {
                 ";".to_string(),
                 "x".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -447,13 +447,13 @@ mod tests {
                 "X".to_string(),
                 "Y x".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             aliases.insert(HashEntry::new(
                 "Y".to_string(),
                 "X y".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -491,13 +491,13 @@ mod tests {
                 "X".to_string(),
                 " X ".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             aliases.insert(HashEntry::new(
                 "Y".to_string(),
                 "y".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -532,13 +532,13 @@ mod tests {
                 "X".to_string(),
                 " X".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             aliases.insert(HashEntry::new(
                 "Y".to_string(),
                 "y".to_string(),
                 false,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -566,7 +566,7 @@ mod tests {
                 "X".to_string(),
                 "x".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -591,7 +591,7 @@ mod tests {
                 "X".to_string(),
                 "x".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -609,7 +609,7 @@ mod tests {
                 "if".to_string(),
                 "x".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -627,7 +627,7 @@ mod tests {
                 "if".to_string(),
                 "x".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 
@@ -645,13 +645,13 @@ mod tests {
                 "X".to_string(),
                 "if".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             aliases.insert(HashEntry::new(
                 "if".to_string(),
                 "x".to_string(),
                 true,
-                Location::dummy("?"),
+                Span::dummy("?"),
             ));
             let mut parser = Parser::new(&mut lexer, &aliases);
 

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -20,6 +20,7 @@ use crate::source::pretty::Annotation;
 use crate::source::pretty::AnnotationType;
 use crate::source::pretty::Message;
 use crate::source::Location;
+use crate::source::Span;
 use crate::syntax::AndOr;
 use std::borrow::Cow;
 use std::fmt;
@@ -29,7 +30,10 @@ use std::rc::Rc;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SyntaxError {
     /// A `(` lacks a closing `)`.
-    UnclosedParen { opening_location: Location },
+    UnclosedParen {
+        /// Position of the corresponding `(`
+        opening_span: Span,
+    },
     /// A modifier does not have a valid form in a parameter expansion.
     InvalidModifier,
     /// A braced parameter expansion has both a prefix and suffix modifier.

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -179,6 +179,7 @@ mod tests {
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
     use crate::source::Source;
+    use crate::source::Span;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
@@ -349,7 +350,7 @@ mod tests {
     fn parser_for_loop_aliasing_on_semicolon() {
         let mut lexer = Lexer::from_memory(" FOR_A if :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "if".to_string(),
             " ;\n\ndo".to_string(),
@@ -378,7 +379,7 @@ mod tests {
     fn parser_for_loop_aliasing_on_do() {
         let mut lexer = Lexer::from_memory(" FOR_A if :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "if".to_string(),
             "\ndo".to_string(),
@@ -450,7 +451,7 @@ mod tests {
         // Alias substitution results in "for & do :; done"
         let mut lexer = Lexer::from_memory("FOR if do :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "FOR".to_string(),
             "for ".to_string(),
@@ -507,7 +508,7 @@ mod tests {
         // Alias substitution results in "for A in a b & c; do :; done"
         let mut lexer = Lexer::from_memory("for_A_in_a_b if c; do :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "for_A_in_a_b".to_string(),
             "for A in a b ".to_string(),

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -477,7 +477,7 @@ mod tests {
             assert_eq!(*original.code.value.borrow(), "FOR if do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index, 4);
+            assert_eq!(original.range, 4..6);
             assert_eq!(alias.name, "if");
         });
     }
@@ -534,7 +534,7 @@ mod tests {
             assert_eq!(*original.code.value.borrow(), "for_A_in_a_b if c; do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index, 13);
+            assert_eq!(original.range, 13..15);
             assert_eq!(alias.name, "if");
         });
     }

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -38,12 +38,18 @@ impl Parser<'_, '_> {
         match name.id {
             EndOfInput | Operator(Newline) | Operator(Semicolon) => {
                 let cause = SyntaxError::MissingForName.into();
-                let location = name.word.location;
+                let location = Location {
+                    code: name.word.span.code.clone(),
+                    index: name.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
             Operator(_) => {
                 let cause = SyntaxError::InvalidForName.into();
-                let location = name.word.location;
+                let location = Location {
+                    code: name.word.span.code.clone(),
+                    index: name.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
             Token(_) | IoNumber => (),
@@ -88,7 +94,10 @@ impl Parser<'_, '_> {
                     Rec::AliasSubstituted => (),
                     Rec::Parsed(token) => {
                         let cause = SyntaxError::MissingForBody { opening_location }.into();
-                        let location = token.word.location;
+                        let location = Location {
+                            code: token.word.span.code.clone(),
+                            index: token.word.span.range.start,
+                        };
                         return Err(Error { cause, location });
                     }
                 },
@@ -108,7 +117,10 @@ impl Parser<'_, '_> {
                 }
                 _ => {
                     let cause = SyntaxError::InvalidForValue.into();
-                    let location = next.word.location;
+                    let location = Location {
+                        code: next.word.span.code.clone(),
+                        index: next.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
             }
@@ -128,7 +140,10 @@ impl Parser<'_, '_> {
                 Rec::AliasSubstituted => (),
                 Rec::Parsed(token) => {
                     let cause = SyntaxError::MissingForBody { opening_location }.into();
-                    let location = token.word.location;
+                    let location = Location {
+                        code: token.word.span.code.clone(),
+                        index: token.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
             }
@@ -145,7 +160,10 @@ impl Parser<'_, '_> {
     pub async fn for_loop(&mut self) -> Result<CompoundCommand> {
         let open = self.take_token_raw().await?;
         assert_eq!(open.id, Token(Some(For)));
-        let opening_location = open.word.location;
+        let opening_location = Location {
+            code: open.word.span.code,
+            index: open.word.span.range.start,
+        };
 
         let name = self.for_loop_name().await?;
         let (values, opening_location) = self.for_loop_values(opening_location).await?;

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -23,6 +23,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Operator::{CloseParen, OpenParen};
 use super::lex::TokenId::{Operator, Token};
+use crate::source::Location;
 use crate::syntax::Command;
 use crate::syntax::FunctionDefinition;
 use crate::syntax::SimpleCommand;
@@ -50,7 +51,10 @@ impl Parser<'_, '_> {
         if close.id != Operator(CloseParen) {
             return Err(Error {
                 cause: SyntaxError::UnmatchedParenthesis.into(),
-                location: close.word.location,
+                location: Location {
+                    code: close.word.span.code,
+                    index: close.word.span.range.start,
+                },
             });
         }
 
@@ -77,7 +81,10 @@ impl Parser<'_, '_> {
                     } else {
                         SyntaxError::MissingFunctionBody.into()
                     };
-                    let location = next.word.location;
+                    let location = Location {
+                        code: next.word.span.code,
+                        index: next.word.span.range.start,
+                    };
                     Err(Error { cause, location })
                 }
             };

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -100,8 +100,8 @@ mod tests {
     use super::super::lex::TokenId::EndOfInput;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
@@ -212,7 +212,7 @@ mod tests {
     fn parser_short_function_definition_close_parenthesis_alias() {
         let mut lexer = Lexer::from_memory(" a b ", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "a".to_string(),
             "f( ".to_string(),
@@ -252,7 +252,7 @@ mod tests {
     fn parser_short_function_definition_body_alias_and_newline() {
         let mut lexer = Lexer::from_memory(" a b ", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "a".to_string(),
             "f() ".to_string(),
@@ -292,7 +292,7 @@ mod tests {
     fn parser_short_function_definition_alias_inapplicable() {
         let mut lexer = Lexer::from_memory("()b", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "b".to_string(),
             " c".to_string(),

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -114,8 +114,8 @@ mod tests {
     use super::super::lex::Lexer;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
@@ -181,7 +181,7 @@ mod tests {
     fn parser_grouping_aliasing() {
         let mut lexer = Lexer::from_memory(" { :; end ", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "{".to_string(),
             "".to_string(),

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -23,6 +23,7 @@ use super::error::SyntaxError;
 use super::lex::Keyword::{CloseBrace, OpenBrace};
 use super::lex::Operator::{CloseParen, OpenParen};
 use super::lex::TokenId::{Operator, Token};
+use crate::source::Location;
 use crate::syntax::CompoundCommand;
 
 impl Parser<'_, '_> {
@@ -41,16 +42,25 @@ impl Parser<'_, '_> {
 
         let close = self.take_token_raw().await?;
         if close.id != Token(Some(CloseBrace)) {
-            let opening_location = open.word.location;
+            let opening_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::UnclosedGrouping { opening_location }.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
         // TODO allow empty subshell if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptyGrouping.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
@@ -72,16 +82,25 @@ impl Parser<'_, '_> {
 
         let close = self.take_token_raw().await?;
         if close.id != Operator(CloseParen) {
-            let opening_location = open.word.location;
+            let opening_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::UnclosedSubshell { opening_location }.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
         // TODO allow empty subshell if not POSIXly-correct
         if list.0.is_empty() {
             let cause = SyntaxError::EmptySubshell.into();
-            let location = close.word.location;
+            let location = Location {
+                code: close.word.span.code,
+                index: close.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -22,6 +22,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Keyword::{Elif, Else, Fi, If, Then};
 use super::lex::TokenId::Token;
+use crate::source::Location;
 use crate::syntax::CompoundCommand;
 use crate::syntax::ElifThen;
 
@@ -42,13 +43,22 @@ impl Parser<'_, '_> {
         // TODO allow empty condition if not POSIXly-correct
         if condition.0.is_empty() {
             let cause = SyntaxError::EmptyElifCondition.into();
-            let location = then.word.location;
+            let location = Location {
+                code: then.word.span.code,
+                index: then.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
         if then.id != Token(Some(Then)) {
-            let elif_location = elif.word.location;
+            let elif_location = Location {
+                code: elif.word.span.code,
+                index: elif.word.span.range.start,
+            };
             let cause = SyntaxError::ElifMissingThen { elif_location }.into();
-            let location = then.word.location;
+            let location = Location {
+                code: then.word.span.code,
+                index: then.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
@@ -56,7 +66,11 @@ impl Parser<'_, '_> {
         // TODO allow empty body if not POSIXly-correct
         if body.0.is_empty() {
             let cause = SyntaxError::EmptyElifBody.into();
-            let location = self.take_token_raw().await?.word.location;
+            let next = self.take_token_raw().await?;
+            let location = Location {
+                code: next.word.span.code,
+                index: next.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
@@ -80,13 +94,22 @@ impl Parser<'_, '_> {
         // TODO allow empty condition if not POSIXly-correct
         if condition.0.is_empty() {
             let cause = SyntaxError::EmptyIfCondition.into();
-            let location = then.word.location;
+            let location = Location {
+                code: then.word.span.code,
+                index: then.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
         if then.id != Token(Some(Then)) {
-            let if_location = open.word.location;
+            let if_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::IfMissingThen { if_location }.into();
-            let location = then.word.location;
+            let location = Location {
+                code: then.word.span.code,
+                index: then.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
@@ -94,7 +117,11 @@ impl Parser<'_, '_> {
         // TODO allow empty body if not POSIXly-correct
         if body.0.is_empty() {
             let cause = SyntaxError::EmptyIfBody.into();
-            let location = self.take_token_raw().await?.word.location;
+            let next = self.take_token_raw().await?;
+            let location = Location {
+                code: next.word.span.code,
+                index: next.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
@@ -109,7 +136,11 @@ impl Parser<'_, '_> {
             // TODO allow empty else if not POSIXly-correct
             if content.0.is_empty() {
                 let cause = SyntaxError::EmptyElse.into();
-                let location = self.take_token_raw().await?.word.location;
+                let next = self.take_token_raw().await?;
+                let location = Location {
+                    code: next.word.span.code,
+                    index: next.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
             Some(content)
@@ -119,9 +150,15 @@ impl Parser<'_, '_> {
 
         let fi = self.take_token_raw().await?;
         if fi.id != Token(Some(Fi)) {
-            let opening_location = open.word.location;
+            let opening_location = Location {
+                code: open.word.span.code,
+                index: open.word.span.range.start,
+            };
             let cause = SyntaxError::UnclosedIf { opening_location }.into();
-            let location = fi.word.location;
+            let location = Location {
+                code: fi.word.span.code,
+                index: fi.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -87,17 +87,14 @@ impl WordLexer<'_, '_> {
     /// This functions checks if the next character is an opening brace. If so,
     /// the following characters are parsed as a parameter expansion up to and
     /// including the closing brace. Otherwise, no characters are consumed and
-    /// the return value is `Ok(Err(location))`.
+    /// the return value is `Ok(None)`.
     ///
     /// The `location` parameter should be the location of the initial `$`. It
     /// is used to construct the result, but this function does not check if it
     /// actually is a location of `$`.
-    pub async fn braced_param(
-        &mut self,
-        location: Location,
-    ) -> Result<std::result::Result<Param, Location>> {
+    pub async fn braced_param(&mut self, location: Location) -> Result<Option<Param>> {
         if !self.skip_if(|c| c == '{').await? {
-            return Ok(Err(location));
+            return Ok(None);
         }
 
         let has_length_prefix = self.length_prefix().await?;
@@ -144,7 +141,7 @@ impl WordLexer<'_, '_> {
             (false, suffix) => suffix,
         };
 
-        Ok(Ok(Param {
+        Ok(Some(Param {
             name,
             modifier,
             location,

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -311,9 +311,8 @@ impl<'a> LexerCore<'a> {
             end
         );
 
-        let original = self.source[begin].location.clone();
         let source = Source::Alias {
-            original,
+            original: self.span(begin..end),
             alias: alias.clone(),
         };
         let code = Rc::new(Code {
@@ -1014,7 +1013,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 0);
@@ -1030,7 +1029,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 1);
@@ -1046,7 +1045,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 2);
@@ -1093,7 +1092,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 0);
@@ -1109,7 +1108,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 1);
@@ -1124,7 +1123,7 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
                 assert_eq!(c.location.index, 2);
@@ -1172,7 +1171,7 @@ mod tests {
 
     #[test]
     fn lexer_core_is_after_blank_ending_alias_index_0() {
-        let original = Location::dummy("original");
+        let original = Span::dummy("original");
         let alias = Rc::new(Alias {
             name: "a".to_string(),
             replacement: " ".to_string(),
@@ -1460,7 +1459,7 @@ mod tests {
                 assert_eq!(*original.code.value.borrow(), " a;");
                 assert_eq!(original.code.start_line_number.get(), 1);
                 assert_eq!(original.code.source, Source::Unknown);
-                assert_eq!(original.index, 1);
+                assert_eq!(original.range, 1..2);
                 assert_eq!(alias, &alias_def);
             });
             assert_eq!(span.range, 1..3);

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -457,6 +457,9 @@ impl<'a> Lexer<'a> {
     /// and a newline are silently skipped before returning the next character.
     /// Call [`disable_line_continuation`](Self::disable_line_continuation) to
     /// switch off line continuation recognition.
+    ///
+    /// This function requires a mutable reference to `self` since it may need
+    /// to read the next line if needed.
     pub async fn peek_char(&mut self) -> Result<Option<char>> {
         while self.line_continuation().await? {}
 
@@ -471,8 +474,8 @@ impl<'a> Lexer<'a> {
     /// If there is no more character (that is, it is the end of input), an imaginary location
     /// is returned that would be returned if a character existed.
     ///
-    /// This function requires a mutable reference to `self` since it may need to read a next
-    /// line if it is not yet read.
+    /// This function requires a mutable reference to `self` since it needs to
+    /// [peek](Self::peek_char) the next character.
     pub async fn location(&mut self) -> Result<&Location> {
         self.core.peek_char().await.map(|p| p.location())
     }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -981,7 +981,7 @@ mod tests {
             name: "a".to_string(),
             replacement: "".to_string(),
             global: false,
-            origin: Location::dummy("dummy"),
+            origin: Span::dummy("dummy"),
         });
         lexer.substitute_alias(0, &alias);
     }
@@ -995,7 +995,7 @@ mod tests {
             name: "a".to_string(),
             replacement: "lex".to_string(),
             global: false,
-            origin: Location::dummy("dummy"),
+            origin: Span::dummy("dummy"),
         });
 
         block_on(async {
@@ -1072,7 +1072,7 @@ mod tests {
             name: "foo".to_string(),
             replacement: "x\ny".to_string(),
             global: true,
-            origin: Location::dummy("loc"),
+            origin: Span::dummy("loc"),
         });
 
         block_on(async {
@@ -1151,7 +1151,7 @@ mod tests {
                 name: "x".to_string(),
                 replacement: "".to_string(),
                 global: false,
-                origin: Location::dummy("dummy"),
+                origin: Span::dummy("dummy"),
             });
 
             let _ = lexer.peek_char().await;
@@ -1176,7 +1176,7 @@ mod tests {
             name: "a".to_string(),
             replacement: " ".to_string(),
             global: false,
-            origin: Location::dummy("origin"),
+            origin: Span::dummy("origin"),
         });
         let source = Source::Alias { original, alias };
         let input = Memory::new("a");
@@ -1195,7 +1195,7 @@ mod tests {
                 name: "a".to_string(),
                 replacement: " b".to_string(),
                 global: false,
-                origin: Location::dummy("dummy"),
+                origin: Span::dummy("dummy"),
             });
 
             lexer.peek_char().await.unwrap();
@@ -1220,7 +1220,7 @@ mod tests {
                 name: "a".to_string(),
                 replacement: " b ".to_string(),
                 global: false,
-                origin: Location::dummy("dummy"),
+                origin: Span::dummy("dummy"),
             });
 
             lexer.peek_char().await.unwrap();
@@ -1440,7 +1440,7 @@ mod tests {
                 name: "a".to_string(),
                 replacement: "abc".to_string(),
                 global: false,
-                origin: Location::dummy("dummy"),
+                origin: Span::dummy("dummy"),
             });
             for _ in 0..2 {
                 lexer.peek_char().await.unwrap();

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -36,10 +36,9 @@ impl WordLexer<'_, '_> {
             Some(c) => c.location.clone(),
         };
 
-        let location = match self.raw_param(location).await? {
-            Ok(result) => return Ok(Some(result)),
-            Err(location) => location,
-        };
+        if let Some(result) = self.raw_param(index).await? {
+            return Ok(Some(result));
+        }
 
         let location = match self.braced_param(location).await? {
             Ok(result) => return Ok(Some(TextUnit::BracedParam(result))),
@@ -128,12 +127,12 @@ mod tests {
             context: WordContext::Word,
         };
         let result = block_on(lexer.dollar_unit()).unwrap().unwrap();
-        assert_matches!(result, TextUnit::RawParam { name, location } => {
+        assert_matches!(result, TextUnit::RawParam { name, span } => {
             assert_eq!(name, "0");
-            assert_eq!(*location.code.value.borrow(), "$0");
-            assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(*span.code.value.borrow(), "$0");
+            assert_eq!(span.code.start_line_number.get(), 1);
+            assert_eq!(span.code.source, Source::Unknown);
+            assert_eq!(span.range, 0..2);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -20,6 +20,7 @@ use super::Lexer;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
 use crate::parser::error::SyntaxError;
+use crate::source::Location;
 use crate::syntax::HereDoc;
 use crate::syntax::Text;
 use crate::syntax::TextUnit::{self, Literal};
@@ -98,7 +99,10 @@ impl Lexer<'_> {
             };
 
             if !self.skip_if(|c| c == NEWLINE).await? {
-                let redir_op_location = here_doc.delimiter.location.clone();
+                let redir_op_location = Location {
+                    code: here_doc.delimiter.span.code.clone(),
+                    index: here_doc.delimiter.span.range.start,
+                };
                 let cause = SyntaxError::UnclosedHereDocContent { redir_op_location }.into();
                 let location = self.location().await?.clone();
                 return Err(Error { cause, location });

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -197,8 +197,8 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(*switch.word.location.code.value.borrow(), "+}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(*switch.word.span.code.value.borrow(), "+}");
+            assert_eq!(switch.word.span.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -225,8 +225,8 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('z')),
                 ]
             );
-            assert_eq!(*switch.word.location.code.value.borrow(), "+a  z}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(*switch.word.span.code.value.borrow(), "+a  z}");
+            assert_eq!(switch.word.span.range, 1..5);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -245,8 +245,8 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Alter);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(*switch.word.span.code.value.borrow(), ":+}");
+            assert_eq!(switch.word.span.range, 2..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -265,8 +265,8 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(*switch.word.location.code.value.borrow(), "-}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(*switch.word.span.code.value.borrow(), "-}");
+            assert_eq!(switch.word.span.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -293,8 +293,8 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('l')),
                 ]
             );
-            assert_eq!(*switch.word.location.code.value.borrow(), ":-cool}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(*switch.word.span.code.value.borrow(), ":-cool}");
+            assert_eq!(switch.word.span.range, 2..6);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -313,8 +313,8 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Assign);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
-            assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(*switch.word.span.code.value.borrow(), ":=}");
+            assert_eq!(switch.word.span.range, 2..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -340,8 +340,8 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('s')),
                 ]
             );
-            assert_eq!(*switch.word.location.code.value.borrow(), "=Yes}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(*switch.word.span.code.value.borrow(), "=Yes}");
+            assert_eq!(switch.word.span.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -360,8 +360,8 @@ mod tests {
             assert_eq!(switch.r#type, SwitchType::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
-            assert_eq!(*switch.word.location.code.value.borrow(), "?}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(*switch.word.span.code.value.borrow(), "?}");
+            assert_eq!(switch.word.span.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -386,8 +386,8 @@ mod tests {
                     WordUnit::Unquoted(TextUnit::Literal('o')),
                 ]
             );
-            assert_eq!(*switch.word.location.code.value.borrow(), ":?No}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(*switch.word.span.code.value.borrow(), ":?No}");
+            assert_eq!(switch.word.span.range, 2..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -437,8 +437,8 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(*trim.pattern.span.code.value.borrow(), "#'*'}");
+            assert_eq!(trim.pattern.span.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -457,8 +457,8 @@ mod tests {
             assert_eq!(trim.side, TrimSide::Prefix);
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
-            assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(*trim.pattern.span.code.value.borrow(), "#'*'}");
+            assert_eq!(trim.pattern.span.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -480,8 +480,8 @@ mod tests {
             assert_matches!(&trim.pattern.units[0], WordUnit::DoubleQuote(Text(units)) => {
                 assert_eq!(units[..], [TextUnit::Literal('?')]);
             });
-            assert_eq!(*trim.pattern.location.code.value.borrow(), r#"##"?"}"#);
-            assert_eq!(trim.pattern.location.index, 2);
+            assert_eq!(*trim.pattern.span.code.value.borrow(), r#"##"?"}"#);
+            assert_eq!(trim.pattern.span.range, 2..5);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -503,8 +503,8 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
-            assert_eq!(*trim.pattern.location.code.value.borrow(), r"%\%}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(*trim.pattern.span.code.value.borrow(), r"%\%}");
+            assert_eq!(trim.pattern.span.range, 1..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -526,8 +526,8 @@ mod tests {
                 trim.pattern.units,
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
-            assert_eq!(*trim.pattern.location.code.value.borrow(), "%%%}");
-            assert_eq!(trim.pattern.location.index, 2);
+            assert_eq!(*trim.pattern.span.code.value.borrow(), "%%%}");
+            assert_eq!(trim.pattern.span.range, 2..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -20,7 +20,6 @@ use super::core::Lexer;
 use super::core::Token;
 use super::core::TokenId;
 use crate::parser::core::Result;
-use crate::source::Location;
 use crate::syntax::Literal;
 use crate::syntax::Unquoted;
 use crate::syntax::Word;
@@ -286,7 +285,6 @@ pub fn is_operator_char(c: char) -> bool {
 /// Return type for [`Lexer::operator_tail`]
 struct OperatorTail {
     pub operator: Operator,
-    pub location: Location,
     pub reversed_key: Vec<char>,
 }
 
@@ -311,21 +309,11 @@ impl Lexer<'_> {
             };
 
             let old_index = self.index();
-            let location = self.location().await?.clone();
             self.consume_char();
 
-            if let Some(OperatorTail {
-                operator,
-                location: _,
-                mut reversed_key,
-            }) = self.operator_tail(edge.next).await?
-            {
-                reversed_key.push(c);
-                return Ok(Some(OperatorTail {
-                    operator,
-                    location,
-                    reversed_key,
-                }));
+            if let Some(mut operator_tail) = self.operator_tail(edge.next).await? {
+                operator_tail.reversed_key.push(c);
+                return Ok(Some(operator_tail));
             }
 
             match edge.value {
@@ -335,7 +323,6 @@ impl Lexer<'_> {
                 }
                 Some(operator) => Ok(Some(OperatorTail {
                     operator,
-                    location,
                     reversed_key: vec![c],
                 })),
             }
@@ -349,7 +336,6 @@ impl Lexer<'_> {
             o.map(|ot| {
                 let OperatorTail {
                     operator,
-                    location,
                     reversed_key,
                 } = ot;
                 let units = reversed_key
@@ -357,7 +343,8 @@ impl Lexer<'_> {
                     .rev()
                     .map(|c| Unquoted(Literal(c)))
                     .collect::<Vec<_>>();
-                let word = Word { units, location };
+                let span = self.span(index..self.index());
+                let word = Word { units, span };
                 let id = TokenId::Operator(operator);
                 Token { word, id, index }
             })
@@ -402,10 +389,10 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('-')));
-        assert_eq!(*t.word.location.code.value.borrow(), "<<-");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "<<-");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..3);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -419,10 +406,10 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(*t.word.location.code.value.borrow(), "<<>");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "<<>");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..2);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.location()).unwrap().index, 2);
@@ -436,10 +423,10 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(*t.word.location.code.value.borrow(), "<<");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "<<");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..2);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -453,10 +440,10 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('<')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('<')));
-        assert_eq!(*t.word.location.code.value.borrow(), "\\\n\\\n<\\\n<\\\n>");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 4);
+        assert_eq!(*t.word.span.code.value.borrow(), "\\\n\\\n<\\\n<\\\n>");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..10);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -493,10 +480,10 @@ mod tests {
 
         let t = block_on(lexer.operator()).unwrap().unwrap();
         assert_eq!(t.word.units, [WordUnit::Unquoted(TextUnit::Literal('\n'))]);
-        assert_eq!(*t.word.location.code.value.borrow(), "\n");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "\n");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }
 }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -350,9 +350,9 @@ mod tests {
         ))
         .unwrap()
         .unwrap();
-        assert_matches!(result, CommandSubst { content, location } => {
+        assert_matches!(result, CommandSubst { content, span } => {
             assert_eq!(content, "");
-            assert_eq!(location.index, 0);
+            assert_eq!(span.range, 0..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -371,9 +371,9 @@ mod tests {
         ))
         .unwrap()
         .unwrap();
-        assert_matches!(result, Backquote { content, location } => {
+        assert_matches!(result, Backquote { content, span } => {
             assert_eq!(content, [BackquoteUnit::Backslashed('"')]);
-            assert_eq!(location.index, 0);
+            assert_eq!(span.range, 0..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -392,12 +392,12 @@ mod tests {
         ))
         .unwrap()
         .unwrap();
-        assert_matches!(result, Backquote { content, location } => {
+        assert_matches!(result, Backquote { content, span } => {
             assert_eq!(
                 content,
                 [BackquoteUnit::Literal('\\'), BackquoteUnit::Literal('"')]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(span.range, 0..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));

--- a/yash-syntax/src/parser/lex/tilde.rs
+++ b/yash-syntax/src/parser/lex/tilde.rs
@@ -201,7 +201,7 @@ mod tests {
     fn word_parse_tilde_front_only_tilde() {
         let input = Word::from_str("~").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(result.units, [Tilde("".to_string())]);
     }
 
@@ -209,7 +209,7 @@ mod tests {
     fn word_parse_tilde_front_with_name() {
         let input = Word::from_str("~foo").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(result.units, [Tilde("foo".to_string())]);
     }
 
@@ -217,7 +217,7 @@ mod tests {
     fn word_parse_tilde_front_ending_with_slash() {
         let input = Word::from_str("~bar/''").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -232,7 +232,7 @@ mod tests {
     fn word_parse_tilde_front_ending_with_colon() {
         let input = Word::from_str("~bar:\"\"").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -247,7 +247,7 @@ mod tests {
     fn word_parse_tilde_front_interrupted_by_non_literal() {
         let input = Word::from_str(r"~foo\/").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -261,7 +261,7 @@ mod tests {
 
         let input = Word::from_str("~bar''").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -293,7 +293,7 @@ mod tests {
     fn word_parse_tilde_front_after_colon() {
         let input = Word::from_str(":~").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [Unquoted(Literal(':')), Unquoted(Literal('~'))]
@@ -301,7 +301,7 @@ mod tests {
 
         let input = Word::from_str(":~foo/a:~bar").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -322,7 +322,7 @@ mod tests {
 
         let input = Word::from_str("~a/b:~c/d").unwrap();
         let result = parse_tilde_front(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -357,7 +357,7 @@ mod tests {
     fn word_parse_tilde_everywhere_only_tilde() {
         let input = Word::from_str("~").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(result.units, [Tilde("".to_string())]);
     }
 
@@ -365,7 +365,7 @@ mod tests {
     fn word_parse_tilde_everywhere_with_name() {
         let input = Word::from_str("~foo").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(result.units, [Tilde("foo".to_string())]);
     }
 
@@ -373,7 +373,7 @@ mod tests {
     fn word_parse_tilde_everywhere_ending_with_slash() {
         let input = Word::from_str("~bar/''").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -388,7 +388,7 @@ mod tests {
     fn word_parse_tilde_everywhere_ending_with_colon() {
         let input = Word::from_str("~bar:\"\"").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -403,7 +403,7 @@ mod tests {
     fn word_parse_tilde_everywhere_interrupted_by_non_literal() {
         let input = Word::from_str(r"~foo\/").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -417,7 +417,7 @@ mod tests {
 
         let input = Word::from_str("~bar''").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -449,7 +449,7 @@ mod tests {
     fn word_parse_tilde_everywhere_after_colon() {
         let input = Word::from_str(":~").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [Unquoted(Literal(':')), Tilde("".to_string())]
@@ -457,7 +457,7 @@ mod tests {
 
         let input = Word::from_str(":~foo/a:~bar").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [
@@ -472,7 +472,7 @@ mod tests {
 
         let input = Word::from_str("~a/b:~c/d").unwrap();
         let result = parse_tilde_everywhere(&input);
-        assert_eq!(result.location, input.location);
+        assert_eq!(result.span, input.span);
         assert_eq!(
             result.units,
             [

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -100,10 +100,10 @@ mod tests {
         let mut lexer = Lexer::from_memory("", Source::Unknown);
 
         let t = block_on(lexer.token()).unwrap();
-        assert_eq!(*t.word.location.code.value.borrow(), "");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..0);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
     }
@@ -117,10 +117,10 @@ mod tests {
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('a')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('b')));
         assert_eq!(t.word.units[2], WordUnit::Unquoted(TextUnit::Literal('c')));
-        assert_eq!(*t.word.location.code.value.borrow(), "abc ");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "abc ");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..3);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
 
@@ -150,10 +150,10 @@ mod tests {
         assert_eq!(t.word.units.len(), 2);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
         assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
-        assert_eq!(*t.word.location.code.value.borrow(), "12<");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "12<");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..2);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
@@ -167,10 +167,10 @@ mod tests {
         let t = block_on(lexer.token()).unwrap();
         assert_eq!(t.word.units.len(), 1);
         assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
-        assert_eq!(*t.word.location.code.value.borrow(), "0>>");
-        assert_eq!(t.word.location.code.start_line_number.get(), 1);
-        assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(*t.word.span.code.value.borrow(), "0>>");
+        assert_eq!(t.word.span.code.start_line_number.get(), 1);
+        assert_eq!(t.word.span.code.source, Source::Unknown);
+        assert_eq!(t.word.span.range, 0..1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
@@ -184,19 +184,19 @@ mod tests {
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(*t.word.location.code.value.borrow(), " a  ");
-            assert_eq!(t.word.location.code.start_line_number.get(), 1);
-            assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index, 1);
+            assert_eq!(*t.word.span.code.value.borrow(), " a  ");
+            assert_eq!(t.word.span.code.start_line_number.get(), 1);
+            assert_eq!(t.word.span.code.source, Source::Unknown);
+            assert_eq!(t.word.span.range, 1..2);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
             lexer.skip_blanks().await.unwrap();
             let t = lexer.token().await.unwrap();
-            assert_eq!(*t.word.location.code.value.borrow(), " a  ");
-            assert_eq!(t.word.location.code.start_line_number.get(), 1);
-            assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index, 4);
+            assert_eq!(*t.word.span.code.value.borrow(), " a  ");
+            assert_eq!(t.word.span.code.start_line_number.get(), 1);
+            assert_eq!(t.word.span.code.source, Source::Unknown);
+            assert_eq!(t.word.span.range, 4..4);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);
         });

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -189,9 +189,9 @@ mod tests {
             block_on(lexer.word_unit(|c| unreachable!("unexpected call to is_delimiter({:?})", c)))
                 .unwrap()
                 .unwrap();
-        assert_matches!(result, Unquoted(CommandSubst { content, location }) => {
+        assert_matches!(result, Unquoted(CommandSubst { content, span }) => {
             assert_eq!(content, "");
-            assert_eq!(location.index, 0);
+            assert_eq!(span.range, 0..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -473,12 +473,12 @@ mod tests {
         let word = block_on(lexer.word(|_| false)).unwrap();
         assert_eq!(word.units.len(), 4);
         assert_eq!(word.units[0], WordUnit::Unquoted(TextUnit::Literal('0')));
-        assert_matches!(&word.units[1], WordUnit::Unquoted(TextUnit::CommandSubst { content, location }) => {
+        assert_matches!(&word.units[1], WordUnit::Unquoted(TextUnit::CommandSubst { content, span }) => {
             assert_eq!(content, ":");
-            assert_eq!(*location.code.value.borrow(), r"0$(:)X\#");
-            assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 1);
+            assert_eq!(*span.code.value.borrow(), r"0$(:)X\#");
+            assert_eq!(span.code.start_line_number.get(), 1);
+            assert_eq!(span.code.source, Source::Unknown);
+            assert_eq!(span.range, 1..5);
         });
         assert_eq!(word.units[2], WordUnit::Unquoted(TextUnit::Literal('X')));
         assert_eq!(

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -63,10 +63,6 @@ impl Parser<'_, '_> {
             };
 
             let and_or = Rc::new(and_or);
-            let async_flag = async_flag.map(|af| Location {
-                code: af.code,
-                index: af.range.start,
-            });
             items.push(Item { and_or, async_flag });
 
             if !next {
@@ -228,21 +224,21 @@ mod tests {
         let list = block_on(parser.list()).unwrap().unwrap();
         assert_eq!(list.0.len(), 3);
 
-        let location = list.0[0].async_flag.as_ref().unwrap();
-        assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
-        assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 4);
+        let span = list.0[0].async_flag.as_ref().unwrap();
+        assert_eq!(*span.code.value.borrow(), "foo & bar ; baz&");
+        assert_eq!(span.code.start_line_number.get(), 1);
+        assert_eq!(span.code.source, Source::Unknown);
+        assert_eq!(span.range, 4..5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
         assert_eq!(list.0[1].async_flag, None);
         assert_eq!(list.0[1].and_or.to_string(), "bar");
 
-        let location = list.0[2].async_flag.as_ref().unwrap();
-        assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
-        assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 15);
+        let span = list.0[2].async_flag.as_ref().unwrap();
+        assert_eq!(*span.code.value.borrow(), "foo & bar ; baz&");
+        assert_eq!(span.code.start_line_number.get(), 1);
+        assert_eq!(span.code.source, Source::Unknown);
+        assert_eq!(span.range, 15..16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
 

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -112,8 +112,8 @@ mod tests {
     use super::super::lex::Lexer;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use futures_executor::block_on;
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
     fn parser_pipeline_no_aliasing_of_bang() {
         let mut lexer = Lexer::from_memory("! ok", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "!".to_string(),
             "; ; ;".to_string(),

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -24,6 +24,7 @@ use super::error::SyntaxError;
 use super::lex::Keyword::Bang;
 use super::lex::Operator::Bar;
 use super::lex::TokenId::{Operator, Token};
+use crate::source::Location;
 use crate::syntax::Pipeline;
 use std::rc::Rc;
 
@@ -57,7 +58,10 @@ impl Parser<'_, '_> {
                             } else {
                                 SyntaxError::MissingCommandAfterBang.into()
                             };
-                            let location = next.word.location;
+                            let location = Location {
+                                code: next.word.span.code,
+                                index: next.word.span.range.start,
+                            };
                             return Err(Error { cause, location });
                         }
                     }
@@ -88,7 +92,10 @@ impl Parser<'_, '_> {
                     } else {
                         SyntaxError::MissingCommandAfterBar.into()
                     };
-                    let location = next.word.location;
+                    let location = Location {
+                        code: next.word.span.code,
+                        index: next.word.span.range.start,
+                    };
                     return Err(Error { cause, location });
                 }
             });

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -39,7 +39,12 @@ impl Parser<'_, '_> {
         let operand = self.take_token_auto(&[]).await?;
         match operand.id {
             Token(_) => (),
-            Operator(_) | EndOfInput => return Ok(Err(operand.word.location)),
+            Operator(_) | EndOfInput => {
+                return Ok(Err(Location {
+                    code: operand.word.span.code,
+                    index: operand.word.span.range.start,
+                }));
+            }
             IoNumber => (), // TODO reject if POSIXly-correct
         }
         Ok(Ok(operand.word))
@@ -111,7 +116,10 @@ impl Parser<'_, '_> {
             } else {
                 return Err(Error {
                     cause: SyntaxError::FdOutOfRange.into(),
-                    location: token.word.location,
+                    location: Location {
+                        code: token.word.span.code,
+                        index: token.word.span.range.start,
+                    },
                 });
             }
         } else {

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -22,6 +22,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Keyword::{Until, While};
 use super::lex::TokenId::Token;
+use crate::source::Location;
 use crate::syntax::CompoundCommand;
 
 impl Parser<'_, '_> {
@@ -41,16 +42,27 @@ impl Parser<'_, '_> {
         // TODO allow empty condition if not POSIXly-correct
         if condition.0.is_empty() {
             let cause = SyntaxError::EmptyWhileCondition.into();
-            let location = self.take_token_raw().await?.word.location;
+            let next = self.take_token_raw().await?;
+            let location = Location {
+                code: next.word.span.code,
+                index: next.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
         let body = match self.do_clause().await? {
             Some(body) => body,
             None => {
-                let opening_location = open.word.location;
+                let opening_location = Location {
+                    code: open.word.span.code,
+                    index: open.word.span.range.start,
+                };
                 let cause = SyntaxError::UnclosedWhileClause { opening_location }.into();
-                let location = self.take_token_raw().await?.word.location;
+                let next = self.take_token_raw().await?;
+                let location = Location {
+                    code: next.word.span.code,
+                    index: next.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
         };
@@ -74,16 +86,27 @@ impl Parser<'_, '_> {
         // TODO allow empty condition if not POSIXly-correct
         if condition.0.is_empty() {
             let cause = SyntaxError::EmptyUntilCondition.into();
-            let location = self.take_token_raw().await?.word.location;
+            let next = self.take_token_raw().await?;
+            let location = Location {
+                code: next.word.span.code,
+                index: next.word.span.range.start,
+            };
             return Err(Error { cause, location });
         }
 
         let body = match self.do_clause().await? {
             Some(body) => body,
             None => {
-                let opening_location = open.word.location;
+                let opening_location = Location {
+                    code: open.word.span.code,
+                    index: open.word.span.range.start,
+                };
                 let cause = SyntaxError::UnclosedUntilClause { opening_location }.into();
-                let location = self.take_token_raw().await?.word.location;
+                let next = self.take_token_raw().await?;
+                let location = Location {
+                    code: next.word.span.code,
+                    index: next.word.span.range.start,
+                };
                 return Err(Error { cause, location });
             }
         };

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -122,8 +122,8 @@ mod tests {
     use super::super::lex::TokenId::EndOfInput;
     use super::*;
     use crate::alias::{AliasSet, HashEntry};
-    use crate::source::Location;
     use crate::source::Source;
+    use crate::source::Span;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
@@ -200,7 +200,7 @@ mod tests {
     fn parser_while_loop_aliasing() {
         let mut lexer = Lexer::from_memory(" while :; DO :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "DO".to_string(),
             "do".to_string(),
@@ -295,7 +295,7 @@ mod tests {
     fn parser_until_loop_aliasing() {
         let mut lexer = Lexer::from_memory(" until :; DO :; done", Source::Unknown);
         let mut aliases = AliasSet::new();
-        let origin = Location::dummy("");
+        let origin = Span::dummy("");
         aliases.insert(HashEntry::new(
             "DO".to_string(),
             "do".to_string(),

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -85,14 +85,14 @@ impl Source {
     /// ```
     /// // `is_alias_for` returns true if the names match
     /// # use yash_syntax::source::*;
-    /// let original = Location::dummy("");
+    /// let original = Span::dummy("");
     /// let alias = std::rc::Rc::new(yash_syntax::alias::Alias{
     ///     name: "foo".to_string(),
     ///     replacement: "".to_string(),
     ///     global: false,
     ///     origin: original.clone()
     /// });
-    /// let source = Source::Alias{ original: original.into(), alias };
+    /// let source = Source::Alias{ original: original, alias };
     /// assert_eq!(source.is_alias_for("foo"), true);
     /// assert_eq!(source.is_alias_for("bar"), false);
     /// ```
@@ -101,22 +101,22 @@ impl Source {
     /// // `is_alias_for` checks aliases recursively.
     /// # use std::rc::Rc;
     /// # use yash_syntax::source::*;
-    /// let mut original = Location::dummy("");
+    /// let mut original = Span::dummy("");
     /// let alias = Rc::new(yash_syntax::alias::Alias{
     ///     name: "foo".to_string(),
     ///     replacement: "".to_string(),
     ///     global: false,
     ///     origin: original.clone()
     /// });
-    /// let source = Source::Alias{original: original.clone().into(), alias};
+    /// let source = Source::Alias{ original: original.clone(), alias };
     /// let alias = Rc::new(yash_syntax::alias::Alias{
     ///     name: "bar".to_string(),
     ///     replacement: "".to_string(),
     ///     global: false,
-    ///     origin: original.clone()
+    ///     origin: original.clone(),
     /// });
     /// Rc::make_mut(&mut original.code).source = source;
-    /// let source = Source::Alias{ original: original.into(), alias };
+    /// let source = Source::Alias{ original, alias };
     /// assert_eq!(source.is_alias_for("foo"), true);
     /// assert_eq!(source.is_alias_for("bar"), true);
     /// assert_eq!(source.is_alias_for("baz"), false);

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -54,7 +54,10 @@ pub enum Source {
     },
 
     /// Command substitution.
-    CommandSubst { original: Location },
+    CommandSubst {
+        /// Position of the command substitution in the source code.
+        original: Span,
+    },
 
     /// Trap command.
     Trap {

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -313,6 +313,7 @@ pub struct Span {
 /// Creates a span ranging over the single character represented by the
 /// location.
 impl From<Location> for Span {
+    // TODO FIXME Remove this
     fn from(location: Location) -> Self {
         let Location { code, index } = location;
         let range = index..index + 1;

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -63,8 +63,9 @@ pub enum Source {
     Trap {
         /// Trap condition name, typically the signal name.
         condition: String,
-        /// Location of the simple command that has set this trap command.
-        origin: Location,
+        /// Position of the simple command word that was parsed as this trap
+        /// command.
+        origin: Span,
     },
     // TODO More Source types
 }

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -46,10 +46,10 @@ pub enum Source {
     /// Alias substitution.
     ///
     /// This applies to a code fragment that replaced another as a result of alias substitution.
-    ///
-    /// `original` is the location of the original word that was replaced.
     Alias {
-        original: Location,
+        /// Position of the original word that was replaced
+        original: Span,
+        /// Definition of the alias that was substituted
         alias: Rc<Alias>,
     },
 
@@ -88,7 +88,7 @@ impl Source {
     ///     global: false,
     ///     origin: original.clone()
     /// });
-    /// let source = Source::Alias{original, alias};
+    /// let source = Source::Alias{ original: original.into(), alias };
     /// assert_eq!(source.is_alias_for("foo"), true);
     /// assert_eq!(source.is_alias_for("bar"), false);
     /// ```
@@ -104,7 +104,7 @@ impl Source {
     ///     global: false,
     ///     origin: original.clone()
     /// });
-    /// let source = Source::Alias{original: original.clone(), alias};
+    /// let source = Source::Alias{original: original.clone().into(), alias};
     /// let alias = Rc::new(yash_syntax::alias::Alias{
     ///     name: "bar".to_string(),
     ///     replacement: "".to_string(),
@@ -112,7 +112,7 @@ impl Source {
     ///     origin: original.clone()
     /// });
     /// Rc::make_mut(&mut original.code).source = source;
-    /// let source = Source::Alias{original, alias};
+    /// let source = Source::Alias{ original: original.into(), alias };
     /// assert_eq!(source.is_alias_for("foo"), true);
     /// assert_eq!(source.is_alias_for("bar"), true);
     /// assert_eq!(source.is_alias_for("baz"), false);

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -122,11 +122,12 @@ impl super::Source {
             }
             Alias { original, alias } => {
                 // TODO Use Extend::extend_one
-                result.extend(std::iter::once(Annotation::new(
-                    AnnotationType::Info,
-                    format!("alias `{}` was substituted here", alias.name).into(),
-                    original,
-                )));
+                // FIXME
+                // result.extend(std::iter::once(Annotation::new(
+                //     AnnotationType::Info,
+                //     format!("alias `{}` was substituted here", alias.name).into(),
+                //     original,
+                // )));
                 original.code.source.complement_annotations(result);
                 result.extend(std::iter::once(Annotation::new(
                     AnnotationType::Info,
@@ -306,7 +307,7 @@ mod annotate_snippets_support {
         use super::super::*;
         use std::num::NonZeroU64;
 
-        let original = Location::dummy("my original");
+        let original = Span::dummy("my original");
         let alias = Rc::new(Alias {
             name: "foo".to_string(),
             replacement: "bar".to_string(),

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -104,13 +104,14 @@ impl super::Source {
         use super::Source::*;
         match self {
             Unknown | Stdin => (),
-            CommandSubst { original } => {
+            CommandSubst { original: _ } => {
                 // TODO Use Extend::extend_one
-                result.extend(std::iter::once(Annotation::new(
-                    AnnotationType::Info,
-                    "command substitution appeared here".into(),
-                    original,
-                )));
+                // FIXME
+                // result.extend(std::iter::once(Annotation::new(
+                //     AnnotationType::Info,
+                //     "command substitution appeared here".into(),
+                //     original,
+                // )));
             }
             Trap { origin, .. } => {
                 // TODO Use Extend::extend_one

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -131,11 +131,12 @@ impl super::Source {
                 //     original,
                 // )));
                 original.code.source.complement_annotations(result);
-                result.extend(std::iter::once(Annotation::new(
-                    AnnotationType::Info,
-                    format!("alias `{}` was defined here", alias.name).into(),
-                    &alias.origin,
-                )));
+                // FIXME
+                // result.extend(std::iter::once(Annotation::new(
+                //     AnnotationType::Info,
+                //     format!("alias `{}` was defined here", alias.name).into(),
+                //     &alias.origin,
+                // )));
                 alias.origin.code.source.complement_annotations(result);
             }
         }
@@ -314,7 +315,7 @@ mod annotate_snippets_support {
             name: "foo".to_string(),
             replacement: "bar".to_string(),
             global: false,
-            origin: Location::dummy("my origin"),
+            origin: Span::dummy("my origin"),
         });
         let code = Rc::new(Code {
             value: "substitution".to_string().into(),

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -113,13 +113,14 @@ impl super::Source {
                 //     original,
                 // )));
             }
-            Trap { origin, .. } => {
+            Trap { origin: _, .. } => {
                 // TODO Use Extend::extend_one
-                result.extend(std::iter::once(Annotation::new(
-                    AnnotationType::Info,
-                    "trap was set here".into(),
-                    origin,
-                )));
+                // FIXME
+                // result.extend(std::iter::once(Annotation::new(
+                //     AnnotationType::Info,
+                //     "trap was set here".into(),
+                //     origin,
+                // )));
             }
             Alias { original, alias } => {
                 // TODO Use Extend::extend_one

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -75,6 +75,7 @@
 
 use crate::parser::lex::Operator;
 use crate::source::Location;
+use crate::source::Span;
 use itertools::Itertools;
 use std::cell::RefCell;
 use std::fmt;
@@ -424,8 +425,8 @@ pub enum TextUnit {
     RawParam {
         /// Parameter name.
         name: String,
-        /// Location of the initial `$` character of this parameter expansion.
-        location: Location,
+        /// Range of this parameter expansion including the initial `$` character.
+        span: Span,
     },
     /// Parameter expansion that is enclosed in braces.
     BracedParam(Param),
@@ -1514,7 +1515,7 @@ mod tests {
 
         let raw_param = RawParam {
             name: "PARAM".to_string(),
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         assert_eq!(raw_param.to_string(), "$PARAM");
 
@@ -1559,7 +1560,7 @@ mod tests {
             Literal('W'),
             RawParam {
                 name: "X".to_string(),
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             },
             CommandSubst {
                 content: "Y".to_string(),

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -435,8 +435,8 @@ pub enum TextUnit {
         /// Command string that will be parsed and executed when the command
         /// substitution is expanded.
         content: String,
-        /// Location of the initial `$` character of this command substitution.
-        location: Location,
+        /// Range of this command substitution including the initial `$` character.
+        span: Span,
     },
     /// Command substitution of the form `` `...` ``.
     Backquote {
@@ -1521,7 +1521,7 @@ mod tests {
 
         let command_subst = CommandSubst {
             content: r"foo\bar".to_string(),
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         assert_eq!(command_subst.to_string(), r"$(foo\bar)");
 
@@ -1564,7 +1564,7 @@ mod tests {
             },
             CommandSubst {
                 content: "Y".to_string(),
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             },
             Backquote {
                 content: vec![BackquoteUnit::Literal('Z')],

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -443,8 +443,9 @@ pub enum TextUnit {
         /// Command string that will be parsed and executed when the command
         /// substitution is expanded.
         content: Vec<BackquoteUnit>,
-        /// Location of the initial backquote character of this command substitution.
-        location: Location,
+        /// Range of this command substitution including the surrounding
+        /// backquotes.
+        span: Span,
     },
     /// Arithmetic expansion.
     Arith {
@@ -1532,7 +1533,7 @@ mod tests {
                 BackquoteUnit::Backslashed('c'),
                 BackquoteUnit::Literal('d'),
             ],
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         assert_eq!(backquote.to_string(), r"`a\b\cd`");
 
@@ -1568,7 +1569,7 @@ mod tests {
             },
             Backquote {
                 content: vec![BackquoteUnit::Literal('Z')],
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             },
             Arith {
                 content: Text(vec![Literal('0')]),
@@ -1597,8 +1598,8 @@ mod tests {
         assert_eq!(is_quoted, true);
 
         let content = vec![BackquoteUnit::Backslashed('X')];
-        let location = Location::dummy("");
-        let quoted = Text(vec![Backquote { content, location }]);
+        let span = Span::dummy("");
+        let quoted = Text(vec![Backquote { content, span }]);
         let (unquoted, is_quoted) = quoted.unquote();
         assert_eq!(unquoted, "`X`");
         assert_eq!(is_quoted, true);

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -45,8 +45,8 @@
 //! Most AST types defined in this module implement the
 //! [`FromStr`](std::str::FromStr) trait, which means you can easily get an AST
 //! out of source code by calling `parse` on a `&str`. However, all
-//! [location](Location)s and [span](Span)s in ASTs constructed this way will
-//! only have [unknown source](crate::source::Source::Unknown).
+//! [span](Span)s in ASTs constructed this way will only have [unknown
+//! source](crate::source::Source::Unknown).
 //!
 //! ```
 //! use std::str::FromStr;
@@ -74,7 +74,6 @@
 //! with here-document contents included, you can use ... TODO TBD.
 
 use crate::parser::lex::Operator;
-use crate::source::Location;
 use crate::source::Span;
 use itertools::Itertools;
 use std::cell::RefCell;
@@ -1219,8 +1218,8 @@ pub struct Item {
     /// The and-or list is contained in `Rc` to allow executing it
     /// asynchronously without cloning it.
     pub and_or: Rc<AndOrList>,
-    /// Location of the `&` operator for this item, if any.
-    pub async_flag: Option<Location>,
+    /// Position of the `&` operator for this item, if any.
+    pub async_flag: Option<Span>,
 }
 
 /// Allows conversion from Item to String.
@@ -2132,7 +2131,7 @@ mod tests {
         let and_or = "second".parse().unwrap();
         let item = Item {
             and_or: Rc::new(and_or),
-            async_flag: Some(Location::dummy("")),
+            async_flag: Some(Span::dummy("")),
         };
         list.0.push(item);
         assert_eq!(list.to_string(), "first; second&");
@@ -2159,7 +2158,7 @@ mod tests {
         let and_or = "second".parse().unwrap();
         let item = Item {
             and_or: Rc::new(and_or),
-            async_flag: Some(Location::dummy("")),
+            async_flag: Some(Span::dummy("")),
         };
         list.0.push(item);
         assert_eq!(format!("{:#}", list), "first; second&");

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -337,8 +337,9 @@ pub struct Param {
     // TODO index
     /// Modifier.
     pub modifier: Modifier,
-    /// Location of the initial `$` character of this parameter expansion.
-    pub location: Location,
+    /// Range of this parameter expansion including the initial `$` character
+    /// and the closing brace.
+    pub span: Span,
 }
 
 impl fmt::Display for Param {
@@ -1407,7 +1408,7 @@ mod tests {
         let param = Param {
             name: "foo".to_string(),
             modifier: Modifier::None,
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         assert_eq!(param.to_string(), "${foo}");
 
@@ -1445,7 +1446,7 @@ mod tests {
         let param = Param {
             name: "foo".to_string(),
             modifier: Modifier::None,
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         let (unquoted, is_quoted) = param.unquote();
         assert_eq!(unquoted, "${foo}");

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -450,8 +450,8 @@ pub enum TextUnit {
     Arith {
         /// Expression that is to be evaluated.
         content: Text,
-        /// Location of the initial `$` character of this command substitution.
-        location: Location,
+        /// Range of this arithmetic expansion including the initial `$` character.
+        span: Span,
     },
 }
 
@@ -1538,7 +1538,7 @@ mod tests {
 
         let arith = Arith {
             content: Text(vec![literal, backslashed, command_subst, backquote]),
-            location: Location::dummy(""),
+            span: Span::dummy(""),
         };
         assert_eq!(arith.to_string(), r"$((A\X$(foo\bar)`a\b\cd`))");
     }
@@ -1572,7 +1572,7 @@ mod tests {
             },
             Arith {
                 content: Text(vec![Literal('0')]),
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             },
         ]);
         let (unquoted, is_quoted) = nonempty.unquote();
@@ -1588,7 +1588,7 @@ mod tests {
             Literal('c'),
             Arith {
                 content: Text(vec![Literal('d')]),
-                location: Location::dummy(""),
+                span: Span::dummy(""),
             },
             Literal('e'),
         ]);
@@ -1604,8 +1604,8 @@ mod tests {
         assert_eq!(is_quoted, true);
 
         let content = Text(vec![Backslashed('X')]);
-        let location = Location::dummy("");
-        let quoted = Text(vec![Arith { content, location }]);
+        let span = Span::dummy("");
+        let quoted = Text(vec![Arith { content, span }]);
         let (unquoted, is_quoted) = quoted.unquote();
         assert_eq!(unquoted, "$((X))");
         assert_eq!(is_quoted, true);

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -45,8 +45,8 @@
 //! Most AST types defined in this module implement the
 //! [`FromStr`](std::str::FromStr) trait, which means you can easily get an AST
 //! out of source code by calling `parse` on a `&str`. However, all
-//! [location](crate::source::Location)s in ASTs constructed this way will only
-//! have [unknown source](crate::source::Source::Unknown).
+//! [location](Location)s and [span](Span)s in ASTs constructed this way will
+//! only have [unknown source](crate::source::Source::Unknown).
 //!
 //! ```
 //! use std::str::FromStr;


### PR DESCRIPTION
annotate-snippets-rs supports annotating character ranges, but currently `yash_syntax::source::Location` only points to a single character in the source code. This pull request modifies the abstract syntax tree (AST) type definition to allow attributing syntax elements with character ranges.

- [x] Define `Span`
- [x] Define a utility function in `Lexer` that creates a `Span` from a given index range
- [ ] Replace `Location`s with `Span`s in AST type definitions
- [ ] Replace `Location`s with `Span`s in parser-related things, such as `Error::location`
- [ ] Replace `Location`s with `Span`s in `yash-semantics`, such as `AttrField`