### PR TITLE
Replace Location::index with range

### DIFF
--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(*alias.origin.code.value.borrow(), "foo=bar baz");
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(alias.origin.code.source, Source::Unknown);
-        assert_eq!(alias.origin.index, 0);
+        assert_eq!(alias.origin.range, 0..11);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(*abc.origin.code.value.borrow(), "abc=xyz");
         assert_eq!(abc.origin.code.start_line_number.get(), 1);
         assert_eq!(abc.origin.code.source, Source::Unknown);
-        assert_eq!(abc.origin.index, 0);
+        assert_eq!(abc.origin.range, 0..7);
 
         let yes = env.aliases.get("yes").unwrap().0.as_ref();
         assert_eq!(yes.name, "yes");
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(*yes.origin.code.value.borrow(), "yes=no");
         assert_eq!(yes.origin.code.start_line_number.get(), 1);
         assert_eq!(yes.origin.code.source, Source::Unknown);
-        assert_eq!(yes.origin.index, 0);
+        assert_eq!(yes.origin.range, 0..6);
 
         let ls = env.aliases.get("ls").unwrap().0.as_ref();
         assert_eq!(ls.name, "ls");
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(*ls.origin.code.value.borrow(), "ls=ls --color");
         assert_eq!(ls.origin.code.start_line_number.get(), 1);
         assert_eq!(ls.origin.code.source, Source::Unknown);
-        assert_eq!(ls.origin.index, 0);
+        assert_eq!(ls.origin.range, 0..13);
     }
 
     #[test]

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -131,6 +131,6 @@ mod tests {
         });
         assert_eq!(*e.location.code.value.borrow(), "v=new");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..5);
     }
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -793,11 +793,11 @@ mod tests {
     #[test]
     fn from_error_for_message() {
         let code = Rc::new(Code {
-            value: "".to_string().into(),
+            value: "hello".to_string().into(),
             start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location { code, index: 0 };
+        let location = Location { code, range: 2..4 };
         let new_value = Variable {
             value: Value::Scalar("value".into()),
             last_assigned_location: Some(Location::dummy("assigned")),

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `source::Location::index: usize` replaced with `range: Range<usize>`
 - The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
     - `parser::Lexer::command_substitution`
+- The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
+    - `parser::Lexer::arithmetic_expansion`
 
 ### Removed
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
     - `parser::lex::Lexer::arithmetic_expansion`
     - `parser::lex::Lexer::command_substitution`
+    - `parser::lex::Lexer::raw_param`
     - `parser::lex::WordLexer::braced_param`
 - The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
     - `parser::lex::Lexer::arithmetic_expansion`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ????-??-??
 
+### Changed
+
+- `source::Location::index: usize` replaced with `range: Range<usize>`
+
 ### Removed
 
 - `source::Location::advance`
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This version simplifies type definitions for the abstract syntax tree (AST);
 `syntax::HereDoc::content` is now wrapped in `RefCell` to remove generic type
-parameters from `RedirBody` and other AST types. 
+parameters from `RedirBody` and other AST types.
 
 ### Changed
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `source::Location::index: usize` replaced with `range: Range<usize>`
 - The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
+    - `parser::Lexer::arithmetic_expansion`
     - `parser::Lexer::command_substitution`
 - The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
     - `parser::Lexer::arithmetic_expansion`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `parser::lex::WordLexer::braced_param`
 - The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
     - `parser::lex::Lexer::arithmetic_expansion`
+    - `parser::lex::Lexer::raw_param`
     - `parser::lex::WordLexer::braced_param`
 
 ### Removed

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ????-??-??
+
+### Removed
+
+- `source::Location::advance`
+
 ## [0.3.0] - 2022-02-06
 
 This version simplifies type definitions for the abstract syntax tree (AST);

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `parser::Lexer::location_range`
+- `parser::lex::Lexer::location_range`
 
 ### Changed
 
 - `source::Location::index: usize` replaced with `range: Range<usize>`
 - The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
-    - `parser::Lexer::arithmetic_expansion`
-    - `parser::Lexer::command_substitution`
+    - `parser::lex::Lexer::arithmetic_expansion`
+    - `parser::lex::Lexer::command_substitution`
 - The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
-    - `parser::Lexer::arithmetic_expansion`
+    - `parser::lex::Lexer::arithmetic_expansion`
+    - `parser::lex::WordLexer::braced_param`
 
 ### Removed
 
@@ -35,7 +36,7 @@ parameters from `RedirBody` and other AST types.
 - `source::Source` now `non_exhaustive`
 - `syntax::HereDoc::content` redefined as `RefCell<Text>` (previously `Text`)
 - `impl From<HereDoc> for RedirBody` replaced with `impl<T: Into<Rc<HereDoc>>> From<T> for RedirBody`
-- `parser::Lexer::here_doc_content` now taking a `&HereDoc` parameter and returning `Result<()>`
+- `parser::lex::Lexer::here_doc_content` now taking a `&HereDoc` parameter and returning `Result<()>`
 - `parser::Parser::memorize_unread_here_doc` now taking an `Rc<HereDoc>` parameter
 
 ### Removed

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
     - `parser::lex::Lexer::arithmetic_expansion`
     - `parser::lex::Lexer::command_substitution`
+    - `parser::lex::WordLexer::braced_param`
 - The following functions now returning `Result<Option<TextUnit>>` instead of `Result<Result<TextUnit, Location>>`:
     - `parser::lex::Lexer::arithmetic_expansion`
     - `parser::lex::WordLexer::braced_param`

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `source::Location::index: usize` replaced with `range: Range<usize>`
+- The following functions now taking the `start_index: usize` parameter instead of `opening_location: Location`:
+    - `parser::Lexer::command_substitution`
 
 ### Removed
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ????-??-??
 
+### Added
+
+- `parser::Lexer::location_range`
+
 ### Changed
 
 - `source::Location::index: usize` replaced with `range: Range<usize>`

--- a/yash-syntax/src/parser/and_or.rs
+++ b/yash-syntax/src/parser/and_or.rs
@@ -128,6 +128,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo &&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..6);
     }
 }

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), ")");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..1);
     }
 
     #[test]
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(esac)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 1..5);
     }
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 1..2);
     }
 
     #[test]
@@ -358,7 +358,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo| |");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..7);
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "(foo bar");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 5);
+        assert_eq!(e.location.range, 5..8);
     }
 
     #[test]
@@ -562,7 +562,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case  ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 7);
+        assert_eq!(e.location.range, 7..7);
     }
 
     #[test]
@@ -576,7 +576,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " case ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..7);
     }
 
     #[test]
@@ -591,12 +591,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " case x esac");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..5);
         });
         assert_eq!(*e.location.code.value.borrow(), " case x esac");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 8);
+        assert_eq!(e.location.range, 8..12);
     }
 
     #[test]
@@ -611,11 +611,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "case x in a) }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..4);
         });
         assert_eq!(*e.location.code.value.borrow(), "case x in a) }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 13);
+        assert_eq!(e.location.range, 13..14);
     }
 }

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -152,12 +152,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " do not close ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..3);
         });
         assert_eq!(*e.location.code.value.borrow(), " do not close ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 14);
+        assert_eq!(e.location.range, 14..14);
     }
 
     #[test]
@@ -171,7 +171,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "do done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..7);
     }
 
     #[test]

--- a/yash-syntax/src/parser/core.rs
+++ b/yash-syntax/src/parser/core.rs
@@ -733,7 +733,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         })
     }
 
@@ -759,7 +759,7 @@ mod tests {
 
             let location = lexer.location().await.unwrap();
             assert_eq!(location.code.start_line_number.get(), 1);
-            assert_eq!(location.index, 4);
+            assert_eq!(location.range, 4..5);
         })
     }
 

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -235,7 +235,7 @@ impl SyntaxError {
             | MissingCommandAfterBar => "expected a command",
             InvalidForValue | MissingCaseSubject | InvalidCaseSubject | MissingPattern
             | InvalidPattern => "expected a word",
-            InvalidModifier => "unexpected character",
+            InvalidModifier => "broken modifier",
             MultipleModifier => "conflicting modifier",
             UnclosedSingleQuote { .. } => "expected `'`",
             UnclosedDoubleQuote { .. } => "expected `\"`",

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -470,7 +470,7 @@ mod tests {
             start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location { code, index: 0 };
+        let location = Location { code, range: 0..42 };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),
             location,
@@ -488,7 +488,7 @@ mod tests {
             start_line_number: NonZeroU64::new(1).unwrap(),
             source: Source::Unknown,
         });
-        let location = Location { code, index: 0 };
+        let location = Location { code, range: 0..42 };
         let error = Error {
             cause: SyntaxError::MissingHereDocDelimiter.into(),
             location,

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 5);
+        assert_eq!(e.location.range, 5..5);
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " for\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..5);
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "for; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..4);
     }
 
     #[test]
@@ -454,12 +454,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForName));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..1);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "FOR if do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index, 4);
+            assert_eq!(original.range, 4..6);
             assert_eq!(alias.name, "if");
         });
     }
@@ -476,12 +476,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "for X\n; do :; done");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..3);
         });
         assert_eq!(*e.location.code.value.borrow(), "for X\n; do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..7);
     }
 
     #[test]
@@ -511,12 +511,12 @@ mod tests {
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidForValue));
         assert_eq!(*e.location.code.value.borrow(), "&");
         assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..1);
         assert_matches!(&e.location.code.source, Source::Alias { original, alias } => {
             assert_eq!(*original.code.value.borrow(), "for_A_in_a_b if c; do :; done");
             assert_eq!(original.code.start_line_number.get(), 1);
             assert_eq!(original.code.source, Source::Unknown);
-            assert_eq!(original.index, 13);
+            assert_eq!(original.range, 13..15);
             assert_eq!(alias.name, "if");
         });
     }
