### PR TITLE
Return location of all tokens in arithmetic expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,6 @@ dependencies = [
 [[package]]
 name = "yash-arith"
 version = "0.1.0"
-dependencies = [
- "assert_matches",
-]
 
 [[package]]
 name = "yash-builtin"

--- a/yash-arith/Cargo.toml
+++ b/yash-arith/Cargo.toml
@@ -13,6 +13,3 @@ license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
 publish = false
-
-[dependencies]
-assert_matches = "1.5.0"

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -18,8 +18,8 @@
 
 use crate::token::Operator;
 use crate::token::Term;
-use crate::token::Token;
 use crate::token::TokenError;
+use crate::token::TokenValue;
 use assert_matches::assert_matches;
 use std::iter::Peekable;
 use std::ops::Range;
@@ -314,15 +314,14 @@ impl From<crate::token::Error> for Error {
 /// Parses postfix operators
 fn parse_postfix<'a, I>(tokens: &mut Peekable<I>, result: &mut Vec<Ast<'a>>) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
-    while let Some(&Ok(Token::Operator { operator, .. })) = tokens.peek() {
+    while let Some(&Ok(TokenValue::Operator { operator, .. })) = tokens.peek() {
         let operator = match operator.as_postfix() {
             Some(operator) => operator,
             None => break,
         };
-        let location =
-            assert_matches!(tokens.next(), Some(Ok(Token::Operator { location, .. })) => location);
+        let location = assert_matches!(tokens.next(), Some(Ok(TokenValue::Operator { location, .. })) => location);
         result.push(Ast::Postfix { operator, location });
     }
     Ok(())
@@ -333,15 +332,15 @@ where
 /// Returns an error if the next token is not a closing parenthesis.
 fn parse_close_paren<'a, I>(tokens: &mut Peekable<I>, location: Range<usize>) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     match tokens.next().transpose()? {
-        Some(Token::Operator {
+        Some(TokenValue::Operator {
             operator: Operator::CloseParen,
             ..
         }) => Ok(()),
 
-        Some(Token::Operator {
+        Some(TokenValue::Operator {
             operator: Operator::Colon,
             location,
         }) => Err(Error {
@@ -362,25 +361,25 @@ where
 /// by unary operators.
 fn parse_leaf<'a, I>(tokens: &mut Peekable<I>, result: &mut Vec<Ast<'a>>) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     let token = tokens
         .next()
         .transpose()?
         .expect("TODO: handle empty expression error");
     match token {
-        Token::Term(term) => {
+        TokenValue::Term(term) => {
             result.push(Ast::Term(term));
             parse_postfix(tokens, result)
         }
 
-        Token::Operator { operator, location } if operator == Operator::OpenParen => {
+        TokenValue::Operator { operator, location } if operator == Operator::OpenParen => {
             parse_tree(tokens, 1, result)?;
             parse_close_paren(tokens, location)?;
             parse_postfix(tokens, result)
         }
 
-        Token::Operator { operator, location } => {
+        TokenValue::Operator { operator, location } => {
             let operator = match operator.as_prefix() {
                 Some(operator) => operator,
                 None => {
@@ -407,7 +406,7 @@ fn parse_binary_rhs<'a, I>(
     result: &mut Vec<Ast<'a>>,
 ) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     let old_len = result.len();
     parse_tree(tokens, min_precedence, result)?;
@@ -429,18 +428,17 @@ fn parse_tree<'a, I>(
     result: &mut Vec<Ast<'a>>,
 ) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     parse_leaf(tokens, result)?;
 
-    while let Some(&Ok(Token::Operator { operator, .. })) = tokens.peek() {
+    while let Some(&Ok(TokenValue::Operator { operator, .. })) = tokens.peek() {
         let precedence = operator.precedence();
         if precedence < min_precedence {
             break;
         }
 
-        let location =
-            assert_matches!(tokens.next(), Some(Ok(Token::Operator { location, .. })) => location);
+        let location = assert_matches!(tokens.next(), Some(Ok(TokenValue::Operator { location, .. })) => location);
 
         use Operator::*;
         if operator == Question {
@@ -450,7 +448,7 @@ where
             // Reject if a colon is missing
             if !matches!(
                 tokens.next().transpose()?,
-                Some(Token::Operator {
+                Some(TokenValue::Operator {
                     operator: Operator::Colon,
                     ..
                 })
@@ -491,12 +489,12 @@ where
 /// Returns an error if there is a next token.
 fn parse_end_of_input<'a, I>(tokens: &mut Peekable<I>) -> Result<(), Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     match tokens.next().transpose()? {
         None => Ok(()),
 
-        Some(Token::Operator {
+        Some(TokenValue::Operator {
             operator: Operator::Colon,
             location,
         }) => Err(Error {
@@ -514,7 +512,7 @@ where
 /// the last node is the root.
 pub fn parse<'a, I>(mut tokens: Peekable<I>) -> Result<Vec<Ast<'a>>, Error>
 where
-    I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
+    I: Iterator<Item = Result<TokenValue<'a>, crate::token::Error>>,
 {
     let mut result = Vec::new();
     parse_tree(&mut tokens, 1, &mut result)?;

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -505,7 +505,11 @@ where
     I: Iterator<Item = Result<Token<'a>, crate::token::Error>>,
 {
     match tokens.next().transpose()? {
-        None => Ok(()),
+        None
+        | Some(Token {
+            value: TokenValue::EndOfInput,
+            ..
+        }) => Ok(()),
 
         Some(Token {
             value: TokenValue::Operator(Operator::Colon),

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -400,6 +400,8 @@ where
             });
             Ok(())
         }
+
+        TokenValue::EndOfInput => todo!("handle empty expression error"),
     }
 }
 

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -24,8 +24,8 @@ use std::ops::Range;
 
 mod token;
 
+use token::PeekableTokens;
 pub use token::TokenError;
-use token::Tokens;
 pub use token::Value;
 
 mod ast;
@@ -114,7 +114,7 @@ impl<E> From<eval::Error<E>> for Error<E> {
 
 /// Performs arithmetic expansion
 pub fn eval<E: Env>(expression: &str, env: &mut E) -> Result<Value, Error<E::AssignVariableError>> {
-    let tokens = Tokens::new(expression).peekable();
+    let tokens = PeekableTokens::from(expression);
     let ast = ast::parse(tokens)?;
     let term = eval::eval(&ast, env)?;
     let value = eval::into_value(term, env)?;

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -134,7 +134,8 @@ pub enum TokenValue<'a> {
     Term(Term<'a>),
     /// Operator
     Operator(Operator),
-    // TODO EndOfInput
+    /// Imaginary token value for the end of input.
+    EndOfInput,
 }
 
 /// Atomic lexical element of an expression

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -127,7 +127,7 @@ pub enum Operator {
     CloseParen,
 }
 
-/// Atomic lexical element of an expression
+/// Value of a [`Token`].
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum TokenValue<'a> {
     /// Term
@@ -136,9 +136,20 @@ pub enum TokenValue<'a> {
     Operator {
         /// Operator kind
         operator: Operator,
+        // TODO Remove location from TokenValue::Operator
         /// Range of the substring where the token occurs in the parsed expression
         location: Range<usize>,
     },
+    // TODO EndOfInput
+}
+
+/// Atomic lexical element of an expression
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Token<'a> {
+    /// Token value
+    pub value: TokenValue<'a>,
+    /// Range of the substring where the token occurs in the parsed expression
+    pub location: Range<usize>,
 }
 
 /// Cause of a tokenization error


### PR DESCRIPTION
This pull request contains refactoring to make it possible for the tokenizer to return the location of all tokens. We need the location of the end-of-input token to produce an `IncompleteExpression` error.