### PR TITLE
glob: Scan current directory for first component pattern

### DIFF
--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -141,10 +141,10 @@ pub trait System: Debug {
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize>;
 
     /// Opens a directory for enumerating entries.
-    fn fdopendir(&self, fd: Fd) -> nix::Result<Box<dyn Dir>>;
+    fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>>;
 
     /// Opens a directory for enumerating entries.
-    fn opendir(&self, path: &CStr) -> nix::Result<Box<dyn Dir>>;
+    fn opendir(&mut self, path: &CStr) -> nix::Result<Box<dyn Dir>>;
 
     /// Returns the current time.
     #[must_use]
@@ -626,11 +626,11 @@ impl System for SharedSystem {
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize> {
         self.0.borrow_mut().write(fd, buffer)
     }
-    fn fdopendir(&self, fd: Fd) -> nix::Result<Box<dyn Dir>> {
-        self.0.borrow().fdopendir(fd)
+    fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>> {
+        self.0.borrow_mut().fdopendir(fd)
     }
-    fn opendir(&self, path: &CStr) -> nix::Result<Box<dyn Dir>> {
-        self.0.borrow().opendir(path)
+    fn opendir(&mut self, path: &CStr) -> nix::Result<Box<dyn Dir>> {
+        self.0.borrow_mut().opendir(path)
     }
     fn now(&self) -> Instant {
         self.0.borrow().now()

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -188,13 +188,13 @@ impl System for RealSystem {
         }
     }
 
-    fn fdopendir(&self, fd: Fd) -> nix::Result<Box<dyn Dir>> {
+    fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>> {
         let dir = unsafe { nix::libc::fdopendir(fd.0) };
         let dir = NonNull::new(dir).ok_or_else(Errno::last)?;
         Ok(Box::new(RealDir(dir)))
     }
 
-    fn opendir(&self, path: &CStr) -> nix::Result<Box<dyn Dir>> {
+    fn opendir(&mut self, path: &CStr) -> nix::Result<Box<dyn Dir>> {
         let dir = unsafe { nix::libc::opendir(path.as_ptr()) };
         let dir = NonNull::new(dir).ok_or_else(Errno::last)?;
         Ok(Box::new(RealDir(dir)))
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn real_system_directory_entries() {
-        let system = unsafe { RealSystem::new() };
+        let mut system = unsafe { RealSystem::new() };
         let path = CString::new(".").unwrap();
         let mut dir = system.opendir(&path).unwrap();
         let mut count = 0;

--- a/yash-env/src/system/virtual/file_system.rs
+++ b/yash-env/src/system/virtual/file_system.rs
@@ -308,6 +308,8 @@ where
     }
 }
 
+// TODO impl Drop for VirtualDir: close backing file descriptor
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -164,8 +164,7 @@ impl SearchEnv<'_> {
             }
             Some(Err(pattern)) => {
                 let dir_path = if self.prefix.is_empty() {
-                    // TODO CString::new(".")
-                    CString::new("/").unwrap()
+                    CString::new(".").unwrap()
                 } else {
                     // TODO What if prefix contains a nul byte?
                     CString::new(self.prefix.as_str()).unwrap()


### PR DESCRIPTION
In the previous implementation, `echo *` prints filenames in the root directory (`/`) rather than in the current directory (`.`). This PR fixes it.