@@ -533,11 +533,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " for X; ! do :; done");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..4);
         });
         assert_eq!(*e.location.code.value.borrow(), " for X; ! do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 8);
+        assert_eq!(e.location.range, 8..9);
     }
 }

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -154,7 +154,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..2);
     }
 
     #[test]
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( ) ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 
     #[test]
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "() foo ; ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..6);
     }
 
     #[test]
@@ -313,6 +313,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "()b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..3);
     }
 }

--- a/yash-syntax/src/parser/grouping.rs
+++ b/yash-syntax/src/parser/grouping.rs
@@ -136,12 +136,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " { oh no ");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..2);
         });
         assert_eq!(*e.location.code.value.borrow(), " { oh no ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 9);
+        assert_eq!(e.location.range, 9..9);
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{ }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..3);
     }
 
     #[test]
@@ -225,12 +225,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), " ( oh no");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..2);
         });
         assert_eq!(*e.location.code.value.borrow(), " ( oh no");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 8);
+        assert_eq!(e.location.range, 8..8);
     }
 
     #[test]
@@ -244,6 +244,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "( )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..3);
     }
 }

--- a/yash-syntax/src/parser/if.rs
+++ b/yash-syntax/src/parser/if.rs
@@ -257,12 +257,12 @@ mod tests {
             assert_eq!(*if_location.code.value.borrow(), " if :; fi");
             assert_eq!(if_location.code.start_line_number.get(), 1);
             assert_eq!(if_location.code.source, Source::Unknown);
-            assert_eq!(if_location.index, 1);
+            assert_eq!(if_location.range, 1..3);
         });
         assert_eq!(*e.location.code.value.borrow(), " if :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 7);
+        assert_eq!(e.location.range, 7..9);
     }
 
     #[test]
@@ -277,12 +277,12 @@ mod tests {
             assert_eq!(*elif_location.code.value.borrow(), "if a; then b; elif c; fi");
             assert_eq!(elif_location.code.start_line_number.get(), 1);
             assert_eq!(elif_location.code.source, Source::Unknown);
-            assert_eq!(elif_location.index, 14);
+            assert_eq!(elif_location.range, 14..18);
         });
         assert_eq!(*e.location.code.value.borrow(), "if a; then b; elif c; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 22);
+        assert_eq!(e.location.range, 22..24);
     }
 
     #[test]
@@ -297,12 +297,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "  if :; then :; }");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 2);
+            assert_eq!(opening_location.range, 2..4);
         });
         assert_eq!(*e.location.code.value.borrow(), "  if :; then :; }");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 16);
+        assert_eq!(e.location.range, 16..17);
     }
 
     #[test]
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "   if then :; fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..10);
     }
 
     #[test]
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 11);
+        assert_eq!(e.location.range, 11..13);
     }
 
     #[test]
@@ -347,7 +347,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 19);
+        assert_eq!(e.location.range, 19..23);
     }
 
     #[test]
@@ -364,7 +364,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 27);
+        assert_eq!(e.location.range, 27..29);
     }
 
     #[test]
@@ -378,6 +378,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "if :; then :; else fi");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 19);
+        assert_eq!(e.location.range, 19..21);
     }
 }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -114,7 +114,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -131,7 +131,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Y");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 0);
+        assert_eq!(location.range, 0..1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
     }
@@ -149,7 +149,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -177,7 +177,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -194,12 +194,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..3);
     }
 
     #[test]
@@ -213,12 +213,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "((1)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "Z");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 0);
+        assert_eq!(location.range, 0..1);
 
         assert_eq!(lexer.index(), 0);
     }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -34,24 +34,21 @@ impl Lexer<'_> {
     /// begin an arithmetic expansion. If the characters are `((`, then the
     /// arithmetic expansion is parsed, in which case this function consumes up
     /// to the closing `))` (inclusive). Otherwise, no characters are consumed
-    /// and the return value is `Ok(Err(location))`.
+    /// and the return value is `Ok(None)`.
     ///
     /// The `location` parameter should be the location of the initial `$`. It
     /// is used to construct the result, but this function does not check if it
     /// actually is a location of `$`.
-    pub async fn arithmetic_expansion(
-        &mut self,
-        location: Location,
-    ) -> Result<std::result::Result<TextUnit, Location>> {
+    pub async fn arithmetic_expansion(&mut self, location: Location) -> Result<Option<TextUnit>> {
         let index = self.index();
 
         // Part 1: Parse `((`
         if !self.skip_if(|c| c == '(').await? {
-            return Ok(Err(location));
+            return Ok(None);
         }
         if !self.skip_if(|c| c == '(').await? {
             self.rewind(index);
-            return Ok(Err(location));
+            return Ok(None);
         }
 
         // Part 2: Parse the content
@@ -77,7 +74,7 @@ impl Lexer<'_> {
             Some(sc) if sc == ')' => self.consume_char(),
             Some(_) => {
                 self.rewind(index);
-                return Ok(Err(location));
+                return Ok(None);
             }
             None => {
                 let opening_location = location;
@@ -87,7 +84,7 @@ impl Lexer<'_> {
             }
         }
 
-        Ok(Ok(TextUnit::Arith { content, location }))
+        Ok(Some(TextUnit::Arith { content, location }))
     }
 }
 
@@ -124,15 +121,7 @@ mod tests {
     fn lexer_arithmetic_expansion_none() {
         let mut lexer = Lexer::from_memory("( foo bar )baz", Source::Unknown);
         let location = Location::dummy("Y");
-
-        let location = block_on(lexer.arithmetic_expansion(location))
-            .unwrap()
-            .unwrap_err();
-        assert_eq!(*location.code.value.borrow(), "Y");
-        assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.range, 0..1);
-
+        assert_eq!(block_on(lexer.arithmetic_expansion(location)), Ok(None));
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
     }
 
@@ -225,15 +214,7 @@ mod tests {
     fn lexer_arithmetic_expansion_unclosed_but_maybe_command_substitution() {
         let mut lexer = Lexer::from_memory("((1) ", Source::Unknown);
         let location = Location::dummy("Z");
-
-        let location = block_on(lexer.arithmetic_expansion(location))
-            .unwrap()
-            .unwrap_err();
-        assert_eq!(*location.code.value.borrow(), "Z");
-        assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.range, 0..1);
-
+        assert_eq!(block_on(lexer.arithmetic_expansion(location)), Ok(None));
         assert_eq!(lexer.index(), 0);
     }
 }

--- a/yash-syntax/src/parser/lex/arith.rs
+++ b/yash-syntax/src/parser/lex/arith.rs
@@ -20,7 +20,6 @@ use super::core::Lexer;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
 use crate::parser::error::SyntaxError;
-use crate::source::Location;
 use crate::syntax::Text;
 use crate::syntax::TextUnit;
 use std::future::Future;
@@ -36,20 +35,22 @@ impl Lexer<'_> {
     /// to the closing `))` (inclusive). Otherwise, no characters are consumed
     /// and the return value is `Ok(None)`.
     ///
