### PR TITLE
Special built-in treatments

### DIFF
--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -193,6 +193,7 @@ mod tests {
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -212,6 +213,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -233,6 +235,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -254,6 +257,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["1"]);
 
@@ -276,6 +280,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["3"]);
 
@@ -299,6 +304,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["5"]);
 
@@ -319,6 +325,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["0"]);
 
@@ -338,6 +345,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["999999999999999999999999999999"]);
 
@@ -355,6 +363,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["1", "1"]);
 
@@ -374,6 +383,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("break"),
+            is_special: true,
         });
         let args = Field::dummies(["--", "1"]);
 

--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -74,7 +74,7 @@
 use crate::common::arg::parse_arguments;
 use crate::common::arg::Mode;
 use crate::common::print_error_message;
-use crate::common::BuiltinName;
+use crate::common::BuiltinEnv;
 use std::future::Future;
 use std::num::ParseIntError;
 use std::ops::ControlFlow::Break;

--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -95,8 +95,7 @@ async fn handle_error(env: &mut Env, title: &str, annotation: Annotation<'_>) ->
         title: title.into(),
         annotations: vec![annotation],
     };
-    print_error_message(env, message).await;
-    (ExitStatus::ERROR, Break(Divert::Interrupt(None)))
+    print_error_message(env, message).await
 }
 
 async fn syntax_error(env: &mut Env, label: &str, location: &Location) -> Result {

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -172,18 +172,14 @@ impl<T: BuiltinEnv + Stdout + Stderr> Print for T {
     }
 }
 
-/// Prints an error message.
+/// Prints a message.
 ///
 /// This function prepares a [`Message`] from the given error, inserts into it
 /// an annotation indicating the [built-in name](BuiltinEnv::builtin_name), and
 /// prints it to the standard error using [`yash_env::io::print_message`].
 ///
-/// Returns `(ExitStatus::ERROR, env.builtin_error())`.
-/// (cf. [`BuiltinEnv::builtin_error`])
-pub async fn print_error_message<'a, E, F>(
-    env: &mut E,
-    error: F,
-) -> (ExitStatus, yash_env::semantics::Result)
+/// Returns [`env.builtin_error()`](BuiltinEnv::builtin_error).
+pub async fn print_message<'a, E, F>(env: &mut E, error: F) -> yash_env::semantics::Result
 where
     E: BuiltinEnv + Stderr,
     F: Into<Message<'a>> + 'a,
@@ -203,7 +199,41 @@ where
 
     yash_env::io::print_message(env, message).await;
 
-    (ExitStatus::ERROR, env.builtin_error())
+    env.builtin_error()
+}
+
+/// Prints a failure message.
+///
+/// This function returns
+/// `(ExitStatus::FAILURE, print_message(env, error).await)`.
+/// See [`print_message`] for details.
+#[inline]
+pub async fn print_failure_message<'a, E, F>(
+    env: &mut E,
+    error: F,
+) -> (ExitStatus, yash_env::semantics::Result)
+where
+    E: BuiltinEnv + Stderr,
+    F: Into<Message<'a>> + 'a,
+{
+    (ExitStatus::FAILURE, print_message(env, error).await)
+}
+
+/// Prints an error message.
+///
+/// This function returns
+/// `(ExitStatus::ERROR, print_message(env, error).await)`.
+/// See [`print_message`] for details.
+#[inline]
+pub async fn print_error_message<'a, E, F>(
+    env: &mut E,
+    error: F,
+) -> (ExitStatus, yash_env::semantics::Result)
+where
+    E: BuiltinEnv + Stderr,
+    F: Into<Message<'a>> + 'a,
+{
+    (ExitStatus::ERROR, print_message(env, error).await)
 }
 
 #[cfg(test)]

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -178,7 +178,8 @@ impl<T: BuiltinEnv + Stdout + Stderr> Print for T {
 /// an annotation indicating the [built-in name](BuiltinEnv::builtin_name), and
 /// prints it to the standard error using [`yash_env::io::print_message`].
 ///
-/// Returns `(ExitStatus::ERROR, ControlFlow::Continue(()))`.
+/// Returns `(ExitStatus::ERROR, env.builtin_error())`.
+/// (cf. [`BuiltinEnv::builtin_error`])
 pub async fn print_error_message<'a, E, F>(
     env: &mut E,
     error: F,
@@ -202,7 +203,7 @@ where
 
     yash_env::io::print_message(env, message).await;
 
-    (ExitStatus::ERROR, Continue(()))
+    (ExitStatus::ERROR, env.builtin_error())
 }
 
 #[cfg(test)]

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -52,7 +52,7 @@ impl BuiltinName for Stack {
     fn builtin_name(&self) -> &Field {
         self.iter()
             .filter_map(|frame| {
-                if let &Frame::Builtin { ref name } = frame {
+                if let &Frame::Builtin { ref name, .. } = frame {
                     Some(name)
                 } else {
                     None
@@ -167,7 +167,8 @@ mod tests {
     #[test]
     fn builtin_name_in_stack() {
         let name = Field::dummy("my built-in");
-        let stack = Stack::from(vec![Frame::Builtin { name }]);
+        let is_special = false;
+        let stack = Stack::from(vec![Frame::Builtin { name, is_special }]);
         // TODO Test with a stack containing a frame other than Frame::Builtin
         assert_eq!(stack.builtin_name().value, "my built-in");
     }

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -101,6 +101,7 @@ mod tests {
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -120,6 +121,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -141,6 +143,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
@@ -162,6 +165,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["1"]);
 
@@ -184,6 +188,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["3"]);
 
@@ -207,6 +212,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["5"]);
 
@@ -227,6 +233,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["0"]);
 
@@ -246,6 +253,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["999999999999999999999999999999"]);
 
@@ -263,6 +271,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["1", "1"]);
 
@@ -282,6 +291,7 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("continue"),
+            is_special: true,
         });
         let args = Field::dummies(["--", "1"]);
 

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -83,6 +83,7 @@ use crate::common::arg::parse_arguments;
 use crate::common::arg::Mode;
 use crate::common::arg::OptionSpec;
 use crate::common::print_error_message;
