### PR TITLE
Refactor JobSet

### DIFF
--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -55,8 +55,8 @@ pub async fn builtin_body(env: &mut Env, _args: Vec<Field>) -> Result {
     });
 
     // Remove terminated jobs
-    env.jobs.retain_jobs(|_, job| {
-        matches!(
+    env.jobs.drain_filter(|_, job| {
+        !matches!(
             job.status,
             WaitStatus::StillAlive | WaitStatus::Continued(_)
         )

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -134,7 +134,7 @@ fn to_job_result(status: WaitStatus) -> Option<(Pid, ExitStatus)> {
 }
 
 fn remove_finished_jobs(jobs: &mut JobSet) {
-    jobs.retain_jobs(|_index, job| to_job_result(job.status).is_none())
+    jobs.drain_filter(|_index, job| to_job_result(job.status).is_some());
 }
 
 async fn wait_for_all_jobs(env: &mut Env) -> ExitStatus {

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -160,7 +160,7 @@ async fn wait_for_all_jobs(env: &mut Env) -> ExitStatus {
 
 async fn wait_for_job(env: &mut Env, index: usize) -> ExitStatus {
     let exit_status = loop {
-        let job = env.jobs.get_job(index).unwrap();
+        let job = env.jobs.get(index).unwrap();
         if let Some((_pid, exit_status)) = to_job_result(job.status) {
             break exit_status;
         }
@@ -175,7 +175,7 @@ async fn wait_for_job(env: &mut Env, index: usize) -> ExitStatus {
             Ok(_) => (),
         }
     };
-    env.jobs.remove_job(index);
+    env.jobs.remove(index);
     exit_status
 }
 
@@ -189,7 +189,7 @@ async fn wait_for_each_job(env: &mut Env, job_specs: Vec<Field>) -> Result {
             Err(e) => return print_error_message(env, &JobSpecError::ParseInt(job_spec, e)).await,
         };
 
-        exit_status = if let Some(index) = env.jobs.job_index_by_pid(pid) {
+        exit_status = if let Some(index) = env.jobs.find_by_pid(pid) {
             wait_for_job(env, index).await
         } else {
             ExitStatus::NOT_FOUND
@@ -266,12 +266,12 @@ mod tests {
                     })
                     .await
                     .unwrap();
-                env.jobs.add_job(Job::new(pid));
+                env.jobs.add(Job::new(pid));
             }
 
             let result = builtin_body(&mut env, vec![]).await;
             assert_eq!(result, (ExitStatus::SUCCESS, Continue(())));
-            assert_eq!(env.jobs.job_count(), 0);
+            assert_eq!(env.jobs.len(), 0);
 
             let state = state.borrow();
             for (cpid, process) in &state.processes {
@@ -293,11 +293,11 @@ mod tests {
         let pid = Pid::from_raw(10);
         let mut job = Job::new(pid);
         job.status = WaitStatus::Exited(pid, 42);
-        let index = env.jobs.add_job(job);
+        let index = env.jobs.add(job);
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::SUCCESS, Continue(())));
-        assert_eq!(env.jobs.get_job(index), None);
+        assert_eq!(env.jobs.get(index), None);
     }
 
     #[test]
@@ -305,14 +305,11 @@ mod tests {
         let mut env = Env::new_virtual();
 
         // Add a running job that is not a proper subshell.
-        let index = env.jobs.add_job(Job::new(Pid::from_raw(1)));
+        let index = env.jobs.add(Job::new(Pid::from_raw(1)));
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::SUCCESS, Continue(())));
-        assert_eq!(
-            env.jobs.get_job(index).unwrap().status,
-            WaitStatus::StillAlive
-        );
+        assert_eq!(env.jobs.get(index).unwrap().status, WaitStatus::StillAlive);
     }
 
     #[test]
@@ -345,7 +342,7 @@ mod tests {
                     .await
                     .unwrap();
                 pids.push(pid);
-                env.jobs.add_job(Job::new(pid));
+                env.jobs.add(Job::new(pid));
             }
 
             let args = pids
@@ -354,7 +351,7 @@ mod tests {
                 .collect();
             let result = builtin_body(&mut env, args).await;
             assert_eq!(result, (ExitStatus(6), Continue(())));
-            assert_eq!(env.jobs.job_count(), 0);
+            assert_eq!(env.jobs.len(), 0);
 
             let state = state.borrow();
             for (cpid, process) in &state.processes {
@@ -376,12 +373,12 @@ mod tests {
         let pid = Pid::from_raw(7);
         let mut job = Job::new(pid);
         job.status = WaitStatus::Exited(pid, 17);
-        let index = env.jobs.add_job(job);
+        let index = env.jobs.add(job);
 
         let args = Field::dummies([pid.to_string()]);
         let result = builtin_body(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus(17), Continue(())));
-        assert_eq!(env.jobs.get_job(index), None);
+        assert_eq!(env.jobs.get(index), None);
     }
 
     #[test]
@@ -389,12 +386,12 @@ mod tests {
         let mut env = Env::new_virtual();
 
         // Add a running job that is not a proper subshell.
-        let index = env.jobs.add_job(Job::new(Pid::from_raw(19)));
+        let index = env.jobs.add(Job::new(Pid::from_raw(19)));
 
         let args = Field::dummies(["19".to_string()]);
         let result = builtin_body(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::NOT_FOUND, Continue(())));
-        assert_eq!(env.jobs.get_job(index), None);
+        assert_eq!(env.jobs.get(index), None);
     }
 
     #[test]

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -323,29 +323,6 @@ impl JobSet {
         job
     }
 
-    /// Conditionally removes jobs from this job set.
-    ///
-    /// Function `f` is called repeatedly with a job and its index.
-    /// The job is removed if `f` returns false.
-    pub fn retain_jobs<F>(&mut self, mut f: F)
-    where
-        F: FnMut(usize, &Job) -> bool,
-    {
-        let max_index = match self.jobs.iter().next_back() {
-            Some((index, _job)) => index,
-            None => return,
-        };
-        for index in 0..=max_index {
-            if let Some(job) = self.get(index) {
-                if !f(index, job) {
-                    self.remove(index);
-                }
-            }
-        }
-
-        debug_assert_eq!(self.jobs.len(), self.pids_to_indices.len());
-    }
-
     /// Returns the job at the specified index.
     ///
     /// The result is `None` if there is no job for the index.
@@ -771,40 +748,6 @@ mod tests {
             set.get(i_first).map(|job| job.name.as_str()),
             Some("first job")
         );
-    }
-
-    #[test]
-    fn job_set_retain_jobs() {
-        let mut set = JobSet::default();
-        set.add(Job::new(Pid::from_raw(4)));
-        set.add(Job::new(Pid::from_raw(5)));
-        set.add(Job::new(Pid::from_raw(6)));
-        set.add(Job::new(Pid::from_raw(7)));
-        set.add(Job::new(Pid::from_raw(8)));
-        set.add(Job::new(Pid::from_raw(9)));
-        set.retain_jobs(|index, job| index != 2 && job.pid != Pid::from_raw(8));
-        let mut pids: Vec<_> = set.iter().map(|(index, job)| (index, job.pid)).collect();
-        pids.sort_unstable();
-        assert_eq!(
-            pids,
-            [
-                (0, Pid::from_raw(4)),
-                (1, Pid::from_raw(5)),
-                (3, Pid::from_raw(7)),
-                (5, Pid::from_raw(9)),
-            ]
-        );
-
-        let mut set = JobSet::default();
-        set.add(Job::new(Pid::from_raw(17)));
-        set.add(Job::new(Pid::from_raw(18)));
-        set.add(Job::new(Pid::from_raw(19)));
-        set.add(Job::new(Pid::from_raw(20)));
-        set.add(Job::new(Pid::from_raw(21)));
-        set.retain_jobs(|_index, job| job.pid.as_raw() % 2 == 0);
-        let mut pids: Vec<_> = set.iter().map(|(index, job)| (index, job.pid)).collect();
-        pids.sort_unstable();
-        assert_eq!(pids, [(1, Pid::from_raw(18)), (3, Pid::from_raw(20))]);
     }
 
     #[test]

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -358,6 +358,18 @@ impl JobSet {
     }
 }
 
+/// Supports indexing operation on `JobSet`.
+impl std::ops::Index<usize> for JobSet {
+    type Output = Job;
+
+    /// Returns a reference to the specified job.
+    ///
+    /// This function will panic if the job does not exist.
+    fn index(&self, index: usize) -> &Job {
+        &self.jobs[index]
+    }
+}
+
 impl JobSet {
     /// Updates the status of a job.
     ///

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -317,6 +317,14 @@ impl JobSet {
         self.jobs.get(index)
     }
 
+    /// Returns a partially mutable reference to the job at the specified index.
+    ///
+    /// The result is `None` if there is no job for the index.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<JobRefMut> {
+        self.jobs.get_mut(index).map(JobRefMut)
+    }
+
     /// Returns the number of jobs in this job set.
     #[inline]
     pub fn len(&self) -> usize {

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -407,6 +407,24 @@ impl JobSet {
     }
 }
 
+impl<'a> IntoIterator for &'a JobSet {
+    type Item = (usize, &'a Job);
+    type IntoIter = Iter<'a>;
+    #[inline(always)]
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut JobSet {
+    type Item = (usize, JobRefMut<'a>);
+    type IntoIter = IterMut<'a>;
+    #[inline(always)]
+    fn into_iter(self) -> IterMut<'a> {
+        self.iter_mut()
+    }
+}
+
 /// Supports indexing operation on `JobSet`.
 impl std::ops::Index<usize> for JobSet {
     type Output = Job;

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -21,13 +21,13 @@
 //! performing the job's task.
 //!
 //! The job set stores jobs in an internal array. The index of a job in the
-//! array never changes once the [job is added](JobSet::add_job) to the job set.
+//! array never changes once the [job is added](JobSet::add) to the job set.
 //! The index of the other jobs does not change when you [remove a
-//! job](JobSet::remove_job). Note that the job set may reuse the index of a
-//! removed job for another job added later.
+//! job](JobSet::remove). Note that the job set may reuse the index of a removed
+//! job for another job added later.
 //!
 //! When the [wait system call](crate::System::wait) returns a new status of a
-//! child process, the caller should pass it to [`JobSet::update_job`], which
+//! child process, the caller should pass it to [`JobSet::update_status`], which
 //! modifies the status of the corresponding job. The `status_updated` flag of
 //! the job is set when the job is updated and should be reset when
 //! [reported](JobSet::report_job).
@@ -183,7 +183,7 @@ impl JobSet {
     /// not, the new job becomes the current job. If the new job and the current
     /// job are suspended but the [previous job](Self::previous_job) is not, the
     /// new job becomes the previous job.
-    pub fn add_job(&mut self, job: Job) -> usize {
+    pub fn add(&mut self, job: Job) -> usize {
         let new_job_is_suspended = job.is_suspended();
         let ex_current_job_is_suspended = self.current_job().map(|(_, job)| job.is_suspended());
         let ex_previous_job_is_suspended = self.previous_job().map(|(_, job)| job.is_suspended());
@@ -228,7 +228,7 @@ impl JobSet {
     /// job is selected for the new previous job, if any.
     /// If the removed job is the previous job, another job is selected for the
     /// new previous job, if any.
-    pub fn remove_job(&mut self, index: usize) -> Option<Job> {
+    pub fn remove(&mut self, index: usize) -> Option<Job> {
         let job = self.jobs.try_remove(index);
 
         if let Some(job) = &job {
@@ -271,9 +271,9 @@ impl JobSet {
             None => return,
         };
         for index in 0..=max_index {
-            if let Some(job) = self.get_job(index) {
+            if let Some(job) = self.get(index) {
                 if !f(index, job) {
-                    self.remove_job(index);
+                    self.remove(index);
                 }
             }
         }
@@ -285,20 +285,20 @@ impl JobSet {
     ///
     /// The result is `None` if there is no job for the index.
     #[inline]
-    pub fn get_job(&self, index: usize) -> Option<&Job> {
+    pub fn get(&self, index: usize) -> Option<&Job> {
         self.jobs.get(index)
     }
 
     /// Returns the number of jobs in this job set.
     #[inline]
-    pub fn job_count(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.jobs.len()
     }
 
     /// Returns true if this job set contains no jobs.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.job_count() == 0
+        self.len() == 0
     }
 
     /// Returns an iterator of jobs with indices.
@@ -312,12 +312,12 @@ impl JobSet {
 
     /// Finds a job by the process ID.
     ///
-    /// This function returns the index of the job that contains a process whose
-    /// process ID is `pid`. The result is `None` if no such job is found.
+    /// This function returns the index of the job whose process ID is `pid`.
+    /// The result is `None` if no such job is found.
     ///
-    /// `JobSet` maintains an internal hash map to find the job quickly from the
+    /// A `JobSet` maintains an internal hash map to quickly find jobs by
     /// process ID.
-    pub fn job_index_by_pid(&self, pid: Pid) -> Option<usize> {
+    pub fn find_by_pid(&self, pid: Pid) -> Option<usize> {
         self.pids_to_indices.get(&pid).copied()
     }
 }
@@ -343,9 +343,9 @@ impl JobSet {
     ///   suspended jobs, the new previous jobs is the old current job.
     /// - If the updated job is the previous job and there is a suspended job
     ///   other than the current job, it becomes the previous job.
-    pub fn update_job(&mut self, status: WaitStatus) -> Option<usize> {
+    pub fn update_status(&mut self, status: WaitStatus) -> Option<usize> {
         let pid = status.pid()?;
-        let index = self.job_index_by_pid(pid);
+        let index = self.find_by_pid(pid);
         if let Some(index) = index {
             // Update the job status.
             let job = &mut self.jobs[index];
@@ -437,7 +437,7 @@ impl JobSet {
     /// If the index does not refer to any job, the `NoSuchJob` error is
     /// returned.
     pub fn set_current_job(&mut self, index: usize) -> Result<(), SetCurrentJobError> {
-        let job = self.get_job(index).ok_or(SetCurrentJobError::NoSuchJob)?;
+        let job = self.get(index).ok_or(SetCurrentJobError::NoSuchJob)?;
         if !job.is_suspended() && self.iter().any(|(_, job)| job.is_suspended()) {
             return Err(SetCurrentJobError::NotSuspended);
         }
@@ -461,7 +461,7 @@ impl JobSet {
     ///
     /// See also [`previous_job`](Self::previous_job).
     pub fn current_job(&self) -> Option<(usize, &Job)> {
-        self.get_job(self.current_job_index)
+        self.get(self.current_job_index)
             .map(|job| (self.current_job_index, job))
     }
 
@@ -484,7 +484,7 @@ impl JobSet {
         if self.previous_job_index == self.current_job_index {
             None
         } else {
-            self.get_job(self.previous_job_index)
+            self.get(self.previous_job_index)
                 .map(|job| (self.previous_job_index, job))
         }
     }
@@ -532,48 +532,48 @@ mod tests {
     use crate::trap::Signal;
 
     #[test]
-    fn job_set_add_and_remove_job() {
+    fn job_set_add_and_remove() {
         // This test case depends on how Slab reuses the index of removed items.
         let mut set = JobSet::default();
 
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(10))), 0);
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(11))), 1);
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(12))), 2);
+        assert_eq!(set.add(Job::new(Pid::from_raw(10))), 0);
+        assert_eq!(set.add(Job::new(Pid::from_raw(11))), 1);
+        assert_eq!(set.add(Job::new(Pid::from_raw(12))), 2);
 
-        assert_eq!(set.remove_job(0).unwrap().pid, Pid::from_raw(10));
-        assert_eq!(set.remove_job(1).unwrap().pid, Pid::from_raw(11));
+        assert_eq!(set.remove(0).unwrap().pid, Pid::from_raw(10));
+        assert_eq!(set.remove(1).unwrap().pid, Pid::from_raw(11));
 
         // Indices are reused in the reverse order of removals.
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(13))), 1);
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(14))), 0);
+        assert_eq!(set.add(Job::new(Pid::from_raw(13))), 1);
+        assert_eq!(set.add(Job::new(Pid::from_raw(14))), 0);
 
-        assert_eq!(set.remove_job(0).unwrap().pid, Pid::from_raw(14));
-        assert_eq!(set.remove_job(1).unwrap().pid, Pid::from_raw(13));
-        assert_eq!(set.remove_job(2).unwrap().pid, Pid::from_raw(12));
+        assert_eq!(set.remove(0).unwrap().pid, Pid::from_raw(14));
+        assert_eq!(set.remove(1).unwrap().pid, Pid::from_raw(13));
+        assert_eq!(set.remove(2).unwrap().pid, Pid::from_raw(12));
 
         // Once the job set is empty, indices start from 0 again.
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(13))), 0);
-        assert_eq!(set.add_job(Job::new(Pid::from_raw(14))), 1);
+        assert_eq!(set.add(Job::new(Pid::from_raw(13))), 0);
+        assert_eq!(set.add(Job::new(Pid::from_raw(14))), 1);
     }
 
     #[test]
-    fn job_set_add_job_same_pid() {
+    fn job_set_add_same_pid() {
         let mut set = JobSet::default();
 
         let mut job = Job::new(Pid::from_raw(10));
         job.name = "first job".to_string();
-        let i_first = set.add_job(job);
+        let i_first = set.add(job);
 
         let mut job = Job::new(Pid::from_raw(10));
         job.name = "second job".to_string();
-        let i_second = set.add_job(job);
+        let i_second = set.add(job);
 
-        let job = set.get_job(i_second).unwrap();
+        let job = set.get(i_second).unwrap();
         assert_eq!(job.pid, Pid::from_raw(10));
         assert_eq!(job.name, "second job");
 
         assert_ne!(
-            set.get_job(i_first).map(|job| job.name.as_str()),
+            set.get(i_first).map(|job| job.name.as_str()),
             Some("first job")
         );
     }
@@ -581,12 +581,12 @@ mod tests {
     #[test]
     fn job_set_retain_jobs() {
         let mut set = JobSet::default();
-        set.add_job(Job::new(Pid::from_raw(4)));
-        set.add_job(Job::new(Pid::from_raw(5)));
-        set.add_job(Job::new(Pid::from_raw(6)));
-        set.add_job(Job::new(Pid::from_raw(7)));
-        set.add_job(Job::new(Pid::from_raw(8)));
-        set.add_job(Job::new(Pid::from_raw(9)));
+        set.add(Job::new(Pid::from_raw(4)));
+        set.add(Job::new(Pid::from_raw(5)));
+        set.add(Job::new(Pid::from_raw(6)));
+        set.add(Job::new(Pid::from_raw(7)));
+        set.add(Job::new(Pid::from_raw(8)));
+        set.add(Job::new(Pid::from_raw(9)));
         set.retain_jobs(|index, job| index != 2 && job.pid != Pid::from_raw(8));
         let mut pids: Vec<_> = set.iter().map(|(index, job)| (index, job.pid)).collect();
         pids.sort_unstable();
@@ -601,11 +601,11 @@ mod tests {
         );
 
         let mut set = JobSet::default();
-        set.add_job(Job::new(Pid::from_raw(17)));
-        set.add_job(Job::new(Pid::from_raw(18)));
-        set.add_job(Job::new(Pid::from_raw(19)));
-        set.add_job(Job::new(Pid::from_raw(20)));
-        set.add_job(Job::new(Pid::from_raw(21)));
+        set.add(Job::new(Pid::from_raw(17)));
+        set.add(Job::new(Pid::from_raw(18)));
+        set.add(Job::new(Pid::from_raw(19)));
+        set.add(Job::new(Pid::from_raw(20)));
+        set.add(Job::new(Pid::from_raw(21)));
         set.retain_jobs(|_index, job| job.pid.as_raw() % 2 == 0);
         let mut pids: Vec<_> = set.iter().map(|(index, job)| (index, job.pid)).collect();
         pids.sort_unstable();
@@ -613,20 +613,20 @@ mod tests {
     }
 
     #[test]
-    fn job_set_job_index_by_pid() {
+    fn job_set_find_by_pid() {
         let mut set = JobSet::default();
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(10)), None);
+        assert_eq!(set.find_by_pid(Pid::from_raw(10)), None);
 
-        let i10 = set.add_job(Job::new(Pid::from_raw(10)));
-        let i20 = set.add_job(Job::new(Pid::from_raw(20)));
-        let i30 = set.add_job(Job::new(Pid::from_raw(30)));
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(10)), Some(i10));
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(20)), Some(i20));
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(30)), Some(i30));
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(40)), None);
+        let i10 = set.add(Job::new(Pid::from_raw(10)));
+        let i20 = set.add(Job::new(Pid::from_raw(20)));
+        let i30 = set.add(Job::new(Pid::from_raw(30)));
+        assert_eq!(set.find_by_pid(Pid::from_raw(10)), Some(i10));
+        assert_eq!(set.find_by_pid(Pid::from_raw(20)), Some(i20));
+        assert_eq!(set.find_by_pid(Pid::from_raw(30)), Some(i30));
+        assert_eq!(set.find_by_pid(Pid::from_raw(40)), None);
 
-        set.remove_job(i10);
-        assert_eq!(set.job_index_by_pid(Pid::from_raw(10)), None);
+        set.remove(i10);
+        assert_eq!(set.find_by_pid(Pid::from_raw(10)), None);
     }
 
     #[test]
