### PR TITLE
xtrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "yash-arith",
  "yash-env",
  "yash-fnmatch",
+ "yash-quote",
  "yash-syntax",
 ]
 

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities"]
 publish = false
 
 [dependencies]
+assert_matches = "1.5.0"
 async-trait = "0.1.56"
 # We need a specific version of bitflags
 # to obtain some auto-generated functions for items exported from yash-env
@@ -27,7 +28,6 @@ yash-quote = { path = "../yash-quote", version = "1.0.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.6.0" }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 futures-executor = "0.3.23"
 futures-util = "0.3.23"
 itertools = "0.10.3"

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1.3.0"
 yash-arith = { path = "../yash-arith", version = "0.1.0" }
 yash-env = { path = "../yash-env", version = "0.1.0" }
 yash-fnmatch = { path = "../yash-fnmatch", version = "1.1.0" }
+yash-quote = { path = "../yash-quote", version = "1.0.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.6.0" }
 
 [dev-dependencies]

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -17,6 +17,8 @@
 //! Assignment.
 
 use crate::expansion::expand_value;
+use crate::xtrace::XTrace;
+use std::fmt::Write;
 use yash_env::semantics::ExitStatus;
 use yash_env::variable::Variable;
 use yash_env::Env;
@@ -34,14 +36,29 @@ pub use yash_syntax::syntax::Assign;
 /// [assigns](yash_env::variable::VariableSet::assign) it to the environment.
 /// The return value is the exit status of the last command substitution
 /// performed during the expansion of the assigned value, if any
