### PR TITLE
Binary operators in arithmetic expansion

### DIFF
--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -199,6 +199,8 @@ fn eval_binary<E: Env>(
         let (Value::Integer(lhs), Value::Integer(rhs)) = (value, rhs);
         use Operator::*;
         value = match op {
+            EqualEqual => Value::Integer((lhs == rhs) as _),
+            BangEqual => Value::Integer((lhs != rhs) as _),
             Less => Value::Integer((lhs < rhs) as _),
             Greater => Value::Integer((lhs > rhs) as _),
             LessEqual => Value::Integer((lhs <= rhs) as _),
@@ -350,6 +352,20 @@ mod tests {
                 location: 2..5,
             })
         );
+    }
+
+    #[test]
+    fn equality_comparison_operators() {
+        let env = &mut HashMap::new();
+        assert_eq!(eval("1==2", env), Ok(Value::Integer(0)));
+        assert_eq!(eval(" 2 == 1 ", env), Ok(Value::Integer(0)));
+        assert_eq!(eval(" 5 == 5 ", env), Ok(Value::Integer(1)));
+        assert_eq!(eval(" 1 == 2 == 2 ", env), Ok(Value::Integer(0)));
+
+        assert_eq!(eval("1!=2", env), Ok(Value::Integer(1)));
+        assert_eq!(eval(" 2 != 1 ", env), Ok(Value::Integer(1)));
+        assert_eq!(eval(" 5 != 5 ", env), Ok(Value::Integer(0)));
+        assert_eq!(eval(" 1 != 1 != 2 ", env), Ok(Value::Integer(1)));
     }
 
     #[test]

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -179,6 +179,9 @@ pub fn eval<E: Env>(expression: &str, env: &mut E) -> Result<Value, Error<E::Ass
                     Operator::Minus => {
                         Value::Integer(lhs.checked_sub(rhs).expect("todo: handle overflow"))
                     }
+                    Operator::Asterisk => {
+                        Value::Integer(lhs.checked_mul(rhs).expect("todo: handle overflow"))
+                    }
                 };
             }
 
@@ -303,6 +306,14 @@ mod tests {
         assert_eq!(eval("2-1", env), Ok(Value::Integer(1)));
         assert_eq!(eval(" 42 - 15 ", env), Ok(Value::Integer(27)));
         assert_eq!(eval(" 10 - 7 - 5 ", env), Ok(Value::Integer(-2)));
+    }
+
+    #[test]
+    fn multiplication_operator() {
+        let env = &mut HashMap::new();
+        assert_eq!(eval("3*6", env), Ok(Value::Integer(18)));
+        assert_eq!(eval(" 5 * 11 ", env), Ok(Value::Integer(55)));
+        assert_eq!(eval(" 2 * 3 * 4 ", env), Ok(Value::Integer(24)));
     }
 
     #[test]

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -199,6 +199,9 @@ fn eval_binary<E: Env>(
         let (Value::Integer(lhs), Value::Integer(rhs)) = (value, rhs);
         use Operator::*;
         value = match op {
+            Bar => Value::Integer(lhs | rhs),
+            Caret => Value::Integer(lhs ^ rhs),
+            And => Value::Integer(lhs & rhs),
             EqualEqual => Value::Integer((lhs == rhs) as _),
             BangEqual => Value::Integer((lhs != rhs) as _),
             Less => Value::Integer((lhs < rhs) as _),
@@ -352,6 +355,25 @@ mod tests {
                 location: 2..5,
             })
         );
+    }
+
+    #[test]
+    fn bitwise_logic_operators() {
+        let env = &mut HashMap::new();
+        assert_eq!(eval("3|5", env), Ok(Value::Integer(7)));
+        assert_eq!(eval(" 5 | 3 ", env), Ok(Value::Integer(7)));
+        assert_eq!(eval(" 10 | 10 ", env), Ok(Value::Integer(10)));
+        assert_eq!(eval(" 7 | 14 | 28 ", env), Ok(Value::Integer(31)));
+
+        assert_eq!(eval("3^5", env), Ok(Value::Integer(6)));
+        assert_eq!(eval(" 5 ^ 3 ", env), Ok(Value::Integer(6)));
+        assert_eq!(eval(" 10 ^ 10 ", env), Ok(Value::Integer(0)));
+        assert_eq!(eval(" 7 ^ 14 ^ 28 ", env), Ok(Value::Integer(21)));
+
+        assert_eq!(eval("3&5", env), Ok(Value::Integer(1)));
+        assert_eq!(eval(" 5 & 3 ", env), Ok(Value::Integer(1)));
+        assert_eq!(eval(" 10 & 10 ", env), Ok(Value::Integer(10)));
+        assert_eq!(eval(" 7 & 14 & 28 ", env), Ok(Value::Integer(4)));
     }
 
     #[test]

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -143,6 +143,11 @@ pub fn eval<E: Env>(expression: &str, env: &mut E) -> Result<Value, Error<E::Ass
             location,
         })) => expand_variable(name, &location, env),
 
