### PR TITLE
Expanding special parameters $@ and $*

### DIFF
--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -22,6 +22,7 @@ pub mod alias;
 pub mod common;
 pub mod readonly;
 pub mod r#return;
+pub mod set;
 pub mod trap;
 
 #[doc(no_inline)]
@@ -50,6 +51,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: r#return::builtin_main,
+        },
+    ),
+    (
+        "set",
+        Builtin {
+            r#type: Special,
+            execute: set::builtin_main,
         },
     ),
     (

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -1,0 +1,79 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Set built-in
+//!
+//! TODO Elaborate
+
+use crate::common::BuiltinName;
+use std::future::ready;
+use std::future::Future;
+use std::ops::ControlFlow::Continue;
+use std::pin::Pin;
+use yash_env::builtin::Result;
+use yash_env::semantics::ExitStatus;
+use yash_env::semantics::Field;
+use yash_env::variable::Array;
+use yash_env::Env;
+
+/// Implementation of the set built-in.
+pub fn builtin_main_sync(env: &mut Env, args: Vec<Field>) -> Result {
+    // TODO Parse options
+    // TODO Print existing variables when no arguments are given
+
+    let location = env.builtin_name().origin.clone();
+    let params = env.variables.positional_params_mut();
+    params.value = Array(args.into_iter().map(|f| f.value).collect());
+    params.last_assigned_location = Some(location);
+
+    (ExitStatus::SUCCESS, Continue(()))
+}
+
+/// Implementation of the set built-in.
+///
+/// This function calls [`builtin_main_sync`] and wraps the result in a `Future`.
+pub fn builtin_main(
+    env: &mut yash_env::Env,
+    args: Vec<Field>,
+) -> Pin<Box<dyn Future<Output = Result>>> {
+    Box::pin(ready(builtin_main_sync(env, args)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yash_env::stack::Frame;
+
+    #[test]
+    fn setting_some_positional_parameters() {
+        let name = Field::dummy("set");
+        let location = name.origin.clone();
+        let mut env = Env::new_virtual();
+        let mut env = env.push_frame(Frame::Builtin { name });
+        let args = Field::dummies(["a", "b", "z"]);
+
+        let result = builtin_main_sync(&mut env, args);
+        assert_eq!(result, (ExitStatus::SUCCESS, Continue(())));
+
+        let v = env.variables.positional_params();
+        assert_eq!(
+            v.value,
+            Array(vec!["a".to_string(), "b".to_string(), "z".to_string()])
+        );
+        assert_eq!(v.read_only_location, None);
+        assert_eq!(v.last_assigned_location.as_ref().unwrap(), &location);
+    }
+}

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -37,7 +37,6 @@ use std::ops::DerefMut;
 
 /// Element of runtime execution context stack
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub enum Frame {
     /// Built-in utility
     Builtin {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -201,7 +201,7 @@ pub async fn expand_word(
     word: &Word,
 ) -> Result<(Field, Option<ExitStatus>)> {
     use self::initial::QuickExpand::*;
-    let mut env = initial::Env::new(env);
+    let mut env = initial::Env::new(env, false);
     let phrase = match word.quick_expand(&mut env) {
         Ready(result) => result?,
         Interim(interim) => word.async_expand(&mut env, interim).await?,
@@ -229,7 +229,7 @@ pub async fn expand_words<'a, I: IntoIterator<Item = &'a Word>>(
 ) -> Result<(Vec<Field>, Option<ExitStatus>)> {
     let words = words.into_iter();
     let mut fields = Vec::with_capacity(words.size_hint().0);
-    let mut env = initial::Env::new(env);
+    let mut env = initial::Env::new(env, true);
     for word in words {
         use self::initial::QuickExpand::*;
         let phrase = match word.quick_expand(&mut env) {

--- a/yash-semantics/src/expansion/initial.rs
+++ b/yash-semantics/src/expansion/initial.rs
@@ -39,15 +39,20 @@ pub struct Env<'a> {
     /// When performing a command substitution during expansion, you must set
     /// its exit status to this field.
     pub last_command_subst_exit_status: Option<ExitStatus>,
-    // TODO pub will_split: bool,
+
+    /// Whether the expansion result will be subjected to field splitting.
+    ///
+    /// This flag will affect the expansion of the `$*` special parameter.
+    pub will_split: bool,
 }
 
 impl<'a> Env<'a> {
     /// Creates a new `Env` instance.
-    pub fn new(inner: &'a mut yash_env::Env) -> Self {
+    pub fn new(inner: &'a mut yash_env::Env, will_split: bool) -> Self {
         Env {
             inner,
             last_command_subst_exit_status: None,
+            will_split,
         }
     }
 }

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -161,7 +161,7 @@ mod tests {
         in_virtual_system(|mut env, _pid, _state| async move {
             let command = "".to_string();
             let location = Location::dummy("");
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             let result = expand(command, location, &mut env).await;
             assert_eq!(result, Ok(Phrase::one_empty_field()));
         })
@@ -173,7 +173,7 @@ mod tests {
             env.builtins.insert("echo", echo_builtin());
             let command = "echo ok".to_string();
             let location = Location::dummy("");
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             let result = expand(command, location, &mut env).await;
 
             let o = AttrChar {
@@ -193,7 +193,7 @@ mod tests {
             env.builtins.insert("echo", echo_builtin());
             let command = "echo 1; echo 2; echo; echo 3; echo; echo".to_string();
             let location = Location::dummy("");
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             let result = expand(command, location, &mut env).await;
             let chars = "1\n2\n\n3"
                 .chars()
@@ -214,7 +214,7 @@ mod tests {
             env.builtins.insert("return", return_builtin());
             let command = "return -n 100".to_string();
             let location = Location::dummy("");
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             let result = expand(command, location, &mut env).await;
             assert_eq!(result, Ok(Phrase::one_empty_field()));
             assert_eq!(env.last_command_subst_exit_status, Some(ExitStatus(100)));
@@ -226,7 +226,7 @@ mod tests {
         let command = "".to_string();
         let location = Location::dummy("foo");
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let result = block_on(expand(command, location.clone(), &mut env));
         let cause = ErrorCause::CommandSubstError(Errno::ENOSYS);
         assert_eq!(result, Err(Error { cause, location }));

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -64,7 +64,7 @@ impl ParamRef<'_> {
         // TODO Switch
         // TODO Check for nounset error
         // TODO Trim & Subst
-        // TODO concat
+        // TODO concat values of $* if not in field splitting context
         // TODO Length
 
         Ok(into_phrase(value))

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -52,7 +52,7 @@ impl ParamRef<'_> {
         // TODO Expand and parse Index
 
         // Lookup //
-        let lookup = match lookup::look_up_special_parameter(env.inner, self.name) {
+        let lookup = match lookup::look_up_special_parameter(env, self.name) {
             Some(lookup) => lookup,
             None => lookup::look_up_ordinary_parameter(&env.inner.variables, self.name),
         };

--- a/yash-semantics/src/expansion/initial/param/lookup.rs
+++ b/yash-semantics/src/expansion/initial/param/lookup.rs
@@ -108,7 +108,7 @@ pub fn look_up_special_parameter<'a>(env: &'a mut Env, name: &str) -> Option<Loo
         return None;
     }
     match first {
-        '@' => todo!(),
+        '@' => Some((&env.variables.positional_params().value).into()),
         '*' => todo!(),
         '#' => todo!(),
         '?' => Some(env.exit_status.to_string().into()),
@@ -176,6 +176,20 @@ mod tests {
         assert_eq!(look_up_special_parameter(&mut env, "%"), None);
         assert_eq!(look_up_special_parameter(&mut env, "??"), None);
         assert_eq!(look_up_special_parameter(&mut env, "!?"), None);
+    }
+
+    #[test]
+    fn special_all_positional_parameters_separate() {
+        let mut env = yash_env::Env::new_virtual();
+        let result = look_up_special_parameter(&mut env, "@").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == [] as [String;0]);
+
+        let params = vec!["a".to_string(), "foo bar".to_string(), "9".to_string()];
+        env.variables.positional_params_mut().value = Value::Array(params.clone());
+        let result = look_up_special_parameter(&mut env, "@").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == params);
     }
 
     #[test]

--- a/yash-semantics/src/expansion/initial/param/lookup.rs
+++ b/yash-semantics/src/expansion/initial/param/lookup.rs
@@ -178,18 +178,22 @@ mod tests {
         assert_eq!(look_up_special_parameter(&mut env, "!?"), None);
     }
 
-    #[test]
-    fn special_all_positional_parameters_separate() {
-        let mut env = yash_env::Env::new_virtual();
-        let result = look_up_special_parameter(&mut env, "@").unwrap();
-        assert_matches!(result, Lookup::Array(values)
-            if values.as_ref() == [] as [String;0]);
+    mod special_positional_parameters {
+        use super::*;
 
-        let params = vec!["a".to_string(), "foo bar".to_string(), "9".to_string()];
-        env.variables.positional_params_mut().value = Value::Array(params.clone());
-        let result = look_up_special_parameter(&mut env, "@").unwrap();
-        assert_matches!(result, Lookup::Array(values)
-            if values.as_ref() == params);
+        #[test]
+        fn at_in_non_splitting_context() {
+            let mut env = yash_env::Env::new_virtual();
+            let result = look_up_special_parameter(&mut env, "@").unwrap();
+            assert_matches!(result, Lookup::Array(values)
+                if values.as_ref() == [] as [String;0]);
+
+            let params = vec!["a".to_string(), "foo bar".to_string(), "9".to_string()];
+            env.variables.positional_params_mut().value = Value::Array(params.clone());
+            let result = look_up_special_parameter(&mut env, "@").unwrap();
+            assert_matches!(result, Lookup::Array(values)
+                if values.as_ref() == params);
+        }
     }
 
     #[test]

--- a/yash-semantics/src/expansion/initial/slice.rs
+++ b/yash-semantics/src/expansion/initial/slice.rs
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn empty_slice() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs: [Stub; 0] = [];
         assert_matches!(stubs.quick_expand(&mut env), Ready(result) => {
             assert_eq!(result, Ok(Phrase::one_empty_field()));
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn slice_of_one_quick_item_returning_zero_fields() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [Stub::new_quick(Ok(Phrase::zero_fields()))];
         assert_matches!(stubs.quick_expand(&mut env), Ready(result) => {
             assert_eq!(result, Ok(Phrase::zero_fields()));
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn slice_of_many_quick_items_returning_zero_fields() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [
             Stub::new_quick(Ok(Phrase::zero_fields())),
             Stub::new_quick(Ok(Phrase::zero_fields())),
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn slice_of_many_quick_items_each_returning_one_empty_field() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [
             Stub::new_quick(Ok(Phrase::one_empty_field())),
             Stub::new_quick(Ok(Phrase::one_empty_field())),
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn slice_of_many_quick_items_each_returning_one_non_empty_field() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let a = dummy_attr_char('a');
         let b = dummy_attr_char('b');
         let c = dummy_attr_char('c');
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn slice_of_one_async_item_returning_zero_fields() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [Stub::new_async(Ok(Phrase::zero_fields()))];
         assert_matches!(stubs.quick_expand(&mut env), Interim(interim) => {
             let result = stubs
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn slice_of_many_async_items_returning_zero_fields() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [
             Stub::new_async(Ok(Phrase::zero_fields())),
             Stub::new_async(Ok(Phrase::zero_fields())),
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn slice_of_many_async_items_each_returning_one_empty_field() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let stubs = [
             Stub::new_async(Ok(Phrase::one_empty_field())),
             Stub::new_async(Ok(Phrase::one_empty_field())),
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn slice_of_many_async_items_each_returning_one_non_empty_field() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let a = dummy_attr_char('a');
         let b = dummy_attr_char('b');
         let c = dummy_attr_char('c');
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn slice_of_quick_and_async_items() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let a = dummy_attr_char('a');
         let b = dummy_attr_char('b');
         let c = dummy_attr_char('c');

--- a/yash-semantics/src/expansion/initial/text.rs
+++ b/yash-semantics/src/expansion/initial/text.rs
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn literal() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         assert_matches!(Literal('L').quick_expand(&mut env), Ready(result) => {
             let c = AttrChar {
                 value: 'L',
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn backslashed() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         assert_matches!(Backslashed('L').quick_expand(&mut env), Ready(result) => {
             let bs = AttrChar {
                 value: '\\',
@@ -226,7 +226,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let name = "foo".to_string();
         let location = Location::dummy("");
         let param = RawParam { name, location };
@@ -256,7 +256,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let param = BracedParam(Param {
             name: "foo".to_string(),
             modifier: Modifier::None,
@@ -277,7 +277,7 @@ mod tests {
     fn command_subst() {
         in_virtual_system(|mut env, _pid, _state| async move {
             env.builtins.insert("echo", echo_builtin());
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             let subst = TextUnit::CommandSubst {
                 content: "echo .".into(),
                 location: Location::dummy(""),
@@ -298,7 +298,7 @@ mod tests {
     fn backquote() {
         in_virtual_system(|mut env, _pid, _state| async move {
             env.builtins.insert("echo", echo_builtin());
-            let mut env = Env::new(&mut env);
+            let mut env = Env::new(&mut env, false);
             use yash_syntax::syntax::BackquoteUnit::*;
             let subst = TextUnit::Backquote {
                 content: vec![

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -99,6 +99,7 @@ impl Expand for WordUnit {
             Unquoted(text_unit) => text_unit.async_expand(env, ()).await,
             SingleQuote(_value) => unimplemented!("async_expand not expecting SingleQuote"),
             DoubleQuote(text) => {
+                // TODO will_split=false
                 let mut phrase = match text.quick_expand(env) {
                     Ready(result) => result,
                     Interim(interim) => text.async_expand(env, interim).await,
@@ -230,7 +231,7 @@ mod tests {
     #[test]
     fn unquoted() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let unit: WordUnit = "x".parse().unwrap();
         assert_matches!(unit.quick_expand(&mut env), Ready(result) => {
             let c = AttrChar {
@@ -277,7 +278,7 @@ mod tests {
     #[test]
     fn async_double_quote() {
         let mut env = yash_env::Env::new_virtual();
-        let mut env = Env::new(&mut env);
+        let mut env = Env::new(&mut env, false);
         let unit = DoubleQuote(Text(vec![TextUnit::Literal('X')]));
         assert_matches!(unit.quick_expand(&mut env), Interim(()));
         let result = unit.async_expand(&mut env, ()).now_or_never().unwrap();


### PR DESCRIPTION
- [x] Expand `$@`
- [x] Add the `will_split` flag to `initial::Env`
- [ ] Expand `$*`
    - Also test that the expansion of `$@` ignores the `will_split` flag
- [ ] Test that the expansion of double quotes resets the `will_split` flag
- [ ] Test that `expand_word` and `expand_words` set the `will_split` flag appropriately
- [ ] Squash commits