+use crate::common::print_failure_message;
 use crate::common::Print;
 use std::fmt::Write;
 use std::future::Future;
@@ -198,8 +199,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
             match job_id.find(&env.jobs) {
                 Ok(index) => accumulator.report(index, &env.jobs[index]),
                 Err(error) => {
-                    print_error_message(env, find_error_message(error, &operand)).await;
-                    return (ExitStatus::FAILURE, Continue(()));
+                    return print_failure_message(env, find_error_message(error, &operand)).await
                 }
             }
         }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -409,6 +409,7 @@ mod tests {
         let args = Field::dummies(["%2"]);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("jobs"),
+            is_special: false,
         });
         let result = builtin_body(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::FAILURE, Continue(())));
@@ -435,6 +436,7 @@ mod tests {
         let args = Field::dummies(["%?first", "%echo"]);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("jobs"),
+            is_special: false,
         });
         let result = builtin_body(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::FAILURE, Continue(())));
@@ -457,6 +459,7 @@ mod tests {
 
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("jobs"),
+            is_special: false,
         });
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::FAILURE, Continue(())));
@@ -493,6 +496,7 @@ mod tests {
 
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("jobs"),
+            is_special: false,
         });
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, (ExitStatus::FAILURE, Continue(())));

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -87,7 +87,6 @@ use crate::common::print_failure_message;
 use crate::common::Print;
 use std::fmt::Write;
 use std::future::Future;
-use std::ops::ControlFlow::Continue;
 use std::pin::Pin;
 use yash_env::builtin::Result;
 use yash_env::job::id::parse;
@@ -205,9 +204,9 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
         }
     }
 
-    let exit_status = env.print(&accumulator.print).await;
+    let result = env.print(&accumulator.print).await;
 
-    if exit_status == ExitStatus::SUCCESS {
+    if result.0 == ExitStatus::SUCCESS {
         for index in accumulator.indices_reported {
             let mut job = env.jobs.get_mut(index).unwrap();
             if job.status.is_finished() {
@@ -218,7 +217,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
         }
     }
 
-    (exit_status, Continue(()))
+    result
 }
 
 /// Wrapper of [`builtin_body`] that returns the future in a pinned box.
@@ -233,6 +232,7 @@ mod tests {
     use crate::tests::assert_stdout;
     use assert_matches::assert_matches;
     use futures_util::future::FutureExt;
+    use std::ops::ControlFlow::Continue;
     use std::rc::Rc;
     use yash_env::io::Fd;
     use yash_env::job::Job;

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -354,8 +354,9 @@ xtrace           off
     fn setting_some_positional_parameters() {
         let name = Field::dummy("set");
         let location = name.origin.clone();
+        let is_special = true;
         let mut env = Env::new_virtual();
-        let mut env = env.push_frame(Frame::Builtin { name });
+        let mut env = env.push_frame(Frame::Builtin { name, is_special });
         let args = Field::dummies(["a", "b", "z"]);
 
         let result = builtin_body(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -121,7 +121,7 @@
 //! place of an option-operand separator. This behavior is not portable either.
 
 use crate::common::print_error_message;
-use crate::common::BuiltinName;
+use crate::common::BuiltinEnv;
 use crate::common::Print;
 use std::fmt::Write;
 use std::future::Future;

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -156,7 +156,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
                 // TODO skip if the name contains a character inappropriate for a name
                 writeln!(print, "{}={}", name, var.value.quote()).unwrap();
             }
-            (env.print(&print).await, Continue(()))
+            env.print(&print).await
         }
 
         Ok(arg::Parse::PrintOptionsHumanReadable) => {
@@ -165,7 +165,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
                 let state = env.options.get(option);
                 writeln!(print, "{option:16} {state}").unwrap();
             }
-            (env.print(&print).await, Continue(()))
+            env.print(&print).await
         }
 
         Ok(arg::Parse::PrintOptionsMachineReadable) => {
@@ -178,7 +178,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
                 };
                 writeln!(print, "{skip}set {flag}o {option}").unwrap();
             }
