### PR TITLE
Separate parsing and evaluation in arithmetic expansion

### DIFF
--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -293,15 +293,6 @@ impl From<crate::token::Error> for Error {
     }
 }
 
-/// Returns the index of the last node.
-///
-/// Panics if the slice is empty.
-fn current_root_index(nodes: &[Ast]) -> usize {
-    let len = nodes.len();
-    assert!(len > 0);
-    len - 1
-}
-
 /// Parses postfix operators
 fn parse_postfix<'a, I>(tokens: &mut Peekable<I>, result: &mut Vec<Ast<'a>>) -> Result<(), Error>
 where

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -24,6 +24,9 @@ use assert_matches::assert_matches;
 use std::iter::Peekable;
 use std::ops::Range;
 
+// TODO: POSIX does not require the increment/decrement operators. Maybe we
+// should provide an option to reject those non-portable operators.
+
 /// Prefix operator kind
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum PrefixOperator {

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -1,0 +1,291 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Abstract syntax tree parser
+
+use crate::token::Operator;
+use crate::token::Term;
+use crate::token::Token;
+use crate::token::TokenError;
+use std::iter::Peekable;
+use std::ops::Range;
+
+/// Postfix operator kind
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum PostfixOperator {
+    /// `++`
+    Increment,
+    /// `--`
+    Decrement,
+}
+
+/// Node of an abstract syntax tree (AST)
+///
+/// A whole AST is meant to be constructed as a vector of `Ast` nodes. Each node
+/// refers to its operand nodes by indexing into the vector rather than using
+/// references or boxes to reduce allocation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Ast<'a> {
+    /// Term: a constant value or variable
+    Term(Term<'a>),
+    /// Prefix operator
+    Prefix {
+        /// Operator
+        operator: Operator,
+        /// Index of the operand node
+        operand: usize,
+        /// Range of the substring where the operator occurs in the parsed expression
+        location: Range<usize>,
+    },
+    /// Postfix operator
+    Postfix {
+        /// Operator
+        operator: PostfixOperator,
+        /// Index of the operand node
+        operand: usize,
+        /// Range of the substring where the operator occurs in the parsed expression
+        location: Range<usize>,
+    },
+    /// Binary operator
+    Binary {
+        /// Operator
+        operator: Operator,
+        /// Index of the left-hand-side node
+        lhs: usize,
+        /// Index of the right-hand-side node
+        rhs: usize,
+        /// Range of the substring where the operator occurs in the parsed expression
+        location: Range<usize>,
+    },
+    /// Conditional ternary operator
+    Conditional {
+        /// Index of the first operand (condition) node.
+        condition_node: usize,
+        /// Index of the second operand (then value) node.
+        then_node: usize,
+        /// Index of the third operand (else value) node.
+        else_node: usize,
+    },
+}
+
+/// Cause of a syntax error
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SyntaxError {
+    /// Error in tokenization
+    TokenError(TokenError),
+    // TODO
+}
+
+impl From<TokenError> for SyntaxError {
+    fn from(e: TokenError) -> Self {
+        SyntaxError::TokenError(e)
+    }
+}
+
+/// Description of an error that occurred during expansion
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Error {
+    /// Cause of the error
+    pub cause: SyntaxError,
+    /// Range of the substring in the evaluated expression string where the error occurred
+    pub location: Range<usize>,
+}
+
+impl From<crate::token::Error> for Error {
+    fn from(e: crate::token::Error) -> Self {
+        Error {
+            cause: e.cause.into(),
+            location: e.location,
+        }
+    }
+}
+
+/// Returns the index of the last node.
+///
+/// Panics if the slice is empty.
+fn current_root_index(nodes: &[Ast]) -> usize {
+    let len = nodes.len();
+    assert!(len > 0);
+    len - 1
+}
+
+/// Parses postfix operators
+fn parse_postfix<'a, I>(tokens: &mut Peekable<I>, result: &mut Vec<Ast<'a>>) -> Result<(), Error>
+where
+    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+{
+    loop {
+        match tokens.peek() {
+            Some(Ok(Token::Operator {
+                operator: Operator::PlusPlus,
+                ref location,
+            })) => {
+                let location = location.clone();
+                tokens.next();
+                result.push(Ast::Postfix {
+                    operator: PostfixOperator::Increment,
+                    operand: current_root_index(&result),
+                    location,
+                });
+            }
+
+            Some(Ok(Token::Operator {
+                operator: Operator::MinusMinus,
+                ref location,
+            })) => {
+                let location = location.clone();
+                tokens.next();
+                result.push(Ast::Postfix {
+                    operator: PostfixOperator::Decrement,
+                    operand: current_root_index(&result),
+                    location,
+                });
+            }
+
+            _ => break Ok(()),
+        }
+    }
+}
+
+/// Parses a leaf expression.
+///
+/// A leaf expression is a term or parenthesized expression, optionally modified
+/// by unary operators.
+fn parse_leaf<'a, I>(tokens: &mut Peekable<I>, result: &mut Vec<Ast<'a>>) -> Result<(), Error>
+where
+    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+{
+    let token = tokens
+        .next()
+        .transpose()?
+        .expect("TODO: handle empty expression error");
+    match token {
+        Token::Term(term) => {
+            result.push(Ast::Term(term));
+            parse_postfix(tokens, result)
+        }
+        Token::Operator { .. } => todo!("parse prefix operators"),
+    }
+}
+
+/// Parses the whole expression.
+///
+/// A successful parse is returned as a non-empty vector of `Ast` nodes, where
+/// the last node is the root.
+pub fn parse<'a, I>(mut tokens: Peekable<I>) -> Result<Vec<Ast<'a>>, Error>
+where
+    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+{
+    let mut result = Vec::new();
+    parse_leaf(&mut tokens, &mut result)?;
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::Tokens;
+    use crate::token::Value;
+    use assert_matches::assert_matches;
+
+    fn parse_str(source: &str) -> Result<Vec<Ast>, Error> {
+        parse(Tokens::new(source).peekable())
+    }
+
+    #[test]
+    fn term() {
+        assert_eq!(
+            parse_str("123").unwrap(),
+            [Ast::Term(Term::Value(Value::Integer(123)))]
+        );
+        assert_eq!(
+            parse_str("0x42").unwrap(),
+            [Ast::Term(Term::Value(Value::Integer(0x42)))]
+        );
+        assert_eq!(
+            parse_str(" foo ").unwrap(),
+            [Ast::Term(Term::Variable {
+                name: "foo",
+                location: 1..4
+            })]
+        );
+    }
+
+    #[test]
+    fn token_error_in_term() {
+        assert_eq!(
+            parse_str("08"),
+            Err(Error {
+                cause: SyntaxError::TokenError(TokenError::InvalidNumericConstant),
+                location: 0..2
+            })
+        );
+    }
+
+    // TODO parentheses
+    // TODO unmatched_parentheses
+
+    #[test]
+    fn increment_postfix_operator() {
+        let nodes = parse_str("a++").unwrap();
+        assert_matches!(nodes.last(), Some(&Ast::Postfix { operator, operand, ref location }) => {
+            assert_eq!(operator, PostfixOperator::Increment);
+            assert_eq!(*location, 1..3);
+            assert_matches!(nodes[operand], Ast::Term(Term::Variable { name, ref location }) => {
+                assert_eq!(name, "a");
+                assert_eq!(*location, 0..1);
+            });
+        });
+    }
+
+    #[test]
+    fn decrement_postfix_operator() {
+        let nodes = parse_str("a--").unwrap();
+        assert_matches!(nodes.last(), Some(&Ast::Postfix { operator, operand, ref location }) => {
+            assert_eq!(operator, PostfixOperator::Decrement);
+            assert_eq!(*location, 1..3);
+            assert_matches!(nodes[operand], Ast::Term(Term::Variable { name, ref location }) => {
+                assert_eq!(name, "a");
+                assert_eq!(*location, 0..1);
+            });
+        });
+    }
+
+    #[test]
+    fn combination_of_postfix_operators() {
+        let nodes = parse_str(" x ++  -- ++ ").unwrap();
+        assert_matches!(nodes.last(), Some(&Ast::Postfix { operator, operand, ref location }) => {
+            assert_eq!(operator, PostfixOperator::Increment);
+            assert_eq!(*location, 10..12);
+            assert_matches!(nodes[operand], Ast::Postfix { operator, operand, ref location } => {
+                assert_eq!(operator, PostfixOperator::Decrement);
+                assert_eq!(*location, 7..9);
+                assert_matches!(nodes[operand], Ast::Postfix { operator, operand, ref location } => {
+                    assert_eq!(operator, PostfixOperator::Increment);
+                    assert_eq!(*location, 3..5);
+                    assert_matches!(nodes[operand], Ast::Term(Term::Variable { name, ref location }) => {
+                        assert_eq!(name, "x");
+                        assert_eq!(*location, 1..2);
+                    });
+                });
+            });
+        });
+    }
+
+    // TODO prefix_operators
+    // TODO binary_operators
+    // TODO conditional_operator
+}

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -181,12 +181,11 @@ impl Operator {
         }
     }
 