+///
+/// If `xtrace` is `Some` instance of `XTrace`, the expanded assignment word is
+/// written to its main buffer.
 pub async fn perform_assignment(
     env: &mut Env,
     assign: &Assign,
     scope: Scope,
     export: bool,
+    xtrace: Option<&mut XTrace>,
 ) -> Result<Option<ExitStatus>> {
     let name = assign.name.clone();
     let (value, exit_status) = expand_value(env, &assign.value).await?;
+
+    if let Some(xtrace) = xtrace {
+        write!(
+            xtrace.main(),
+            "{}={} ",
+            yash_quote::quote(&name),
+            value.quote()
+        )
+        .unwrap();
+    }
+
     let value = Variable {
         value: Some(value),
         quirk: None,
@@ -61,15 +78,20 @@ pub async fn perform_assignment(
 /// This function calls [`perform_assignment`] for each [`Assign`].
 /// The return value is the exit status of the last command substitution
 /// performed during the expansion of the assigned values, if any
+///
+/// If `xtrace` is `Some` instance of `XTrace`, the expanded assignment words
+/// are written to its main buffer.
 pub async fn perform_assignments(
     env: &mut Env,
     assigns: &[Assign],
     scope: Scope,
     export: bool,
+    mut xtrace: Option<&mut XTrace>,
 ) -> Result<Option<ExitStatus>> {
     let mut exit_status = None;
     for assign in assigns {
-        let new_exit_status = perform_assignment(env, assign, scope, export).await?;
+        let new_exit_status =
+            perform_assignment(env, assign, scope, export, xtrace.as_deref_mut()).await?;
         exit_status = new_exit_status.or(exit_status);
     }
     Ok(exit_status)
@@ -89,7 +111,7 @@ mod tests {
     fn perform_assignment_new_value() {
         let mut env = Env::new_virtual();
         let a: Assign = "foo=bar".parse().unwrap();
-        let exit_status = perform_assignment(&mut env, &a, Scope::Global, false)
+        let exit_status = perform_assignment(&mut env, &a, Scope::Global, false, None)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -104,13 +126,13 @@ mod tests {
     fn perform_assignment_overwriting() {
         let mut env = Env::new_virtual();
         let a: Assign = "foo=bar".parse().unwrap();
-        let exit_status = perform_assignment(&mut env, &a, Scope::Global, false)
+        let exit_status = perform_assignment(&mut env, &a, Scope::Global, false, None)
             .now_or_never()
             .unwrap()
             .unwrap();
         assert_eq!(exit_status, None);
         let a: Assign = "foo=baz".parse().unwrap();
-        let exit_status = perform_assignment(&mut env, &a, Scope::Global, true)
+        let exit_status = perform_assignment(&mut env, &a, Scope::Global, true, None)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -132,7 +154,7 @@ mod tests {
             .assign(Scope::Global, "v".to_string(), v)
             .unwrap();
         let a: Assign = "v=new".parse().unwrap();
-        let e = perform_assignment(&mut env, &a, Scope::Global, false)
+        let e = perform_assignment(&mut env, &a, Scope::Global, false, None)
             .now_or_never()
             .unwrap()
             .unwrap_err();
@@ -147,6 +169,27 @@ mod tests {
     }
 
     #[test]
+    fn perform_assignment_with_xtrace() {
+        let mut xtrace = XTrace::new();
+        let mut env = Env::new_virtual();
+
+        let a: Assign = "foo=bar${unset-&}".parse().unwrap();
+        let _ = perform_assignment(&mut env, &a, Scope::Global, false, Some(&mut xtrace))
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let a: Assign = "one=1".parse().unwrap();
+        let _ = perform_assignment(&mut env, &a, Scope::Global, false, Some(&mut xtrace))
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "foo='bar&' one=1\n");
+    }
+
+    #[test]
     fn perform_assignments_exit_status() {
         in_virtual_system(|mut env, _pid, _state| async move {
             env.builtins.insert("return", return_builtin());
@@ -154,7 +197,7 @@ mod tests {
                 "a=A$(return -n 1)".parse().unwrap(),
                 "b=($(return -n 2))".parse().unwrap(),
             ];
-            let exit_status = perform_assignments(&mut env, &assigns, Scope::Global, false)
+            let exit_status = perform_assignments(&mut env, &assigns, Scope::Global, false, None)
                 .await
                 .unwrap();
             assert_eq!(exit_status, Some(ExitStatus(2)));

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -18,6 +18,8 @@
 
 use super::Command;
 use crate::redir::RedirGuard;
+use crate::xtrace::finish;
+use crate::xtrace::XTrace;
 use crate::Handle;
 use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
@@ -26,6 +28,19 @@ use yash_env::semantics::Result;
 use yash_env::stack::Frame;
 use yash_env::Env;
 use yash_syntax::syntax;
+use yash_syntax::syntax::Redir;
+
+/// Performs redirections, printing their trace if required.
+async fn perform_redirs(
+    env: &mut RedirGuard<'_>,
+    redirs: &[Redir],
+) -> std::result::Result<Option<ExitStatus>, crate::redir::Error> {
+    let mut xtrace = XTrace::from_options(&env.options);
+    let result = env.perform_redirs(redirs, xtrace.as_mut()).await;
+    let xtrace = finish(env, xtrace).await;
+    env.print_error(&xtrace).await;
+    result
+}
 
 /// Executes the condition of an if/while/until command.
 async fn evaluate_condition(env: &mut Env, condition: &syntax::List) -> Result<bool> {
@@ -49,7 +64,7 @@ mod while_loop;
 impl Command for syntax::FullCompoundCommand {
     async fn execute(&self, env: &mut Env) -> Result {
         let mut env = RedirGuard::new(env);
-        match env.perform_redirs(&self.redirs, None).await {
+        match perform_redirs(&mut env, &self.redirs).await {
             Ok(_) => self.command.execute(&mut env).await,
             Err(error) => {
                 error.handle(&mut env).await?;
@@ -133,6 +148,7 @@ impl Command for syntax::CompoundCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::assert_stderr;
     use crate::tests::assert_stdout;
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
@@ -200,6 +216,18 @@ mod tests {
         assert_matches!(&file.body, FileBody::Regular { content, .. } => {
             assert_eq!(from_utf8(content).unwrap(), "1\n2\n");
         });
+    }
+
+    #[test]
+    fn tracing_redirections() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Box::new(system));
+        env.builtins.insert("echo", echo_builtin());
+        env.options.set(yash_env::option::Option::XTrace, On);
+        let command: syntax::FullCompoundCommand = "{ echo X; } > /file < /file".parse().unwrap();
+        let _ = command.execute(&mut env).now_or_never().unwrap();
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "1>/file 0</file\n"));
     }
 
     #[test]

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -49,7 +49,7 @@ mod while_loop;
 impl Command for syntax::FullCompoundCommand {
     async fn execute(&self, env: &mut Env) -> Result {
         let mut env = RedirGuard::new(env);
-        match env.perform_redirs(&self.redirs).await {
+        match env.perform_redirs(&self.redirs, None).await {
             Ok(_) => self.command.execute(&mut env).await,
             Err(error) => {
                 error.handle(&mut env).await?;

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -227,7 +227,9 @@ mod tests {
         env.options.set(yash_env::option::Option::XTrace, On);
         let command: syntax::FullCompoundCommand = "{ echo X; } > /file < /file".parse().unwrap();
         let _ = command.execute(&mut env).now_or_never().unwrap();
-        assert_stderr(&state, |stderr| assert_eq!(stderr, "1>/file 0</file\n"));
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "1>/file 0</file\necho X\n");
+        });
     }
 
     #[test]

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -1131,7 +1131,7 @@ mod tests {
         command.execute(&mut env).now_or_never().unwrap();
 
         assert_stderr(&state, |stderr| {
-            assert_eq!(stderr, "x=hello foo bar 0<>/dev/null\n");
+            assert_eq!(stderr, "x=hello foo bar 0<>/dev/null\nfor i in\n");
         });
     }
 

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -226,7 +226,7 @@ async fn execute_absent_target(
         let redir_results = env.run_in_subshell(move |env| {
             Box::pin(async move {
                 let env = &mut RedirGuard::new(env);
-                let redir_exit_status = match env.perform_redirs(&*redirs).await {
+                let redir_exit_status = match env.perform_redirs(&*redirs, None).await {
                     Ok(exit_status) => exit_status,
                     Err(e) => {
                         e.handle(env).await?;
@@ -271,7 +271,7 @@ async fn execute_builtin(
     let is_special = builtin.r#type == Special;
     let env = &mut env.push_frame(Frame::Builtin { name, is_special });
     let env = &mut RedirGuard::new(env);
-    if let Err(e) = env.perform_redirs(redirs).await {
+    if let Err(e) = env.perform_redirs(redirs, None).await {
         e.handle(env).await?;
         return match builtin.r#type {
             Special => Break(Divert::Interrupt(None)),
@@ -303,7 +303,7 @@ async fn execute_function(
     redirs: &[Redir],
 ) -> Result {
     let env = &mut RedirGuard::new(env);
-    if let Err(e) = env.perform_redirs(redirs).await {
+    if let Err(e) = env.perform_redirs(redirs, None).await {
         return e.handle(env).await;
     };
 
@@ -340,7 +340,7 @@ async fn execute_external_utility(
     let args = to_c_strings(fields);
 
     let env = &mut RedirGuard::new(env);
-    if let Err(e) = env.perform_redirs(redirs).await {
+    if let Err(e) = env.perform_redirs(redirs, None).await {
         return e.handle(env).await;
     };
 

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -30,6 +30,7 @@ pub mod command_search;
 pub mod expansion;
 pub mod redir;
 pub mod trap;
+pub mod xtrace;
 
 #[doc(no_inline)]
 pub use yash_env::semantics::*;

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -16,20 +16,14 @@
 
 //! Here-documents
 
-use super::Error;
 use super::ErrorCause;
-use super::FdSpec;
-use crate::expansion::expand_text;
 use std::path::Path;
 use yash_env::io::Fd;
-use yash_env::semantics::ExitStatus;
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_env::System;
-use yash_syntax::source::Location;
-use yash_syntax::syntax::HereDoc;
 
-async fn write_content(env: &mut Env, fd: Fd, content: &str) -> Result<(), Errno> {
+async fn fill_content(env: &mut Env, fd: Fd, content: &str) -> Result<(), Errno> {
     env.system.write_all(fd, content.as_bytes()).await?;
     env.system.lseek(fd, std::io::SeekFrom::Start(0))?;
     Ok(())
@@ -37,95 +31,41 @@ async fn write_content(env: &mut Env, fd: Fd, content: &str) -> Result<(), Errno
 
 /// Opens a here-document.
 ///
-/// This function expands the here-document content to an anonymous temporary
+/// This function writes the here-document content to an anonymous temporary
 /// file and returns a file descriptor to the file you can read the content
 /// from.
-#[allow(clippy::await_holding_refcell_ref)]
-pub(super) async fn open(
-    env: &mut Env,
-    here_doc: &HereDoc,
-) -> Result<(FdSpec, Location, Option<ExitStatus>), Error> {
-    let (content, exit_status) = expand_text(env, &here_doc.content.borrow()).await?;
-    let location = here_doc.delimiter.location.clone();
-
+pub(super) async fn open_fd(env: &mut Env, content: String) -> Result<Fd, ErrorCause> {
     // TODO Use a pipe for short content
-
     let fd = match env.system.open_tmpfile(Path::new("/tmp")) {
         Ok(fd) => fd,
-        Err(errno) => {
-            return Err(Error {
-                cause: ErrorCause::TemporaryFileUnavailable(errno),
-                location,
-            })
-        }
+        Err(errno) => return Err(ErrorCause::TemporaryFileUnavailable(errno)),
     };
-
-    match write_content(env, fd, &content).await {
-        Ok(()) => (),
+    match fill_content(env, fd, &content).await {
+        Ok(()) => Ok(fd),
         Err(errno) => {
             let _ = env.system.close(fd);
-            return Err(Error {
-                cause: ErrorCause::TemporaryFileUnavailable(errno),
-                location,
-            });
+            Err(ErrorCause::TemporaryFileUnavailable(errno))
         }
-    };
-
-    Ok((FdSpec::Owned(fd), location, exit_status))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::echo_builtin;
-    use crate::tests::in_virtual_system;
-    use crate::tests::return_builtin;
-    use assert_matches::assert_matches;
     use futures_util::FutureExt;
-    use std::cell::RefCell;
     use yash_env::System;
-    use yash_syntax::syntax::Text;
 
     #[test]
-    fn empty_here_doc() {
+    fn open_fd_and_read_from_it() {
+        let text = "Here document content\n";
         let mut env = Env::new_virtual();
-        let here_doc = HereDoc {
-            delimiter: "END".parse().unwrap(),
-            remove_tabs: false,
-            content: RefCell::new(Text(vec![])),
-        };
+        let fd = open_fd(&mut env, text.to_owned())
+            .now_or_never()
+            .unwrap()
+            .unwrap();
 
-        let (fd_spec, location, exit_status) =
-            open(&mut env, &here_doc).now_or_never().unwrap().unwrap();
-        assert_matches!(fd_spec, FdSpec::Owned(fd) => {
-            let mut buffer = [0; 1];
-            let read_count = env.system.read(fd, &mut buffer).unwrap();
-            assert_eq!(read_count, 0);
-        });
-        assert_eq!(location, here_doc.delimiter.location);
-        assert_eq!(exit_status, None);
-    }
-
-    #[test]
-    fn here_doc_with_command_substitution() {
-        in_virtual_system(|mut env, _pid, _state| async move {
-            env.builtins.insert("echo", echo_builtin());
-            env.builtins.insert("return", return_builtin());
-            let here_doc = HereDoc {
-                delimiter: "EOF".parse().unwrap(),
-                remove_tabs: false,
-                content: RefCell::new("$(echo foo)$(echo bar; return -n 42)\n".parse().unwrap()),
-            };
-
-            let (fd_spec, location, exit_status) = open(&mut env, &here_doc).await.unwrap();
-            assert_matches!(fd_spec, FdSpec::Owned(fd) => {
-                let mut buffer = [0; 8];
-                let read_count = env.system.read(fd, &mut buffer).unwrap();
-                assert_eq!(read_count, 7);
-                assert_eq!(&buffer[..7], b"foobar\n");
-            });
-            assert_eq!(location, here_doc.delimiter.location);
-            assert_eq!(exit_status, Some(ExitStatus(42)));
-        })
+        let mut buffer = [0; 30];
+        let count = env.system.read(fd, &mut buffer).unwrap();
+        assert_eq!(std::str::from_utf8(&buffer[..count]), Ok(text));
     }
 }

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -35,6 +35,7 @@
 
 use crate::expansion::expand_text;
 use crate::Handle;
+use std::fmt::Write;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::variable::Value::Scalar;
@@ -114,6 +115,39 @@ impl XTrace {
             State::On => Some(Self::new()),
             State::Off => None,
         }
+    }
+
+    /// Returns a reference to the main buffer.
+    ///
+    /// The main buffer is for tracing command words and assignments.
+    /// When writing to the buffer, the content should end with a space.
+    #[inline]
+    #[must_use]
+    pub fn main(&mut self) -> &mut impl Write {
+        &mut self.main
+    }
+
+    /// Returns a reference to the redirections buffer.
+    ///
+    /// The redirections buffer is for tracing redirections.
+    /// When writing to the buffer, the content should end with a space.
+    ///
+    /// You should not write the contents of here-documents to this buffer.
+    /// See also [`here_doc_contents`](Self::here_doc_contents).
+    #[inline]
+    #[must_use]
+    pub fn redirs(&mut self) -> &mut impl Write {
+        &mut self.redirs
+    }
+
+    /// Returns a reference to the here-document contents buffer.
+    ///
+    /// You should write the contents of here-documents you wrote to the
+    /// [redirections buffer](Self::redirs()).
+    #[inline]
+    #[must_use]
+    pub fn here_doc_contents(&mut self) -> &mut impl Write {
+        &mut self.here_doc_contents
     }
 
     /// Clears the buffer contents.

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -1,0 +1,243 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2022 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Helper items for printing expansion results
+//!
+//! When the `xtrace` [shell option](yash_env::option) is on, the shell traces
+//! words expanded during command execution. For each command executed, the
+//! shell prints to the standard error a line containing the following:
+//!
+//! - An expansion of `$PS4`
+//! - Expanded command words (assignments, command name, and arguments)
+//! - Expanded redirections, possibly followed by here-document contents
+//!
+//! The trace of a command is printed at a time even though many separate steps
+//! perform expansions during the execution of the command. [`XTrace`] is a
+//! collection of string buffers that accumulates the results of expansions
+//! until they are printed to the standard error.
+//!
+//! It is no use to collect the expansions when the `xtrace` option is off, so
+//! you should create an `XTrace` only if the option is on.
+//! [`XTrace::from_options`] is a convenient method to do so.
+
+use crate::expansion::expand_text;
+use crate::Handle;
+use yash_env::option::OptionSet;
+use yash_env::option::State;
+use yash_env::variable::Value::Scalar;
+use yash_env::variable::Variable;
+use yash_env::Env;
+use yash_syntax::syntax::Text;
+
+fn join(a: String, b: String) -> String {
+    if a.is_empty() {
+        b
+    } else {
+        a + &b
+    }
+}
+
+async fn expand_ps4(env: &mut Env) -> String {
+    let value = match env.variables.get("PS4") {
+        Some(Variable {
+            value: Some(Scalar(value)),
+            ..
+        }) => value.to_owned(),
+
+        _ => String::new(),
+    };
+
+    let text = match value.parse::<Text>() {
+        Ok(text) => text,
+        Err(error) => {
+            error.handle(env).await;
+            return value;
+        }
+    };
+
+    match expand_text(env, &text).await {
+        Ok((expansion, _exit_status)) => expansion,
+        Err(error) => {
+            error.handle(env).await;
+            value
+        }
+    }
+}
+
+/// Collection of temporary string buffers that accumulate expanded strings
+///
+/// See the [module documentation](self) for details.
+///
+/// An `XTrace` contains three string buffers that accumulate each of the
+/// following:
+///
+/// - Command words (assignments, command name, and arguments)
+/// - Redirections
+/// - Here-document contents
+///
+/// The [`finish`](Self::finish) function creates the final string to be
+/// printed.
+#[derive(Clone, Debug, Default)]
+pub struct XTrace {
+    main: String,
+    redirs: String,
+    here_doc_contents: String,
+}
+
+impl XTrace {
+    /// Creates a new trace buffer.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new trace buffer if the `xtrace` option is on.
+    ///
+    /// If the option is off, this function returns `None`.
+    #[must_use]
+    pub fn from_options(options: &OptionSet) -> Option<Self> {
+        match options.get(yash_env::option::Option::XTrace) {
+            State::On => Some(Self::new()),
+            State::Off => None,
+        }
+    }
+
+    /// Clears the buffer contents.
+    pub fn clear(&mut self) {
+        self.main.clear();
+        self.redirs.clear();
+        self.here_doc_contents.clear();
+    }
+
+    /// Constructs the final trace to be printed to stderr.
+    ///
+    /// If all the buffers are empty, the result is empty. Otherwise, the result
+    /// is the concatenation of the following:
+    ///
+    /// - The expansion of `$PS4`
+    /// - The concatenation of the `main` and `redirs` buffers with trailing
+    ///   spaces trimmed and a newline appended
+    /// - The `here_doc_contents` buffer
+    ///
+    /// If `$PS4` fails to expand, this function prints an error message and
+    /// uses the variable value intact.
+    pub async fn finish(self, env: &mut Env) -> String {
+        let mut result = join(self.main, self.redirs);
+        if !result.is_empty() || !self.here_doc_contents.is_empty() {
+            let ps4 = expand_ps4(env).await;
+            // TODO Support $YASH_PS4 and $YASH_PS4S
+            result.truncate(result.trim_end_matches(' ').len());
+            result = join(ps4, result);
+            result.push('\n');
+        }
+        join(result, self.here_doc_contents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt;
+    use yash_env::variable::Scope::Global;
+
+    #[test]
+    fn joining() {
+        assert_eq!(join(String::new(), String::new()), "");
+        assert_eq!(join("foo".to_owned(), String::new()), "foo");
+        assert_eq!(join(String::new(), "bar".to_owned()), "bar");
+        assert_eq!(join("to".to_owned(), "night".to_owned()), "tonight");
+    }
+
+    fn fixture() -> Env {
+        let mut env = Env::new_virtual();
+        env.variables
+            .assign(Global, "PS4".to_owned(), Variable::new("+${X=x}+ "))
+            .unwrap();
+        env
+    }
+
+    #[test]
+    fn empty_finish() {
+        let mut env = fixture();
+        let result = XTrace::new().finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "");
+
+        // $PS4 should not have been expanded
+        assert_eq!(env.variables.get("X"), None);
+    }
+
+    #[test]
+    fn finish_with_main() {
+        let mut env = fixture();
+
+        let mut xtrace = XTrace::new();
+        xtrace.main.push_str("abc '~' foo ");
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ abc '~' foo\n");
+
+        // $PS4 should have been expanded
+        assert_ne!(env.variables.get("X"), None);
+    }
+
+    #[test]
+    fn finish_with_redirs() {
+        let mut env = fixture();
+
+        let mut xtrace = XTrace::new();
+        xtrace.redirs.push_str("0< /dev/null 1> foo/bar ");
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ 0< /dev/null 1> foo/bar\n");
+    }
+
+    #[test]
+    fn finish_with_main_and_redirs() {
+        let mut env = fixture();
+
+        let mut xtrace = XTrace::new();
+        xtrace.main.push_str("VAR=X echo argument ");
+        xtrace.redirs.push_str("2> errors ");
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ VAR=X echo argument 2> errors\n");
+
+        let mut xtrace = XTrace::new();
+        xtrace.main.push(' ');
+        xtrace.redirs.push(' ');
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ \n");
+    }
+
+    #[test]
+    fn finish_with_here_doc_contents() {
+        let mut env = fixture();
+
+        let mut xtrace = XTrace::new();
+        xtrace.here_doc_contents.push_str("EOF\n");
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ \nEOF\n");
+    }
+
+    #[test]
+    fn finish_with_redirs_and_here_doc_contents() {
+        let mut env = fixture();
+
+        let mut xtrace = XTrace::new();
+        xtrace.redirs.push_str("0<< END ");
+        xtrace.here_doc_contents.push_str(" X \nEND\n");
+        let result = xtrace.finish(&mut env).now_or_never().unwrap();
+        assert_eq!(result, "+x+ 0<< END\n X \nEND\n");
+    }
+}

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -182,6 +182,15 @@ impl XTrace {
     }
 }
 
+/// Convenience function for calling [`XTrace::finish`] on an optional `XTrace`.
+pub async fn finish(env: &mut Env, xtrace: Option<XTrace>) -> String {
+    if let Some(xtrace) = xtrace {
+        xtrace.finish(env).await
+    } else {
+        String::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Rework of #225.

- [x] Define `XTrace`
    - [x] Define helpers for interacting with an optional `XTrace`
- [x] Trace redirections
    - [x] Normal redirections
    - [x] Here-docs
        - [x] Multiple here-docs in one trace
- [x] Trace assignments
- [x] Trace command words
- [x] Trace simple command (words, assignments, and redirections)
    - [x] Absent target
    - [x] Built-in
    - [x] Function
    - [x] External
- [x] Trace for loop
- [x] Trace case command (word and patterns)
- [x] Trace redirections on compound commands
- [x] Print $PS4
    - [x] Expand $PS4

Topics to be addressed in another PR:

- Disable recursive trace while expanding $PS4
- Provide source information to the parse of $PS4
- Support $YASH_PS4 and $YASH_PS4S

execute_absent_target requires tracing redirections and assignments separately because we must run redirections in a subshell while assignments in the current.

## The `XTrace` struct

This struct cannot contain (a reference to) the environment because the struct is conditionally created depending on whether the trace is enabled. The struct is conditionally created so that the caller does not have to create it when it does not care for tracing.
