### PR TITLE
Refactor items in yash_env::trap

### DIFF
--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -28,7 +28,7 @@ use std::pin::Pin;
 use yash_env::builtin::Result;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::trap::Trap;
+use yash_env::trap::Action;
 use yash_env::Env;
 use yash_quote::quoted;
 
@@ -42,9 +42,9 @@ pub async fn print_traps(env: &mut Env) -> Result {
             (None, None) => continue,
         };
         let command = match &trap.action {
-            Trap::Default => continue,
-            Trap::Ignore => "",
-            Trap::Command(command) => command,
+            Action::Default => continue,
+            Action::Ignore => "",
+            Action::Command(command) => command,
         };
         let signal = &signal.as_str()[3..];
         writeln!(output, "trap -- {} {}", quoted(command), signal).ok();
@@ -76,9 +76,9 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
         Err(_) => return Result::new(ExitStatus::FAILURE),
     };
     let action = match value.as_str() {
-        "-" => Trap::Default,
-        "" => Trap::Ignore,
-        _ => Trap::Command(value.into()),
+        "-" => Action::Default,
+        "" => Action::Ignore,
+        _ => Action::Command(value.into()),
     };
 
     match env

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -83,7 +83,7 @@ pub async fn builtin_body(env: &mut Env, args: Vec<Field>) -> Result {
 
     match env
         .traps
-        .set_trap(&mut env.system, signal, action, origin, false)
+        .set_action(&mut env.system, signal, action, origin, false)
     {
         Ok(()) => Result::new(ExitStatus::SUCCESS),
         // TODO Print error message

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -559,7 +559,7 @@ mod tests {
             }
             env.wait_for_signal(Signal::SIGCHLD).await;
 
-            let trap_state = env.traps.get_trap(Signal::SIGCHLD).0.unwrap();
+            let trap_state = env.traps.get_state(Signal::SIGCHLD).0.unwrap();
             assert!(trap_state.pending);
         })
     }