-    // TODO Make this private
     /// Returns the precedence of the operator.
     ///
     /// If the operator acts as both a unary and binary operator, the result is
     /// the precedence as a binary operator.
-    pub fn precedence(self) -> u8 {
+    fn precedence(self) -> u8 {
         use Operator::*;
         match self {
             CloseParen | Colon => 0,
@@ -307,7 +306,7 @@ where
             assert_matches!(tokens.next(), Some(Ok(Token::Operator { location, .. })) => location);
         result.push(Ast::Postfix { operator, location });
     }
-    return Ok(());
+    Ok(())
 }
 
 /// Parses a leaf expression.
@@ -472,9 +471,6 @@ mod tests {
             })
         );
     }
-
-    // TODO parentheses
-    // TODO unmatched_parentheses
 
     #[test]
     fn increment_postfix_operator() {
@@ -1339,4 +1335,6 @@ mod tests {
             ]
         );
     }
+
+    // TODO unmatched_parentheses
 }

--- a/yash-arith/src/eval.rs
+++ b/yash-arith/src/eval.rs
@@ -74,7 +74,7 @@ fn expand_variable<E: Env>(
 }
 
 /// Evaluates a term into a value.
-fn into_value<E: Env>(term: Term, env: &E) -> Result<Value, Error<E::AssignVariableError>> {
+pub fn into_value<E: Env>(term: Term, env: &E) -> Result<Value, Error<E::AssignVariableError>> {
     match term {
         Term::Value(value) => Ok(value),
         Term::Variable { name, location } => expand_variable(name, &location, env),

--- a/yash-arith/src/eval.rs
+++ b/yash-arith/src/eval.rs
@@ -17,6 +17,7 @@
 //! Evaluation of the expression
 
 use crate::ast::Ast;
+use crate::ast::PrefixOperator;
 use crate::env::Env;
 use crate::token::Term;
 use crate::token::Value;
@@ -48,6 +49,108 @@ pub struct Error<E> {
     pub location: Range<usize>,
 }
 
+/// Expands a variable to its value.
+fn expand_variable<E: Env>(
+    name: &str,
+    location: &Range<usize>,
+    env: &E,
+) -> Result<Value, Error<E::AssignVariableError>> {
+    if let Some(value) = env.get_variable(name) {
+        // TODO Parse non-decimal integer and float
+        match value.parse() {
+            Ok(number) => Ok(Value::Integer(number)),
+            Err(_) => Err(Error {
+                cause: EvalError::InvalidVariableValue(value.to_string()),
+                location: location.clone(),
+            }),
+        }
+    } else {
+        Ok(Value::Integer(0))
+    }
+}
+
+/// Evaluates a term into a value.
+fn into_value<E: Env>(term: Term, env: &E) -> Result<Value, Error<E::AssignVariableError>> {
+    match term {
+        Term::Value(value) => Ok(value),
+        Term::Variable { name, location } => expand_variable(name, &location, env),
+    }
+}
+
+/// Extracts a successful computation result or returns an overflow error.
+fn unwrap_or_overflow<T, E>(
+    checked_computation: Option<T>,
+    location: &Range<usize>,
+) -> Result<T, Error<E>> {
+    checked_computation.ok_or_else(|| Error {
+        cause: EvalError::Overflow,
+        location: location.clone(),
+    })
+}
+
+/// Assigns a value to a variable and returns the value.
+fn assign<E: Env>(
+    name: &str,
+    value: Value,
+    location: Range<usize>,
+    env: &mut E,
+) -> Result<Value, Error<E::AssignVariableError>> {
+    match env.assign_variable(name, value.to_string()) {
+        Ok(()) => Ok(value),
+        Err(e) => Err(Error {
+            cause: EvalError::AssignVariableError(e),
+            location,
+        }),
+    }
+}
+
+/// Applies a prefix operator to a term.
+fn apply_prefix<'a, E: Env>(
+    term: Term<'a>,
+    operator: PrefixOperator,
+    op_location: &Range<usize>,
+    env: &mut E,
+) -> Result<Value, Error<E::AssignVariableError>> {
+    match operator {
+        PrefixOperator::Increment => match term {
+            Term::Value(_) => todo!("reject non-variable"),
+            Term::Variable { name, location } => match expand_variable(name, &location, env)? {
+                Value::Integer(value) => {
+                    let new_value =
+                        Value::Integer(unwrap_or_overflow(value.checked_add(1), op_location)?);
+                    assign(name, new_value, location, env)
+                }
+            },
+        },
+        PrefixOperator::Decrement => match term {
+            Term::Value(_) => todo!("reject non-variable"),
+            Term::Variable { name, location } => match expand_variable(name, &location, env)? {
+                Value::Integer(value) => {
+                    let new_value =
+                        Value::Integer(unwrap_or_overflow(value.checked_sub(1), op_location)?);
+                    assign(name, new_value, location, env)
+                }
+            },
+        },
+        PrefixOperator::NumericCoercion => into_value(term, env),
+        PrefixOperator::NumericNegation => match into_value(term, env)? {
+            Value::Integer(value) => match value.checked_neg() {
+                Some(result) => Ok(Value::Integer(result)),
+                None => Err(Error {
+                    cause: EvalError::Overflow,
+                    location: op_location.clone(),
+                }),
+            },
+        },
+        PrefixOperator::LogicalNegation => match into_value(term, env)? {
+            Value::Integer(value) => Ok(Value::Integer((value == 0) as _)),
+        },
+        PrefixOperator::BitwiseNegation => match into_value(term, env)? {
+            Value::Integer(value) => Ok(Value::Integer(!value)),
+        },
+    }
+}
+
 /// Evaluates an expression.
 ///
 /// The given `ast` must not be empty, or this function will **panic**.
@@ -58,7 +161,12 @@ pub fn eval<'a, E: Env>(
     let (root, children) = ast.split_last().expect("evaluating an empty expression");
     match root {
         Ast::Term(term) => Ok(term.clone()),
-        Ast::Prefix { operator, location } => todo!(),
+
+        Ast::Prefix { operator, location } => {
+            let term = eval(children, env)?;
+            apply_prefix(term, *operator, location, env).map(Term::Value)
+        }
+
         Ast::Postfix { operator, location } => todo!(),
         Ast::Binary {
             operator,
@@ -75,6 +183,268 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
+    fn expand_variable_non_existing() {
+        let env = &mut HashMap::new();
+        assert_eq!(expand_variable("a", &(10..11), env), Ok(Value::Integer(0)));
+        assert_eq!(expand_variable("b", &(11..12), env), Ok(Value::Integer(0)));
+    }
+
+    #[test]
+    fn expand_variable_valid() {
+        let env = &mut HashMap::new();
+        env.insert("a".to_string(), "42".to_string());
+        env.insert("b".to_string(), "-123".to_string());
+        assert_eq!(expand_variable("a", &(10..11), env), Ok(Value::Integer(42)));
+        assert_eq!(
+            expand_variable("b", &(11..12), env),
+            Ok(Value::Integer(-123))
+        );
+    }
+
+    #[test]
+    fn expand_variable_invalid() {
+        let env = &mut HashMap::new();
+        env.insert("a".to_string(), "*".to_string());
+        assert_eq!(
+            expand_variable("a", &(10..11), env),
+            Err(Error {
+                cause: EvalError::InvalidVariableValue("*".to_string()),
+                location: 10..11,
+            })
+        );
+    }
+
+    #[test]
+    fn apply_prefix_increment() {
+        let env = &mut HashMap::new();
+
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Increment,
+                &(3..5),
+                env
+            ),
+            Ok(Value::Integer(1))
+        );
+        assert_eq!(env["i"], "1");
+
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Increment,
+                &(3..5),
+                env
+            ),
+            Ok(Value::Integer(2))
+        );
+        assert_eq!(env["i"], "2");
+    }
+
+    #[test]
+    fn apply_prefix_increment_overflow() {
+        let env = &mut HashMap::new();
+        env.insert("i".to_string(), "9223372036854775807".to_string());
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Increment,
+                &(3..5),
+                env
+            ),
+            Err(Error {
+                cause: EvalError::Overflow,
+                location: 3..5,
+            })
+        );
+    }
+
+    // TODO apply_prefix_increment_not_variable
+
+    #[test]
+    fn apply_prefix_decrement() {
+        let env = &mut HashMap::new();
+
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Decrement,
+                &(3..5),
+                env
+            ),
+            Ok(Value::Integer(-1))
+        );
+        assert_eq!(env["i"], "-1");
+
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Decrement,
+                &(3..5),
+                env
+            ),
+            Ok(Value::Integer(-2))
+        );
+        assert_eq!(env["i"], "-2");
+    }
+
+    #[test]
+    fn apply_prefix_decrement_overflow() {
+        let env = &mut HashMap::new();
+        env.insert("i".to_string(), "-9223372036854775808".to_string());
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "i",
+                    location: 6..7
+                },
+                PrefixOperator::Decrement,
+                &(3..5),
+                env
+            ),
+            Err(Error {
+                cause: EvalError::Overflow,
+                location: 3..5,
+            })
+        );
+    }
+
+    // TODO apply_prefix_decrement_not_variable
+
+    #[test]
+    fn apply_prefix_numeric_coercion() {
+        let env = &mut HashMap::new();
+        env.insert("a".to_string(), "12".to_string());
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(7)),
+                PrefixOperator::NumericCoercion,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(7))
+        );
+        assert_eq!(
+            apply_prefix(
+                Term::Variable {
+                    name: "a",
+                    location: 5..7,
+                },
+                PrefixOperator::NumericCoercion,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(12))
+        );
+    }
+
+    #[test]
+    fn apply_prefix_numeric_negation() {
+        let env = &mut HashMap::new();
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(7)),
+                PrefixOperator::NumericNegation,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(-7))
+        );
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(-10)),
+                PrefixOperator::NumericNegation,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(10))
+        );
+    }
+
+    #[test]
+    fn apply_prefix_numeric_negation_overflow() {
+        let env = &mut HashMap::new();
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(i64::MIN)),
+                PrefixOperator::NumericNegation,
+                &(3..4),
+                env
+            ),
+            Err(Error {
+                cause: EvalError::Overflow,
+                location: 3..4,
+            })
+        );
+    }
+
+    #[test]
+    fn apply_prefix_logical_negation() {
+        let env = &mut HashMap::new();
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(0)),
+                PrefixOperator::LogicalNegation,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(1))
+        );
+
+        for i in [-1, 1, 2, 100, i64::MAX, i64::MIN] {
+            assert_eq!(
+                apply_prefix(
+                    Term::Value(Value::Integer(i)),
+                    PrefixOperator::LogicalNegation,
+                    &(3..4),
+                    env
+                ),
+                Ok(Value::Integer(0)),
+                "i={:?}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn apply_prefix_bitwise_negation() {
+        let env = &mut HashMap::new();
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(0)),
+                PrefixOperator::BitwiseNegation,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(!0))
+        );
+        assert_eq!(
+            apply_prefix(
+                Term::Value(Value::Integer(-10000)),
+                PrefixOperator::BitwiseNegation,
+                &(3..4),
+                env
+            ),
+            Ok(Value::Integer(!-10000))
+        );
+    }
+
+    #[test]
     fn eval_term() {
         let env = &mut HashMap::new();
 
@@ -86,5 +456,18 @@ mod tests {
             location: 10..11,
         };
         assert_eq!(eval(&[Ast::Term(t.clone())], env), Ok(t));
+    }
+
+    #[test]
+    fn eval_prefix() {
+        let env = &mut HashMap::new();
+        let ast = &[
+            Ast::Term(Term::Value(Value::Integer(15))),
+            Ast::Prefix {
+                operator: PrefixOperator::NumericNegation,
+                location: 2..3,
+            },
+        ];
+        assert_eq!(eval(ast, env), Ok(Term::Value(Value::Integer(-15))));
     }
 }

