### PR TITLE
Most semantics of parameter expansion switches

### DIFF
--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -80,6 +80,7 @@ use self::attr_strip::Strip;
 use self::glob::glob;
 use self::initial::expand;
 use self::initial::ArithError;
+use self::initial::EmptyError;
 #[cfg(doc)]
 use self::initial::Expand;
 use self::quote_removal::skip_quotes;
@@ -108,6 +109,8 @@ pub enum ErrorCause {
     ArithError(ArithError),
     /// Assignment to a read-only variable.
     AssignReadOnly(ReadOnlyError),
+    /// Expansion of an empty value with an error switch
+    EmptyExpansion(EmptyError),
 }
 
 impl ErrorCause {
@@ -120,6 +123,7 @@ impl ErrorCause {
             CommandSubstError(_) => "error performing the command substitution",
             ArithError(_) => "error evaluating the arithmetic expansion",
             AssignReadOnly(_) => "cannot assign to read-only variable",
+            EmptyExpansion(_) => "parameter expansion with empty value",
         }
     }
 
@@ -132,6 +136,7 @@ impl ErrorCause {
             CommandSubstError(e) => e.desc().into(),
             ArithError(e) => e.to_string().into(),
             AssignReadOnly(e) => e.to_string().into(),
+            EmptyExpansion(e) => e.state.description().into(),
         }
     }
 
@@ -148,6 +153,7 @@ impl ErrorCause {
                 &e.read_only_location,
                 "the variable was made read-only here",
             )),
+            EmptyExpansion(_) => None,
         }
     }
 }
@@ -159,6 +165,7 @@ impl std::fmt::Display for ErrorCause {
             CommandSubstError(errno) => write!(f, "error in command substitution: {errno}"),
             ArithError(error) => error.fmt(f),
             AssignReadOnly(error) => error.fmt(f),
+            EmptyExpansion(error) => error.fmt(f),
         }
     }
 }

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -123,7 +123,7 @@ impl ErrorCause {
             CommandSubstError(_) => "error performing the command substitution",
             ArithError(_) => "error evaluating the arithmetic expansion",
             AssignReadOnly(_) => "cannot assign to read-only variable",
-            EmptyExpansion(_) => "parameter expansion with empty value",
+            EmptyExpansion(error) => error.message_or_default(),
         }
     }
 

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -78,7 +78,9 @@ use self::attr::AttrField;
 use self::attr::Origin;
 use self::attr_strip::Strip;
 use self::glob::glob;
+use self::initial::expand;
 use self::initial::ArithError;
+#[cfg(doc)]
 use self::initial::Expand;
 use self::quote_removal::skip_quotes;
 use self::split::Ifs;
