### PR TITLE
xtrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "yash-arith",
  "yash-env",
  "yash-fnmatch",
+ "yash-quote",
  "yash-syntax",
 ]
 

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1.3.0"
 yash-arith = { path = "../yash-arith", version = "0.1.0" }
 yash-env = { path = "../yash-env", version = "0.1.0" }
 yash-fnmatch = { path = "../yash-fnmatch", version = "1.1.0" }
+yash-quote = { path = "../yash-quote", version = "1.0.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.6.0" }
 
 [dev-dependencies]

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -1089,10 +1089,10 @@ mod tests {
                 "VAR=123 /some/file foo bar >/dev/null".parse().unwrap();
             let _ = command.execute(&mut env).await;
 
-            // TODO $PS4, assignments, redirections
+            // TODO $PS4, redirections
             assert_stderr(&state, |stderr| {
                 assert!(
-                    stderr.starts_with("/some/file foo bar\n"),
+                    stderr.starts_with("VAR=123 /some/file foo bar\n"),
                     "stderr = {:?}",
                     stderr
                 )

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -19,6 +19,8 @@
 use crate::command_search::search;
 use crate::expansion::expand_words;
 use crate::redir::RedirGuard;
+use crate::xtrace::flush;
+use crate::xtrace::trace_fields;
 use crate::xtrace::XTrace;
 use crate::Command;
 use crate::Handle;
@@ -350,7 +352,6 @@ async fn execute_external_utility(
 ) -> Result {
     let name = fields[0].clone();
     let location = name.origin.clone();
-    let args = to_c_strings(fields);
 
     let mut xtrace = XTrace::from_options(&env.options);
 
@@ -362,7 +363,8 @@ async fn execute_external_utility(
     let mut env = env.push_context(ContextType::Volatile);
     perform_assignments(&mut env, assigns, true, xtrace.as_mut()).await?;
 
-    // TODO flush xtrace
+    trace_fields(xtrace.as_mut(), &fields);
+    flush(&mut env, xtrace).await;
 
     if path.to_bytes().is_empty() {
         print_error(
@@ -376,6 +378,7 @@ async fn execute_external_utility(
         return Continue(());
     }
 
+    let args = to_c_strings(fields);
     let subshell = env.run_in_subshell(move |env| {
         Box::pin(async move {
             env.traps.disable_internal_handlers(&mut env.system).ok();
@@ -1059,6 +1062,40 @@ mod tests {
             let stdout = stdout.borrow();
             assert_matches!(&stdout.body, FileBody::Regular { content, .. } => {
                 assert_eq!(from_utf8(content), Ok(""));
+            });
+        });
+    }
+
+    #[test]
+    fn xtrace_for_external_command() {
+        in_virtual_system(|mut env, _pid, state| async move {
+            env.options
+                .set(yash_env::option::XTrace, yash_env::option::On);
+
+            let mut content = INode::default();
+            content.body = FileBody::Regular {
+                content: Vec::new(),
+                is_native_executable: true,
+            };
+            content.permissions.0 |= 0o100;
+            let content = Rc::new(RefCell::new(content));
+            state
+                .borrow_mut()
+                .file_system
+                .save("/some/file", content)
+                .unwrap();
+
+            let command: syntax::SimpleCommand =
+                "VAR=123 /some/file foo bar >/dev/null".parse().unwrap();
+            let _ = command.execute(&mut env).await;
+
+            // TODO $PS4, assignments, redirections
+            assert_stderr(&state, |stderr| {
+                assert!(
+                    stderr.starts_with("/some/file foo bar\n"),
+                    "stderr = {:?}",
+                    stderr
+                )
             });
         });
     }

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -356,7 +356,8 @@ async fn execute_external_utility(
     let mut xtrace = XTrace::from_options(&env.options);
 
     let env = &mut RedirGuard::new(env);
-    if let Err(e) = env.perform_redirs(redirs, xtrace.as_mut()).await {
+    // TODO xtrace for redirections
+    if let Err(e) = env.perform_redirs(redirs, None).await {
         return e.handle(env).await;
     };
 

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -34,6 +34,8 @@ pub mod trap;
 #[doc(no_inline)]
 pub use yash_env::semantics::*;
 
+mod xtrace;
+
 mod command;
 pub use command::Command;
 

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -29,10 +29,30 @@ use yash_env::System;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::HereDoc;
 
-async fn write_content(env: &mut Env, fd: Fd, content: &str) -> Result<(), Errno> {
+async fn fill_content(env: &mut Env, fd: Fd, content: &str) -> Result<(), Errno> {
     env.system.write_all(fd, content.as_bytes()).await?;
     env.system.lseek(fd, std::io::SeekFrom::Start(0))?;
     Ok(())
+}
+
+/// Opens a here-document.
+///
+/// This function writes the here-document content to an anonymous temporary
+/// file and returns a file descriptor to the file you can read the content
+/// from.
+pub(super) async fn open_fd(env: &mut Env, content: String) -> Result<Fd, ErrorCause> {
+    // TODO Use a pipe for short content
+    let fd = match env.system.open_tmpfile(Path::new("/tmp")) {
+        Ok(fd) => fd,
+        Err(errno) => return Err(ErrorCause::TemporaryFileUnavailable(errno)),
+    };
+    match fill_content(env, fd, &content).await {
+        Ok(()) => Ok(fd),
+        Err(errno) => {
+            let _ = env.system.close(fd);
+            Err(ErrorCause::TemporaryFileUnavailable(errno))
+        }
+    }
 }
 
 /// Opens a here-document.
@@ -47,31 +67,10 @@ pub(super) async fn open(
 ) -> Result<(FdSpec, Location, Option<ExitStatus>), Error> {
     let (content, exit_status) = expand_text(env, &here_doc.content.borrow()).await?;
     let location = here_doc.delimiter.location.clone();
-
-    // TODO Use a pipe for short content
-
-    let fd = match env.system.open_tmpfile(Path::new("/tmp")) {
-        Ok(fd) => fd,
-        Err(errno) => {
-            return Err(Error {
-                cause: ErrorCause::TemporaryFileUnavailable(errno),
-                location,
-            })
-        }
-    };
-
-    match write_content(env, fd, &content).await {
-        Ok(()) => (),
-        Err(errno) => {
-            let _ = env.system.close(fd);
-            return Err(Error {
-                cause: ErrorCause::TemporaryFileUnavailable(errno),
-                location,
-            });
-        }
-    };
-
-    Ok((FdSpec::Owned(fd), location, exit_status))
+    match open_fd(env, content).await {
+        Ok(fd) => Ok((FdSpec::Owned(fd), location, exit_status)),
+        Err(cause) => Err(Error { cause, location }),
+    }
 }
 
 #[cfg(test)]
@@ -85,6 +84,20 @@ mod tests {
     use std::cell::RefCell;
     use yash_env::System;
     use yash_syntax::syntax::Text;
+
+    #[test]
+    fn open_fd_and_read_from_it() {
+        let text = "Here document content\n";
+        let mut env = Env::new_virtual();
+        let fd = open_fd(&mut env, text.to_owned())
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let mut buffer = [0; 30];
+        let count = env.system.read(fd, &mut buffer).unwrap();
+        assert_eq!(std::str::from_utf8(&buffer[..count]), Ok(text));
+    }
 
     #[test]
     fn empty_here_doc() {

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -17,6 +17,8 @@
 //! Printing expansion results
 
 use std::fmt::Write;
+use yash_env::option::OptionSet;
+use yash_env::option::State;
 use yash_env::Env;
 
 /// Temporary buffer that accumulates expanded strings
@@ -36,8 +38,18 @@ pub struct XTrace {
 
 impl XTrace {
     /// Creates a new trace buffer.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a new trace buffer if the `xtrace` option is on.
+    #[must_use]
+    pub fn from_options(options: &OptionSet) -> Option<Self> {
+        match options.get(yash_env::option::Option::XTrace) {
+            State::On => Some(Self::new()),
+            State::Off => None,
+        }
     }
 
     /// Clears the buffer.
@@ -66,6 +78,13 @@ impl XTrace {
         // TODO Expand $PS4
         // TODO Trim trailing spaces
         // TODO Prevent recursive tracing
+    }
+}
+
+/// Convenience function for flushing an optional trace.
+pub async fn flush(env: &mut Env, xtrace: Option<XTrace>) {
+    if let Some(mut xtrace) = xtrace {
+        xtrace.flush(env).await
     }
 }
 

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -17,6 +17,7 @@
 //! Printing expansion results
 
 use std::fmt::Write;
+use std::ops::Add;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::semantics::Field;
@@ -118,6 +119,19 @@ impl Write for XTrace {
     }
 }
 
+/// Concatenates two traces.
+impl Add<XTrace> for XTrace {
+    type Output = XTrace;
+    fn add(mut self, rhs: XTrace) -> XTrace {
+        if self.buffer.is_empty() {
+            rhs
+        } else {
+            self.buffer += &rhs.buffer;
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,5 +192,23 @@ mod tests {
         let mut xtrace = XTrace::new();
         trace_fields(Some(&mut xtrace), &Field::dummies(["foo", "~bar"]));
         assert_eq!(xtrace.as_str(), "foo '~bar' ");
+    }
+
+    #[test]
+    fn add_xtrace_and_xtrace() {
+        let a = XTrace::new();
+        let b = XTrace::new();
+        let c = a + b;
+        assert_eq!(c.as_str(), "");
+
+        let mut d = XTrace::new();
+        d.write_str("first").unwrap();
+        let e = c + d;
+        assert_eq!(e.as_str(), "first");
+
+        let mut f = XTrace::new();
+        f.write_str(" second").unwrap();
+        let g = e + f;
+        assert_eq!(g.as_str(), "first second");
     }
 }

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -54,6 +54,12 @@ impl XTrace {
         }
     }
 
+    /// Returns the current buffer content.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.buffer.as_str()
+    }
+
     /// Clears the buffer.
     pub fn clear(&mut self) {
         self.buffer.clear()
@@ -153,13 +159,10 @@ mod tests {
 
     #[test]
     fn flush_clears_buffer() {
-        let (mut xtrace, mut env, state) = fixture();
+        let (mut xtrace, mut env, _state) = fixture();
         xtrace.write_str("foo").unwrap();
         xtrace.flush(&mut env).now_or_never().unwrap();
-        // The first `flush` clears the buffer, so the second is a no-op.
-        // Compare `non_empty_flush`
-        xtrace.flush(&mut env).now_or_never().unwrap();
-        assert_stderr(&state, |stderr| assert_eq!(stderr, "foo\n"));
+        assert_eq!(xtrace.as_str(), "");
     }
 
     #[test]
@@ -172,9 +175,8 @@ mod tests {
 
     #[test]
     fn trace_fields_some() {
-        let (mut xtrace, mut env, state) = fixture();
+        let mut xtrace = XTrace::new();
         trace_fields(Some(&mut xtrace), &Field::dummies(["foo", "~bar"]));
-        xtrace.flush(&mut env).now_or_never().unwrap();
-        assert_stderr(&state, |stderr| assert_eq!(stderr, "foo '~bar'\n"));
+        assert_eq!(xtrace.as_str(), "foo '~bar' ");
     }
 }

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -1,0 +1,128 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Printing expansion results
+
+use std::fmt::Write;
+use yash_env::Env;
+
+/// Temporary buffer that accumulates expanded strings
+///
+/// An `XTrace` object is a string buffer that keeps words to be printed as a
+/// trace. We print all the assignments and command line words expanded in a
+/// single simple command in a single line of trace, so we use this object
+/// to accumulate expansions until everything is ready.
+///
+/// To add words to the buffer, call methods of [`Write`] on the `XTrace`.
+/// To print the collected words, call [`flush`](Self::flush).
+#[derive(Clone, Debug, Default)]
+pub struct XTrace {
+    /// Accumulated trace
+    buffer: String,
+}
+
+impl XTrace {
+    /// Creates a new trace buffer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clears the buffer.
+    pub fn clear(&mut self) {
+        self.buffer.clear()
+    }
+
+    /// Prints and clears the buffer content.
+    ///
+    /// If the buffer is not empty, it is printed to the standard error,
+    /// preceded by an expansion of the `$PS4` variable and followed by a
+    /// newline.
+    ///
+    /// This function trims trailing spaces.
+    ///
+    /// This function ignores any error that may occur while printing, so there
+    /// is no return value.
+    pub async fn flush(&mut self, env: &mut Env) {
+        if self.buffer.is_empty() {
+            return;
+        }
+        self.buffer.push('\n');
+        env.print_error(&self.buffer).await;
+        self.clear();
+        // TODO Prefix $PS4
+        // TODO Expand $PS4
+        // TODO Trim trailing spaces
+        // TODO Prevent recursive tracing
+    }
+}
+
+impl Write for XTrace {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.buffer.write_str(s)
+    }
+    fn write_char(&mut self, c: char) -> std::fmt::Result {
+        self.buffer.write_char(c)
+    }
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> std::fmt::Result {
+        self.buffer.write_fmt(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::assert_stderr;
+    use futures_util::FutureExt;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use yash_env::system::r#virtual::SystemState;
+    use yash_env::VirtualSystem;
+
+    fn fixture() -> (XTrace, Env, Rc<RefCell<SystemState>>) {
+        let xtrace = XTrace::new();
+        let system = Box::new(VirtualSystem::new());
+        let state = Rc::clone(&system.state);
+        let env = Env::with_system(system);
+        (xtrace, env, state)
+    }
+
+    #[test]
+    fn empty_flush() {
+        // TODO Check if $PS4 is ignored
+        let (mut xtrace, mut env, state) = fixture();
+        xtrace.flush(&mut env).now_or_never().unwrap();
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn non_empty_flush() {
+        let (mut xtrace, mut env, state) = fixture();
+        xtrace.write_str("foo").unwrap();
+        xtrace.flush(&mut env).now_or_never().unwrap();
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "foo\n"));
+    }
+
+    #[test]
+    fn flush_clears_buffer() {
+        let (mut xtrace, mut env, state) = fixture();
+        xtrace.write_str("foo").unwrap();
+        xtrace.flush(&mut env).now_or_never().unwrap();
+        // The first `flush` clears the buffer, so the second is a no-op.
+        // Compare `non_empty_flush`
+        xtrace.flush(&mut env).now_or_never().unwrap();
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "foo\n"));
+    }
+}


### PR DESCRIPTION
- [x] Define `XTrace`
    - [x] Do we need multiple buffers in order to print assignments before words and redirections in a trace?
        - We can make two buffers, one for redirections and the other for assignments and words, and join the two just before printing.
    - [ ] Redefine `XTrace` as a triple of strings.
        - We need another buffer for here-document contents.
- [ ] simple command (words, assignments, and redirections)
    - [x] Redirections
        - [x] Normal redirections
        - [x] Here-docs
            - [ ] Multiple here-docs in one trace
    - [x] Assignments
    - [x] Command words
    - [x] Absent target
    - [ ] Built-in
    - [ ] Function
    - [x] External
- [ ] for loop
- [ ] case command (word and patterns)
- [ ] redirections on compound commands
- [ ] Print $PS4
    - [ ] Expand $PS4
        - [ ] Disable recursive trace while expanding $PS4

execute_absent_target requires tracing redirections and assignments separately because we must run redirections in a subshell while assignments in the current.

## The `XTrace` struct

This struct cannot contain (a reference to) the environment because the struct is conditionally created depending on whether the trace is enabled. The struct is conditionally created so that the caller does not have to create it when it does not care for tracing.