--- a/yash-arith/src/eval.rs
+++ b/yash-arith/src/eval.rs
@@ -1,0 +1,90 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Evaluation of the expression
+
+use crate::ast::Ast;
+use crate::env::Env;
+use crate::token::Term;
+use crate::token::Value;
+use std::ops::Range;
+
+/// Cause of an evaluation error
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum EvalError<E> {
+    /// A variable value that is not a valid number
+    InvalidVariableValue(String),
+    /// Result out of bounds
+    Overflow,
+    /// Division by zero
+    DivisionByZero,
+    /// Left bit-shifting of a negative value
+    LeftShiftingNegative,
+    /// Bit-shifting with a negative right-hand-side operand
+    ReverseShifting,
+    /// Error assigning a variable value.
+    AssignVariableError(E),
+}
+
+/// Description of an error that occurred during evaluation
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Error<E> {
+    /// Cause of the error
+    pub cause: EvalError<E>,
+    /// Range of the substring in the evaluated expression string where the error occurred
+    pub location: Range<usize>,
+}
+
+/// Evaluates an expression.
+///
+/// The given `ast` must not be empty, or this function will **panic**.
+pub fn eval<'a, E: Env>(
+    ast: &[Ast<'a>],
+    env: &mut E,
+) -> Result<Term<'a>, Error<E::AssignVariableError>> {
+    let (root, children) = ast.split_last().expect("evaluating an empty expression");
+    match root {
+        Ast::Term(term) => Ok(term.clone()),
+        Ast::Prefix { operator, location } => todo!(),
+        Ast::Postfix { operator, location } => todo!(),
+        Ast::Binary {
+            operator,
+            rhs_len,
+            location,
+        } => todo!(),
+        Ast::Conditional { then_len, else_len } => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn eval_term() {
+        let env = &mut HashMap::new();
+
+        let t = Term::Value(Value::Integer(42));
+        assert_eq!(eval(&[Ast::Term(t.clone())], env), Ok(t));
+
+        let t = Term::Variable {
+            name: "a",
+            location: 10..11,
+        };
+        assert_eq!(eval(&[Ast::Term(t.clone())], env), Ok(t));
+    }
+}

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -39,6 +39,8 @@ mod ast;
 // use ast::Ast;
 pub use ast::SyntaxError;
 
