### PR TITLE
Basic pathname expansion semantics

### DIFF
--- a/yash-env/src/system/virtual/file_system.rs
+++ b/yash-env/src/system/virtual/file_system.rs
@@ -268,6 +268,13 @@ impl TryFrom<&FileBody> for VirtualDir<std::vec::IntoIter<Rc<OsStr>>> {
             entries.push(Rc::from(OsStr::new(".")));
             entries.push(Rc::from(OsStr::new("..")));
             entries.extend(files.keys().cloned());
+
+            // You should not pose any assumption on the order of entries.
+            // Here, we deliberately disorder the entries.
+            let entry = entries.pop().unwrap();
+            let i = entries.len() / 2;
+            entries.insert(i, entry);
+
             Ok(Self::new(entries.into_iter()))
         } else {
             Err(Errno::ENOTDIR)

--- a/yash-fnmatch/src/lib.rs
+++ b/yash-fnmatch/src/lib.rs
@@ -211,12 +211,11 @@ impl Pattern {
     ///
     /// If the pattern is made up only of literal characters, this function
     /// returns the characters as a string. If the pattern contains any `?`,
-    /// `*`, or bracket expression, the result is `None`.
-    #[must_use]
-    pub fn into_literal(self) -> Option<String> {
+    /// `*`, or bracket expression, the result is `Err(self)`.
+    pub fn into_literal(self) -> Result<String, Self> {
         match self.body {
-            Body::Literal(s) => Some(s),
-            Body::Regex { .. } => None,
+            Body::Literal(s) => Ok(s),
+            Body::Regex { .. } => Err(self),
         }
     }
 

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -51,8 +51,9 @@
 //!
 //! ## Pathname expansion
 //!
-//! The pathname expansion performs pattern matching on the name of existing
-//! files to produce pathnames. This operation is also known as "globbing."
+//! The [pathname expansion](mod@glob) performs pattern matching on the name of
+//! existing files to produce pathnames. This operation is also known as
+//! "globbing."
 //!
 //! # Quote removal and attribute stripping
 //!

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -74,6 +74,7 @@ pub mod split;
 use self::attr::AttrChar;
 use self::attr::AttrField;
 use self::attr::Origin;
+use self::glob::glob;
 use self::initial::Expand;
 use self::split::Ifs;
 use std::borrow::Cow;
@@ -263,13 +264,11 @@ pub async fn expand_words<'a, I: IntoIterator<Item = &'a Word>>(
     }
     drop(ifs);
 
-    // TODO pathname expansion
-
-    // quote removal and attribute stripping //
-    let fields = split_fields
-        .into_iter()
-        .map(AttrField::remove_quotes_and_strip)
-        .collect();
+    // pathname expansion (including quote removal and attribute stripping) //
+    let mut fields = Vec::with_capacity(split_fields.len());
+    for field in split_fields {
+        fields.extend(glob(env.inner, field));
+    }
     Ok((fields, env.last_command_subst_exit_status))
 }
 

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -101,8 +101,9 @@ pub fn glob(env: &mut Env, field: AttrField) -> Glob {
     let chars = field.chars.iter().filter_map(|c| {
         if c.is_quoting {
             None
+        } else if c.is_quoted {
+            Some(PatternChar::Literal(c.value))
         } else {
-            // TODO c.is_quoted
             Some(PatternChar::Normal(c.value))
         }
     });
@@ -209,7 +210,17 @@ mod tests {
         assert_eq!(i.next(), None);
     }
 
-    // TODO AttrChar::is_quoted
+    #[test]
+    fn quoted_characters_do_not_expand() {
+        let mut env = Env::new_virtual();
+        create_dummy_file(&mut env, "foo.exe");
+        let mut f = dummy_attr_field("foo.*");
+        f.chars[4].is_quoted = true;
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().value, "foo.*");
+        assert_eq!(i.next(), None);
+    }
+
     // TODO Origin::HardExpansion is literal
 
     #[test]

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -421,7 +421,15 @@ mod tests {
         assert_eq!(i.next(), None);
     }
 
-    // TODO multi_component_pattern_with_adjacent_slashes
+    #[test]
+    fn multi_component_pattern_with_adjacent_slashes() {
+        let mut env = env_with_dummy_files(["a/b", "b/a"]);
+        let f = dummy_attr_field("?//?");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().value, "a//b");
+        assert_eq!(i.next().unwrap().value, "b//a");
+        assert_eq!(i.next(), None);
+    }
 
     #[test]
     fn invalid_pattern_remains_intact() {
@@ -432,5 +440,12 @@ mod tests {
         assert_eq!(i.next(), None);
     }
 
-    // TODO slash_between_brackets "[a/b]"
+    #[test]
+    fn slash_between_brackets() {
+        let mut env = env_with_dummy_files(["abd", "a/d"]);
+        let f = dummy_attr_field("a[b/c]d");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().value, "a[b/c]d");
+        assert_eq!(i.next(), None);
+    }
 }

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -171,13 +171,13 @@ impl SearchEnv<'_> {
                     CString::new(self.prefix.as_str()).unwrap()
                 };
 