-    /// The `location` parameter should be the location of the initial `$`. It
-    /// is used to construct the result, but this function does not check if it
-    /// actually is a location of `$`.
-    pub async fn arithmetic_expansion(&mut self, location: Location) -> Result<Option<TextUnit>> {
-        let index = self.index();
+    /// The `start_index` parameter should be the index for the initial `$`. It is
+    /// used to construct the result, but this function does not check if it
+    /// actually points to the `$`.
+    pub async fn arithmetic_expansion(&mut self, start_index: usize) -> Result<Option<TextUnit>> {
+        let orig_index = self.index();
 
         // Part 1: Parse `((`
         if !self.skip_if(|c| c == '(').await? {
             return Ok(None);
         }
         if !self.skip_if(|c| c == '(').await? {
-            self.rewind(index);
+            self.rewind(orig_index);
             return Ok(None);
         }
+
+        let opening_location = self.location_range(start_index..self.index());
 
         // Part 2: Parse the content
         let is_delimiter = |c| c == ')';
@@ -64,7 +65,6 @@ impl Lexer<'_> {
             Some(sc) if sc == ')' => self.consume_char(),
             Some(_) => unreachable!(),
             None => {
-                let opening_location = location;
                 let cause = SyntaxError::UnclosedArith { opening_location }.into();
                 let location = self.location().await?.clone();
                 return Err(Error { cause, location });
@@ -73,17 +73,17 @@ impl Lexer<'_> {
         match self.peek_char().await? {
             Some(sc) if sc == ')' => self.consume_char(),
             Some(_) => {
-                self.rewind(index);
+                self.rewind(orig_index);
                 return Ok(None);
             }
             None => {
-                let opening_location = location;
                 let cause = SyntaxError::UnclosedArith { opening_location }.into();
                 let location = self.location().await?.clone();
                 return Err(Error { cause, location });
             }
         }
 
+        let location = self.location_range(start_index..self.index());
         Ok(Some(TextUnit::Arith { content, location }))
     }
 }
@@ -100,18 +100,17 @@ mod tests {
 
     #[test]
     fn lexer_arithmetic_expansion_empty() {
-        let mut lexer = Lexer::from_memory("(());", Source::Unknown);
-        let location = Location::dummy("X");
+        let mut lexer = Lexer::from_memory("$(());", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.arithmetic_expansion(location))
-            .unwrap()
-            .unwrap();
+        let result = block_on(lexer.arithmetic_expansion(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(content.0, []);
-            assert_eq!(*location.code.value.borrow(), "X");
+            assert_eq!(*location.code.value.borrow(), "$(());");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..5);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -119,26 +118,26 @@ mod tests {
 
     #[test]
     fn lexer_arithmetic_expansion_none() {
-        let mut lexer = Lexer::from_memory("( foo bar )baz", Source::Unknown);
-        let location = Location::dummy("Y");
-        assert_eq!(block_on(lexer.arithmetic_expansion(location)), Ok(None));
+        let mut lexer = Lexer::from_memory("$( foo bar )baz", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+        assert_eq!(block_on(lexer.arithmetic_expansion(0)), Ok(None));
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('(')));
     }
 
     #[test]
     fn lexer_arithmetic_expansion_line_continuations() {
-        let mut lexer = Lexer::from_memory("(\\\n\\\n(\\\n)\\\n\\\n);", Source::Unknown);
-        let location = Location::dummy("X");
+        let mut lexer = Lexer::from_memory("$(\\\n\\\n(\\\n)\\\n\\\n);", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.arithmetic_expansion(location))
-            .unwrap()
-            .unwrap();
+        let result = block_on(lexer.arithmetic_expansion(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(content.0, []);
-            assert_eq!(*location.code.value.borrow(), "X");
+            assert_eq!(*location.code.value.borrow(), "$(\\\n\\\n(\\\n)\\\n\\\n);");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..15);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -146,12 +145,13 @@ mod tests {
 
     #[test]
     fn lexer_arithmetic_expansion_escapes() {
-        let mut lexer = Lexer::from_memory(r#"((\\\"\`\$));"#, Source::Unknown);
-        let location = Location::dummy("X");
+        let mut lexer = Lexer::from_memory(r#".$((\\\"\`\$));"#, Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.arithmetic_expansion(location))
-            .unwrap()
-            .unwrap();
+        let result = block_on(lexer.arithmetic_expansion(1)).unwrap().unwrap();
         assert_matches!(result, TextUnit::Arith { content, location } => {
             assert_eq!(
                 content.0,
@@ -163,10 +163,10 @@ mod tests {
                     Backslashed('$')
                 ]
             );
-            assert_eq!(*location.code.value.borrow(), "X");
+            assert_eq!(*location.code.value.borrow(), r#".$((\\\"\`\$));"#);
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 1..14);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -174,47 +174,50 @@ mod tests {
 
     #[test]
     fn lexer_arithmetic_expansion_unclosed_first() {
-        let mut lexer = Lexer::from_memory("((1", Source::Unknown);
-        let location = Location::dummy("Z");
+        let mut lexer = Lexer::from_memory("$((1", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
+        let e = block_on(lexer.arithmetic_expansion(0)).unwrap_err();
         assert_matches!(e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "Z");
+            assert_eq!(*opening_location.code.value.borrow(), "$((1");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.range, 0..1);
+            assert_eq!(opening_location.range, 0..3);
         });
-        assert_eq!(*e.location.code.value.borrow(), "((1");
-        assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.range, 3..3);
-    }
-
-    #[test]
-    fn lexer_arithmetic_expansion_unclosed_second() {
-        let mut lexer = Lexer::from_memory("((1)", Source::Unknown);
-        let location = Location::dummy("Z");
-
-        let e = block_on(lexer.arithmetic_expansion(location)).unwrap_err();
-        assert_matches!(e.cause,
-            ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "Z");
-            assert_eq!(opening_location.code.start_line_number.get(), 1);
-            assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.range, 0..1);
-        });
-        assert_eq!(*e.location.code.value.borrow(), "((1)");
+        assert_eq!(*e.location.code.value.borrow(), "$((1");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 4..4);
     }
 
     #[test]
+    fn lexer_arithmetic_expansion_unclosed_second() {
+        let mut lexer = Lexer::from_memory("$((1)", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+
+        let e = block_on(lexer.arithmetic_expansion(0)).unwrap_err();
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedArith { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "$((1)");
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
+            assert_eq!(opening_location.range, 0..3);
+        });
+        assert_eq!(*e.location.code.value.borrow(), "$((1)");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 5..5);
+    }
+
+    #[test]
     fn lexer_arithmetic_expansion_unclosed_but_maybe_command_substitution() {
-        let mut lexer = Lexer::from_memory("((1) ", Source::Unknown);
-        let location = Location::dummy("Z");
-        assert_eq!(block_on(lexer.arithmetic_expansion(location)), Ok(None));
-        assert_eq!(lexer.index(), 0);
+        let mut lexer = Lexer::from_memory("$((1) ", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+        assert_eq!(block_on(lexer.arithmetic_expansion(0)), Ok(None));
+        assert_eq!(lexer.index(), 1);
     }
 }

--- a/yash-syntax/src/parser/lex/backquote.rs
+++ b/yash-syntax/src/parser/lex/backquote.rs
@@ -110,7 +110,7 @@ mod tests {
         let result = block_on(lexer.backquote()).unwrap().unwrap();
         assert_matches!(result, TextUnit::Backquote { content, location } => {
             assert_eq!(content, []);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -134,7 +134,7 @@ mod tests {
                     BackquoteUnit::Literal('o')
                 ]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..6);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -163,7 +163,7 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..15);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -193,7 +193,7 @@ mod tests {
                     BackquoteUnit::Literal('\'')
                 ]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..15);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -212,7 +212,7 @@ mod tests {
                 content,
                 [BackquoteUnit::Literal('a'), BackquoteUnit::Literal('b')]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..12);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -231,12 +231,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "`");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 1..1);
     }
 
     #[test]
@@ -251,11 +251,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "`foo");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "`foo");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 }

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "$");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 0);
+        assert_eq!(location.range, 0..1);
     }
 
     #[test]
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{};");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 0..2);
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 1..2);
     }
 
     #[test]
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "{_;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..3);
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
         let e = block_on(lexer.braced_param(location)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
         assert_eq!(*e.location.code.value.borrow(), "{#x+};");
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..4);
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -22,7 +22,6 @@ use super::raw_param::is_special_parameter_char;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
 use crate::parser::error::SyntaxError;
-use crate::source::Location;
 use crate::syntax::Modifier;
 use crate::syntax::Param;
 