+mod eval;
+
 /// Cause of an arithmetic expansion error
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ErrorCause<E> {

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -32,6 +32,13 @@ pub use token::TokenError;
 use token::Tokens;
 pub use token::Value;
 
+mod ast;
+
+// TODO Consider making these public
+// use ast::parse;
+// use ast::Ast;
+pub use ast::SyntaxError;
+
 /// Cause of an arithmetic expansion error
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ErrorCause<E> {

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -18,68 +18,63 @@
 //!
 //! TODO Elaborate
 
-use assert_matches::assert_matches;
+use std::fmt::Debug;
 use std::fmt::Display;
-use std::iter::Peekable;
+use std::fmt::Pointer;
 use std::ops::Range;
 
 mod token;
 
-use token::Operator;
-use token::Term;
-use token::Token;
 pub use token::TokenError;
 use token::Tokens;
 pub use token::Value;
 
 mod ast;
 
-// TODO Consider making these public
-// use ast::parse;
-// use ast::Ast;
 pub use ast::SyntaxError;
 
+mod env;
+
+pub use env::Env;
+
 mod eval;
+
+pub use eval::EvalError;
 
 /// Cause of an arithmetic expansion error
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ErrorCause<E> {
-    /// Error in tokenization
-    TokenError(TokenError),
-    /// A variable value that is not a valid number
-    InvalidVariableValue(String),
-    /// Result out of bounds
-    Overflow,
-    /// Division by zero
-    DivisionByZero,
-    /// Left bit-shifting of a negative value
-    LeftShiftingNegative,
-    /// Bit-shifting with a negative right-hand-side operand
-    ReverseShifting,
-    /// Error assigning a variable value.
-    AssignVariableError(E),
+    /// Syntax error parsing the expression
+    SyntaxError(SyntaxError),
+    /// Error evaluating the parsed expression
+    EvalError(EvalError<E>),
 }
 
 impl<E: Display> Display for ErrorCause<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ErrorCause::*;
         match self {
-            TokenError(e) => e.fmt(f),
-            InvalidVariableValue(v) => {
-                write!(f, "variable value {:?} cannot be parsed as a number", v)
-            }
-            Overflow => "overflow".fmt(f),
-            DivisionByZero => "division by zero".fmt(f),
-            LeftShiftingNegative => "negative value cannot be left-shifted".fmt(f),
-            ReverseShifting => "bit-shifting with negative right-hand-side operand".fmt(f),
-            AssignVariableError(e) => e.fmt(f),
+            SyntaxError(e) => e.fmt(f),
+            EvalError(e) => e.fmt(f),
         }
     }
 }
 
 impl<E> From<TokenError> for ErrorCause<E> {
     fn from(e: TokenError) -> Self {
-        ErrorCause::TokenError(e)
+        ErrorCause::SyntaxError(e.into())
+    }
+}
+
+impl<E> From<SyntaxError> for ErrorCause<E> {
+    fn from(e: SyntaxError) -> Self {
+        ErrorCause::SyntaxError(e)
+    }
+}
+
+impl<E> From<EvalError<E>> for ErrorCause<E> {
+    fn from(e: EvalError<E>) -> Self {
+        ErrorCause::EvalError(e)
     }
 }
 