+        Some(Ok(Token {
+            value: TokenValue::Operator(_op),
+            location: _,
+        })) => todo!("handle orphan operator"),
+
         Some(Err(error)) => Err(error.into()),
         None => todo!("handle missing token"),
     }

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -27,6 +27,8 @@ pub enum Operator {
     Plus,
     /// `-`
     Minus,
+    /// `*`
+    Asterisk,
 }
 
 /// Value of a token
@@ -97,6 +99,7 @@ impl<'a> Iterator for Tokens<'a> {
             None => return None,
             Some('+') => (Ok(TokenValue::Operator(Operator::Plus)), 1),
             Some('-') => (Ok(TokenValue::Operator(Operator::Minus)), 1),
+            Some('*') => (Ok(TokenValue::Operator(Operator::Asterisk)), 1),
             Some(c) if c.is_alphanumeric() => {
                 let remainder =
                     source.trim_start_matches(|c: char| c.is_alphanumeric() || c == '_');
@@ -323,6 +326,13 @@ mod tests {
             Tokens::new("-").next(),
             Some(Ok(Token {
                 value: TokenValue::Operator(Operator::Minus),
+                location: 0..1
+            })),
+        );
+        assert_eq!(
+            Tokens::new("*").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Asterisk),
                 location: 0..1
             })),
         );

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -32,6 +32,8 @@ pub enum Operator {
     Asterisk,
     /// `/`
     Slash,
+    /// `%`
+    Percent,
 }
 
 impl Operator {
@@ -43,7 +45,7 @@ impl Operator {
         use Operator::*;
         match self {
             Plus | Minus => 10,
-            Asterisk | Slash => 11,
+            Asterisk | Slash | Percent => 11,
         }
     }
 }
@@ -118,6 +120,7 @@ impl<'a> Iterator for Tokens<'a> {
             Some('-') => (Ok(TokenValue::Operator(Operator::Minus)), 1),
             Some('*') => (Ok(TokenValue::Operator(Operator::Asterisk)), 1),
             Some('/') => (Ok(TokenValue::Operator(Operator::Slash)), 1),
+            Some('%') => (Ok(TokenValue::Operator(Operator::Percent)), 1),
             Some(c) if c.is_alphanumeric() => {
                 let remainder =
                     source.trim_start_matches(|c: char| c.is_alphanumeric() || c == '_');
@@ -358,6 +361,13 @@ mod tests {
             Tokens::new("/").next(),
             Some(Ok(Token {
                 value: TokenValue::Operator(Operator::Slash),
+                location: 0..1
+            })),
+        );
+        assert_eq!(
+            Tokens::new("%").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Percent),
                 location: 0..1
             })),
         );

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -91,7 +91,7 @@ impl<'a> Iterator for Tokens<'a> {
         let start_of_token = self.source.len() - source.len();
         if source.chars().next()?.is_ascii_digit() {
             let token_len = source
-                .find(char::is_whitespace) // TODO Should delimit at an operator
+                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
                 .unwrap_or(source.len());
             let token_source = &source[..token_len];
             let parse = if let Some(token_source) = token_source.strip_prefix("0X") {
@@ -376,5 +376,31 @@ mod tests {
         assert_eq!(tokens.next(), None);
     }
 
-    // TODO parsing_many_tokens "10.0e+3+0"
+    #[test]
+    fn parsing_many_tokens() {
+        // TODO "10.0e+3+0"
+        let mut tokens = Tokens::new(" 10+0 ");
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Term(Term::Value(Value::Integer(10))),
+                location: 1..3,
+            })),
+        );
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Plus),
+                location: 3..4,
+            })),
+        );
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Term(Term::Value(Value::Integer(0))),
+                location: 4..5,
+            })),
+        );
+        assert_eq!(tokens.next(), None);
+    }
 }

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -25,6 +25,8 @@ use std::ops::Range;
 pub enum Operator {
     /// `+`
     Plus,
+    /// `-`
+    Minus,
 }
 
 /// Value of a token
@@ -94,6 +96,7 @@ impl<'a> Iterator for Tokens<'a> {
         let (result, token_len) = match chars.next() {
             None => return None,
             Some('+') => (Ok(TokenValue::Operator(Operator::Plus)), 1),
+            Some('-') => (Ok(TokenValue::Operator(Operator::Minus)), 1),
             Some(c) if c.is_alphanumeric() => {
                 let remainder =
                     source.trim_start_matches(|c: char| c.is_alphanumeric() || c == '_');
@@ -316,6 +319,13 @@ mod tests {
                 location: 0..1
             })),
         );
+        assert_eq!(
+            Tokens::new("-").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Minus),
+                location: 0..1
+            })),
+        );
     }
 
     #[test]