@@ -89,13 +88,15 @@ impl WordLexer<'_, '_> {
     /// including the closing brace. Otherwise, no characters are consumed and
     /// the return value is `Ok(None)`.
     ///
-    /// The `location` parameter should be the location of the initial `$`. It
-    /// is used to construct the result, but this function does not check if it
-    /// actually is a location of `$`.
-    pub async fn braced_param(&mut self, location: Location) -> Result<Option<Param>> {
+    /// The `start_index` parameter should be the index for the initial `$`. It is
+    /// used to construct the result, but this function does not check if it
+    /// actually points to the `$`.
+    pub async fn braced_param(&mut self, start_index: usize) -> Result<Option<Param>> {
         if !self.skip_if(|c| c == '{').await? {
             return Ok(None);
         }
+
+        let opening_location = self.location_range(start_index..self.index());
 
         let has_length_prefix = self.length_prefix().await?;
 
@@ -111,11 +112,11 @@ impl WordLexer<'_, '_> {
             }
             name
         } else if c == '}' {
+            // TODO Consider merging EmptyParam & UnclosedParam into InvalidParamName
             let cause = SyntaxError::EmptyParam.into();
             let location = self.location().await?.clone();
             return Err(Error { cause, location });
         } else {
-            let opening_location = location;
             let cause = SyntaxError::UnclosedParam { opening_location }.into();
             let location = self.location().await?.clone();
             return Err(Error { cause, location });
@@ -125,7 +126,6 @@ impl WordLexer<'_, '_> {
         let suffix = self.suffix_modifier().await?;
 
         if !self.skip_if(|c| c == '}').await? {
-            let opening_location = location;
             let cause = SyntaxError::UnclosedParam { opening_location }.into();
             let location = self.location().await?.clone();
             return Err(Error { cause, location });
@@ -144,7 +144,7 @@ impl WordLexer<'_, '_> {
         Ok(Some(Param {
             name,
             modifier,
-            location,
+            location: self.location_range(start_index..self.index()),
         }))
     }
 }
@@ -163,236 +163,274 @@ mod tests {
     use assert_matches::assert_matches;
     use futures_executor::block_on;
 
-    fn assert_opening_location(location: &Location) {
-        assert_eq!(*location.code.value.borrow(), "$");
-        assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.range, 0..1);
-    }
-
     #[test]
     fn lexer_braced_param_none() {
-        let mut lexer = Lexer::from_memory("foo", Source::Unknown);
+        let mut lexer = Lexer::from_memory("$foo", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
-        assert_eq!(block_on(lexer.braced_param(location)), Ok(None));
+        assert_eq!(block_on(lexer.braced_param(0)), Ok(None));
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('f')));
     }
 
     #[test]
     fn lexer_braced_param_minimum() {
-        let mut lexer = Lexer::from_memory("{@};", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${@};", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "@");
         assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${@};");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..4);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
 
     #[test]
     fn lexer_braced_param_alphanumeric_name() {
-        let mut lexer = Lexer::from_memory("{foo_123}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("X${foo_123}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(1)).unwrap().unwrap();
         assert_eq!(result.name, "foo_123");
         assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "X${foo_123}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 1..11);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_numeric_name() {
-        let mut lexer = Lexer::from_memory("{123}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${123}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "123");
         assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${123}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash() {
-        let mut lexer = Lexer::from_memory("{#}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..4);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_missing_name() {
-        let mut lexer = Lexer::from_memory("{};", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${};", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        let e = block_on(lexer.braced_param(0)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::EmptyParam));
-        assert_eq!(*e.location.code.value.borrow(), "{};");
-        assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.range, 0..2);
-    }
-
-    #[test]
-    fn lexer_braced_param_unclosed_without_name() {
-        let mut lexer = Lexer::from_memory("{;", Source::Unknown);
-        let mut lexer = WordLexer {
-            lexer: &mut lexer,
-            context: WordContext::Word,
-        };
-        let location = Location::dummy("$");
-
-        let e = block_on(lexer.braced_param(location)).unwrap_err();
-        assert_matches!(e.cause,
-            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
-            assert_opening_location(&opening_location);
-        });
-        assert_eq!(*e.location.code.value.borrow(), "{;");
-        assert_eq!(e.location.code.start_line_number.get(), 1);
-        assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.range, 1..2);
-    }
-
-    #[test]
-    fn lexer_braced_param_unclosed_with_name() {
-        let mut lexer = Lexer::from_memory("{_;", Source::Unknown);
-        let mut lexer = WordLexer {
-            lexer: &mut lexer,
-            context: WordContext::Word,
-        };
-        let location = Location::dummy("$");
-
-        let e = block_on(lexer.braced_param(location)).unwrap_err();
-        assert_matches!(e.cause,
-            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
-            assert_opening_location(&opening_location);
-        });
-        assert_eq!(*e.location.code.value.borrow(), "{_;");
+        assert_eq!(*e.location.code.value.borrow(), "${};");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 2..3);
     }
 
     #[test]
-    fn lexer_braced_param_length_alphanumeric_name() {
-        let mut lexer = Lexer::from_memory("{#foo_123}<", Source::Unknown);
+    fn lexer_braced_param_unclosed_without_name() {
+        let mut lexer = Lexer::from_memory("${;", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let e = block_on(lexer.braced_param(0)).unwrap_err();
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "${;");
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
+            assert_eq!(opening_location.range, 0..2);
+        });
+        assert_eq!(*e.location.code.value.borrow(), "${;");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 2..3);
+    }
+
+    #[test]
+    fn lexer_braced_param_unclosed_with_name() {
+        let mut lexer = Lexer::from_memory("${_;", Source::Unknown);
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+
+        let e = block_on(lexer.braced_param(0)).unwrap_err();
+        assert_matches!(e.cause,
+            ErrorCause::Syntax(SyntaxError::UnclosedParam { opening_location }) => {
+            assert_eq!(*opening_location.code.value.borrow(), "${_;");
+            assert_eq!(opening_location.code.start_line_number.get(), 1);
+            assert_eq!(opening_location.code.source, Source::Unknown);
+            assert_eq!(opening_location.range, 0..2);
+        });
+        assert_eq!(*e.location.code.value.borrow(), "${_;");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 3..4);
+    }
+
+    #[test]
+    fn lexer_braced_param_length_alphanumeric_name() {
+        let mut lexer = Lexer::from_memory("${#foo_123}<", Source::Unknown);
+        let mut lexer = WordLexer {
+            lexer: &mut lexer,
+            context: WordContext::Word,
+        };
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "foo_123");
         assert_eq!(result.modifier, Modifier::Length);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#foo_123}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..11);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_length_hash() {
-        let mut lexer = Lexer::from_memory("{##}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${##}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_eq!(result.modifier, Modifier::Length);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${##}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..5);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_length_question() {
-        let mut lexer = Lexer::from_memory("{#?}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#?}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "?");
         assert_eq!(result.modifier, Modifier::Length);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#?}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..5);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_length_hyphen() {
-        let mut lexer = Lexer::from_memory("{#-}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#-}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "-");
         assert_eq!(result.modifier, Modifier::Length);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#-}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..5);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_switch_minimum() {
-        let mut lexer = Lexer::from_memory("{x+})", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${x+})", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "x");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
@@ -400,21 +438,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${x+})");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..5);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(')')));
     }
 
     #[test]
     fn lexer_braced_param_switch_full() {
-        let mut lexer = Lexer::from_memory("{foo:?'!'})", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${foo:?'!'})", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "foo");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
@@ -422,21 +464,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "'!'");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${foo:?'!'})");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..11);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(')')));
     }
 
     #[test]
     fn lexer_braced_param_hash_suffix_alter() {
-        let mut lexer = Lexer::from_memory("{#+?}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#+?}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Alter);
@@ -444,21 +490,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "?");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#+?}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash_suffix_default() {
-        let mut lexer = Lexer::from_memory("{#--}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#--}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
@@ -466,21 +516,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "-");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#--}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash_suffix_assign() {
-        let mut lexer = Lexer::from_memory("{#=?}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#=?}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Assign);
@@ -488,21 +542,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "?");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#=?}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash_suffix_error() {
-        let mut lexer = Lexer::from_memory("{#??}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#??}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Error);
@@ -510,21 +568,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "?");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#??}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash_suffix_with_colon() {
-        let mut lexer = Lexer::from_memory("{#:-}<", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#:-}<", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Switch(switch) => {
             assert_eq!(switch.r#type, SwitchType::Default);
@@ -532,21 +594,25 @@ mod tests {
             assert_eq!(switch.word.to_string(), "");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#:-}<");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
     }
 
     #[test]
     fn lexer_braced_param_hash_with_longest_prefix_trim() {
-        let mut lexer = Lexer::from_memory("{###};", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${###};", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Prefix);
@@ -554,21 +620,25 @@ mod tests {
             assert_eq!(trim.pattern.to_string(), "");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${###};");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..6);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
 
     #[test]
     fn lexer_braced_param_hash_with_suffix_trim() {
-        let mut lexer = Lexer::from_memory("{#%};", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#%};", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_matches!(result.modifier, Modifier::Trim(trim) => {
             assert_eq!(trim.side, TrimSide::Suffix);
@@ -576,58 +646,73 @@ mod tests {
             assert_eq!(trim.pattern.to_string(), "");
         });
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#%};");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..5);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
 
     #[test]
     fn lexer_braced_param_multiple_modifier() {
-        let mut lexer = Lexer::from_memory("{#x+};", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#x+};", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let e = block_on(lexer.braced_param(location)).unwrap_err();
+        let e = block_on(lexer.braced_param(0)).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::MultipleModifier));
-        assert_eq!(*e.location.code.value.borrow(), "{#x+};");
-        assert_eq!(e.location.range, 3..4);
+        assert_eq!(*e.location.code.value.borrow(), "${#x+};");
+        assert_eq!(e.location.range, 4..5);
     }
 
     #[test]
     fn lexer_braced_param_line_continuations() {
-        let mut lexer = Lexer::from_memory("{\\\n#\\\n\\\na_\\\n1\\\n\\\n}z", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${\\\n#\\\n\\\na_\\\n1\\\n\\\n}z", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "a_1");
         assert_eq!(result.modifier, Modifier::Length);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(
+            *result.location.code.value.borrow(),
+            "${\\\n#\\\n\\\na_\\\n1\\\n\\\n}z"
+        );
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..19);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('z')));
     }
 
     #[test]
     fn lexer_braced_param_line_continuations_hash() {
-        let mut lexer = Lexer::from_memory("{#\\\n\\\n}z", Source::Unknown);
+        let mut lexer = Lexer::from_memory("${#\\\n\\\n}z", Source::Unknown);
         let mut lexer = WordLexer {
             lexer: &mut lexer,
             context: WordContext::Word,
         };
-        let location = Location::dummy("$");
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.braced_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.braced_param(0)).unwrap().unwrap();
         assert_eq!(result.name, "#");
         assert_eq!(result.modifier, Modifier::None);
         // TODO assert about other result members
-        assert_opening_location(&result.location);
+        assert_eq!(*result.location.code.value.borrow(), "${#\\\n\\\n}z");
+        assert_eq!(result.location.code.start_line_number.get(), 1);
+        assert_eq!(result.location.code.source, Source::Unknown);
+        assert_eq!(result.location.range, 0..8);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('z')));
     }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -78,7 +78,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "X");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
             assert_eq!(content, " foo bar ");
         });
 
@@ -86,7 +86,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), "( foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.index, 11);
+        assert_eq!(next.range, 11..11);
     }
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(*next.code.value.borrow(), " foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.index, 0);
+        assert_eq!(next.range, 0..0);
     }
 
     #[test]
@@ -115,11 +115,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "Z");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "( foo bar baz");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 13);
+        assert_eq!(e.location.range, 13..13);
     }
 }

--- a/yash-syntax/src/parser/lex/command_subst.rs
+++ b/yash-syntax/src/parser/lex/command_subst.rs
@@ -20,7 +20,6 @@ use super::core::Lexer;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
 use crate::parser::error::SyntaxError;
-use crate::source::Location;
 use crate::syntax::TextUnit;
 
 impl Lexer<'_> {
@@ -33,16 +32,14 @@ impl Lexer<'_> {
     /// function returns. Otherwise, no characters are consumed and the return
     /// value is `Ok(None)`.
     ///
-    /// `opening_location` should be the location of the initial `$`. It is used
-    /// to construct the result, but this function does not check if it actually
-    /// is a location of `$`.
-    pub async fn command_substitution(
-        &mut self,
-        opening_location: Location,
-    ) -> Result<Option<TextUnit>> {
-        if !self.skip_if(|c| c == '(').await? {
-            return Ok(None);
-        }
+    /// The `start_index` parameter should be the index for the initial `$`. It is
+    /// used to construct the result, but this function does not check if it
+    /// actually points to the `$`.
+    pub async fn command_substitution(&mut self, start_index: usize) -> Result<Option<TextUnit>> {
+        let opening_location = match self.consume_char_if(|c| c == '(').await? {
+            Some(ch) => ch.location.clone(),
+            None => return Ok(None),
+        };
 
         let content = self.inner_program_boxed().await?;
 
@@ -53,7 +50,7 @@ impl Lexer<'_> {
             return Err(Error { cause, location });
         }
 
-        let location = opening_location;
+        let location = self.location_range(start_index..self.index());
         Ok(Some(TextUnit::CommandSubst { content, location }))
     }
 }