@@ -100,8 +95,8 @@ impl<E: Display> Display for Error<E> {
 
 impl<E: std::fmt::Debug + Display> std::error::Error for Error<E> {}
 
-impl<E> From<token::Error> for Error<E> {
-    fn from(e: token::Error) -> Self {
+impl<E> From<ast::Error> for Error<E> {
+    fn from(e: ast::Error) -> Self {
         Error {
             cause: e.cause.into(),
             location: e.location,
@@ -109,362 +104,22 @@ impl<E> From<token::Error> for Error<E> {
     }
 }
 
-mod env;
-
-pub use env::Env;
-
-/// Expands a variable to its value.
-fn expand_variable<E: Env>(
-    name: &str,
-    location: &Range<usize>,
-    mode: Mode,
-    env: &E,
-) -> Result<Value, Error<E::AssignVariableError>> {
-    if let (Mode::Eval, Some(value)) = (mode, env.get_variable(name)) {
-        match value.parse() {
-            Ok(number) => Ok(Value::Integer(number)),
-            Err(_) => Err(Error {
-                cause: ErrorCause::InvalidVariableValue(value.to_string()),
-                location: location.clone(),
-            }),
-        }
-    } else {
-        Ok(Value::Integer(0))
-    }
-}
-
-/// Specifies the behavior of parse functions.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Mode {
-    /// Evaluate the (sub)expression parsed.
-    Eval,
-    /// Just parse a (sub)expression; don't evaluate.
-    Skip,
-}
-
-impl Term<'_> {
-    /// Evaluate the term into a value.
-    fn into_value<E: Env>(
-        self,
-        mode: Mode,
-        env: &E,
-    ) -> Result<Value, Error<E::AssignVariableError>> {
-        match mode {
-            Mode::Eval => match self {
-                Term::Value(value) => Ok(value),
-                Term::Variable { name, location } => expand_variable(name, &location, mode, env),
-            },
-            Mode::Skip => Ok(Value::Integer(0)),
+impl<E> From<eval::Error<E>> for Error<E> {
+    fn from(e: eval::Error<E>) -> Self {
+        Error {
+            cause: e.cause.into(),
+            location: e.location,
         }
     }
-}
-
-fn unwrap_or_overflow<T, E>(result: Option<T>, location: Range<usize>) -> Result<T, Error<E>> {
-    result.ok_or(Error {
-        cause: ErrorCause::Overflow,
-        location,
-    })
-}
-
-/// Applies a unary operator.
-fn apply_unary<E>(
-    operator: Operator,
-    operand: Value,
-    location: Range<usize>,
-) -> Result<Value, Error<E>> {
-    let Value::Integer(value) = operand;
-    use Operator::*;
-    Ok(match operator {
-        Plus => Value::Integer(value),
-        Minus => Value::Integer(unwrap_or_overflow(value.checked_neg(), location)?),
-        Tilde => Value::Integer(!value),
-        Bang => Value::Integer((value == 0) as i64),
-        PlusPlus => Value::Integer(unwrap_or_overflow(value.checked_add(1), location)?),
-        MinusMinus => Value::Integer(unwrap_or_overflow(value.checked_sub(1), location)?),
-        _ => panic!("not a unary operator: {:?}", operator),
-    })
-}
-
-/// Parses optional postfix operators.
-fn parse_postfix<'a, E: Env>(
-    operand: Term<'a>,
-    tokens: &mut Peekable<Tokens<'a>>,
-    mode: Mode,
-    env: &mut E,
-) -> Result<Term<'a>, Error<E::AssignVariableError>> {
-    if let Some(Ok(Token::Operator {
-        operator: Operator::PlusPlus | Operator::MinusMinus,
-        ..
-    })) = tokens.peek()
-    {
-        let (operator, op_location) = assert_matches!(
-            tokens.next(),
-            Some(Ok(Token::Operator { operator, location })) => (operator, location)
-        );
-        match operand {
-            Term::Value(_) => todo!("reject non-variable"),
-            Term::Variable { name, location } => {
-                let old_value = expand_variable(name, &location, mode, env)?;
-                let new_value = apply_unary(operator, old_value.clone(), op_location.clone())?;
-
-                if mode == Mode::Eval {
-                    env.assign_variable(name, new_value.to_string())
-                        .map_err(|e| Error {
-                            cause: ErrorCause::AssignVariableError(e),
-                            location: op_location,
-                        })?;
-                }
-                Ok(Term::Value(old_value))
-            }
-        }
-    } else {
-        Ok(operand)
-    }
-}
-
-/// Parses a leaf expression.
-///
-/// A leaf expression is a constant number, variable, or parenthesized
-/// expression, optionally modified by a unary operator.
-fn parse_leaf<'a, E: Env>(
-    tokens: &mut Peekable<Tokens<'a>>,
-    mode: Mode,
-    env: &mut E,
-) -> Result<Term<'a>, Error<E::AssignVariableError>> {
-    use Operator::*;
-    match tokens.next().transpose()? {
-        Some(Token::Term(term)) => parse_postfix(term, tokens, mode, env),
-
-        Some(Token::Operator {
-            operator,
-            location: op_location,
-        }) => match operator {
-            OpenParen => {
-                let inner = parse_binary(tokens, 1, mode, env)?;
-                tokens.next().transpose()?; // TODO Check if this token is a closing parenthesis
-                parse_postfix(inner, tokens, mode, env)
-            }
-            Plus | Minus | Tilde | Bang => {
-                let operand = parse_leaf(tokens, mode, env)?.into_value(mode, env)?;
-                apply_unary(operator, operand, op_location).map(Term::Value)
-            }
-            PlusPlus | MinusMinus => match parse_leaf(tokens, mode, env)? {
-                Term::Value(_) => todo!("reject non-variable"),
-                Term::Variable { name, location } => {
-                    let old_value = expand_variable(name, &location, mode, env)?;
-                    let result = if mode == Mode::Eval {
-                        let new_value = apply_unary(operator, old_value, op_location.clone())?;
-                        env.assign_variable(name, new_value.to_string())
-                            .map_err(|e| Error {
-                                cause: ErrorCause::AssignVariableError(e),
-                                location: op_location,
-                            })?;
-                        new_value
-                    } else {
-                        Value::Integer(0)
-                    };
-                    Ok(Term::Value(result))
-                }
-            },
-            _ => todo!("handle orphan operator: {:?}", operator),
-        },
-
-        None => todo!("handle missing token"),
-    }
-}
-
-/// Applies a binary operator.
-///
-/// If `op` is a compound assignment operator, only the binary operation is
-/// performed, ignoring the assignment. For `Operator::Equal`, `rhs` is
-/// returned, ignoring `lhs`.
-fn apply_binary<E>(
-    op: Operator,
-    lhs: Value,
-    rhs: Value,
-    location: Range<usize>,
-) -> Result<Value, Error<E>> {
-    let (Value::Integer(lhs), Value::Integer(rhs)) = (lhs, rhs);
-    use Operator::*;
-    Ok(match op {
-        Equal => Value::Integer(rhs),
-        BarBar => Value::Integer((lhs != 0 || rhs != 0) as _),
-        AndAnd => Value::Integer((lhs != 0 && rhs != 0) as _),
-        Bar | BarEqual => Value::Integer(lhs | rhs),
-        Caret | CaretEqual => Value::Integer(lhs ^ rhs),
-        And | AndEqual => Value::Integer(lhs & rhs),
-        EqualEqual => Value::Integer((lhs == rhs) as _),
-        BangEqual => Value::Integer((lhs != rhs) as _),
-        Less => Value::Integer((lhs < rhs) as _),
-        Greater => Value::Integer((lhs > rhs) as _),
-        LessEqual => Value::Integer((lhs <= rhs) as _),
-        GreaterEqual => Value::Integer((lhs >= rhs) as _),
-        LessLess | LessLessEqual => {
-            if lhs < 0 {
-                return Err(Error {
-                    cause: ErrorCause::LeftShiftingNegative,
-                    location,
-                });
-            }
-            if rhs < 0 {
-                return Err(Error {
-                    cause: ErrorCause::ReverseShifting,
-                    location,
-                });
-            }
-            let rhs = unwrap_or_overflow(rhs.try_into().ok(), location.clone())?;
-            let result = unwrap_or_overflow(lhs.checked_shl(rhs), location.clone())?;
-            if result >> rhs != lhs {
-                return Err(Error {
-                    cause: ErrorCause::Overflow,
-                    location,
-                });
-            }
-            Value::Integer(result)
-        }
-        GreaterGreater | GreaterGreaterEqual => {
-            if rhs < 0 {
-                return Err(Error {
-                    cause: ErrorCause::ReverseShifting,
-                    location,
-                });
-            }
-            Value::Integer(unwrap_or_overflow(
-                rhs.try_into().ok().and_then(|rhs| lhs.checked_shr(rhs)),
-                location,
-            )?)
-        }
-        Plus | PlusEqual => Value::Integer(unwrap_or_overflow(lhs.checked_add(rhs), location)?),
-        Minus | MinusEqual => Value::Integer(unwrap_or_overflow(lhs.checked_sub(rhs), location)?),
-        Asterisk | AsteriskEqual => {
-            Value::Integer(unwrap_or_overflow(lhs.checked_mul(rhs), location)?)
-        }
-        Slash | SlashEqual => {
-            if rhs == 0 {
-                return Err(Error {
-                    cause: ErrorCause::DivisionByZero,
-                    location,
-                });
-            } else {
-                Value::Integer(unwrap_or_overflow(lhs.checked_div(rhs), location)?)
-            }
-        }
-        Percent | PercentEqual => {
-            if rhs == 0 {
-                return Err(Error {
-                    cause: ErrorCause::DivisionByZero,
-                    location,
-                });
-            } else {
-                Value::Integer(unwrap_or_overflow(lhs.checked_rem(rhs), location)?)
-            }
-        }
-        Question | Colon | Tilde | Bang | PlusPlus | MinusMinus | OpenParen | CloseParen => {
-            panic!("not a binary operator: {:?}", op)
-        }
-    })
-}
-
-/// Parses an expression that may contain binary operators.
-///
-/// This function consumes binary operators with precedence equal to or greater
-/// than the given minimum precedence, which must be greater than 0.
-fn parse_binary<'a, E: Env>(
-    tokens: &mut Peekable<Tokens<'a>>,
-    min_precedence: u8,
-    mode: Mode,
-    env: &mut E,
-) -> Result<Term<'a>, Error<E::AssignVariableError>> {
-    let mut term = parse_leaf(tokens, mode, env)?;
-
-    while let Some(&Ok(Token::Operator { operator, .. })) = tokens.peek() {
-        let precedence = operator.precedence();
-        if precedence < min_precedence {
-            break;
-        }
-
-        let op_location =
-            assert_matches!(tokens.next(), Some(Ok(Token::Operator { location, .. })) => location);
-
-        use Operator::*;
-        match operator {
-            Equal | BarEqual | CaretEqual | AndEqual | LessLessEqual | GreaterGreaterEqual
-            | PlusEqual | MinusEqual | AsteriskEqual | SlashEqual | PercentEqual => match term {
-                Term::Value(_) => todo!(),
-                Term::Variable { name, location } => {
-                    let lhs = if operator == Equal {
-                        Value::Integer(0)
-                    } else {
-                        expand_variable(name, &location, mode, env)?
-                    };
-                    let rhs = parse_binary(tokens, precedence, mode, env)?.into_value(mode, env)?;
-                    let result = if mode == Mode::Eval {
-                        let result = apply_binary(operator, lhs, rhs, op_location.clone())?;
-                        env.assign_variable(name, result.to_string())
-                            .map_err(|e| Error {
-                                cause: ErrorCause::AssignVariableError(e),
-                                location: op_location,
-                            })?;
-                        result
-                    } else {
-                        Value::Integer(0)
-                    };
-                    term = Term::Value(result);
-                }
-            },
-            Question => {
-                let Value::Integer(condition) = term.into_value(mode, env)?;
-                let (then_mode, else_mode) = if condition != 0 {
-                    (mode, Mode::Skip)
-                } else {
-                    (Mode::Skip, mode)
-                };
-                debug_assert_eq!(precedence, 2);
-                let then_result = parse_binary(tokens, 1, then_mode, env)?;
-                // TODO Reject if a colon is missing
-                tokens.next().transpose()?;
-                let else_result = parse_binary(tokens, 2, else_mode, env)?;
-                term = if condition != 0 {
-                    then_result
-                } else {
-                    else_result
-                };
-                // TODO result into_value
-            }
-            BarBar | AndAnd => {
-                let Value::Integer(lhs) = term.into_value(mode, env)?;
-                let skip_rhs = match operator {
-                    BarBar => lhs != 0,
-                    AndAnd => lhs == 0,
-                    _ => unreachable!(),
-                };
-                let rhs_mode = if skip_rhs { Mode::Skip } else { mode };
-                let rhs = parse_binary(tokens, precedence + 1, rhs_mode, env)?
-                    .into_value(rhs_mode, env)?;
-                let value = apply_binary(operator, Value::Integer(lhs), rhs, op_location)?;
-                term = Term::Value(value);
-            }
-            Bar | Caret | And | EqualEqual | BangEqual | Less | LessEqual | Greater
-            | GreaterEqual | LessLess | GreaterGreater | Plus | Minus | Asterisk | Slash
-            | Percent => {
-                let rhs = parse_binary(tokens, precedence + 1, mode, env)?;
-                let (lhs, rhs) = (term.into_value(mode, env)?, rhs.into_value(mode, env)?);
-                term = Term::Value(apply_binary(operator, lhs, rhs, op_location)?);
-            }
-            Colon | Tilde | Bang | PlusPlus | MinusMinus | OpenParen => todo!("syntax error"),
-            CloseParen => panic!("min_precedence must not be 0"),
-        };
-    }
-
-    Ok(term)
 }
 
 /// Performs arithmetic expansion
 pub fn eval<E: Env>(expression: &str, env: &mut E) -> Result<Value, Error<E::AssignVariableError>> {
-    let mut tokens = Tokens::new(expression).peekable();
-    let term = parse_binary(&mut tokens, 1, Mode::Eval, env)?;
-    assert_eq!(tokens.next(), None, "todo: handle orphan term");
-    term.into_value(Mode::Eval, env)
+    let tokens = Tokens::new(expression).peekable();
+    let ast = ast::parse(tokens)?;
+    let term = eval::eval(&ast, env)?;
+    let value = eval::into_value(term, env)?;
+    Ok(value)
 }
 
 #[cfg(test)]