@@ -700,7 +700,7 @@ mod tests {
                 .start_subshell(|env| {
                     Box::pin(async move {
                         let trap_state = assert_matches!(
-                            env.traps.get_trap(Signal::SIGCHLD),
+                            env.traps.get_state(Signal::SIGCHLD),
                             (None, Some(trap_state)) => trap_state
                         );
                         assert_matches!(

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -543,7 +543,7 @@ mod tests {
     fn wait_for_signal_remembers_signal_in_trap_set() {
         in_virtual_system(|mut env, pid, state| async move {
             env.traps
-                .set_trap(
+                .set_action(
                     &mut env.system,
                     Signal::SIGCHLD,
                     Action::Command("".into()),
@@ -569,7 +569,7 @@ mod tests {
         let shared_system = SharedSystem::new(Box::new(system.clone()));
         let mut env = Env::with_system(Box::new(shared_system));
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGCHLD,
                 Action::Command("".into()),
@@ -688,7 +688,7 @@ mod tests {
     fn trap_reset_in_subshell() {
         in_virtual_system(|mut env, _pid, _state| async move {
             env.traps
-                .set_trap(
+                .set_action(
                     &mut env.system,
                     Signal::SIGCHLD,
                     Action::Command("echo foo".into()),

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -498,7 +498,7 @@ mod tests {
     use crate::job::Job;
     use crate::system::r#virtual::SystemState;
     use crate::system::Errno;
-    use crate::trap::Trap;
+    use crate::trap::Action;
     use assert_matches::assert_matches;
     use futures_executor::LocalPool;
     use futures_util::task::LocalSpawnExt;
@@ -546,7 +546,7 @@ mod tests {
                 .set_trap(
                     &mut env.system,
                     Signal::SIGCHLD,
-                    Trap::Command("".into()),
+                    Action::Command("".into()),
                     Location::dummy(""),
                     false,
                 )
@@ -572,7 +572,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGCHLD,
-                Trap::Command("".into()),
+                Action::Command("".into()),
                 Location::dummy(""),
                 false,
             )
@@ -691,7 +691,7 @@ mod tests {
                 .set_trap(
                     &mut env.system,
                     Signal::SIGCHLD,
-                    Trap::Command("echo foo".into()),
+                    Action::Command("echo foo".into()),
                     Location::dummy(""),
                     false,
                 )
@@ -705,7 +705,7 @@ mod tests {
                         );
                         assert_matches!(
                             &trap_state.action,
-                            Trap::Command(body) => assert_eq!(&**body, "echo foo")
+                            Action::Command(body) => assert_eq!(&**body, "echo foo")
                         );
                         Continue(())
                     })

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -167,7 +167,7 @@ impl From<&Setting> for SignalHandling {
 
 /// Whole configuration for a signal.
 #[derive(Clone, Debug)]
-struct SignalState {
+struct GrandState {
     /// Setting that is effective in the current environment.
     current_setting: Setting,
 
@@ -183,7 +183,7 @@ struct SignalState {
 /// [`TrapSet::iter`] returns this type of iterator.
 #[must_use]
 pub struct Iter<'a> {
-    inner: std::collections::btree_map::Iter<'a, Signal, SignalState>,
+    inner: std::collections::btree_map::Iter<'a, Signal, GrandState>,
 }
 
 impl<'a> Iterator for Iter<'a> {
@@ -207,7 +207,7 @@ impl<'a> Iterator for Iter<'a> {
 /// See the [module documentation](self) for details.
 #[derive(Clone, Debug, Default)]
 pub struct TrapSet {
-    signals: BTreeMap<Signal, SignalState>,
+    signals: BTreeMap<Signal, GrandState>,
 }
 
 // TODO Extend internal handlers for other signals
@@ -279,7 +279,7 @@ impl TrapSet {
                     let initial_handling =
                         system.set_signal_handling(signal, SignalHandling::Ignore)?;
                     if initial_handling == SignalHandling::Ignore {
-                        vacant.insert(SignalState {
+                        vacant.insert(GrandState {
                             current_setting: Setting::InitiallyIgnored,
                             parent_setting: None,
                             internal_handler_enabled: false,
@@ -303,7 +303,7 @@ impl TrapSet {
 
         system.set_signal_handling(signal, (&state.action).into())?;
 
-        let state = SignalState {
+        let state = GrandState {
             current_setting: Setting::UserSpecified(state),
             parent_setting: None,
             internal_handler_enabled: false,
@@ -424,7 +424,7 @@ impl TrapSet {
                 } else {
                     Setting::InitiallyDefaulted
                 };
-                vacant.insert(SignalState {
+                vacant.insert(GrandState {
                     current_setting,
                     parent_setting: None,
                     internal_handler_enabled: true,

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -100,7 +100,7 @@ mod tests {
         let mut env = Env::with_system(Box::new(system.clone()));
         env.builtins.insert("echo", echo_builtin());
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGUSR1,
                 Action::Command("echo USR1".into()),

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -89,8 +89,8 @@ mod tests {
     use futures_util::FutureExt;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
+    use yash_env::trap::Action;
     use yash_env::trap::Signal;
-    use yash_env::trap::Trap;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
 
@@ -103,7 +103,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGUSR1,
-                Trap::Command("echo USR1".into()),
+                Action::Command("echo USR1".into()),
                 Location::dummy(""),
                 false,
             )

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -176,8 +176,8 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::trap::Action;
     use yash_env::trap::Signal;
-    use yash_env::trap::Trap;
     use yash_syntax::source::Location;
     use yash_syntax::source::Source;
 
@@ -305,7 +305,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGUSR1,
-                Trap::Command("echo USR1".into()),
+                Action::Command("echo USR1".into()),
                 Location::dummy(""),
                 false,
             )

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -302,7 +302,7 @@ mod tests {
         let mut env = Env::with_system(Box::new(system.clone()));
         env.builtins.insert("echo", echo_builtin());
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGUSR1,
                 Action::Command("echo USR1".into()),

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -127,7 +127,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGINT,
                 Action::Command("echo trapped".into()),
@@ -136,7 +136,7 @@ mod tests {
             )
             .unwrap();
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGUSR1,
                 Action::Command("return 56".into()),
@@ -219,7 +219,7 @@ mod tests {
         let r#type = yash_env::builtin::Type::Intrinsic;
         env.builtins.insert("check", Builtin { r#type, execute });
         env.traps
-            .set_trap(
+            .set_action(
                 &mut env.system,
                 Signal::SIGINT,
                 Action::Command("check".into()),
@@ -249,7 +249,7 @@ mod tests {
         let (mut env, system) = signal_env();
         for signal in [Signal::SIGUSR1, Signal::SIGUSR2] {
             env.traps
-                .set_trap(
+                .set_action(
                     &mut env.system,
                     signal,
                     Action::Command("echo $?; echo $?".into()),

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -47,7 +47,7 @@ use std::ops::ControlFlow::Continue;
 use std::pin::Pin;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
-use yash_env::trap::Trap;
+use yash_env::trap::Action;
 #[cfg(doc)]
 use yash_env::trap::TrapSet;
 use yash_env::Env;
@@ -82,7 +82,7 @@ pub async fn run_traps_for_caught_signals(env: &mut Env) -> Result {
     }
 
     while let Some((signal, state)) = env.traps.take_caught_signal() {
-        let code = if let Trap::Command(command) = &state.action {
+        let code = if let Action::Command(command) = &state.action {
             command.clone()
         } else {
             continue;
@@ -116,8 +116,8 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
+    use yash_env::trap::Action;
     use yash_env::trap::Signal;
-    use yash_env::trap::Trap;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
 
@@ -130,7 +130,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGINT,
-                Trap::Command("echo trapped".into()),
+                Action::Command("echo trapped".into()),
                 Location::dummy(""),
                 false,
             )
@@ -139,7 +139,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGUSR1,
-                Trap::Command("return 56".into()),
+                Action::Command("return 56".into()),
                 Location::dummy(""),
                 false,
             )
@@ -222,7 +222,7 @@ mod tests {
             .set_trap(
                 &mut env.system,
                 Signal::SIGINT,
-                Trap::Command("check".into()),
+                Action::Command("check".into()),
                 Location::dummy(""),
                 false,
             )
@@ -252,7 +252,7 @@ mod tests {
                 .set_trap(
                     &mut env.system,
                     signal,
-                    Trap::Command("echo $?; echo $?".into()),
+                    Action::Command("echo $?; echo $?".into()),
                     Location::dummy(""),
                     false,
                 )


### PR DESCRIPTION
- [x] Rename `Trap` to `Action`
- [x] Rename `get_trap` to `get_state`
- [x] Rename `set_trap` to `set_action`
- [x] Rename `SetTrapError` to `SetActionError`
- [x] Rename `UserSignalState` to `Setting`
- [x] Rename `UserSignalState::Trap` to `Setting::UserSpecified`
- [x] Rename `SignalState` to `GrandState`
- [x] Rename `SignalState::current_user_state` to `GrandState::current_setting`
- [x] Rename `SignalState::parent_user_state` to `GrandState::parent_setting`

``` rust
pub enum Action {
    Default, Ignore, Command(Rc<str>),
}
pub enum SetActionError {
    InitiallyIgnored,
    SIGKILL,
    SIGSTOP,
    SystemError(Errno),
}
pub struct TrapState {
    action: Action,
    origin: Location,
    pending: bool,
}
enum Setting {
    InitiallyDefaulted,
    InitiallyIgnored,
    UserSpecified(TrapState),
}
struct GrandState {
    current_setting: Setting,
    parent_setting: Option<Setting>,
    internal_handler_enabled: bool,
}
```