### PR TITLE
Here-document semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +201,15 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "itertools"
@@ -267,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +309,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "slab"
@@ -301,6 +337,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -415,6 +465,7 @@ dependencies = [
  "itertools",
  "nix",
  "slab",
+ "tempfile",
  "yash-quote",
  "yash-syntax",
 ]

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -24,6 +24,7 @@ futures-util = "0.3.23"
 itertools = "0.10.3"
 nix = "0.23.1"
 slab = "0.4.6"
+tempfile = "3.3.0"
 yash-quote = { path = "../yash-quote", version = "1.0.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.5.0", features = ["annotate-snippets"] }
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -60,6 +60,7 @@ use std::future::Future;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::os::raw::c_int;
+use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -110,6 +111,12 @@ pub trait System: Debug {
     ///
     /// This is a thin wrapper around the `open` system call.
     fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> nix::Result<Fd>;
+
+    /// Opens a file descriptor associated with an anonymous temporary file.
+    ///
+    /// This function works similarly to the `O_TMPFILE` flag specified to the
+    /// `open` function.
+    fn open_tmpfile(&mut self, parent_dir: &Path) -> nix::Result<Fd>;
 
     /// Closes a file descriptor.
     ///
@@ -629,6 +636,9 @@ impl System for SharedSystem {
     }
     fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> nix::Result<Fd> {
         self.0.borrow_mut().open(path, option, mode)
+    }
+    fn open_tmpfile(&mut self, parent_dir: &Path) -> nix::Result<Fd> {
+        self.0.borrow_mut().open_tmpfile(parent_dir)
     }
     fn close(&mut self, fd: Fd) -> nix::Result<()> {
         self.0.borrow_mut().close(fd)

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -57,6 +57,7 @@ use std::ffi::CString;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::future::Future;
+use std::io::SeekFrom;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::os::raw::c_int;
@@ -154,6 +155,9 @@ pub trait System: Debug {
     /// to support concurrent I/O in an `async` function context and ensure the
     /// whole `buffer` is written.
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize>;
+
+    /// Moves the position of the open file description.
+    fn lseek(&mut self, fd: Fd, position: SeekFrom) -> nix::Result<u64>;
 
     /// Opens a directory for enumerating entries.
     fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>>;
@@ -657,6 +661,9 @@ impl System for SharedSystem {
     }
     fn write(&mut self, fd: Fd, buffer: &[u8]) -> nix::Result<usize> {
         self.0.borrow_mut().write(fd, buffer)
+    }
+    fn lseek(&mut self, fd: Fd, position: SeekFrom) -> nix::Result<u64> {
+        self.0.borrow_mut().lseek(fd, position)
     }
     fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>> {
         self.0.borrow_mut().fdopendir(fd)

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -44,10 +44,12 @@ use nix::sys::stat::stat;
 use nix::unistd::access;
 use nix::unistd::AccessFlags;
 use std::convert::Infallible;
+use std::convert::TryInto;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
 use std::future::Future;
+use std::io::SeekFrom;
 use std::os::raw::c_int;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::IntoRawFd;
@@ -204,6 +206,19 @@ impl System for RealSystem {
                 return result;
             }
         }
+    }
+
+    fn lseek(&mut self, fd: Fd, position: SeekFrom) -> nix::Result<u64> {
+        use nix::unistd::Whence::*;
+        let (offset, whence) = match position {
+            SeekFrom::Start(offset) => {
+                let offset = offset.try_into().map_err(|_| Errno::EOVERFLOW)?;
+                (offset, SeekSet)
+            }
+            SeekFrom::End(offset) => (offset, SeekEnd),
+            SeekFrom::Current(offset) => (offset, SeekCur),
+        };
+        nix::unistd::lseek(fd.0, offset, whence).map(|new_offset| new_offset as u64)
     }
 
     fn fdopendir(&mut self, fd: Fd) -> nix::Result<Box<dyn Dir>> {

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -338,6 +338,8 @@ async fn open_normal(
     }
 }
 
+mod here_doc;
+
 /// Performs a redirection.
 async fn perform(env: &mut Env, redir: &Redir) -> Result<(SavedFd, Option<ExitStatus>), Error> {
     // Save the current open file description at `target_fd`
@@ -361,7 +363,7 @@ async fn perform(env: &mut Env, redir: &Redir) -> Result<(SavedFd, Option<ExitSt
             let (fd, location) = open_normal(env, *operator, expansion).await?;
             (fd, location, exit_status)
         }
-        RedirBody::HereDoc(_) => todo!(),
+        RedirBody::HereDoc(here_doc) => here_doc::open(env, here_doc).await?,
     };
 
     if let Some(fd) = fd_spec.as_fd() {

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -111,6 +111,8 @@ pub enum ErrorCause {
     UnreadableFd(Fd),
     /// `>&` applied to an unwritable file descriptor
     UnwritableFd(Fd),
+    /// Error preparing a temporary file to save here-document content
+    TemporaryFileUnavailable(Errno),
 }
 
 impl ErrorCause {
@@ -126,6 +128,7 @@ impl ErrorCause {
             OpenFile(_, _) => "cannot open the file",
             MalformedFd(_, _) => "not a valid file descriptor",
             UnreadableFd(_) | UnwritableFd(_) => "cannot copy file descriptor",
+            TemporaryFileUnavailable(_) => "cannot prepare here-document",
         }
     }
 
@@ -142,6 +145,7 @@ impl ErrorCause {
             MalformedFd(value, error) => format!("{}: {}", value, error).into(),
             UnreadableFd(fd) => format!("{}: not a readable file descriptor", fd).into(),
             UnwritableFd(fd) => format!("{}: not a writable file descriptor", fd).into(),
+            TemporaryFileUnavailable(errno) => errno.desc().into(),
         }
     }
 }
@@ -164,6 +168,7 @@ impl std::fmt::Display for ErrorCause {
             }
             UnreadableFd(fd) => write!(f, "{} is not a readable file descriptor", fd),
             UnwritableFd(fd) => write!(f, "{} is not a writable file descriptor", fd),
+            TemporaryFileUnavailable(errno) => write!(f, "cannot prepare here-document: {}", errno),
         }
     }
 }

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -47,7 +47,10 @@
 //!
 //! TODO `noclobber` option
 //!
