### PR TITLE
Implement errexit option

### DIFF
--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -50,9 +50,10 @@ use self::job::JobSet;
 use self::job::Pid;
 use self::job::WaitStatus;
 use self::job::WaitStatusEx;
-use self::option::AllExport;
 use self::option::OptionSet;
+use self::option::{AllExport, ErrExit};
 use self::option::{Off, On};
+use self::semantics::Divert;
 use self::semantics::ExitStatus;
 use self::stack::Frame;
 use self::stack::Stack;
@@ -73,7 +74,7 @@ use futures_util::task::noop_waker_ref;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
-use std::ops::ControlFlow::{Break, Continue};
+use std::ops::ControlFlow::{self, Break, Continue};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Context;
@@ -433,6 +434,20 @@ impl Env {
         };
         self.variables.assign(scope, name, value)
     }
+
+    /// Returns a `Divert` if the `ErrExit` [shell option](self::option::Option) is on.
+    ///
+    /// This function should be called when a command failed for some reasons.
+    /// The function returns `Break(Divert::Exit)` if the `ErrExit` option is on
+    /// and the current stack has no `Condition` [frame](Frame); otherwise,
+    /// `Continue(())`.
+    pub fn apply_errexit(&self) -> ControlFlow<Divert> {
+        if self.options.get(ErrExit) == Off || self.stack.contains(&Frame::Condition) {
+            Continue(())
+        } else {
+            Break(Divert::Exit(None))
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -459,7 +474,6 @@ mod tests {
     use futures_util::task::LocalSpawnExt;
     use std::cell::Cell;
     use std::cell::RefCell;
-    use std::ops::ControlFlow::Continue;
     use yash_syntax::source::Location;
 
     /// Helper function to perform a test in a virtual system with an executor.
@@ -790,5 +804,26 @@ mod tests {
 
         assert_eq!(env.variables.get("a").unwrap(), &a.export());
         assert_eq!(env.variables.get("b").unwrap(), &b);
+    }
+
+    #[test]
+    fn errexit_on() {
+        let mut env = Env::new_virtual();
+        env.options.set(ErrExit, On);
+        assert_eq!(env.apply_errexit(), Break(Divert::Exit(None)));
+    }
+
+    #[test]
+    fn errexit_in_condition() {
+        let mut env = Env::new_virtual();
+        env.options.set(ErrExit, On);
+        let env = env.push_frame(Frame::Condition);
+        assert_eq!(env.apply_errexit(), Continue(()));
+    }
+
+    #[test]
+    fn errexit_off() {
+        let env = Env::new_virtual();
+        assert_eq!(env.apply_errexit(), Continue(()));
     }
 }

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -44,6 +44,12 @@ pub enum Frame {
     /// Subshell
     Subshell,
 
+    /// Context where the `ErrExit` [option](crate::option::Option) is ignored
+    ///
+    /// This frame is pushed when executing negated commands, the condition part
+    /// of and-or lists and the `if`, `while`, and `until` commands.
+    Condition,
+
     /// Built-in utility
     Builtin {
         /// Name of the built-in

--- a/yash-semantics/src/command_impl/and_or_list.rs
+++ b/yash-semantics/src/command_impl/and_or_list.rs
@@ -20,8 +20,11 @@ use super::Command;
 use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
 use yash_env::semantics::Result;
+use yash_env::stack::Frame;
 use yash_env::Env;
+use yash_syntax::syntax::AndOr::{self, AndThen, OrElse};
 use yash_syntax::syntax::AndOrList;
+use yash_syntax::syntax::Pipeline;
 
 /// Executes the and-or list.
 ///
@@ -33,21 +36,49 @@ use yash_syntax::syntax::AndOrList;
 ///
 /// The exit status of the and-or list will be that of the last executed
 /// pipeline.
+///
+/// [`Frame::Condition`] is pushed to the environment's stack while the
+/// execution of the pipelines except for the last.
 #[async_trait(?Send)]
 impl Command for AndOrList {
     async fn execute(&self, env: &mut Env) -> Result {
-        use yash_syntax::syntax::AndOr::*;
-        self.first.execute(env).await?;
-        for (and_or, pipeline) in &self.rest {
-            let success = env.exit_status.is_successful();
-            let run = match and_or {
-                AndThen => success,
-                OrElse => !success,
-            };
-            if run {
-                pipeline.execute(env).await?;
-            }
+        if self.rest.is_empty() {
+            return self.first.execute(env).await;
         }
+
+        // Execute `first`
+        let mut env2 = env.push_frame(Frame::Condition);
+        self.first.execute(&mut env2).await?;
+
+        // Execute `rest` but last
+        let mut i = self.rest.iter().peekable();
+        let mut pipeline;
+        loop {
+            pipeline = i.next().unwrap();
+            if i.peek().is_none() {
+                break;
+            }
+            execute_conditional_pipeline(&mut env2, pipeline).await?;
+        }
+        drop(env2);
+
+        // Execute last
+        execute_conditional_pipeline(env, pipeline).await
+    }
+}
+
+async fn execute_conditional_pipeline(
+    env: &mut Env,
+    (and_or, pipeline): &(AndOr, Pipeline),
+) -> Result {
+    let success = env.exit_status.is_successful();
+    let run = match and_or {
+        AndThen => success,
+        OrElse => !success,
+    };
+    if run {
+        pipeline.execute(env).await
+    } else {
         Continue(())
     }
 }
@@ -58,11 +89,17 @@ mod tests {
     use crate::tests::assert_stdout;
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
+    use assert_matches::assert_matches;
     use futures_executor::block_on;
-    use std::ops::ControlFlow::Break;
+    use std::future::Future;
+    use std::ops::ControlFlow::{self, Break};
+    use std::pin::Pin;
     use std::rc::Rc;
+    use yash_env::builtin::Builtin;
+    use yash_env::builtin::Type::Special;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
+    use yash_env::semantics::Field;
     use yash_env::VirtualSystem;
 
     #[test]
@@ -256,5 +293,54 @@ mod tests {
         let result = block_on(list.execute(&mut env));
         assert_eq!(result, Break(Divert::Return));
         assert_eq!(env.exit_status, ExitStatus(0));
+    }
+
+    #[test]
+    fn stack_in_list() {
+        fn stub_builtin_condition(
+            env: &mut Env,
+            _args: Vec<Field>,
+        ) -> Pin<Box<dyn Future<Output = (ExitStatus, ControlFlow<Divert>)> + '_>> {
+            Box::pin(async move {
+                assert_matches!(
+                    env.stack.as_slice(),
+                    [Frame::Condition, Frame::Builtin { .. }]
+                );
+                (ExitStatus::SUCCESS, Continue(()))
+            })
+        }
+        fn stub_builtin_no_condition(
+            env: &mut Env,
+            _args: Vec<Field>,
+        ) -> Pin<Box<dyn Future<Output = (ExitStatus, ControlFlow<Divert>)> + '_>> {
+            Box::pin(async move {
+                assert_matches!(env.stack.as_slice(), [Frame::Builtin { .. }]);
+                (ExitStatus::SUCCESS, Continue(()))
+            })
+        }
+
+        let mut env = Env::new_virtual();
+        env.builtins.insert(
+            "head",
+            Builtin {
+                r#type: Special,
+                execute: stub_builtin_condition,
+            },
+        );
+        env.builtins.insert(
+            "tail",
+            Builtin {
+                r#type: Special,
+                execute: stub_builtin_no_condition,
+            },
+        );
+
+        let list: AndOrList = "tail".parse().unwrap();
+        let result = block_on(list.execute(&mut env));
+        assert_eq!(result, Continue(()));
+
+        let list: AndOrList = "head && head && tail".parse().unwrap();
+        let result = block_on(list.execute(&mut env));
+        assert_eq!(result, Continue(()));
     }
 }

--- a/yash-semantics/src/command_impl/and_or_list.rs
+++ b/yash-semantics/src/command_impl/and_or_list.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
     use assert_matches::assert_matches;
-    use futures_executor::block_on;
+    use futures_util::FutureExt;
     use std::future::Future;
     use std::ops::ControlFlow::{self, Break};
     use std::pin::Pin;
@@ -107,7 +107,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 36".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(36));
     }
@@ -120,7 +120,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         let list: AndOrList = "echo one && echo two".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         assert_stdout(&state, |stdout| assert_eq!(stdout, "one\ntwo\n"));
@@ -131,7 +131,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 0 && return -n 5".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(5));
     }
@@ -145,7 +145,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 1 && echo !".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(1));
         assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
@@ -159,7 +159,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         let list: AndOrList = "echo 1 && echo 2 && echo 3".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         assert_stdout(&state, |stdout| assert_eq!(stdout, "1\n2\n3\n"));
@@ -174,7 +174,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 0 && return -n 2 && echo !".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(2));
         assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
@@ -185,7 +185,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 8 && X || return -n 0".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(0));
     }