-            (env.print(&print).await, Continue(()))
+            env.print(&print).await
         }
 
         Ok(arg::Parse::Modify {

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -214,6 +214,7 @@ mod tests {
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("trap"),
+            is_special: true,
         });
         let args = Field::dummies(["echo", "INT"]);
         let _ = builtin_body(&mut *env, args).now_or_never().unwrap();

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -50,7 +50,7 @@ pub async fn print_traps(env: &mut Env) -> Result {
         let signal = &signal.as_str()[3..];
         writeln!(output, "trap -- {} {}", &quote(command), signal).ok();
     }
-    (env.print(&output).await, Continue(()))
+    env.print(&output).await
 }
 
 /// Implementation of the trap built-in.
@@ -109,8 +109,10 @@ mod tests {
     use crate::tests::assert_stdout;
     use futures_executor::block_on;
     use futures_util::future::FutureExt;
+    use std::ops::ControlFlow::Break;
     use std::rc::Rc;
     use yash_env::io::Fd;
+    use yash_env::semantics::Divert;
     use yash_env::stack::Frame;
     use yash_env::system::SignalHandling;
     use yash_env::trap::Signal;
@@ -220,7 +222,10 @@ mod tests {
         let _ = builtin_body(&mut *env, args).now_or_never().unwrap();
 
         let result = block_on(builtin_body(&mut *env, vec![]));
-        assert_eq!(result, (ExitStatus::FAILURE, Continue(())));
+        assert_eq!(
+            result,
+            (ExitStatus::FAILURE, Break(Divert::Interrupt(None)))
+        );
         assert_stderr(&state, |stderr| assert_ne!(stderr, ""));
     }
 

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -409,6 +409,7 @@ mod tests {
         let mut env = Env::with_system(Box::new(system));
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("wait"),
+            is_special: false,
         });
         let args = Field::dummies(["abc"]);
 
@@ -424,6 +425,7 @@ mod tests {
         let mut env = Env::with_system(Box::new(system));
         let mut env = env.push_frame(Frame::Builtin {
             name: Field::dummy("wait"),
+            is_special: false,
         });
         let args = Field::dummies(["0"]);
 

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -40,13 +40,23 @@ use std::ops::DerefMut;
 pub enum Frame {
     /// For, while, or until loop
     Loop,
+
     /// Subshell
     Subshell,
+
     /// Built-in utility
     Builtin {
         /// Name of the built-in
         name: Field,
+
+        /// Whether the utility acts as a special built-in
+        ///
+        /// This value determines whether an error in the built-in interrupts
+        /// the shell. This will be false if a special built-in is executed
+        /// through the `command` built-in.
+        is_special: bool,
     },
+
     /// Trap
     Trap,
     // TODO dot script, eval
@@ -214,6 +224,7 @@ mod tests {
         let mut stack = Stack::default();
         let mut stack = stack.push(Frame::Builtin {
             name: Field::dummy(""),
+            is_special: false,
         });
         assert_eq!(stack.loop_count(usize::MAX), 0);
         let stack = stack.push(Frame::Trap);


### PR DESCRIPTION
Implements part of #204.

- [x] Add `Frame::Builtin::is_special`
- [x] Add `BuiltinEnv::is_executing_special_builtin` (`BuiltinEnv` renamed from `BuiltinName`)
- [x] Add ~~`BuiltinEnv::interrupt_if_executing_special_builtin`~~ `BuiltinEnv::builtin_error`
- [x] Use `BuiltinEnv::builtin_error` in `print_error_message`
- [x] Interrupt on special built-in utility error (only if the topmost frame `is_special`)