### PR TITLE
Expanding positional parameters $@ and $*

### DIFF
--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -200,8 +200,12 @@ pub async fn expand_word(
     env: &mut yash_env::Env,
     word: &Word,
 ) -> Result<(Field, Option<ExitStatus>)> {
-    use self::initial::QuickExpand::*;
     let mut env = initial::Env::new(env);
+    // It would be technically correct to set `will_split` to false, but it does
+    // not affect the final results because we will join the results anyway.
+    // env.will_split = false;
+
+    use self::initial::QuickExpand::*;
     let phrase = match word.quick_expand(&mut env) {
         Ready(result) => result?,
         Interim(interim) => word.async_expand(&mut env, interim).await?,

--- a/yash-semantics/src/expansion/initial.rs
+++ b/yash-semantics/src/expansion/initial.rs
@@ -39,15 +39,23 @@ pub struct Env<'a> {
     /// When performing a command substitution during expansion, you must set
     /// its exit status to this field.
     pub last_command_subst_exit_status: Option<ExitStatus>,
-    // TODO pub will_split: bool,
+
+    /// Whether the expansion result will be subjected to field splitting.
+    ///
+    /// This flag will affect the expansion of the `$*` special parameter.
+    pub will_split: bool,
 }
 
 impl<'a> Env<'a> {
     /// Creates a new `Env` instance.
+    ///
+    /// The `last_command_subst_exit_status` and `will_split` field are
+    /// initialized to be `None` and `true`, respectively.
     pub fn new(inner: &'a mut yash_env::Env) -> Self {
         Env {
             inner,
             last_command_subst_exit_status: None,
+            will_split: true,
         }
     }
 }

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -99,13 +99,13 @@ fn to_field(value: &str) -> Vec<AttrChar> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use futures_util::FutureExt;
     use yash_env::variable::Scope;
     use yash_env::variable::Variable;
 
-    fn env_with_positional_params_and_ifs() -> yash_env::Env {
+    pub fn env_with_positional_params_and_ifs() -> yash_env::Env {
         let mut env = yash_env::Env::new_virtual();
         env.variables.positional_params_mut().value =
             Value::Array(vec!["a".to_string(), "c".to_string()]);
@@ -124,7 +124,7 @@ mod tests {
         env
     }
 
-    fn param<N: ToString>(name: N) -> Param {
+    pub fn param<N: ToString>(name: N) -> Param {
         Param {
             name: name.to_string(),
             modifier: Modifier::None,

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -64,10 +64,13 @@ impl ParamRef<'_> {
         // TODO Switch
         // TODO Check for nounset error
         // TODO Trim & Subst
-        // TODO concat
         // TODO Length
 
-        Ok(into_phrase(value))
+        let mut phrase = into_phrase(value);
+        if !env.will_split && self.name == "*" {
+            phrase = Phrase::Field(phrase.ifs_join(&env.inner.variables));
+        }
+        Ok(phrase)
     }
 }
 
@@ -98,6 +101,93 @@ fn to_field(value: &str) -> Vec<AttrChar> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::FutureExt;
+    use yash_env::variable::Scope;
+    use yash_env::variable::Variable;
+
+    fn env_with_positional_params_and_ifs() -> yash_env::Env {
+        let mut env = yash_env::Env::new_virtual();
+        env.variables.positional_params_mut().value =
+            Value::Array(vec!["a".to_string(), "c".to_string()]);
+        env.variables
+            .assign(
+                Scope::Global,
+                "IFS".to_string(),
+                Variable {
+                    value: Value::Scalar("&?!".to_string()),
+                    last_assigned_location: None,
+                    is_exported: false,
+                    read_only_location: None,
+                },
+            )
+            .unwrap();
+        env
+    }
+
+    fn param<N: ToString>(name: N) -> Param {
+        Param {
+            name: name.to_string(),
+            modifier: Modifier::None,
+            location: Location::dummy(""),
+        }
+    }
+
+    #[test]
+    fn expand_at_no_join_in_non_splitting_context() {
+        let mut env = env_with_positional_params_and_ifs();
+        let param = param("@");
+        let param = ParamRef::from(&param);
+        let mut env = Env::new(&mut env);
+        env.will_split = false;
+        let phrase = param.expand(&mut env).now_or_never().unwrap().unwrap();
+
+        let a = AttrChar {
+            value: 'a',
+            origin: Origin::SoftExpansion,
+            is_quoted: false,
+            is_quoting: false,
+        };
+        let c = AttrChar { value: 'c', ..a };
+        assert_eq!(phrase, Phrase::Full(vec![vec![a], vec![c]]));
+    }
+
+    #[test]
+    fn expand_asterisk_no_join_in_splitting_context() {
+        let mut env = env_with_positional_params_and_ifs();
+        let param = param("*");
+        let param = ParamRef::from(&param);
+        let mut env = Env::new(&mut env);
+        let phrase = param.expand(&mut env).now_or_never().unwrap().unwrap();
+
+        let a = AttrChar {
+            value: 'a',
+            origin: Origin::SoftExpansion,
+            is_quoted: false,
+            is_quoting: false,
+        };
+        let c = AttrChar { value: 'c', ..a };
+        assert_eq!(phrase, Phrase::Full(vec![vec![a], vec![c]]));
+    }
+
+    #[test]
+    fn expand_asterisk_ifs_join_in_non_splitting_context() {
+        let mut env = env_with_positional_params_and_ifs();
+        let param = param("*");
+        let param = ParamRef::from(&param);
+        let mut env = Env::new(&mut env);
+        env.will_split = false;
+        let phrase = param.expand(&mut env).now_or_never().unwrap().unwrap();
+
+        let a = AttrChar {
+            value: 'a',
+            origin: Origin::SoftExpansion,
+            is_quoted: false,
+            is_quoting: false,
+        };
+        let amp = AttrChar { value: '&', ..a };
+        let c = AttrChar { value: 'c', ..a };
+        assert_eq!(phrase, Phrase::Field(vec![a, amp, c]));
+    }
 
     #[test]
     fn none_into_phrase() {

--- a/yash-semantics/src/expansion/initial/param/lookup.rs
+++ b/yash-semantics/src/expansion/initial/param/lookup.rs
@@ -108,8 +108,7 @@ pub fn look_up_special_parameter<'a>(env: &'a mut Env, name: &str) -> Option<Loo
         return None;
     }
     match first {
-        '@' => todo!(),
-        '*' => todo!(),
+        '@' | '*' => Some((&env.variables.positional_params().value).into()),
         '#' => todo!(),
         '?' => Some(env.exit_status.to_string().into()),
         '-' => todo!(),
@@ -176,6 +175,34 @@ mod tests {
         assert_eq!(look_up_special_parameter(&mut env, "%"), None);
         assert_eq!(look_up_special_parameter(&mut env, "??"), None);
         assert_eq!(look_up_special_parameter(&mut env, "!?"), None);
+    }
+
+    #[test]
+    fn special_positional_parameters_at() {
+        let mut env = yash_env::Env::new_virtual();
+        let result = look_up_special_parameter(&mut env, "@").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == [] as [String;0]);
+
+        let params = vec!["a".to_string(), "foo bar".to_string(), "9".to_string()];
+        env.variables.positional_params_mut().value = Value::Array(params.clone());
+        let result = look_up_special_parameter(&mut env, "@").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == params);
+    }
+
+    #[test]
+    fn special_positional_parameters_asterisk() {
+        let mut env = yash_env::Env::new_virtual();
+        let result = look_up_special_parameter(&mut env, "*").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == [] as [String;0]);
+
+        let params = vec!["a".to_string(), "foo bar".to_string(), "9".to_string()];
+        env.variables.positional_params_mut().value = Value::Array(params.clone());
+        let result = look_up_special_parameter(&mut env, "*").unwrap();
+        assert_matches!(result, Lookup::Array(values)
+            if values.as_ref() == params);
     }
 
     #[test]

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -99,6 +99,7 @@ impl Expand for WordUnit {
             Unquoted(text_unit) => text_unit.async_expand(env, ()).await,
             SingleQuote(_value) => unimplemented!("async_expand not expecting SingleQuote"),
             DoubleQuote(text) => {
+                // TODO will_split=false
                 let mut phrase = match text.quick_expand(env) {
                     Ready(result) => result,
                     Interim(interim) => text.async_expand(env, interim).await,

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -99,11 +99,15 @@ impl Expand for WordUnit {
             Unquoted(text_unit) => text_unit.async_expand(env, ()).await,
             SingleQuote(_value) => unimplemented!("async_expand not expecting SingleQuote"),
             DoubleQuote(text) => {
-                // TODO will_split=false
-                let mut phrase = match text.quick_expand(env) {
+                let would_split = env.will_split;
+                env.will_split = false;
+                let result = match text.quick_expand(env) {
                     Ready(result) => result,
                     Interim(interim) => text.async_expand(env, interim).await,
-                }?;
+                };
+                env.will_split = would_split;
+
+                let mut phrase = result?;
                 double_quote(&mut phrase);
                 Ok(phrase)
             }
@@ -136,6 +140,8 @@ impl Expand for Word {
 
 #[cfg(test)]
 mod tests {
+    use super::super::param::tests::env_with_positional_params_and_ifs;
+    use super::super::param::tests::param;
     use super::*;
     use assert_matches::assert_matches;
     use futures_util::FutureExt;
@@ -295,5 +301,31 @@ mod tests {
             is_quoting: false,
         };
         assert_eq!(result, Ok(Phrase::Field(vec![quote, x, quote])));
+    }
+
+    #[test]
+    fn inside_double_quote_is_non_splitting_context() {
+        let mut env = env_with_positional_params_and_ifs();
+        let mut env = Env::new(&mut env);
+        let unit = DoubleQuote(Text(vec![TextUnit::BracedParam(param("*"))]));
+        assert_matches!(unit.quick_expand(&mut env), Interim(()));
+        let result = unit.async_expand(&mut env, ()).now_or_never().unwrap();
+
+        assert!(env.will_split);
+        let quote = AttrChar {
+            value: '"',
+            origin: Origin::Literal,
+            is_quoted: false,
+            is_quoting: true,
+        };
+        let a = AttrChar {
+            value: 'a',
+            origin: Origin::SoftExpansion,
+            is_quoted: true,
+            is_quoting: false,
+        };
+        let amp = AttrChar { value: '&', ..a };
+        let c = AttrChar { value: 'c', ..a };
+        assert_eq!(result, Ok(Phrase::Field(vec![quote, a, amp, c, quote])));
     }
 }


### PR DESCRIPTION
Reworks #144

- [x] Lookup
- [x] Add the `will_split` flag to `initial::Env`
- [x] ParamRef::expand (join values of `$*` in non-splitting context)
- [x] Reset the `will_split` flag in expansion of double quotes
- [ ] ~~Test that `expand_word` and `expand_words` set the `will_split` flag appropriately~~
- [ ] ~~Add integration tests based on requirements in POSIX~~