@@ -634,22 +634,22 @@ mod tests {
     fn updating_job_status() {
         let mut set = JobSet::default();
         let status = WaitStatus::Exited(Pid::from_raw(20), 15);
-        assert_eq!(set.update_job(status), None);
+        assert_eq!(set.update_status(status), None);
 
-        let i10 = set.add_job(Job::new(Pid::from_raw(10)));
-        let i20 = set.add_job(Job::new(Pid::from_raw(20)));
-        let i30 = set.add_job(Job::new(Pid::from_raw(30)));
-        assert_eq!(set.get_job(i20).unwrap().status, WaitStatus::StillAlive);
+        let i10 = set.add(Job::new(Pid::from_raw(10)));
+        let i20 = set.add(Job::new(Pid::from_raw(20)));
+        let i30 = set.add(Job::new(Pid::from_raw(30)));
+        assert_eq!(set.get(i20).unwrap().status, WaitStatus::StillAlive);
 
         set.report_job(i20, |_| true);
 
-        let i20_2 = set.update_job(status);
+        let i20_2 = set.update_status(status);
         assert_eq!(i20_2, Some(i20));
-        assert_eq!(set.get_job(i20).unwrap().status, status);
-        assert_eq!(set.get_job(i20).unwrap().status_changed, true);
+        assert_eq!(set.get(i20).unwrap().status, status);
+        assert_eq!(set.get(i20).unwrap().status_changed, true);
 
-        assert_eq!(set.get_job(i10).unwrap().status, WaitStatus::StillAlive);
-        assert_eq!(set.get_job(i30).unwrap().status, WaitStatus::StillAlive);
+        assert_eq!(set.get(i10).unwrap().status, WaitStatus::StillAlive);
+        assert_eq!(set.get(i30).unwrap().status, WaitStatus::StillAlive);
     }
 
     #[test]
@@ -658,22 +658,22 @@ mod tests {
         let mut set = JobSet::default();
         set.report_job(0, |_| unreachable!());
 
-        let i5 = set.add_job(Job::new(Pid::from_raw(5)));
+        let i5 = set.add(Job::new(Pid::from_raw(5)));
         set.report_job(i5, |job| {
             assert_eq!(job.status_changed, true);
             false
         });
-        assert_eq!(set.get_job(i5).unwrap().status_changed, true);
+        assert_eq!(set.get(i5).unwrap().status_changed, true);
         set.report_job(i5, |job| {
             assert_eq!(job.status_changed, true);
             true
         });
-        assert_eq!(set.get_job(i5).unwrap().status_changed, false);
+        assert_eq!(set.get(i5).unwrap().status_changed, false);
         set.report_job(i5, |job| {
             assert_eq!(job.status_changed, false);
             true
         });
-        assert_eq!(set.get_job(i5).unwrap().status_changed, false);
+        assert_eq!(set.get(i5).unwrap().status_changed, false);
     }
 
     #[test]
@@ -682,9 +682,9 @@ mod tests {
         let mut set = JobSet::default();
         set.report_jobs(|_, _| unreachable!());
 
-        let i5 = set.add_job(Job::new(Pid::from_raw(5)));
-        let i7 = set.add_job(Job::new(Pid::from_raw(7)));
-        let i9 = set.add_job(Job::new(Pid::from_raw(9)));
+        let i5 = set.add(Job::new(Pid::from_raw(5)));
+        let i7 = set.add(Job::new(Pid::from_raw(7)));
+        let i9 = set.add(Job::new(Pid::from_raw(9)));
         let mut args = Vec::new();
         set.report_jobs(|index, job| {
             args.push((index, job.pid));
@@ -698,9 +698,9 @@ mod tests {
                 (i9, Pid::from_raw(9)),
             ]
         );
-        assert_eq!(set.get_job(i5).unwrap().status_changed, true);
-        assert_eq!(set.get_job(i7).unwrap().status_changed, false);
-        assert_eq!(set.get_job(i9).unwrap().status_changed, true);
+        assert_eq!(set.get(i5).unwrap().status_changed, true);
+        assert_eq!(set.get(i7).unwrap().status_changed, false);
+        assert_eq!(set.get(i9).unwrap().status_changed, true);
     }
 
     #[test]
@@ -714,7 +714,7 @@ mod tests {
     fn current_and_previous_job_in_job_set_with_one_job() {
         let mut set = JobSet::default();
         let job = Job::new(Pid::from_raw(10));
-        let i10 = set.add_job(job.clone());
+        let i10 = set.add(job.clone());
         assert_eq!(set.current_job(), Some((i10, &job)));
         assert_eq!(set.previous_job(), None);
     }
@@ -727,15 +727,15 @@ mod tests {
         let mut suspended = Job::new(Pid::from_raw(10));
         suspended.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGSTOP);
         let running = Job::new(Pid::from_raw(20));
-        let i10 = set.add_job(suspended.clone());
-        let i20 = set.add_job(running.clone());
+        let i10 = set.add(suspended.clone());
+        let i20 = set.add(running.clone());
         assert_eq!(set.current_job(), Some((i10, &suspended)));
         assert_eq!(set.previous_job(), Some((i20, &running)));
 
         // The order of adding jobs does not matter in this case.
         set = JobSet::default();
-        let i20 = set.add_job(running.clone());
-        let i10 = set.add_job(suspended.clone());
+        let i20 = set.add(running.clone());
+        let i10 = set.add(suspended.clone());
         assert_eq!(set.current_job(), Some((i10, &suspended)));
         assert_eq!(set.previous_job(), Some((i20, &running)));
     }
@@ -745,15 +745,15 @@ mod tests {
         let mut set = JobSet::default();
         let running_1 = Job::new(Pid::from_raw(11));
         let running_2 = Job::new(Pid::from_raw(12));
-        set.add_job(running_1);
-        set.add_job(running_2);
+        set.add(running_1);
+        set.add(running_2);
         let ex_current_job_index = set.current_job().unwrap().0;
         let ex_previous_job_index = set.previous_job().unwrap().0;
         assert_ne!(ex_current_job_index, ex_previous_job_index);
 
         let mut suspended = Job::new(Pid::from_raw(20));
         suspended.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGSTOP);
-        let i20 = set.add_job(suspended);
+        let i20 = set.add(suspended);
         let now_current_job_index = set.current_job().unwrap().0;
         let now_previous_job_index = set.previous_job().unwrap().0;
         assert_eq!(now_current_job_index, i20);
@@ -765,11 +765,11 @@ mod tests {
         let mut set = JobSet::default();
 
         let running = Job::new(Pid::from_raw(18));
-        let i18 = set.add_job(running);
+        let i18 = set.add(running);
 
         let mut suspended_1 = Job::new(Pid::from_raw(19));
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(19), Signal::SIGSTOP);
-        let i19 = set.add_job(suspended_1);
+        let i19 = set.add(suspended_1);
 
         let ex_current_job_index = set.current_job().unwrap().0;
         let ex_previous_job_index = set.previous_job().unwrap().0;
@@ -778,7 +778,7 @@ mod tests {
 
         let mut suspended_2 = Job::new(Pid::from_raw(20));
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGSTOP);
-        let i20 = set.add_job(suspended_2);
+        let i20 = set.add(suspended_2);
 
         let now_current_job_index = set.current_job().unwrap().0;
         let now_previous_job_index = set.previous_job().unwrap().0;
@@ -791,7 +791,7 @@ mod tests {
         let mut set = JobSet::default();
 
         let running = Job::new(Pid::from_raw(10));
-        let i10 = set.add_job(running);
+        let i10 = set.add(running);
 
         let mut suspended_1 = Job::new(Pid::from_raw(11));
         let mut suspended_2 = Job::new(Pid::from_raw(12));
@@ -799,16 +799,16 @@ mod tests {
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(11), Signal::SIGSTOP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGSTOP);
         suspended_3.status = WaitStatus::Stopped(Pid::from_raw(13), Signal::SIGSTOP);
-        set.add_job(suspended_1);
-        set.add_job(suspended_2);
-        set.add_job(suspended_3);
+        set.add(suspended_1);
+        set.add(suspended_2);
+        set.add(suspended_3);
 
         let current_job_index_1 = set.current_job().unwrap().0;
         let previous_job_index_1 = set.previous_job().unwrap().0;
         assert_ne!(current_job_index_1, i10);
         assert_ne!(previous_job_index_1, i10);
 
-        set.remove_job(current_job_index_1);
+        set.remove(current_job_index_1);
         let current_job_index_2 = set.current_job().unwrap().0;
         let (previous_job_index_2, previous_job_2) = set.previous_job().unwrap();
         assert_eq!(current_job_index_2, previous_job_index_1);
@@ -816,14 +816,14 @@ mod tests {
         // The new previous job is chosen from suspended jobs other than the current job.
         assert!(previous_job_2.is_suspended(), "{:?}", previous_job_2);
 
-        set.remove_job(current_job_index_2);
+        set.remove(current_job_index_2);
         let current_job_index_3 = set.current_job().unwrap().0;
         let previous_job_index_3 = set.previous_job().unwrap().0;
         assert_eq!(current_job_index_3, previous_job_index_2);
         // There is no other suspended job, so the new previous job is a running job.
         assert_eq!(previous_job_index_3, i10);
 
-        set.remove_job(current_job_index_3);
+        set.remove(current_job_index_3);
         let current_job_index_4 = set.current_job().unwrap().0;
         assert_eq!(current_job_index_4, i10);
         // No more job to be selected for the previous job.
@@ -835,7 +835,7 @@ mod tests {
         let mut set = JobSet::default();
 
         let running = Job::new(Pid::from_raw(10));
-        let i10 = set.add_job(running);
+        let i10 = set.add(running);
 
         let mut suspended_1 = Job::new(Pid::from_raw(11));
         let mut suspended_2 = Job::new(Pid::from_raw(12));
@@ -843,16 +843,16 @@ mod tests {
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(11), Signal::SIGSTOP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGSTOP);
         suspended_3.status = WaitStatus::Stopped(Pid::from_raw(13), Signal::SIGSTOP);
-        set.add_job(suspended_1);
-        set.add_job(suspended_2);
-        set.add_job(suspended_3);
+        set.add(suspended_1);
+        set.add(suspended_2);
+        set.add(suspended_3);
 
         let ex_current_job_index = set.current_job().unwrap().0;
         let ex_previous_job_index = set.previous_job().unwrap().0;
         assert_ne!(ex_current_job_index, i10);
         assert_ne!(ex_previous_job_index, i10);
 
-        set.remove_job(ex_previous_job_index);
+        set.remove(ex_previous_job_index);
         let now_current_job_index = set.current_job().unwrap().0;
         let (now_previous_job_index, now_previous_job) = set.previous_job().unwrap();
         assert_eq!(now_current_job_index, ex_current_job_index);
@@ -866,21 +866,21 @@ mod tests {
         let mut set = JobSet::default();
 
         let running = Job::new(Pid::from_raw(10));
-        let i10 = set.add_job(running);
+        let i10 = set.add(running);
 
         let mut suspended_1 = Job::new(Pid::from_raw(11));
         let mut suspended_2 = Job::new(Pid::from_raw(12));
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(11), Signal::SIGSTOP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGSTOP);
-        set.add_job(suspended_1);
-        set.add_job(suspended_2);
+        set.add(suspended_1);
+        set.add(suspended_2);
 
         let ex_current_job_index = set.current_job().unwrap().0;
         let ex_previous_job_index = set.previous_job().unwrap().0;
         assert_ne!(ex_current_job_index, i10);
         assert_ne!(ex_previous_job_index, i10);
 
-        set.remove_job(ex_previous_job_index);
+        set.remove(ex_previous_job_index);
         let now_current_job_index = set.current_job().unwrap().0;
         let now_previous_job_index = set.previous_job().unwrap().0;
         assert_eq!(now_current_job_index, ex_current_job_index);
@@ -892,8 +892,8 @@ mod tests {
     #[test]
     fn set_current_job_with_running_jobs_only() {
         let mut set = JobSet::default();
-        let i21 = set.add_job(Job::new(Pid::from_raw(21)));
-        let i22 = set.add_job(Job::new(Pid::from_raw(22)));
+        let i21 = set.add(Job::new(Pid::from_raw(21)));
+        let i22 = set.add(Job::new(Pid::from_raw(22)));
 
         assert_eq!(set.set_current_job(i21), Ok(()));
         assert_eq!(set.current_job().unwrap().0, i21);
@@ -905,14 +905,14 @@ mod tests {
     #[test]
     fn set_current_job_to_suspended_job() {
         let mut set = JobSet::default();
-        set.add_job(Job::new(Pid::from_raw(20)));
+        set.add(Job::new(Pid::from_raw(20)));
 
         let mut suspended_1 = Job::new(Pid::from_raw(21));
         let mut suspended_2 = Job::new(Pid::from_raw(22));
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(21), Signal::SIGSTOP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(22), Signal::SIGSTOP);
-        let i21 = set.add_job(suspended_1);
-        let i22 = set.add_job(suspended_2);
+        let i21 = set.add(suspended_1);
+        let i22 = set.add(suspended_2);
 
         assert_eq!(set.set_current_job(i21), Ok(()));
         assert_eq!(set.current_job().unwrap().0, i21);
@@ -935,8 +935,8 @@ mod tests {
         let mut suspended = Job::new(Pid::from_raw(10));
         suspended.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         let running = Job::new(Pid::from_raw(20));
-        let i10 = set.add_job(suspended);
-        let i20 = set.add_job(running);
+        let i10 = set.add(suspended);
+        let i20 = set.add(running);
         assert_eq!(
             set.set_current_job(i20),
             Err(SetCurrentJobError::NotSuspended)
@@ -947,8 +947,8 @@ mod tests {
     #[test]
     fn set_current_job_no_change() {
         let mut set = JobSet::default();
-        set.add_job(Job::new(Pid::from_raw(5)));
-        set.add_job(Job::new(Pid::from_raw(6)));
+        set.add(Job::new(Pid::from_raw(5)));
+        set.add(Job::new(Pid::from_raw(6)));
         let old_current_job_index = set.current_job().unwrap().0;
         let old_previous_job_index = set.previous_job().unwrap().0;
         set.set_current_job(old_current_job_index).unwrap();
@@ -964,9 +964,9 @@ mod tests {
         let mut suspended = Job::new(Pid::from_raw(10));
         suspended.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         let running = Job::new(Pid::from_raw(20));
-        let i10 = set.add_job(suspended);
-        let i20 = set.add_job(running);
-        set.update_job(WaitStatus::Continued(Pid::from_raw(10)));
+        let i10 = set.add(suspended);
+        let i20 = set.add(running);
+        set.update_status(WaitStatus::Continued(Pid::from_raw(10)));
         assert_eq!(set.current_job().unwrap().0, i10);
         assert_eq!(set.previous_job().unwrap().0, i20);
     }
@@ -978,10 +978,10 @@ mod tests {
         let mut suspended_2 = Job::new(Pid::from_raw(20));
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGTSTP);
-        let i10 = set.add_job(suspended_1);
-        let i20 = set.add_job(suspended_2);
+        let i10 = set.add(suspended_1);
+        let i20 = set.add(suspended_2);
         set.set_current_job(i10).unwrap();
-        set.update_job(WaitStatus::Continued(Pid::from_raw(10)));
+        set.update_status(WaitStatus::Continued(Pid::from_raw(10)));
         // The current job must be a suspended job, if any.
         assert_eq!(set.current_job().unwrap().0, i20);
         assert_eq!(set.previous_job().unwrap().0, i10);
@@ -996,13 +996,13 @@ mod tests {
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGTSTP);
         suspended_3.status = WaitStatus::Stopped(Pid::from_raw(30), Signal::SIGTSTP);
-        set.add_job(suspended_1);
-        set.add_job(suspended_2);
-        set.add_job(suspended_3);
+        set.add(suspended_1);
+        set.add(suspended_2);
+        set.add(suspended_3);
         let ex_current_job_pid = set.current_job().unwrap().1.pid;
         let ex_previous_job_index = set.previous_job().unwrap().0;
 
-        set.update_job(WaitStatus::Continued(ex_current_job_pid));
+        set.update_status(WaitStatus::Continued(ex_current_job_pid));
         let now_current_job_index = set.current_job().unwrap().0;
         let (now_previous_job_index, now_previous_job) = set.previous_job().unwrap();
         assert_eq!(now_current_job_index, ex_previous_job_index);
@@ -1020,13 +1020,13 @@ mod tests {
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGTSTP);
         suspended_3.status = WaitStatus::Stopped(Pid::from_raw(30), Signal::SIGTSTP);
-        set.add_job(suspended_1);
-        set.add_job(suspended_2);
-        set.add_job(suspended_3);
+        set.add(suspended_1);
+        set.add(suspended_2);
+        set.add(suspended_3);
         let ex_current_job_index = set.current_job().unwrap().0;
         let ex_previous_job_pid = set.previous_job().unwrap().1.pid;
 
-        set.update_job(WaitStatus::Continued(ex_previous_job_pid));
+        set.update_status(WaitStatus::Continued(ex_previous_job_pid));
         let now_current_job_index = set.current_job().unwrap().0;
         let (now_previous_job_index, now_previous_job) = set.previous_job().unwrap();
         assert_eq!(now_current_job_index, ex_current_job_index);
@@ -1044,12 +1044,12 @@ mod tests {
         suspended_1.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTSTP);
         suspended_2.status = WaitStatus::Stopped(Pid::from_raw(20), Signal::SIGTSTP);
         suspended_3.status = WaitStatus::Stopped(Pid::from_raw(30), Signal::SIGTSTP);
-        let i10 = set.add_job(suspended_1);
-        let i20 = set.add_job(suspended_2);
-        let _i30 = set.add_job(suspended_3);
+        let i10 = set.add(suspended_1);
+        let i20 = set.add(suspended_2);
+        let _i30 = set.add(suspended_3);
         set.set_current_job(i20).unwrap();
         set.set_current_job(i10).unwrap();
-        set.update_job(WaitStatus::Continued(Pid::from_raw(30)));
+        set.update_status(WaitStatus::Continued(Pid::from_raw(30)));
         assert_eq!(set.current_job().unwrap().0, i10);
         assert_eq!(set.previous_job().unwrap().0, i20);
     }
@@ -1057,10 +1057,10 @@ mod tests {
     #[test]
     fn suspending_current_job() {
         let mut set = JobSet::default();
-        let i11 = set.add_job(Job::new(Pid::from_raw(11)));
-        let i12 = set.add_job(Job::new(Pid::from_raw(12)));
+        let i11 = set.add(Job::new(Pid::from_raw(11)));
+        let i12 = set.add(Job::new(Pid::from_raw(12)));
         set.set_current_job(i11).unwrap();
-        set.update_job(WaitStatus::Stopped(Pid::from_raw(11), Signal::SIGTTOU));
+        set.update_status(WaitStatus::Stopped(Pid::from_raw(11), Signal::SIGTTOU));
         assert_eq!(set.current_job().unwrap().0, i11);
         assert_eq!(set.previous_job().unwrap().0, i12);
     }
@@ -1068,10 +1068,10 @@ mod tests {
     #[test]
     fn suspending_previous_job() {
         let mut set = JobSet::default();
-        let i11 = set.add_job(Job::new(Pid::from_raw(11)));
-        let i12 = set.add_job(Job::new(Pid::from_raw(12)));
+        let i11 = set.add(Job::new(Pid::from_raw(11)));
+        let i12 = set.add(Job::new(Pid::from_raw(12)));
         set.set_current_job(i11).unwrap();
-        set.update_job(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTOU));
+        set.update_status(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTOU));
         assert_eq!(set.current_job().unwrap().0, i12);
         assert_eq!(set.previous_job().unwrap().0, i11);
     }
@@ -1079,11 +1079,11 @@ mod tests {
     #[test]
     fn suspending_job_with_running_current_job() {
         let mut set = JobSet::default();
-        let i10 = set.add_job(Job::new(Pid::from_raw(10)));
-        let _i11 = set.add_job(Job::new(Pid::from_raw(11)));
-        let i12 = set.add_job(Job::new(Pid::from_raw(12)));
+        let i10 = set.add(Job::new(Pid::from_raw(10)));
+        let _i11 = set.add(Job::new(Pid::from_raw(11)));
+        let i12 = set.add(Job::new(Pid::from_raw(12)));
         set.set_current_job(i10).unwrap();
-        set.update_job(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTIN));
+        set.update_status(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTIN));
         assert_eq!(set.current_job().unwrap().0, i12);
         assert_eq!(set.previous_job().unwrap().0, i10);
     }
@@ -1091,15 +1091,15 @@ mod tests {
     #[test]
     fn suspending_job_with_running_previous_job() {
         let mut set = JobSet::default();
-        let i11 = set.add_job(Job::new(Pid::from_raw(11)));
-        let i12 = set.add_job(Job::new(Pid::from_raw(12)));
+        let i11 = set.add(Job::new(Pid::from_raw(11)));
+        let i12 = set.add(Job::new(Pid::from_raw(12)));
         let mut suspended = Job::new(Pid::from_raw(10));
         suspended.status = WaitStatus::Stopped(Pid::from_raw(10), Signal::SIGTTIN);
-        let i10 = set.add_job(suspended);
+        let i10 = set.add(suspended);
         assert_eq!(set.current_job().unwrap().0, i10);
         assert_eq!(set.previous_job().unwrap().0, i11);
 
-        set.update_job(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTOU));
+        set.update_status(WaitStatus::Stopped(Pid::from_raw(12), Signal::SIGTTOU));
         assert_eq!(set.current_job().unwrap().0, i12);
         assert_eq!(set.previous_job().unwrap().0, i10);
     }

--- a/yash-semantics/src/command_impl/item.rs
+++ b/yash-semantics/src/command_impl/item.rs
@@ -68,7 +68,7 @@ async fn execute_async(env: &mut Env, and_or: &Rc<AndOrList>, async_flag: &Locat
         Ok(pid) => {
             let mut job = Job::new(pid);
             job.name = and_or.to_string();
-            env.jobs.add_job(job);
+            env.jobs.add(job);
             env.jobs.set_last_async_pid(pid);
             env.exit_status = ExitStatus::SUCCESS;
             Continue(())
@@ -177,7 +177,7 @@ mod tests {
         };
         executor.run_until(item.execute(&mut env));
 
-        let job = env.jobs.get_job(0).unwrap();
+        let job = env.jobs.get(0).unwrap();
         assert!(job.status_changed);
         assert_eq!(job.status, WaitStatus::StillAlive);
         assert_eq!(job.name, "return -n 42");


### PR DESCRIPTION
- [x] Rename methods, removing the word "job"
- [x] Add `JobRefMut`
- [x] Add `get_mut`
- [x] Implement `Index<usize>` ~~and `IndexMut<usize>`~~
- [x] Add `drain_filter`
- [x] Add `iter_mut`
- [x] Implement `IntoIterator` for `&JobSet` and `&mut JobSet`
- [x] Remove `retain_jobs`
- [x] Remove `report_job` and `report_jobs`