@@ -199,7 +199,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "echo + || return -n 100".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         assert_stdout(&state, |stdout| assert_eq!(stdout, "+\n"));
@@ -216,7 +216,7 @@ mod tests {
             .parse()
             .unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         assert_stdout(&state, |stdout| assert_eq!(stdout, "one\ntwo\n"));
@@ -233,7 +233,7 @@ mod tests {
             .parse()
             .unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(2));
         assert_stdout(&state, |stdout| assert_eq!(stdout, "one\ntwo\n"));
@@ -245,7 +245,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 1 || return -n 2 || return -n 3".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(3));
     }
@@ -259,7 +259,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 3 || echo + || return -n 4".parse().unwrap();
 
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         assert_stdout(&state, |stdout| assert_eq!(stdout, "+\n"));
@@ -270,7 +270,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 0 || X && return -n 9".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(9));
     }
@@ -280,7 +280,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return 97".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Break(Divert::Return));
         assert_eq!(env.exit_status, ExitStatus(97));
     }
@@ -290,7 +290,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 7 || return 0 && X".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Break(Divert::Return));
         assert_eq!(env.exit_status, ExitStatus(0));
     }
@@ -336,11 +336,11 @@ mod tests {
         );
 
         let list: AndOrList = "tail".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
 
         let list: AndOrList = "head && head && tail".parse().unwrap();