@@ -494,14 +149,14 @@ mod tests {
         assert_eq!(
             eval("08", env),
             Err(Error {
-                cause: ErrorCause::TokenError(TokenError::InvalidNumericConstant),
+                cause: TokenError::InvalidNumericConstant.into(),
                 location: 0..2,
             })
         );
         assert_eq!(
             eval("0192", env),
             Err(Error {
-                cause: ErrorCause::TokenError(TokenError::InvalidNumericConstant),
+                cause: TokenError::InvalidNumericConstant.into(),
                 location: 0..4,
             })
         );
@@ -543,21 +198,21 @@ mod tests {
         assert_eq!(
             eval("foo", env),
             Err(Error {
-                cause: ErrorCause::InvalidVariableValue("".to_string()),
+                cause: EvalError::InvalidVariableValue("".to_string()).into(),
                 location: 0..3,
             })
         );
         assert_eq!(
             eval("bar", env),
             Err(Error {
-                cause: ErrorCause::InvalidVariableValue("*".to_string()),
+                cause: EvalError::InvalidVariableValue("*".to_string()).into(),
                 location: 0..3,
             })
         );
         assert_eq!(
             eval("  oops ", env),
             Err(Error {
-                cause: ErrorCause::InvalidVariableValue("foo".to_string()),
+                cause: EvalError::InvalidVariableValue("foo".to_string()).into(),
                 location: 2..6,
             })
         );
@@ -767,21 +422,21 @@ mod tests {
         assert_eq!(
             eval("0x4000000000000000<<1", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 18..20,
             })
         );
         assert_eq!(
             eval("0<<1000", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..3,
             })
         );
         assert_eq!(
             eval("0<<0x100000000", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..3,
             })
         );