-                // TODO Handle opendir error
-                let mut dir = self.env.system.opendir(&dir_path).unwrap();
-                while let Ok(Some(entry)) = dir.next() {
-                    // TODO Handle name.as_str error
-                    let name = entry.name.to_str().unwrap();
-                    if pattern.is_match(name) {
-                        self.push_component(new_suffix, |prefix| prefix.push_str(name));
+                if let Ok(mut dir) = self.env.system.opendir(&dir_path) {
+                    while let Ok(Some(entry)) = dir.next() {
+                        // TODO Handle name.as_str error
+                        let name = entry.name.to_str().unwrap();
+                        if pattern.is_match(name) {
+                            self.push_component(new_suffix, |prefix| prefix.push_str(name));
+                        }
                     }
                 }
             }
@@ -398,6 +398,9 @@ mod tests {
             "/a/b/a/a",
             "/b/a/a/a",
             "/b/a/b/b",
+            "/b/a/c",
+            "/b/a/no",
+            "/c/a",
             "/no/a",
         ]);
         let f = dummy_attr_field("/?/a/?/a");

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -354,7 +354,23 @@ mod tests {
         assert_eq!(i.next(), None);
     }
 
-    // TODO multi_component_patterns
+    #[test]
+    fn multi_component_pattern_ending_with_pattern() {
+        let mut env = env_with_dummy_files([
+            "a/a/a/a", "a/a/a/b", "a/a/a/no", "a/a/b/a", "a/b/a/a", "a/b/a/b", "a/b/a/no",
+            "a/no/a/a", "b/a/a/a",
+        ]);
+        let f = dummy_attr_field("a/?/a/?");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().value, "a/a/a/a");
+        assert_eq!(i.next().unwrap().value, "a/a/a/b");
+        assert_eq!(i.next().unwrap().value, "a/b/a/a");
+        assert_eq!(i.next().unwrap().value, "a/b/a/b");
+        assert_eq!(i.next(), None);
+    }
+
+    // TODO multi_component_pattern_ending_with_literal
+    // TODO multi_component_pattern_with_adjacent_slashes
 
     #[test]
     fn invalid_pattern_remains_intact() {
@@ -364,4 +380,6 @@ mod tests {
         assert_eq!(i.next().unwrap().value, "*[[:wrong:]]*");
         assert_eq!(i.next(), None);
     }
+
+    // TODO slash_between_brackets "[a/b]"
 }

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -411,7 +411,16 @@ mod tests {
         assert_eq!(i.next(), None);
     }
 
-    // TODO multi_component_pattern_ending_with_slash
+    #[test]
+    fn multi_component_pattern_ending_with_slash() {
+        let mut env = env_with_dummy_files(["a/a/_", "a/b/_", "a/c"]);
+        let f = dummy_attr_field("a/*/");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().value, "a/a/");
+        assert_eq!(i.next().unwrap().value, "a/b/");
+        assert_eq!(i.next(), None);
+    }
+
     // TODO multi_component_pattern_with_adjacent_slashes
 
     #[test]

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -26,7 +26,7 @@
 //!
 //! - `?`
 //! - `*`
-//! - Character classes (a set of characters enclosed in brackets)
+//! - Bracket expression (a set of characters enclosed in brackets)
 //!
 //! Refer to the [`yash-fnmatch`](yash_fnmatch) crate for pattern syntax and
 //! semantics details.
@@ -48,3 +48,38 @@
 //!
 //! If the input field contains no non-literal elements subject to pattern
 //! matching at all, the result is the input intact.
+
+use super::attr::AttrField;
+use std::marker::PhantomData;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Iterator that provides results of parameter expansion
+///
+/// This iterator is created with the [`glob`] function.
+pub struct Glob<'a> {
+    /// Dummy to allow retaining a mutable reference to `Env` in the future
+    ///
+    /// The current [`glob`] implementation pre-computes all results before
+    /// returning a `Glob`. The future implementation may optimize by using a
+    /// [generator], which will need a real reference to `Env`.
+    ///
+    /// [generator]: https://github.com/rust-lang/rust/issues/43122
+    env: PhantomData<&'a mut Env>,
+}
+
+impl Iterator for Glob<'_> {
+    type Item = Field;
+    fn next(&mut self) -> Option<Field> {
+        // TODO
+        None
+    }
+}
+
+/// Performs parameter expansion.
+///
+/// This function returns an iterator that yields fields resulting from the
+/// expansion.
+pub fn glob(_env: &mut Env, _field: AttrField) -> Glob {
+    Glob { env: PhantomData }
+}


### PR DESCRIPTION
**Notable limitation:** For the first directory component in a pathname pattern, the code in this PR searches the root directory where it should search the current working directory. This wrong behavior is because the current virtual file system implementation used in testing does not yet support the notion of the working directory. This issue will be addressed in another PR.

Some error case handlings are missing in this PR and should also be addressed in another PR.