### PR TITLE
Stopper handlers in non-controlled job

### DIFF
--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -233,7 +233,7 @@ mod tests {
         let _ = builtin_body(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["", "TERM"]);
         let _ = builtin_body(&mut env, args).now_or_never().unwrap();
-        env.traps.enter_subshell(&mut env.system, false);
+        env.traps.enter_subshell(&mut env.system, false, false);
 
         let result = builtin_body(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -251,7 +251,7 @@ mod tests {
         let _ = builtin_body(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["", "TERM"]);
         let _ = builtin_body(&mut env, args).now_or_never().unwrap();
-        env.traps.enter_subshell(&mut env.system, false);
+        env.traps.enter_subshell(&mut env.system, false, false);
         let args = Field::dummies(["ls", "QUIT"]);
         let _ = builtin_body(&mut env, args).now_or_never().unwrap();
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -158,6 +158,7 @@ where
         let ignores_sigint_sigquit = self.ignores_sigint_sigquit
             && job_control.is_none()
             && mask_guard.block_sigint_sigquit();
+        let keeps_stopper_handlers = false;
 
         // Define the child process task
         const ME: Pid = Pid::from_raw(0);
@@ -180,8 +181,11 @@ where
                     }
                 }
 
-                env.traps
-                    .enter_subshell(&mut env.system, ignores_sigint_sigquit);
+                env.traps.enter_subshell(
+                    &mut env.system,
+                    ignores_sigint_sigquit,
+                    keeps_stopper_handlers,
+                );
 
                 let result = (self.task)(env, job_control).await;
                 env.apply_result(result);


### PR DESCRIPTION
An interactive job-controlling shell should make its non-controlled subshells ignore the SIGTSTP, SIGTTIN, and SIGTTOU signals so that the signals cannot stop them. If such a subshell were stopped, you could never resume it!