-        let result = block_on(list.execute(&mut env));
+        let result = list.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
     }
 }

--- a/yash-semantics/src/command_impl/compound_command.rs
+++ b/yash-semantics/src/command_impl/compound_command.rs
@@ -63,6 +63,8 @@ impl Command for syntax::FullCompoundCommand {
 /// A subshell is executed by running the contained list in a
 /// [subshell](Env::run_in_subshell).
 ///
+/// After the subshell has finished, [`Env::apply_errexit`] is called.
+///
 /// # For loop
 ///
 /// Executing a for loop starts with expanding the `name` and `values`. If

--- a/yash-semantics/src/command_impl/compound_command.rs
+++ b/yash-semantics/src/command_impl/compound_command.rs
@@ -16,19 +16,27 @@
 
 //! Implementation of the compound command semantics.
 
+use super::Command;
+use crate::redir::RedirGuard;
+use crate::Handle;
+use async_trait::async_trait;
+use std::ops::ControlFlow::Continue;
+use yash_env::semantics::ExitStatus;
+use yash_env::semantics::Result;
+use yash_env::Env;
+use yash_syntax::syntax;
+
+/// Executes the condition of an if/while/until command.
+async fn evaluate_condition(env: &mut Env, condition: &syntax::List) -> Result<bool> {
+    condition.execute(env).await?;
+    Continue(env.exit_status == ExitStatus::SUCCESS)
+}
+
 mod case;
 mod for_loop;
 mod r#if;
 mod subshell;
 mod while_loop;
-
-use super::Command;
-use crate::redir::RedirGuard;
-use crate::Handle;
-use async_trait::async_trait;
-use yash_env::semantics::Result;
-use yash_env::Env;
-use yash_syntax::syntax;
 
 /// Executes the compound command.
 #[async_trait(?Send)]

--- a/yash-semantics/src/command_impl/compound_command/if.rs
+++ b/yash-semantics/src/command_impl/compound_command/if.rs
@@ -16,6 +16,7 @@
 
 //! Execution of the if command
 
+use super::evaluate_condition;
 use crate::Command;
 use std::ops::ControlFlow::Continue;
 use yash_env::semantics::ExitStatus;
@@ -23,11 +24,6 @@ use yash_env::semantics::Result;
 use yash_env::Env;
 use yash_syntax::syntax::ElifThen;
 use yash_syntax::syntax::List;
-
-async fn execute_condition(env: &mut Env, condition: &List) -> Result<bool> {
-    condition.execute(env).await?;
-    Continue(env.exit_status == ExitStatus::SUCCESS)
-}
 
 /// Executes the if command.
 pub async fn execute(
@@ -37,11 +33,11 @@ pub async fn execute(
     elifs: &[ElifThen],
     r#else: &Option<List>,
 ) -> Result {
-    if execute_condition(env, condition).await? {
+    if evaluate_condition(env, condition).await? {
         return body.execute(env).await;
     }
     for ElifThen { condition, body } in elifs {
-        if execute_condition(env, condition).await? {
+        if evaluate_condition(env, condition).await? {
             return body.execute(env).await;
         }
     }

--- a/yash-semantics/src/command_impl/compound_command/while_loop.rs
+++ b/yash-semantics/src/command_impl/compound_command/while_loop.rs
@@ -34,13 +34,10 @@ struct Loop<'a> {
 }
 
 impl Loop<'_> {
-    async fn evaluate_condition(&mut self) -> Result<bool> {
-        self.condition_command.execute(self.env).await?;
-        Continue(self.env.exit_status == ExitStatus::SUCCESS)
-    }
-
     async fn iterate(&mut self) -> Result {
-        while self.evaluate_condition().await? == self.expected_condition {
+        while super::evaluate_condition(self.env, self.condition_command).await?
+            == self.expected_condition
+        {
             self.body.execute(self.env).await?;
             self.exit_status = self.env.exit_status;
         }

--- a/yash-semantics/src/command_impl/function_definition.rs
+++ b/yash-semantics/src/command_impl/function_definition.rs
@@ -38,41 +38,48 @@ use yash_syntax::syntax;
 /// function that is read-only, the execution ends with a non-zero exit status.
 /// Finally, the function definition is inserted into the environment, and the
 /// execution ends with an exit status of zero.
+///
+/// The `ErrExit` shell option is [applied](Env::apply_errexit) on error.
 #[async_trait(?Send)]
 impl Command for syntax::FunctionDefinition {
     async fn execute(&self, env: &mut Env) -> Result {
-        // Expand the function name
-        let Field {
-            value: name,
-            origin,
-        } = match expand_word(env, &self.name).await {
-            Ok((field, _exit_status)) => field,
-            Err(error) => return error.handle(env).await,
-        };
-
-        // Avoid overwriting a read-only function
-        if let Some(function) = env.functions.get(name.as_str()) {
-            if function.0.is_read_only {
-                // TODO Use pretty::Message and annotate_snippet
-                env.print_error(&format!("cannot re-define read-only function {:?}\n", name))
-                    .await;
-                env.exit_status = ExitStatus::ERROR;
-                return Continue(());
-            }
-        }
-
-        // Define the function
-        let function = Function {
-            name,
-            body: Rc::clone(&self.body),
-            origin,
-            is_read_only: false,
-        };
-        let entry = HashEntry(Rc::new(function));
-        env.functions.replace(entry);
-        env.exit_status = ExitStatus::SUCCESS;
-        Continue(())
+        define_function(env, self).await?;
+        env.apply_errexit()
     }
+}
+
+async fn define_function(env: &mut Env, def: &syntax::FunctionDefinition) -> Result {
+    // Expand the function name
+    let Field {
+        value: name,
+        origin,
+    } = match expand_word(env, &def.name).await {
+        Ok((field, _exit_status)) => field,
+        Err(error) => return error.handle(env).await,
+    };
+
+    // Avoid overwriting a read-only function
+    if let Some(function) = env.functions.get(name.as_str()) {
+        if function.0.is_read_only {
+            // TODO Use pretty::Message and annotate_snippet
+            env.print_error(&format!("cannot re-define read-only function {:?}\n", name))
+                .await;
+            env.exit_status = ExitStatus::ERROR;
+            return Continue(());
+        }
+    }
+
+    // Define the function
+    let function = Function {
+        name,
+        body: Rc::clone(&def.body),
+        origin,
+        is_read_only: false,
+    };
+    let entry = HashEntry(Rc::new(function));
+    env.functions.replace(entry);
+    env.exit_status = ExitStatus::SUCCESS;
+    Continue(())
 }
 
 #[cfg(test)]
@@ -80,6 +87,10 @@ mod tests {
     use super::*;
     use crate::tests::assert_stderr;
     use futures_executor::block_on;
+    use std::ops::ControlFlow::Break;
+    use yash_env::option::On;
+    use yash_env::option::Option::ErrExit;
+    use yash_env::semantics::Divert;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
 
@@ -180,5 +191,27 @@ mod tests {
         assert_eq!(env.exit_status, ExitStatus::SUCCESS);
         let names: Vec<&str> = env.functions.iter().map(|f| f.0.name.as_str()).collect();
         assert_eq!(names, ["a"]);
+    }
+
+    #[test]
+    fn errexit_in_function_definition() {
+        let mut env = Env::new_virtual();
+        let function = Rc::new(Function {
+            name: "foo".to_string(),
+            body: Rc::new("{ :; }".parse().unwrap()),
+            origin: Location::dummy("dummy"),
+            is_read_only: true,
+        });
+        env.functions.insert(HashEntry(Rc::clone(&function)));
+        let definition = syntax::FunctionDefinition {
+            has_keyword: false,
+            name: "foo".parse().unwrap(),
+            body: Rc::new("( :; )".parse().unwrap()),
+        };
+        env.options.set(ErrExit, On);
+
+        let result = block_on(definition.execute(&mut env));
+        assert_eq!(result, Break(Divert::Exit(None)));
+        assert_eq!(env.exit_status, ExitStatus::ERROR);
     }
 }

--- a/yash-semantics/src/command_impl/pipeline.rs
+++ b/yash-semantics/src/command_impl/pipeline.rs
@@ -245,7 +245,7 @@ mod tests {
     use crate::tests::in_virtual_system;
     use crate::tests::return_builtin;
     use assert_matches::assert_matches;
-    use futures_executor::block_on;
+    use futures_util::FutureExt;
     use std::future::Future;
     use std::ops::ControlFlow;
     use std::pin::Pin;
@@ -264,7 +264,7 @@ mod tests {
             commands: vec![],
             negation: false,
         };
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(0));
     }
@@ -274,7 +274,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let pipeline: syntax::Pipeline = "return -n 93".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(93));
     }
@@ -284,7 +284,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let pipeline: syntax::Pipeline = "return 37".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Break(Divert::Return));
         assert_eq!(env.exit_status, ExitStatus(37));
     }
@@ -385,7 +385,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let pipeline: syntax::Pipeline = "! return -n 42".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(0));
     }