@@ -789,14 +444,14 @@ mod tests {
         assert_eq!(
             eval("0>>1000", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..3,
             })
         );
         assert_eq!(
             eval("0>>0x100000000", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..3,
             })
         );
@@ -810,14 +465,14 @@ mod tests {
         assert_eq!(
             eval("-1<<1", env),
             Err(Error {
-                cause: ErrorCause::LeftShiftingNegative,
+                cause: EvalError::LeftShiftingNegative.into(),
                 location: 2..4,
             })
         );
         assert_eq!(
             eval("(-0x7FFFFFFFFFFFFFFF-1)<<1", env),
             Err(Error {
-                cause: ErrorCause::LeftShiftingNegative,
+                cause: EvalError::LeftShiftingNegative.into(),
                 location: 23..25,
             })
         );
@@ -833,7 +488,7 @@ mod tests {
         assert_eq!(
             eval("1 << -1", env),
             Err(Error {
-                cause: ErrorCause::ReverseShifting,
+                cause: EvalError::ReverseShifting.into(),
                 location: 2..4,
             })
         );
@@ -841,7 +496,7 @@ mod tests {
         assert_eq!(
             eval("1 >> -1", env),
             Err(Error {
-                cause: ErrorCause::ReverseShifting,
+                cause: EvalError::ReverseShifting.into(),
                 location: 2..4,
             })
         );
@@ -861,7 +516,7 @@ mod tests {
         assert_eq!(
             eval("9223372036854775807+1", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 19..20,
             })
         );
@@ -881,7 +536,7 @@ mod tests {
         assert_eq!(
             eval("0-9223372036854775807-2", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 21..22,
             })
         );
@@ -901,7 +556,7 @@ mod tests {
         assert_eq!(
             eval("0x100000000 * 0x80000000", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 12..13,
             })
         );
@@ -921,21 +576,21 @@ mod tests {
         assert_eq!(
             eval("1/0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 1..2,
             })
         );
         assert_eq!(
             eval("0/0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 1..2,
             })
         );
         assert_eq!(
             eval("10/0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 2..3,
             })
         );
@@ -947,7 +602,7 @@ mod tests {
         assert_eq!(
             eval("(-0x7FFFFFFFFFFFFFFF-1)/-1", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 23..24,
             })
         );
@@ -967,21 +622,21 @@ mod tests {
         assert_eq!(
             eval("1%0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 1..2,
             })
         );
         assert_eq!(
             eval("0%0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 1..2,
             })
         );
         assert_eq!(
             eval("10%0", env),
             Err(Error {
-                cause: ErrorCause::DivisionByZero,
+                cause: EvalError::DivisionByZero.into(),
                 location: 2..3,
             })
         );