@@ -386,6 +396,33 @@ mod tests {
             Some(Ok(Token {
                 value: TokenValue::Term(Term::Value(Value::Integer(0))),
                 location: 4..5,
+            })),
+        );
+        assert_eq!(tokens.next(), None);
+    }
+
+    #[test]
+    fn parsing_adjacent_operators() {
+        let mut tokens = Tokens::new("+-0");
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Plus),
+                location: 0..1,
+            })),
+        );
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Minus),
+                location: 1..2,
+            })),
+        );
+        assert_eq!(
+            tokens.next(),
+            Some(Ok(Token {
+                value: TokenValue::Term(Term::Value(Value::Integer(0))),
+                location: 2..3,
             })),
         );
         assert_eq!(tokens.next(), None);

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -24,6 +24,12 @@ use std::ops::Range;
 /// Operator
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Operator {
+    /// `|`
+    Bar,
+    /// `^`
+    Caret,
+    /// `&`
+    And,
     /// `==`
     EqualEqual,
     /// `!=`
@@ -60,6 +66,9 @@ impl Operator {
     pub fn precedence(self) -> u8 {
         use Operator::*;
         match self {
+            Bar => 4,
+            Caret => 5,
+            And => 6,
             EqualEqual | BangEqual => 7,
             Less | LessEqual | Greater | GreaterEqual => 8,
             LessLess | GreaterGreater => 9,
@@ -135,6 +144,9 @@ impl<'a> Iterator for Tokens<'a> {
         let mut chars = source.chars();
         let (result, token_len) = match chars.next() {
             None => return None,
+            Some('|') => (Ok(TokenValue::Operator(Operator::Bar)), 1),
+            Some('^') => (Ok(TokenValue::Operator(Operator::Caret)), 1),
+            Some('&') => (Ok(TokenValue::Operator(Operator::And)), 1),
             Some('=') => match chars.next() {
                 Some('=') => (Ok(TokenValue::Operator(Operator::EqualEqual)), 2),
                 c => todo!("unrecognized character {:?}", c),
@@ -373,6 +385,27 @@ mod tests {
 
     #[test]
     fn operators() {
+        assert_eq!(
+            Tokens::new("|").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Bar),
+                location: 0..1
+            })),
+        );
+        assert_eq!(
+            Tokens::new("^").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Caret),
+                location: 0..1
+            })),
+        );
+        assert_eq!(
+            Tokens::new("&").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::And),
+                location: 0..1
+            })),
+        );
         assert_eq!(
             Tokens::new("==").next(),
             Some(Ok(Token {

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -21,6 +21,7 @@ use super::Value;
 use std::fmt::Display;
 use std::ops::Range;
 
+/// Operator
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Operator {
     /// `+`
@@ -29,6 +30,20 @@ pub enum Operator {
     Minus,
     /// `*`
     Asterisk,
+}
+
+impl Operator {
+    /// Returns the precedence of the operator.
+    ///
+    /// If the operator acts as both a unary and binary operator, the result is
+    /// the precedence as a binary operator.
+    pub fn precedence(self) -> u8 {
+        use Operator::*;
+        match self {
+            Plus | Minus => 10,
+            Asterisk => 11,
+        }
+    }
 }
 
 /// Value of a token

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -30,6 +30,8 @@ pub enum Operator {
     Minus,
     /// `*`
     Asterisk,
+    /// `/`
+    Slash,
 }
 
 impl Operator {
@@ -41,7 +43,7 @@ impl Operator {
         use Operator::*;
         match self {
             Plus | Minus => 10,
-            Asterisk => 11,
+            Asterisk | Slash => 11,
         }
     }
 }
@@ -115,6 +117,7 @@ impl<'a> Iterator for Tokens<'a> {
             Some('+') => (Ok(TokenValue::Operator(Operator::Plus)), 1),
             Some('-') => (Ok(TokenValue::Operator(Operator::Minus)), 1),
             Some('*') => (Ok(TokenValue::Operator(Operator::Asterisk)), 1),
+            Some('/') => (Ok(TokenValue::Operator(Operator::Slash)), 1),
             Some(c) if c.is_alphanumeric() => {
                 let remainder =
                     source.trim_start_matches(|c: char| c.is_alphanumeric() || c == '_');
@@ -348,6 +351,13 @@ mod tests {
             Tokens::new("*").next(),
             Some(Ok(Token {
                 value: TokenValue::Operator(Operator::Asterisk),
+                location: 0..1
+            })),
+        );
+        assert_eq!(
+            Tokens::new("/").next(),
+            Some(Ok(Token {
+                value: TokenValue::Operator(Operator::Slash),
                 location: 0..1
             })),
         );


### PR DESCRIPTION
Implements the following operators: `|`, `^`, `&`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `<<`, `>>`, `+`, `-`, `*`, `/`, `%`

This PR does not implement conditional binary operators (that is, operators where the right-hand-side may or may not be evaluated depending on the value of the left-hand-side).