@@ -214,13 +216,7 @@ pub async fn expand_text(
     // It would be technically correct to set `will_split` to false, but it does
     // not affect the final results because we will join the results anyway.
     // env.will_split = false;
-
-    use self::initial::QuickExpand::*;
-    let phrase = match text.quick_expand(&mut env) {
-        Ready(result) => result?,
-        Interim(interim) => text.async_expand(&mut env, interim).await?,
-    };
-
+    let phrase = expand(&mut env, text).await?;
     let chars = phrase.ifs_join(&env.inner.variables);
     let result = skip_quotes(chars).strip().collect();
     Ok((result, env.last_command_subst_exit_status))
@@ -242,13 +238,7 @@ pub async fn expand_word_attr(
     // It would be technically correct to set `will_split` to false, but it does
     // not affect the final results because we will join the results anyway.
     // env.will_split = false;
-
-    use self::initial::QuickExpand::*;
-    let phrase = match word.quick_expand(&mut env) {
-        Ready(result) => result?,
-        Interim(interim) => word.async_expand(&mut env, interim).await?,
-    };
-
+    let phrase = expand(&mut env, word).await?;
     let chars = phrase.ifs_join(&env.inner.variables);
     let origin = word.location.clone();
     let field = AttrField { chars, origin };
@@ -292,11 +282,7 @@ pub async fn expand_words<'a, I: IntoIterator<Item = &'a Word>>(
     let words = words.into_iter();
     let mut fields = Vec::with_capacity(words.size_hint().0);
     for word in words {
-        use self::initial::QuickExpand::*;
-        let phrase = match word.quick_expand(&mut env) {
-            Ready(result) => result?,
-            Interim(interim) => word.async_expand(&mut env, interim).await?,
-        };
+        let phrase = expand(&mut env, word).await?;
         fields.extend(phrase.into_iter().map(|chars| AttrField {
             chars,
             origin: word.location.clone(),

--- a/yash-semantics/src/expansion/initial.rs
+++ b/yash-semantics/src/expansion/initial.rs
@@ -131,3 +131,5 @@ mod tilde;
 mod word;
 
 pub use arith::ArithError;
+pub use param::EmptyError;
+pub use param::ValueState;

--- a/yash-semantics/src/expansion/initial.rs
+++ b/yash-semantics/src/expansion/initial.rs
@@ -111,6 +111,17 @@ pub trait Expand {
     ) -> Result<Phrase, Error>;
 }
 
+/// Performs initial expansion.
+///
+/// This is a convenience function that calls [`Expand`]'s methods to obtain an
+/// expansion result.
+pub async fn expand<E: Expand>(env: &mut Env<'_>, e: &E) -> Result<Phrase, Error> {
+    match e.quick_expand(env) {
+        QuickExpand::Ready(result) => result,
+        QuickExpand::Interim(interim) => e.async_expand(env, interim).await,
+    }
+}
+
 mod arith;
 mod command_subst;
 mod param;

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -47,6 +47,9 @@ impl<'a> From<&'a Param> for ParamRef<'a> {
 mod lookup;
 mod switch;
 
+pub use switch::EmptyError;
+pub use switch::ValueState;
+
 impl ParamRef<'_> {
     /// Performs parameter expansion.
     pub async fn expand(&self, env: &mut Env<'_>) -> Result<Phrase, Error> {

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -67,7 +67,9 @@ impl ParamRef<'_> {
 
         // Switch //
         if let Modifier::Switch(switch) = &self.modifier {
-            if let Some(result) = switch::apply(env, switch, &mut value, self.location).await {
+            if let Some(result) =
+                switch::apply(env, switch, self.name, &mut value, self.location).await
+            {
                 return result;
             }
         }

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -67,7 +67,7 @@ impl ParamRef<'_> {
 
         // Switch //
         if let Modifier::Switch(switch) = &self.modifier {
-            if let Some(result) = switch::apply(env, switch, &mut value).await {
+            if let Some(result) = switch::apply(env, switch, &mut value, self.location).await {
                 return result;
             }
         }

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -53,6 +53,10 @@ impl ValueState {
 }
 
 /// Modifies the origin of characters in the phrase to `SoftExpansion`.
+///
+/// This function updates the result of [`expand`]. Since the switch modifier is
+/// part of a parameter expansion, the substitution produced by the switch
+/// should be regarded as originating from a parameter expansion.
 fn attribute(mut phrase: Phrase) -> Phrase {
     phrase.for_each_char_mut(|c| match c.origin {
         Origin::Literal => c.origin = Origin::SoftExpansion,

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -1,0 +1,165 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Parameter expansion switch semantics
+
+use super::Env;
+use super::Error;
+use super::Phrase;
+use crate::expansion::attr::Origin;
+use crate::expansion::initial::expand;
+use yash_env::variable::Value;
+use yash_syntax::syntax::Switch;
+use yash_syntax::syntax::SwitchCondition;
+use yash_syntax::syntax::SwitchType;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum ValueState {
+    Set,
+    Unset,
+}
+
+impl ValueState {
+    fn with(_cond: SwitchCondition, value: &Option<Value>) -> Self {
+        // TODO Apply the condition
+        match value {
+            Some(_) => ValueState::Set,
+            None => ValueState::Unset,
+        }
+    }
+}
+
+/// Modifies the origin of characters in the phrase to `SoftExpansion`.
+fn attribute(mut phrase: Phrase) -> Phrase {
+    phrase.for_each_char_mut(|c| match c.origin {
+        Origin::Literal => c.origin = Origin::SoftExpansion,
+        Origin::HardExpansion | Origin::SoftExpansion => (),
+    });
+    phrase
+}
+
+/// Applies a switch.
+///
+/// If this function returns `Some(_)`, that should be the result of the whole
+/// parameter expansion containing the switch. Otherwise, the parameter
+/// expansion should continue processing other modifiers.
+pub async fn apply(
+    env: &mut Env<'_>,
+    switch: &Switch,
+    value: &mut Option<Value>,
+) -> Option<Result<Phrase, Error>> {
+    use SwitchType::*;
+    use ValueState::*;
+    match (switch.r#type, ValueState::with(switch.condition, value)) {
+        (Alter, Set) => Some(expand(env, &switch.word).await.map(attribute)),
+        (Alter, Unset) => None,
+        (Default, Set) => todo!(),
+        (Default, Unset) => todo!(),
+        (Assign, Set) => todo!(),
+        (Assign, Unset) => todo!(),
+        (Error, Set) => todo!(),
+        (Error, Unset) => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::to_field;
+    use super::*;
+    use crate::expansion::attr::AttrChar;
+    use futures_util::FutureExt;
+    use yash_env::variable::Value::*;
+    use yash_syntax::syntax::SwitchCondition::*;
+    use yash_syntax::syntax::SwitchType::*;
+
+    #[test]
+    fn attributing() {
+        let phrase = Phrase::Field(vec![
+            AttrChar {
+                value: 'a',
+                origin: Origin::Literal,
+                is_quoted: false,
+                is_quoting: false,
+            },
+            AttrChar {
+                value: 'b',
+                origin: Origin::SoftExpansion,
+                is_quoted: false,
+                is_quoting: false,
+            },
+            AttrChar {
+                value: 'c',
+                origin: Origin::HardExpansion,
+                is_quoted: false,
+                is_quoting: false,
+            },
+        ]);
+
+        let phrase = attribute(phrase);
+        assert_eq!(
+            phrase,
+            Phrase::Field(vec![
+                AttrChar {
+                    value: 'a',
+                    origin: Origin::SoftExpansion,
+                    is_quoted: false,
+                    is_quoting: false,
+                },
+                AttrChar {
+                    value: 'b',
+                    origin: Origin::SoftExpansion,
+                    is_quoted: false,
+                    is_quoting: false,
+                },
+                AttrChar {
+                    value: 'c',
+                    origin: Origin::HardExpansion,
+                    is_quoted: false,
+                    is_quoting: false,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn alter_unset() {
+        let mut env = yash_env::Env::new_virtual();
+        let mut env = Env::new(&mut env);
+        let switch = Switch {
+            r#type: Alter,
+            condition: Unset,
+            word: "foo".parse().unwrap(),
+        };
+        let mut value = None;
+        let result = apply(&mut env, &switch, &mut value).now_or_never().unwrap();
+        assert_eq!(result, None);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn alter_non_empty() {
+        let mut env = yash_env::Env::new_virtual();
+        let mut env = Env::new(&mut env);
+        let switch = Switch {
+            r#type: Alter,
+            condition: Unset,
+            word: "foo".parse().unwrap(),
+        };
+        let mut value = Some(Scalar("bar".to_string()));
+        let result = apply(&mut env, &switch, &mut value).now_or_never().unwrap();
+        assert_eq!(result, Some(Ok(Phrase::Field(to_field("foo")))));
+    }
+}

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -19,6 +19,7 @@
 use super::super::attr::AttrChar;
 use super::super::attr::Origin;
 use super::super::Error;
+use super::expand;
 use super::Env;
 use super::Expand;
 use super::Phrase;
@@ -119,10 +120,7 @@ impl Expand for WordUnit {
             SingleQuote(_value) => unimplemented!("async_expand not expecting SingleQuote"),
             DoubleQuote(text) => {
                 let would_split = std::mem::replace(&mut env.will_split, false);
-                let result = match text.quick_expand(env) {
-                    Ready(result) => result,
-                    Interim(interim) => text.async_expand(env, interim).await,
-                };
+                let result = expand(env, text).await;
                 env.will_split = would_split;
 
                 let mut phrase = result?;

--- a/yash-semantics/src/expansion/phrase.rs
+++ b/yash-semantics/src/expansion/phrase.rs
@@ -296,6 +296,18 @@ impl Phrase {
             },
         }
     }
+
+    /// Applies a function to every character in the phrase.
+    pub fn for_each_char_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut AttrChar),
+    {
+        match self {
+            Char(c) => f(c),
+            Field(field) => field.iter_mut().for_each(f),
+            Full(fields) => fields.iter_mut().flatten().for_each(f),
+        }
+    }
 }
 
 impl From<AttrChar> for Phrase {


### PR DESCRIPTION
This PR implements the semantics of parameter expansion switches.

To-dos not addressed in this PR:
- Rejecting assignment to a non-assignable parameter as in `${1:=foo}`
- Assignment to an array as in `${a[1]:=foo}`