@@ -68,58 +65,59 @@ mod tests {
 
     #[test]
     fn lexer_command_substitution_success() {
-        let mut lexer = Lexer::from_memory("( foo bar )baz", Source::Unknown);
-        let location = Location::dummy("X");
+        let mut lexer = Lexer::from_memory("$( foo bar )baz", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.command_substitution(location))
-            .unwrap()
-            .unwrap();
+        let result = block_on(lexer.command_substitution(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::CommandSubst { location, content } => {
-            assert_eq!(*location.code.value.borrow(), "X");
+            assert_eq!(*location.code.value.borrow(), "$( foo bar )baz");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..12);
             assert_eq!(content, " foo bar ");
         });
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(*next.code.value.borrow(), "( foo bar )baz");
+        assert_eq!(*next.code.value.borrow(), "$( foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.range, 11..11);
+        assert_eq!(next.range, 12..13);
     }
 
     #[test]
     fn lexer_command_substitution_none() {
-        let mut lexer = Lexer::from_memory(" foo bar )baz", Source::Unknown);
-        let location = Location::dummy("Y");
+        let mut lexer = Lexer::from_memory("$ foo bar )baz", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.command_substitution(location)).unwrap();
+        let result = block_on(lexer.command_substitution(0)).unwrap();
         assert_eq!(result, None);
 
         let next = block_on(lexer.location()).unwrap();
-        assert_eq!(*next.code.value.borrow(), " foo bar )baz");
+        assert_eq!(*next.code.value.borrow(), "$ foo bar )baz");
         assert_eq!(next.code.start_line_number.get(), 1);
         assert_eq!(next.code.source, Source::Unknown);
-        assert_eq!(next.range, 0..0);
+        assert_eq!(next.range, 1..2);
     }
 
     #[test]
     fn lexer_command_substitution_unclosed() {
-        let mut lexer = Lexer::from_memory("( foo bar baz", Source::Unknown);
-        let location = Location::dummy("Z");
+        let mut lexer = Lexer::from_memory("$( foo bar baz", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let e = block_on(lexer.command_substitution(location)).unwrap_err();
+        let e = block_on(lexer.command_substitution(0)).unwrap_err();
         assert_matches!(e.cause,
             ErrorCause::Syntax(SyntaxError::UnclosedCommandSubstitution { opening_location }) => {
-            assert_eq!(*opening_location.code.value.borrow(), "Z");
+            assert_eq!(*opening_location.code.value.borrow(), "$( foo bar baz");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.range, 0..1);
+            assert_eq!(opening_location.range, 1..2);
         });
-        assert_eq!(*e.location.code.value.borrow(), "( foo bar baz");
+        assert_eq!(*e.location.code.value.borrow(), "$( foo bar baz");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.range, 13..13);
+        assert_eq!(e.location.range, 14..14);
     }
 }

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -309,9 +309,8 @@ impl<'a> LexerCore<'a> {
             end
         );
 
-        let original = self.source[begin].location.clone();
         let source = Source::Alias {
-            original,
+            original: self.location_range(begin..end),
             alias: alias.clone(),
         };
         let code = Rc::new(Code {

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -167,7 +167,7 @@ impl<'a> LexerCore<'a> {
                         // End of input
                         self.state = InputState::EndOfInput(Location {
                             code: Rc::clone(&self.raw_code),
-                            index: self.index,
+                            range: self.index..self.index,
                         });
                     } else {
                         // Successful read
@@ -181,7 +181,7 @@ impl<'a> LexerCore<'a> {
                         cause: io_error.into(),
                         location: Location {
                             code: Rc::clone(&self.raw_code),
-                            index: self.index,
+                            range: self.index..self.index,
                         },
                     });
                 }
@@ -739,7 +739,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "");
             assert_eq!(location.code.start_line_number, line);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..0);
         });
     }
 
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "");
         assert_eq!(e.location.code.start_line_number, line);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..0);
     }
 
     #[test]
@@ -784,14 +784,14 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number, line);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index, 0);
+            assert_eq!(c.location.range, 0..1);
         });
         assert_matches!(result, Ok(PeekChar::Char(c)) => {
             assert_eq!(c.value, 'a');
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number, line);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index, 0);
+            assert_eq!(c.location.range, 0..1);
         });
         lexer.consume_char();
 
@@ -801,7 +801,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\n");
             assert_eq!(c.location.code.start_line_number, line);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index, 1);
+            assert_eq!(c.location.range, 1..2);
         });
         lexer.consume_char();
 
@@ -811,7 +811,7 @@ mod tests {
             assert_eq!(*c.location.code.value.borrow(), "a\nb");
             assert_eq!(c.location.code.start_line_number.get(), 1);
             assert_eq!(c.location.code.source, Source::Unknown);
-            assert_eq!(c.location.index, 2);
+            assert_eq!(c.location.range, 2..3);
         });
         lexer.consume_char();
 
@@ -820,7 +820,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "a\nb");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 3);
+            assert_eq!(location.range, 3..3);
         });
     }
 
@@ -895,7 +895,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "abc");
                 assert_eq!(c.location.code.start_line_number, line);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index, 0);
+                assert_eq!(c.location.range, 0..1);
             });
         });
     }
@@ -967,10 +967,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 0);
+                assert_eq!(c.location.range, 0..1);
             });
             lexer.consume_char();
 
@@ -983,10 +983,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 1);
+                assert_eq!(c.location.range, 1..2);
             });
             lexer.consume_char();
 
@@ -999,10 +999,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), "a b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 0);
+                    assert_eq!(original.range, 0..1);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 2);
+                assert_eq!(c.location.range, 2..3);
             });
             lexer.consume_char();
 
@@ -1011,7 +1011,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "a b");
                 assert_eq!(c.location.code.start_line_number, line);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index, 1);
+                assert_eq!(c.location.range, 1..2);
             });
             lexer.consume_char();
         });
@@ -1046,10 +1046,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 0);
+                assert_eq!(c.location.range, 0..1);
             });
             lexer.consume_char();
 
@@ -1062,10 +1062,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 1);
+                assert_eq!(c.location.range, 1..2);
             });
             lexer.consume_char();
 
@@ -1077,10 +1077,10 @@ mod tests {
                     assert_eq!(*original.code.value.borrow(), " foo b");
                     assert_eq!(original.code.start_line_number, line);
                     assert_eq!(original.code.source, Source::Unknown);
-                    assert_eq!(original.index, 1);
+                    assert_eq!(original.range, 1..4);
                     assert_eq!(alias2, &alias);
                 });
-                assert_eq!(c.location.index, 2);
+                assert_eq!(c.location.range, 2..3);
             });
             lexer.consume_char();
 
@@ -1089,7 +1089,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), " foo b");
                 assert_eq!(c.location.code.start_line_number, line);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index, 4);
+                assert_eq!(c.location.range, 4..5);
             });
             lexer.consume_char();
         });
@@ -1118,7 +1118,7 @@ mod tests {
                 assert_eq!(*c.location.code.value.borrow(), "x ");
                 assert_eq!(c.location.code.start_line_number, line);
                 assert_eq!(c.location.code.source, Source::Unknown);
-                assert_eq!(c.location.index, 1);
+                assert_eq!(c.location.range, 1..2);
             });
         });
     }
@@ -1239,11 +1239,11 @@ mod tests {
             assert_eq!(*location_1.code.value.borrow(), " \n\n");
             assert_eq!(location_1.code.start_line_number.get(), 1);
             assert_eq!(location_1.code.source, Source::Unknown);
-            assert_eq!(location_1.index, 0);
+            assert_eq!(location_1.range, 0..1);
             assert_eq!(*location_2.code.value.borrow(), "\t\n");
             assert_eq!(location_2.code.start_line_number.get(), 3);
             assert_eq!(location_2.code.source, Source::Unknown);
-            assert_eq!(location_2.index, 1);
+            assert_eq!(location_2.range, 1..2);
         });
     }
 
