### PR TITLE
Manage jobs in JobSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "syn"
@@ -353,6 +353,7 @@ dependencies = [
  "futures-util",
  "itertools",
  "nix",
+ "slab",
  "yash-quote",
  "yash-syntax",
 ]

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -23,6 +23,7 @@ enumset = "1.0.10"
 futures-util = "0.3.21"
 itertools = "0.10.3"
 nix = "0.23.1"
+slab = "0.4.6"
 yash-quote = { path = "../yash-quote", version = "1.0.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.4.0" }
 

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -179,6 +179,17 @@ impl JobSet {
         job
     }
 
+    /// Conditionally removes jobs from this job set.
+    ///
+    /// Function `f` is called repeatedly with a job and its index.
+    /// The job is removed if `f` returns false.
+    pub fn retain_jobs<F>(&mut self, mut f: F)
+    where
+        F: FnMut(usize, &Job) -> bool,
+    {
+        self.jobs.retain(|index, job| f(index, job))
+    }
+
     /// Returns the job at the specified index.
     ///
     /// The result is `None` if there is no job for the index.

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -187,6 +187,18 @@ impl JobSet {
         self.jobs.get(index)
     }
 
+    /// Returns the number of jobs in this job set.
+    #[inline]
+    pub fn job_count(&self) -> usize {
+        self.jobs.len()
+    }
+
+    /// Returns true if this job set contains no jobs.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.job_count() == 0
+    }
+
     /// Returns an iterator of jobs with indices.
     ///
     /// The item type of the returned iterator is `(usize, &Job)`.

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -53,9 +53,6 @@ pub struct Job {
 
     /// String representation of this process
     pub name: String,
-    /*
-    pub known_by_user: bool,
-    */
 }
 
 impl Job {
@@ -273,24 +270,7 @@ impl JobSet {
     /// This function returns the value that has been set by
     /// [`set_last_async_pid`](Self::set_last_async_pid), or 0 if no value has
     /// been set.
-    ///
-    /// When expanding the special parameter `$!`, you must use
-    /// [`expand_last_async_pid`](Self::expand_last_async_pid) instead of this
-    /// function.
     pub fn last_async_pid(&self) -> Pid {
-        self.last_async_pid
-    }
-
-    /// Returns the process ID of the most recently executed asynchronous
-    /// command.
-    ///
-    /// This function is similar to [`last_async_pid`](Self::last_async_pid),
-    /// but also updates an internal flag so that the asynchronous command is
-    /// not disowned too soon.
-    ///
-    /// TODO Elaborate on automatic disowning
-    pub fn expand_last_async_pid(&mut self) -> Pid {
-        // TODO Keep the async process from being disowned.
         self.last_async_pid
     }
 

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -21,6 +21,52 @@ pub use nix::sys::wait::WaitStatus;
 #[doc(no_inline)]
 pub use nix::unistd::Pid;
 
+/// Set of one or more processes executing a pipeline
+///
+/// In the current implementation, a job contains the process ID of one child
+/// process of the shell. Though there may be more processes involved in the
+/// execution of the pipeline, the shell takes care of only one process of the
+/// job.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Job {
+    /// Process ID
+    pub pid: Pid,
+
+    /// Whether the job is job-controlled.
+    ///
+    /// If the job is job-controlled, the job process runs in its own process
+    /// group.
+    pub job_controlled: bool,
+
+    /// Status of the process
+    pub status: WaitStatus,
+
+    /*
+    pub status_changed: bool,
+    */
+    /// String representation of this process
+    pub name: String,
+    /*
+    pub known_by_user: bool,
+    */
+}
+
+impl Job {
+    /// Creates a new job instance.
+    ///
+    /// This function requires a process ID to initialize the new job. The other
+    /// members of the job are defaulted.
+    pub fn new(pid: Pid) -> Self {
+        Job {
+            pid,
+            job_controlled: false,
+            status: WaitStatus::StillAlive,
+            name: String::new(),
+        }
+    }
+}
+
 /// Collection of jobs.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JobSet {

--- a/yash-semantics/src/command_impl.rs
+++ b/yash-semantics/src/command_impl.rs
@@ -36,7 +36,8 @@ impl Command for syntax::Command {
     /// Executes the command.
     ///
     /// After executing the command body, this function [runs
-    /// traps](run_traps_for_caught_signals) if any caught signals are pending.
+    /// traps](run_traps_for_caught_signals) if any caught signals are pending,
+    /// and [updates subshell statuses](Env::update_all_subshell_statuses).
     async fn execute(&self, env: &mut Env) -> Result {
         use syntax::Command::*;
         let main_result = match self {
@@ -46,6 +47,7 @@ impl Command for syntax::Command {
         };
 
         let trap_result = run_traps_for_caught_signals(env).await;
+        env.update_all_subshell_statuses();
 
         match (main_result, trap_result) {
             (_, Continue(())) => main_result,

--- a/yash-semantics/src/expansion/initial/text.rs
+++ b/yash-semantics/src/expansion/initial/text.rs
@@ -57,7 +57,7 @@ use yash_syntax::syntax::Unquote;
 ///
 /// - `?` expands to the [last exit status](yash_env::Env::exit_status).
 /// - `!` expands to the [process ID of the last asynchronous
-///   command](yash_env::job::JobSet::expand_last_async_pid).
+///   command](yash_env::job::JobSet::last_async_pid).
 /// - `@` expands to all positional parameters. When expanded in double-quotes
 ///   as in `"${@}"`, it produces the correct number of fields exactly matching
 ///   the current positional parameters. Especially if there are zero positional

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -39,8 +39,9 @@ use yash_syntax::parser::Parser;
 /// If the input source code contains no commands, the exit status is set to
 /// zero.
 ///
-/// [Pending traps are run](run_traps_for_caught_signals) between parsing input
-/// and running commands.
+/// [Pending traps are run](run_traps_for_caught_signals) and [subshell statuses
+/// are updated](Env::update_all_subshell_statuses) between parsing input and
+/// running commands.
 ///
 /// TODO: `Break(Divert::Interrupt(...))` should not end the loop in an
 /// interactive shell
@@ -72,6 +73,7 @@ pub async fn read_eval_loop(env: &mut Env, lexer: &mut Lexer<'_>) -> Result {
         match parser.command_line().await {
             Ok(Some(command)) => {
                 run_traps_for_caught_signals(env).await?;
+                env.update_all_subshell_statuses();
                 command.execute(env).await?
             }
             Ok(None) => break,


### PR DESCRIPTION
- [x] Complete implementation of `JobSet`
- [x] Add a job to the job set on starting an asynchronous job
- [x] Remove jobs that are updated in the wait built-in without operands
- [x] Remove jobs that have exited and waited for but not yet reported in the wait built-in without operands
- [x] Remove jobs that are updated in the wait built-in with operands
- [x] Refactor the wait built-in body
- [x] Call update_all_subshell_statuses occasionally during execution