@@ -993,7 +648,7 @@ mod tests {
         assert_eq!(
             eval("(-0x7FFFFFFFFFFFFFFF-1)%-1", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 23..24,
             })
         );
@@ -1026,7 +681,7 @@ mod tests {
         assert_eq!(
             eval(" - (-0x7FFFFFFFFFFFFFFF-1)", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..2
             })
         );
@@ -1069,7 +724,7 @@ mod tests {
         assert_eq!(
             eval("  ++ i", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 2..4,
             })
         );
@@ -1092,7 +747,7 @@ mod tests {
         assert_eq!(
             eval(" -- i", env),
             Err(Error {
-                cause: ErrorCause::Overflow,
+                cause: EvalError::Overflow.into(),
                 location: 1..3,
             })
         );

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -20,10 +20,10 @@ use std::fmt::Display;
 use std::ops::Range;
 
 /// Result of evaluating an expression
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Value {
     Integer(i64),
-    // TODO Float, String
+    // TODO Float
 }
 
 impl Display for Value {

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -127,33 +127,6 @@ pub enum Operator {
     CloseParen,
 }
 
-impl Operator {
-    /// Returns the precedence of the operator.
-    ///
-    /// If the operator acts as both a unary and binary operator, the result is
-    /// the precedence as a binary operator.
-    pub fn precedence(self) -> u8 {
-        use Operator::*;
-        match self {
-            CloseParen | Colon => 0,
-            Equal | BarEqual | CaretEqual | AndEqual | LessLessEqual | GreaterGreaterEqual
-            | PlusEqual | MinusEqual | AsteriskEqual | SlashEqual | PercentEqual => 1,
-            Question => 2,
-            BarBar => 3,
-            AndAnd => 4,
-            Bar => 5,
-            Caret => 6,
-            And => 7,
-            EqualEqual | BangEqual => 8,
-            Less | LessEqual | Greater | GreaterEqual => 9,
-            LessLess | GreaterGreater => 10,
-            Plus | Minus => 11,
-            Asterisk | Slash | Percent => 12,
-            Tilde | Bang | PlusPlus | MinusMinus | OpenParen => 13,
-        }
-    }
-}
-
 /// Atomic lexical element of an expression
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Token<'a> {


### PR DESCRIPTION
This pull request refactors the arithmetic expansion implementation.

Previously, We performed syntax parsing and evaluation in a single pass. This PR splits them into separate processes.

The motivation for this refactoring comes from the difficulty in implementing and testing the evaluation `Mode`. To implement conditional evaluation required by the `||`, `&&`, and `? :` operator, we need to conditionally skip evaluation of part of the expression and prevent any side effects. We used the `Mode` flag to indicate the condition to trigger skipping, but we still need to parse the whole expression syntax regardless of the flag. That was making the implementation complicated and hard to understand.

By separating the parser from evaluation, skipping evaluation can be coded much more intuitively just by not calling the evaluation function.