@@ -1264,7 +1264,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.index, 0);
+        assert_eq!(c.location.range, 0..1);
 
         let mut called = 0;
         let r = block_on(lexer.consume_char_if(|c| {
@@ -1297,7 +1297,7 @@ mod tests {
         assert_eq!(*c.location.code.value.borrow(), "word\n");
         assert_eq!(c.location.code.start_line_number.get(), 1);
         assert_eq!(c.location.code.source, Source::Unknown);
-        assert_eq!(c.location.index, 1);
+        assert_eq!(c.location.range, 1..2);
 
         block_on(lexer.consume_char_if(|c| {
             assert_eq!(c, 'r');
@@ -1343,6 +1343,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< )");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..4);
     }
 }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -31,23 +31,19 @@ impl WordLexer<'_, '_> {
     /// characters are consumed and the return value is `Ok(None)`.
     pub async fn dollar_unit(&mut self) -> Result<Option<TextUnit>> {
         let start_index = self.index();
-        let location = match self.consume_char_if(|c| c == '$').await? {
-            None => return Ok(None),
-            Some(c) => c.location.clone(),
-        };
+        if !self.skip_if(|c| c == '$').await? {
+            return Ok(None);
+        }
 
-        if let Some(result) = self.raw_param(location).await? {
+        if let Some(result) = self.raw_param(start_index).await? {
             return Ok(Some(result));
-        };
-
+        }
         if let Some(result) = self.braced_param(start_index).await? {
             return Ok(Some(TextUnit::BracedParam(result)));
-        };
-
+        }
         if let Some(result) = self.arithmetic_expansion(start_index).await? {
             return Ok(Some(result));
         }
-
         if let Some(result) = self.command_substitution(start_index).await? {
             return Ok(Some(result));
         }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -41,9 +41,8 @@ impl WordLexer<'_, '_> {
             Err(location) => location,
         };
 
-        let _location = match self.braced_param(location).await? {
-            Ok(result) => return Ok(Some(TextUnit::BracedParam(result))),
-            Err(location) => location,
+        if let Some(result) = self.braced_param(location).await? {
+            return Ok(Some(TextUnit::BracedParam(result)));
         };
 
         if let Some(result) = self.arithmetic_expansion(start_index).await? {

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -36,9 +36,8 @@ impl WordLexer<'_, '_> {
             Some(c) => c.location.clone(),
         };
 
-        let _location = match self.raw_param(location).await? {
-            Ok(result) => return Ok(Some(result)),
-            Err(location) => location,
+        if let Some(result) = self.raw_param(location).await? {
+            return Ok(Some(result));
         };
 
         if let Some(result) = self.braced_param(start_index).await? {

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -36,12 +36,12 @@ impl WordLexer<'_, '_> {
             Some(c) => c.location.clone(),
         };
 
-        let location = match self.raw_param(location).await? {
+        let _location = match self.raw_param(location).await? {
             Ok(result) => return Ok(Some(result)),
             Err(location) => location,
         };
 
-        if let Some(result) = self.braced_param(location).await? {
+        if let Some(result) = self.braced_param(start_index).await? {
             return Ok(Some(TextUnit::BracedParam(result)));
         };
 

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -41,12 +41,12 @@ impl WordLexer<'_, '_> {
             Err(location) => location,
         };
 
-        let location = match self.braced_param(location).await? {
+        let _location = match self.braced_param(location).await? {
             Ok(result) => return Ok(Some(TextUnit::BracedParam(result))),
             Err(location) => location,
         };
 
-        if let Some(result) = self.arithmetic_expansion(location).await? {
+        if let Some(result) = self.arithmetic_expansion(start_index).await? {
             return Ok(Some(result));
         }
 

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -133,7 +133,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$0");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..2);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -150,7 +150,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$()");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..3);
             assert_eq!(content, "");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -165,7 +165,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$( foo bar )");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..12);
             assert_eq!(content, " foo bar ");
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -184,7 +184,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$((1))");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..6);
         });
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -30,7 +30,7 @@ impl WordLexer<'_, '_> {
     /// substitution, or arithmetic expansion is parsed. Otherwise, no
     /// characters are consumed and the return value is `Ok(None)`.
     pub async fn dollar_unit(&mut self) -> Result<Option<TextUnit>> {
-        let index = self.index();
+        let start_index = self.index();
         let location = match self.consume_char_if(|c| c == '$').await? {
             None => return Ok(None),
             Some(c) => c.location.clone(),
@@ -46,17 +46,17 @@ impl WordLexer<'_, '_> {
             Err(location) => location,
         };
 
-        let location = match self.arithmetic_expansion(location).await? {
+        let _location = match self.arithmetic_expansion(location).await? {
             Ok(result) => return Ok(Some(result)),
             Err(location) => location,
         };
 
-        if let Some(result) = self.command_substitution(location).await? {
+        if let Some(result) = self.command_substitution(start_index).await? {
             return Ok(Some(result));
         }
 
         // TODO maybe reject unrecognized dollar unit?
-        self.rewind(index);
+        self.rewind(start_index);
         Ok(None)
     }
 }

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -46,10 +46,9 @@ impl WordLexer<'_, '_> {
             Err(location) => location,
         };
 
-        let _location = match self.arithmetic_expansion(location).await? {
-            Ok(result) => return Ok(Some(result)),
-            Err(location) => location,
-        };
+        if let Some(result) = self.arithmetic_expansion(location).await? {
+            return Ok(Some(result));
+        }
 
         if let Some(result) = self.command_substitution(start_index).await? {
             return Ok(Some(result));

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -174,7 +174,7 @@ mod tests {
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(*location.code.value.borrow(), "END\nX");
         assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.index, 4);
+        assert_eq!(location.range, 4..5);
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(*location.code.value.borrow(), "content\nFOO\nX");
         assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.index, 12);
+        assert_eq!(location.range, 12..13);
     }
 
     #[test]
@@ -206,7 +206,7 @@ mod tests {
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(*location.code.value.borrow(), "foo\n\tBAR\n\nbaz\nBAR\nX");
         assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.index, 18);
+        assert_eq!(location.range, 18..19);
     }
 
     #[test]
@@ -287,7 +287,7 @@ END
         let location = block_on(lexer.location()).unwrap();
         assert_eq!(*location.code.value.borrow(), "\t\t\tfoo\n\tBAR\n\n");
         assert_eq!(location.code.start_line_number.get(), 1);
-        assert_eq!(location.index, 12);
+        assert_eq!(location.range, 12..13);
     }
 
     #[test]
@@ -301,11 +301,11 @@ END
             assert_eq!(*redir_op_location.code.value.borrow(), "END");
             assert_eq!(redir_op_location.code.start_line_number.get(), 1);
             assert_eq!(redir_op_location.code.source, Source::Unknown);
-            assert_eq!(redir_op_location.index, 0);
+            assert_eq!(redir_op_location.range, 0..3);
         });
         assert_eq!(*e.location.code.value.borrow(), "");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..0);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -34,15 +34,18 @@ use std::future::Future;
 use std::pin::Pin;
 
 impl Lexer<'_> {
-    async fn invalid_modifier(&mut self) -> Result<Modifier> {
+    /// Returns an invalid modifier error.
+    ///
+    /// The `start_index` must be the index of the first character of the modifier.
+    fn invalid_modifier(&mut self, start_index: usize) -> Result<Modifier> {
         let cause = SyntaxError::InvalidModifier.into();
-        let location = self.location().await?.clone();
+        let location = self.location_range(start_index..self.index());
         Err(Error { cause, location })
     }
 
-    async fn suffix_modifier_not_found(&mut self, colon: bool) -> Result<Modifier> {
+    fn suffix_modifier_not_found(&mut self, start_index: usize, colon: bool) -> Result<Modifier> {
         if colon {
-            self.invalid_modifier().await
+            self.invalid_modifier(start_index)
         } else {
             Ok(Modifier::None)
         }
@@ -52,12 +55,12 @@ impl Lexer<'_> {
     ///
     /// This function blindly consumes the current character, which must be
     /// `symbol`.
-    async fn trim(&mut self, colon: bool, symbol: char) -> Result<Modifier> {
+    async fn trim(&mut self, start_index: usize, colon: bool, symbol: char) -> Result<Modifier> {
+        self.consume_char();
         if colon {
-            return self.invalid_modifier().await;
+            return self.invalid_modifier(start_index);
         }
 
-        self.consume_char();
         let side = match symbol {
             '#' => TrimSide::Prefix,
             '%' => TrimSide::Suffix,
@@ -133,16 +136,17 @@ impl WordLexer<'_, '_> {
     /// `` ` ``, `\` and `}` can be escaped and single quotes are not recognized
     /// in the word.
     pub async fn suffix_modifier(&mut self) -> Result<Modifier> {
+        let start_index = self.index();
         let colon = self.skip_if(|c| c == ':').await?;
 
         if let Some(symbol) = self.peek_char().await? {
             match symbol {
                 '+' | '-' | '=' | '?' => self.switch(colon, symbol).await,
-                '#' | '%' => self.trim(colon, symbol).await,
-                _ => self.suffix_modifier_not_found(colon).await,
+                '#' | '%' => self.trim(start_index, colon, symbol).await,
+                _ => self.suffix_modifier_not_found(start_index, colon),
             }
         } else {
-            self.suffix_modifier_not_found(colon).await
+            self.suffix_modifier_not_found(start_index, colon)
         }
     }
 }
@@ -586,6 +590,6 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":#}");
-        assert_eq!(e.location.range, 0..1);
+        assert_eq!(e.location.range, 0..2);
     }
 }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -198,7 +198,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "+}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(switch.word.location.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -226,7 +226,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "+a  z}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(switch.word.location.range, 1..5);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -246,7 +246,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(switch.word.location.range, 2..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -266,7 +266,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "-}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(switch.word.location.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -294,7 +294,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":-cool}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(switch.word.location.range, 2..6);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -314,7 +314,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(switch.word.location.range, 2..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -341,7 +341,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), "=Yes}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(switch.word.location.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -361,7 +361,7 @@ mod tests {
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "?}");
-            assert_eq!(switch.word.location.index, 1);
+            assert_eq!(switch.word.location.range, 1..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -387,7 +387,7 @@ mod tests {
                 ]
             );
             assert_eq!(*switch.word.location.code.value.borrow(), ":?No}");
-            assert_eq!(switch.word.location.index, 2);
+            assert_eq!(switch.word.location.range, 2..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -438,7 +438,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(trim.pattern.location.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -458,7 +458,7 @@ mod tests {
             assert_eq!(trim.length, TrimLength::Shortest);
             assert_eq!(trim.pattern.units, [WordUnit::SingleQuote("*".to_string())]);
             assert_eq!(*trim.pattern.location.code.value.borrow(), "#'*'}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(trim.pattern.location.range, 1..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -481,7 +481,7 @@ mod tests {
                 assert_eq!(units[..], [TextUnit::Literal('?')]);
             });
             assert_eq!(*trim.pattern.location.code.value.borrow(), r#"##"?"}"#);
-            assert_eq!(trim.pattern.location.index, 2);
+            assert_eq!(trim.pattern.location.range, 2..5);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -504,7 +504,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Backslashed('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), r"%\%}");
-            assert_eq!(trim.pattern.location.index, 1);
+            assert_eq!(trim.pattern.location.range, 1..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -527,7 +527,7 @@ mod tests {
                 [WordUnit::Unquoted(TextUnit::Literal('%'))]
             );
             assert_eq!(*trim.pattern.location.code.value.borrow(), "%%%}");
-            assert_eq!(trim.pattern.location.index, 2);
+            assert_eq!(trim.pattern.location.range, 2..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('}')));
@@ -558,7 +558,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":");
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 0..1);
     }
 
     #[test]
@@ -572,7 +572,7 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":x}");
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 0..1);
     }
 
     #[test]
@@ -586,6 +586,6 @@ mod tests {
         let e = block_on(lexer.suffix_modifier()).unwrap_err();
         assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidModifier));
         assert_eq!(*e.location.code.value.borrow(), ":#}");
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 0..1);
     }
 }

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -405,7 +405,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<-");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..3);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLessDash));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -422,10 +422,10 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..2);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
-        assert_eq!(block_on(lexer.location()).unwrap().index, 2);
+        assert_eq!(block_on(lexer.location()).unwrap().range, 2..3);
     }
 
     #[test]
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "<<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..2);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -456,7 +456,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "\\\n\\\n<\\\n<\\\n>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 4);
+        assert_eq!(t.word.location.range, 0..10);
         assert_eq!(t.id, TokenId::Operator(Operator::LessLess));
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "\n");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..1);
         assert_eq!(t.id, TokenId::Operator(Operator::Newline));
     }
 }

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -18,7 +18,6 @@
 
 use super::core::Lexer;
 use crate::parser::core::Result;