@@ -395,7 +395,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let pipeline: syntax::Pipeline = "! return -n 0".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
         assert_eq!(env.exit_status, ExitStatus(1));
     }
@@ -405,7 +405,7 @@ mod tests {
         let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let pipeline: syntax::Pipeline = "! return 15".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Break(Divert::Return));
         assert_eq!(env.exit_status, ExitStatus(15));
     }
@@ -431,7 +431,7 @@ mod tests {
             },
         );
         let pipeline: syntax::Pipeline = "foo".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
     }
 
@@ -459,7 +459,7 @@ mod tests {
             },
         );
         let pipeline: syntax::Pipeline = "! foo".parse().unwrap();
-        let result = block_on(pipeline.execute(&mut env));
+        let result = pipeline.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Continue(()));
     }
 


### PR DESCRIPTION
- [x] Implement `Env::apply_errexit`
- [x] Push `Frame::Condition` in if/while/until conditions
- [x] Push `Frame::Condition` in negated command
- [x] Push `Frame::Condition` in and-or lists
- [x] Exit on simple command returning non-zero exit status
- [x] Exit on subshell command returning non-zero exit status
- [x] Exit on function definition command returning non-zero exit status
- [x] Exit on redirection error in compound command

----

- Exit on expansion error in for loop word → not needed because expansion error exits the shell by default
- Exit on assignment error in for loop variable → not needed because assignment error exits the shell by default
- Exit on expansion error in case command word or pattern → not needed because expansion error exits the shell by default
- Exit on double bracket command returning non-zero exit status → not implemented in this PR because the double bracket command itself is not yet implemented