-//! If the body is `HereDoc`, (TODO Elaborate).
+//! If the body is `HereDoc`, the redirection opens a readable file descriptor
+//! that yields [expansion](crate::expansion) of the content. The current
+//! implementation uses an unnamed temporary file for the file descriptor, but
+//! we may change the behavior in the future.
 //!
 //! # Performing redirections
 //!
@@ -339,7 +342,8 @@ async fn open_normal(
         FileInOut => open_file(env, OFlag::O_RDWR | OFlag::O_CREAT, operand),
         FdIn => copy_fd(env, operand, OFlag::O_RDONLY),
         FdOut => copy_fd(env, operand, OFlag::O_WRONLY),
-        _ => todo!(),
+        Pipe => todo!("pipe redirection: {:?}", operand.value),
+        String => todo!("here-string: {:?}", operand.value),
     }
 }
 

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -1,0 +1,115 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Here-documents
+
+use super::Error;
+use super::FdSpec;
+use crate::expansion::expand_text;
+use std::path::Path;
+use yash_env::semantics::ExitStatus;
+use yash_env::Env;
+use yash_env::System;
+use yash_syntax::source::Location;
+use yash_syntax::syntax::HereDoc;
+
+/// Opens a here-document.
+///
+/// This function expands the here-document content to an anonymous temporary
+/// file and returns a file descriptor to the file you can read the content
+/// from.
+#[allow(clippy::await_holding_refcell_ref)]
+pub(super) async fn open(
+    env: &mut Env,
+    here_doc: &HereDoc,
+) -> Result<(FdSpec, Location, Option<ExitStatus>), Error> {
+    let (content, exit_status) = expand_text(env, &here_doc.content.borrow()).await?;
+
+    let fd = env
+        .system
+        .open_tmpfile(Path::new("/tmp"))
+        .expect("todo: handle error");
+
+    env.system
+        .write_all(fd, content.as_bytes())
+        .await
+        .expect("todo: handle error");
+
+    env.system
+        .lseek(fd, std::io::SeekFrom::Start(0))
+        .expect("todo: handle error");
+
+    // TODO Make the file descriptor read-only
+
+    let location = here_doc.delimiter.location.clone();
+    Ok((FdSpec::Owned(fd), location, exit_status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::echo_builtin;
+    use crate::tests::in_virtual_system;
+    use crate::tests::return_builtin;
+    use assert_matches::assert_matches;
+    use futures_util::FutureExt;
+    use std::cell::RefCell;
+    use yash_env::System;
+    use yash_syntax::syntax::Text;
+
+    #[test]
+    fn empty_here_doc() {
+        let mut env = Env::new_virtual();
+        let here_doc = HereDoc {
+            delimiter: "END".parse().unwrap(),
+            remove_tabs: false,
+            content: RefCell::new(Text(vec![])),
+        };
+
+        let (fd_spec, location, exit_status) =
+            open(&mut env, &here_doc).now_or_never().unwrap().unwrap();
+        assert_matches!(fd_spec, FdSpec::Owned(fd) => {
+            let mut buffer = [0; 1];
+            let read_count = env.system.read(fd, &mut buffer).unwrap();
+            assert_eq!(read_count, 0);
+        });
+        assert_eq!(location, here_doc.delimiter.location);
+        assert_eq!(exit_status, None);
+    }
+
+    #[test]
+    fn here_doc_with_command_substitution() {
+        in_virtual_system(|mut env, _pid, _state| async move {
+            env.builtins.insert("echo", echo_builtin());
+            env.builtins.insert("return", return_builtin());
+            let here_doc = HereDoc {
+                delimiter: "EOF".parse().unwrap(),
+                remove_tabs: false,
+                content: RefCell::new("$(echo foo)$(echo bar; return -n 42)\n".parse().unwrap()),
+            };
+
+            let (fd_spec, location, exit_status) = open(&mut env, &here_doc).await.unwrap();
+            assert_matches!(fd_spec, FdSpec::Owned(fd) => {
+                let mut buffer = [0; 8];
+                let read_count = env.system.read(fd, &mut buffer).unwrap();
+                assert_eq!(read_count, 7);
+                assert_eq!(&buffer[..7], b"foobar\n");
+            });
+            assert_eq!(location, here_doc.delimiter.location);
+            assert_eq!(exit_status, Some(ExitStatus(42)));
+        })
+    }
+}

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -48,6 +48,8 @@ pub(super) async fn open(
     let (content, exit_status) = expand_text(env, &here_doc.content.borrow()).await?;
     let location = here_doc.delimiter.location.clone();
 
+    // TODO Use a pipe for short content
+
     let fd = match env.system.open_tmpfile(Path::new("/tmp")) {
         Ok(fd) => fd,
         Err(errno) => {

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -841,8 +841,10 @@ pub struct HereDoc {
 
     /// Content of the here-document.
     ///
-    /// The content ends with a newline unless it is empty. If the delimiter
-    /// is quoted, the content must be all literal.
+    /// The content ends with a newline unless it is empty. If the delimiter is
+    /// quoted, the content must be all literal. If `remove_tabs` is `true`,
+    /// each content line does not start with tabs as they are removed when
+    /// parsed.
     ///
     /// This value is wrapped in `RefCell` because the here-doc content is
     /// parsed separately from the here-doc operator. When the operator is


### PR DESCRIPTION
- [x] Add `/tmp` in default virtual system
- [x] Add `System::lseek`
- [x] Open a file descriptor to a temporary file
- [x] Expand here-document contents
- [x] Write here-document contents to the temporary file
- [x] Rewind the temporary file's open file description
- [x] ~~Implement~~ (or add todo on) here-string
- [x] Extend documentation
    - Todo about optimization using a pipe