-use crate::source::Location;
 use crate::syntax::TextUnit;
 
 /// Tests if a character can be part of a POSIXly-portable name.
@@ -56,22 +55,23 @@ impl Lexer<'_> {
     /// parameter name. If so, the name is consumed and returned. Otherwise, no
     /// characters are consumed and the return value is `Ok(None)`.
     ///
-    /// The `location` parameter should be the location of the initial `$`. It
-    /// is used to construct the result, but this function does not check if it
-    /// actually is a location of `$`.
-    pub async fn raw_param(&mut self, location: Location) -> Result<Option<TextUnit>> {
-        if let Some(c) = self.consume_char_if(is_single_char_name).await? {
-            let name = c.value.to_string();
-            Ok(Some(TextUnit::RawParam { name, location }))
+    /// The `start_index` parameter should be the index for the initial `$`. It is
+    /// used to construct the result, but this function does not check if it
+    /// actually points to the `$`.
+    pub async fn raw_param(&mut self, start_index: usize) -> Result<Option<TextUnit>> {
+        let name = if let Some(c) = self.consume_char_if(is_single_char_name).await? {
+            c.value.to_string()
         } else if let Some(c) = self.consume_char_if(is_portable_name_char).await? {
             let mut name = c.value.to_string();
             while let Some(c) = self.consume_char_if(is_portable_name_char).await? {
                 name.push(c.value);
             }
-            Ok(Some(TextUnit::RawParam { name, location }))
+            name
         } else {
-            Ok(None)
-        }
+            return Ok(None);
+        };
+        let location = self.location_range(start_index..self.index());
+        Ok(Some(TextUnit::RawParam { name, location }))
     }
 }
 
@@ -84,16 +84,17 @@ mod tests {
 
     #[test]
     fn lexer_raw_param_special_parameter() {
-        let mut lexer = Lexer::from_memory("@;", Source::Unknown);
-        let location = Location::dummy("$");
+        let mut lexer = Lexer::from_memory("$@;", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.raw_param(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "@");
-            assert_eq!(*location.code.value.borrow(), "$");
+            assert_eq!(*location.code.value.borrow(), "$@;");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -101,16 +102,17 @@ mod tests {
 
     #[test]
     fn lexer_raw_param_digit() {
-        let mut lexer = Lexer::from_memory("12", Source::Unknown);
-        let location = Location::dummy("$");
+        let mut lexer = Lexer::from_memory("$12", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.raw_param(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "1");
-            assert_eq!(*location.code.value.borrow(), "$");
+            assert_eq!(*location.code.value.borrow(), "$12");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..2);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('2')));
@@ -118,16 +120,17 @@ mod tests {
 
     #[test]
     fn lexer_raw_param_posix_name() {
-        let mut lexer = Lexer::from_memory("az_AZ_019<", Source::Unknown);
-        let location = Location::dummy("$");
+        let mut lexer = Lexer::from_memory("$az_AZ_019<", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.raw_param(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "az_AZ_019");
-            assert_eq!(*location.code.value.borrow(), "$");
+            assert_eq!(*location.code.value.borrow(), "$az_AZ_019<");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..10);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
@@ -135,16 +138,17 @@ mod tests {
 
     #[test]
     fn lexer_raw_param_posix_name_line_continuations() {
-        let mut lexer = Lexer::from_memory("a\\\n\\\nb\\\n\\\nc\\\n>", Source::Unknown);
-        let location = Location::dummy("$");
+        let mut lexer = Lexer::from_memory("$a\\\n\\\nb\\\n\\\nc\\\n>", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
 
-        let result = block_on(lexer.raw_param(location)).unwrap().unwrap();
+        let result = block_on(lexer.raw_param(0)).unwrap().unwrap();
         assert_matches!(result, TextUnit::RawParam { name, location } => {
             assert_eq!(name, "abc");
-            assert_eq!(*location.code.value.borrow(), "$");
+            assert_eq!(*location.code.value.borrow(), "$a\\\n\\\nb\\\n\\\nc\\\n>");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.range, 0..1);
+            assert_eq!(location.range, 0..14);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -152,9 +156,10 @@ mod tests {
 
     #[test]
     fn lexer_raw_param_not_parameter() {
-        let mut lexer = Lexer::from_memory(";", Source::Unknown);
-        let location = Location::dummy("X");
-        assert_eq!(block_on(lexer.raw_param(location)), Ok(None));
+        let mut lexer = Lexer::from_memory("$;", Source::Unknown);
+        block_on(lexer.peek_char()).unwrap();
+        lexer.consume_char();
+        assert_eq!(block_on(lexer.raw_param(0)), Ok(None));
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }
 }

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -96,7 +96,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
@@ -113,7 +113,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('2')));
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('<')));
@@ -147,7 +147,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), "$");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..1);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some('>')));
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "X");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 0);
+        assert_eq!(location.range, 0..1);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(Some(';')));
     }

--- a/yash-syntax/src/parser/lex/text.rs
+++ b/yash-syntax/src/parser/lex/text.rs
@@ -352,7 +352,7 @@ mod tests {
         .unwrap();
         assert_matches!(result, CommandSubst { content, location } => {
             assert_eq!(content, "");
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -373,7 +373,7 @@ mod tests {
         .unwrap();
         assert_matches!(result, Backquote { content, location } => {
             assert_eq!(content, [BackquoteUnit::Backslashed('"')]);
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -397,7 +397,7 @@ mod tests {
                 content,
                 [BackquoteUnit::Literal('\\'), BackquoteUnit::Literal('"')]
             );
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..4);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -595,11 +595,11 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "x(()");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 1);
+            assert_eq!(opening_location.range, 1..2);
         });
         assert_eq!(*e.location.code.value.borrow(), "x(()");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 }

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..0);
         assert_eq!(t.id, TokenId::EndOfInput);
         assert_eq!(t.index, 0);
     }
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "abc ");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..3);
         assert_eq!(t.id, TokenId::Token(None));
         assert_eq!(t.index, 0);
 
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "12<");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..2);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
@@ -170,11 +170,11 @@ mod tests {
         assert_eq!(*t.word.location.code.value.borrow(), "0>>");
         assert_eq!(t.word.location.code.start_line_number.get(), 1);
         assert_eq!(t.word.location.code.source, Source::Unknown);
-        assert_eq!(t.word.location.index, 0);
+        assert_eq!(t.word.location.range, 0..1);
         assert_eq!(t.id, TokenId::IoNumber);
         assert_eq!(t.index, 0);
 
-        assert_eq!(block_on(lexer.location()).unwrap().index, 1);
+        assert_eq!(block_on(lexer.location()).unwrap().range, 1..2);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index, 1);
+            assert_eq!(t.word.location.range, 1..2);
             assert_eq!(t.id, TokenId::Token(None));
             assert_eq!(t.index, 1);
 
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(*t.word.location.code.value.borrow(), " a  ");
             assert_eq!(t.word.location.code.start_line_number.get(), 1);
             assert_eq!(t.word.location.code.source, Source::Unknown);
-            assert_eq!(t.word.location.index, 4);
+            assert_eq!(t.word.location.range, 4..4);
             assert_eq!(t.id, TokenId::EndOfInput);
             assert_eq!(t.index, 4);
         });

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -156,11 +156,12 @@ impl WordLexer<'_, '_> {
 
     /// Dynamic version of [`Self::word`].
     async fn word_dyn(&mut self, is_delimiter: &dyn Fn(char) -> bool) -> Result<Word> {
-        let location = self.location().await?.clone();
+        let start = self.index();
         let mut units = vec![];
         while let Some(unit) = self.word_unit_dyn(is_delimiter).await? {
             units.push(unit)
         }
+        let location = self.location_range(start..self.index());
         Ok(Word { units, location })
     }
 }

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -191,7 +191,7 @@ mod tests {
                 .unwrap();
         assert_matches!(result, Unquoted(CommandSubst { content, location }) => {
             assert_eq!(content, "");
-            assert_eq!(location.index, 0);
+            assert_eq!(location.range, 0..3);
         });
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
@@ -338,12 +338,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "'abc\ndef\\");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "'abc\ndef\\");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 9);
+        assert_eq!(e.location.range, 9..9);
     }
 
     #[test]
@@ -454,12 +454,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "\"abc\ndef");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "\"abc\ndef");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 8);
+        assert_eq!(e.location.range, 8..8);
     }
 
     #[test]
@@ -478,7 +478,7 @@ mod tests {
             assert_eq!(*location.code.value.borrow(), r"0$(:)X\#");
             assert_eq!(location.code.start_line_number.get(), 1);
             assert_eq!(location.code.source, Source::Unknown);
-            assert_eq!(location.index, 1);
+            assert_eq!(location.range, 1..5);
         });
         assert_eq!(word.units[2], WordUnit::Unquoted(TextUnit::Literal('X')));
         assert_eq!(
@@ -488,7 +488,7 @@ mod tests {
         assert_eq!(*word.location.code.value.borrow(), r"0$(:)X\#");
         assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
-        assert_eq!(word.location.index, 0);
+        assert_eq!(word.location.range, 0..8);
 
         assert_eq!(block_on(lexer.peek_char()), Ok(None));
     }
@@ -506,7 +506,7 @@ mod tests {
         assert_eq!(*word.location.code.value.borrow(), "");
         assert_eq!(word.location.code.start_line_number.get(), 1);
         assert_eq!(word.location.code.source, Source::Unknown);
-        assert_eq!(word.location.index, 0);
+        assert_eq!(word.location.range, 0..0);
     }
 
     #[test]

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 4);
+        assert_eq!(location.range, 4..5);
         assert_eq!(list.0[0].and_or.to_string(), "foo");
 
         assert_eq!(list.0[1].async_flag, None);
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(*location.code.value.borrow(), "foo & bar ; baz&");
         assert_eq!(location.code.start_line_number.get(), 1);
         assert_eq!(location.code.source, Source::Unknown);
-        assert_eq!(location.index, 15);
+        assert_eq!(location.range, 15..16);
         assert_eq!(list.0[2].and_or.to_string(), "baz");
     }
 
@@ -308,7 +308,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<END");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..5);
     }
 
     #[test]
@@ -322,6 +322,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..4);
     }
 }

--- a/yash-syntax/src/parser/pipeline.rs
+++ b/yash-syntax/src/parser/pipeline.rs
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " !  !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..5);
     }
 
     #[test]
@@ -185,7 +185,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "!\n");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 1);
+        assert_eq!(e.location.range, 1..2);
     }
 
     #[test]
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | ;");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..7);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "foo | !");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 6);
+        assert_eq!(e.location.range, 6..7);
     }
 
     #[test]

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -341,7 +341,7 @@ mod tests {
         );
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 0);
+        assert_eq!(e.location.range, 0..40);
     }
 
     #[test]
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " < >");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..4);
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  < ");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 
     #[test]
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<< <<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 3);
+        assert_eq!(e.location.range, 3..5);
     }
 
     #[test]
@@ -418,6 +418,6 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "<<");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..2);
     }
 }

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -235,12 +235,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a b");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a b");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 4);
+        assert_eq!(e.location.range, 4..4);
     }
 
     #[test]
@@ -254,12 +254,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "(a;b)");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..1);
         });
         assert_eq!(*e.location.code.value.borrow(), "(a;b)");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 2);
+        assert_eq!(e.location.range, 2..3);
     }
 
     #[test]
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "my=assignment");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index, 0);
+        assert_eq!(sc.assigns[0].location.range, 0..13);
     }
 
     #[test]
@@ -315,19 +315,19 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index, 0);
+        assert_eq!(sc.assigns[0].location.range, 0..2);
         assert_eq!(sc.assigns[1].name, "b");
         assert_eq!(sc.assigns[1].value.to_string(), "!");
         assert_eq!(*sc.assigns[1].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[1].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[1].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[1].location.index, 3);
+        assert_eq!(sc.assigns[1].location.range, 3..6);
         assert_eq!(sc.assigns[2].name, "c");
         assert_eq!(sc.assigns[2].value.to_string(), "X");
         assert_eq!(*sc.assigns[2].location.code.value.borrow(), "a= b=! c=X");
         assert_eq!(sc.assigns[2].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[2].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[2].location.index, 7);
+        assert_eq!(sc.assigns[2].location.range, 7..10);
     }
 
     #[test]
@@ -514,7 +514,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a= ()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index, 0);
+        assert_eq!(sc.assigns[0].location.range, 0..2);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));
@@ -535,7 +535,7 @@ mod tests {
         assert_eq!(*sc.assigns[0].location.code.value.borrow(), "a=b()");
         assert_eq!(sc.assigns[0].location.code.start_line_number.get(), 1);
         assert_eq!(sc.assigns[0].location.code.source, Source::Unknown);
-        assert_eq!(sc.assigns[0].location.index, 0);
+        assert_eq!(sc.assigns[0].location.range, 0..3);
 
         let next = block_on(parser.peek_token()).unwrap();
         assert_eq!(next.id, Operator(OpenParen));

--- a/yash-syntax/src/parser/while_loop.rs
+++ b/yash-syntax/src/parser/while_loop.rs
@@ -148,12 +148,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "while :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..5);
         });
         assert_eq!(*e.location.code.value.borrow(), "while :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 7);
+        assert_eq!(e.location.range, 7..7);
     }
 
     #[test]
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), " while do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 7);
+        assert_eq!(e.location.range, 7..9);
     }
 
     #[test]
@@ -243,12 +243,12 @@ mod tests {
             assert_eq!(*opening_location.code.value.borrow(), "until :");
             assert_eq!(opening_location.code.start_line_number.get(), 1);
             assert_eq!(opening_location.code.source, Source::Unknown);
-            assert_eq!(opening_location.index, 0);
+            assert_eq!(opening_location.range, 0..5);
         });
         assert_eq!(*e.location.code.value.borrow(), "until :");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 7);
+        assert_eq!(e.location.range, 7..7);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(*e.location.code.value.borrow(), "  until do :; done");
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(e.location.code.source, Source::Unknown);
-        assert_eq!(e.location.index, 8);
+        assert_eq!(e.location.range, 8..10);
     }
 
     #[test]

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -45,10 +45,10 @@ pub enum Source {
     /// Alias substitution.
     ///
     /// This applies to a code fragment that replaced another as a result of alias substitution.
-    ///
-    /// `original` is the location of the original word that was replaced.
     Alias {
+        /// Position of the original word that was replaced
         original: Location,
+        /// Definition of the alias that was substituted
         alias: Rc<Alias>,
     },
 

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -226,13 +226,6 @@ impl Location {
         }
         with_line(value.into())
     }
-
-    /// Increases the `index` by `count`.
-    ///
-    /// This function panics if the result overflows.
-    pub fn advance(&mut self, count: usize) {
-        self.index = self.index.checked_add(count).unwrap();
-    }
 }
 
 /// Character with source description.
@@ -242,33 +235,4 @@ pub struct SourceChar {
     pub value: char,
     /// Location of this character in source code.
     pub location: Location,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn location_advance() {
-        let code = Rc::new(Code {
-            value: RefCell::new("line\n".to_owned()),
-            start_line_number: NonZeroU64::new(1).unwrap(),
-            source: Source::Unknown,
-        });
-        let mut location = Location {
-            code: code.clone(),
-            index: 0,
-        };
-
-        location.advance(1);
-        assert_eq!(location.index, 1);
-        location.advance(2);
-        assert_eq!(location.index, 3);
-
-        // The advance function does not check the line length.
-        location.advance(5);
-        assert_eq!(location.index, 8);
-
-        assert!(Rc::ptr_eq(&location.code, &code));
-    }
 }

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -424,7 +424,7 @@ pub enum TextUnit {
     RawParam {
         /// Parameter name.
         name: String,
-        /// Location of the initial `$` character of this parameter expansion.
+        /// Position of this parameter expansion in the source code.
         location: Location,
     },
     /// Parameter expansion that is enclosed in braces.

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -434,7 +434,7 @@ pub enum TextUnit {
         /// Command string that will be parsed and executed when the command
         /// substitution is expanded.
         content: String,
-        /// Location of the initial `$` character of this command substitution.
+        /// Position of this command substitution in the source code.
         location: Location,
     },
     /// Command substitution of the form `` `...` ``.

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -449,7 +449,7 @@ pub enum TextUnit {
     Arith {
         /// Expression that is to be evaluated.
         content: Text,
-        /// Location of the initial `$` character of this command substitution.
+        /// Position of this arithmetic expansion in the source code.
         location: Location,
     },
 }

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -625,7 +625,7 @@ impl MaybeLiteral for WordUnit {
 pub struct Word {
     /// Word units that constitute the word.
     pub units: Vec<WordUnit>,
-    /// Location of the first character of the word.
+    /// Position of the word in the source code.
     pub location: Location,
 }
 
@@ -653,9 +653,8 @@ pub enum Value {
     /// Scalar value, a possibly empty word.
     ///
     /// Note: Because a scalar assignment value is created from a normal command
-    /// word, the location of the word in the scalar value points to the first
-    /// character of the entire assignment word rather than that of the assigned
-    /// value.
+    /// word, the location of the word in the scalar value refers to the entire
+    /// assignment word rather than the assigned value.
     Scalar(Word),
 
     /// Array, possibly empty list of non-empty words.
@@ -684,7 +683,7 @@ pub struct Assign {
     pub name: String,
     /// Value assigned to the variable.
     pub value: Value,
-    /// Location of the first character of the assignment word.
+    /// Location of the assignment word.
     pub location: Location,
 }
 

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -336,7 +336,7 @@ pub struct Param {
     // TODO index
     /// Modifier.
     pub modifier: Modifier,
-    /// Location of the initial `$` character of this parameter expansion.
+    /// Position of this parameter expansion in the source code.
     pub location: Location,
 }
 

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -442,7 +442,7 @@ pub enum TextUnit {
         /// Command string that will be parsed and executed when the command
         /// substitution is expanded.
         content: Vec<BackquoteUnit>,
-        /// Location of the initial backquote character of this command substitution.
+        /// Position of this command substitution in the source code.
         location: Location,
     },
     /// Arithmetic expansion.


### PR DESCRIPTION
annotate-snippets-rs supports annotating character ranges, but currently `yash_syntax::source::Location` only points to a single character in the source code. This pull request modifies `Location` so that it can refer to a range of characters.

This is a rework of #135.

- [x] Remove Location::advance
- [x] Change Location::index to range
- [x] Define Lexer::location_range
- [x] Fix failing tests
- [x] Update documentation for various fields in AST