### PR TITLE
Unset built-in

### DIFF
--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -20,7 +20,7 @@ use super::Mode;
 use crate::common::BuiltinEnv;
 use std::path::Path;
 use std::path::PathBuf;
-use yash_env::variable::ReadOnlyError;
+use yash_env::variable::AssignError;
 use yash_env::variable::Scope::Global;
 use yash_env::variable::Value::Scalar;
 use yash_env::variable::Variable;
@@ -47,7 +47,7 @@ pub async fn set_oldpwd(env: &mut Env, value: String) {
     };
     match env.assign_variable(Global, "OLDPWD".to_string(), oldpwd) {
         Ok(_) => {}
-        Err(error) => handle_read_only_error(env, error).await,
+        Err(error) => handle_assign_error(env, error).await,
     }
 }
 
@@ -70,14 +70,14 @@ pub async fn set_pwd(env: &mut Env, path: PathBuf) {
     };
     match env.assign_variable(Global, "PWD".to_string(), pwd) {
         Ok(_) => {}
-        Err(error) => handle_read_only_error(env, error).await,
+        Err(error) => handle_assign_error(env, error).await,
     }
 }
 
 /// Prints a warning message for a read-only variable.
 ///
 /// The message is only a warning because it does not affect the exit status.
-async fn handle_read_only_error(env: &mut Env, error: ReadOnlyError) {
+async fn handle_assign_error(env: &mut Env, error: AssignError) {
     let builtin_name = env.stack.builtin_name();
     let message = Message {
         r#type: AnnotationType::Warning,

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -40,6 +40,7 @@ pub mod readonly;
 pub mod r#return;
 pub mod set;
 pub mod trap;
+pub mod unset;
 pub mod wait;
 
 #[doc(no_inline)]
@@ -135,6 +136,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: |env, args| Box::pin(trap::main(env, args)),
+        },
+    ),
+    (
+        "unset",
+        Builtin {
+            r#type: Special,
+            execute: |env, args| Box::pin(unset::main(env, args)),
         },
     ),
     (

--- a/yash-builtin/src/readonly.rs
+++ b/yash-builtin/src/readonly.rs
@@ -21,7 +21,7 @@
 use yash_env::builtin::Result;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::variable::ReadOnlyError;
+use yash_env::variable::AssignError;
 use yash_env::variable::Scope;
 use yash_env::variable::Variable;
 use yash_env::Env;
@@ -46,7 +46,7 @@ pub fn main(env: &mut Env, args: Vec<Field>) -> Result {
 
             match env.assign_variable(Scope::Global, name, var) {
                 Ok(_old_value) => (),
-                Err(ReadOnlyError {
+                Err(AssignError {
                     name,
                     read_only_location: _,
                     new_value: _,

--- a/yash-builtin/src/unset.rs
+++ b/yash-builtin/src/unset.rs
@@ -1,0 +1,121 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Unset built-in
+//!
+//! The **`unset`** built-in unsets the values of shell variables.
+//!
+//! # Syntax
+//!
+//! ```sh
+//! unset [-fv] name...
+//! ```
+//!
+//! # Semantics
+//!
+//! The built-in unsets shell variables or functions named by the operands.
+//!
+//! # Options
+//!
+//! Either of the following options may be used to select what to unset:
+//!
+//! - The **`-v`** (**`--variables`**) option causes the built-in to unset shell variables.
+//!   This is the default behavior.
+//! - The **`-f`** (**`--functions`**) option causes the built-in to unset shell functions.
+//!
+//! (TODO: The `-l` (`--local`) option causes the built-in to unset local variables only.)
+//!
+//! # Operands
+//!
+//! Operands are the names of shell variables or functions to unset.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Errors
+//!
+//! Unsetting a read-only variable is an error.
+//!
+//! It is not an error to unset a variable or function that is not set.
+//! The built-in ignores such operands.
+//!
+//! # Portability
+//!
+//! The behavior is not portable when both `-f` and `-v` are specified. Earlier
+//! versions of yash used to honor the last specified option, but this version
+//! errors out.
+//!
+//! If neither `-f` nor `-v` is specified and the variable named by an operand
+//! is not set, POSIX allows the built-in to unset the same-named function if it
+//! exists. Yash does not do this.
+//!
+//! (TODO TBD: In the POSIXly-correct mode, the built-in requires at least one operand.)
+//!
+//! When a global variable is hidden by a local variable, the current
+//! implementation unsets the both. This is not portable. Old versions of yash
+//! used to unset the local variable only.
+
+use crate::common::print_error_message;
+use crate::Result;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Selection of what to unset
+#[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Mode {
+    /// Unsets shell variables.
+    #[default]
+    Variables,
+
+    /// Unsets shell functions.
+    Functions,
+}
+
+/// Parsed command line arguments
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Command {
+    /// What to unset
+    pub mode: Mode,
+
+    /// Names of shell variables or functions to unset
+    pub names: Vec<Field>,
+}
+
+pub mod semantics;
+pub mod syntax;
+
+/// Entry point of the `unset` built-in
+pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
+    let command = match syntax::parse(env, args) {
+        Ok(command) => command,
+        Err(e) => return print_error_message(env, &e).await,
+    };
+
+    match command.mode {
+        Mode::Variables => match semantics::unset_variables(env, &command.names) {
+            Ok(()) => Result::default(),
+            Err(errors) => semantics::print_variables_error(env, &errors).await,
+        },
+
+        Mode::Functions => match semantics::unset_functions(env, &command.names) {
+            Ok(()) => Result::default(),
+            Err(errors) => semantics::print_functions_error(env, &errors).await,
+        },
+    }
+}

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -1,0 +1,332 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines the behavior of the unset built-in.
+
+use crate::common::print_failure_message;
+use crate::common::AsStderr;
+use crate::common::BuiltinEnv;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::variable::Scope::Global;
+use yash_env::Env;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
+use yash_syntax::source::Location;
+
+/// Error returned by [`unset_variables`].
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub struct UnsetVariablesError<'a> {
+    /// The name of the read-only variable
+    pub name: &'a Field,
+    /// The location where the variable was made read-only
+    pub read_only_location: Location,
+}
+
+impl std::fmt::Display for UnsetVariablesError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let error = yash_env::variable::UnsetError {
+            name: &self.name.value,
+            read_only_location: &self.read_only_location,
+        };
+        error.fmt(f)
+    }
+}
+
+/// Unsets shell variables.
+///
+/// This function tries to unset all the variables named by `names`. Any error
+/// for a variable is reported in the returned vector and the function continues
+/// to unset the remaining variables.
+///
+/// TODO Allow unsetting local variables only.
+pub fn unset_variables<'a>(
+    env: &mut Env,
+    names: &'a [Field],
+) -> Result<(), Vec<UnsetVariablesError<'a>>> {
+    let mut errors = Vec::new();
+    for name in names {
+        match env.variables.unset(Global, &name.value) {
+            Ok(_) => (),
+            Err(error) => errors.push(UnsetVariablesError {
+                name,
+                read_only_location: error.read_only_location.clone(),
+            }),
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+pub async fn print_variables_error<E>(
+    env: &mut E,
+    errors: &[UnsetVariablesError<'_>],
+) -> crate::Result
+where
+    E: BuiltinEnv + AsStderr,
+{
+    let annotations = errors
+        .iter()
+        .flat_map(|error| {
+            [
+                Annotation::new(
+                    AnnotationType::Error,
+                    error.to_string().into(),
+                    &error.name.origin,
+                ),
+                Annotation::new(
+                    AnnotationType::Info,
+                    format!("variable `{}` was made read-only here", error.name).into(),
+                    &error.read_only_location,
+                ),
+            ]
+        })
+        .collect();
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: "cannot unset variable".into(),
+        annotations,
+    };
+    print_failure_message(env, message).await
+}
+
+/// Error returned by [`unset_functions`].
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("cannot unset read-only function `{name}`")]
+pub struct UnsetFunctionsError<'a> {
+    /// The name of the function
+    pub name: &'a Field,
+    /// The location where the function was made read-only
+    pub read_only_location: Location,
+}
+
+/// Unsets shell functions.
+///
+/// This function tries to unset all the functions named by `names`. Any error
+/// for a function is reported in the returned vector and the function continues
+/// to unset the remaining functions.
+pub fn unset_functions<'a>(
+    env: &mut Env,
+    names: &'a [Field],
+) -> Result<(), Vec<UnsetFunctionsError<'a>>> {
+    let mut errors = Vec::new();
+    for name in names {
+        match env.functions.unset(&name.value) {
+            Ok(_) => (),
+            Err(error) => errors.push(UnsetFunctionsError {
+                name,
+                read_only_location: error.existing.read_only_location.clone().unwrap(),
+            }),
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+pub async fn print_functions_error<E>(
+    env: &mut E,
+    errors: &[UnsetFunctionsError<'_>],
+) -> crate::Result
+where
+    E: BuiltinEnv + AsStderr,
+{
+    let annotations = errors
+        .iter()
+        .flat_map(|error| {
+            [
+                Annotation::new(
+                    AnnotationType::Error,
+                    error.to_string().into(),
+                    &error.name.origin,
+                ),
+                Annotation::new(
+                    AnnotationType::Info,
+                    format!("function `{}` was made read-only here", error.name).into(),
+                    &error.read_only_location,
+                ),
+            ]
+        })
+        .collect();
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: "cannot unset function".into(),
+        annotations,
+    };
+    print_failure_message(env, message).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use yash_env::function::Function;
+    use yash_env::variable::Value;
+    use yash_env::variable::Variable;
+    use yash_syntax::source::Location;
+    use yash_syntax::syntax::FullCompoundCommand;
+
+    #[test]
+    fn unsetting_one_variable() {
+        let mut env = Env::new_virtual();
+        env.assign_variable(Global, "foo".to_string(), Variable::new("FOO"))
+            .unwrap();
+        env.assign_variable(Global, "bar".to_string(), Variable::new("BAR"))
+            .unwrap();
+        env.assign_variable(Global, "baz".to_string(), Variable::new("BAZ"))
+            .unwrap();
+
+        unset_variables(&mut env, &Field::dummies(["bar"])).unwrap();
+        assert_eq!(
+            env.variables.get("foo").unwrap().value,
+            Some(Value::scalar("FOO")),
+        );
+        assert_eq!(env.variables.get("bar"), None);
+        assert_eq!(
+            env.variables.get("baz").unwrap().value,
+            Some(Value::scalar("BAZ")),
+        );
+    }
+
+    #[test]
+    fn unsetting_many_variables() {
+        let mut env = Env::new_virtual();
+        env.assign_variable(Global, "foo".to_string(), Variable::new("FOO"))
+            .unwrap();
+        env.assign_variable(Global, "bar".to_string(), Variable::new("BAR"))
+            .unwrap();
+        env.assign_variable(Global, "baz".to_string(), Variable::new("BAZ"))
+            .unwrap();
+
+        unset_variables(&mut env, &Field::dummies(["bar", "foo", "baz"])).unwrap();
+        assert_eq!(env.variables.get("foo"), None);
+        assert_eq!(env.variables.get("bar"), None);
+        assert_eq!(env.variables.get("baz"), None);
+    }
+
+    #[test]
+    fn unsetting_readonly_variables() {
+        let mut env = Env::new_virtual();
+        env.assign_variable(Global, "a".to_string(), Variable::new("A"))
+            .unwrap();
+        let location_b = Location::dummy("readonly b");
+        env.assign_variable(
+            Global,
+            "b".to_string(),
+            Variable::new("B").make_read_only(location_b.clone()),
+        )
+        .unwrap();
+        let location_c = Location::dummy("readonly c");
+        env.assign_variable(
+            Global,
+            "c".to_string(),
+            Variable::new("C").make_read_only(location_c.clone()),
+        )
+        .unwrap();
+        env.assign_variable(Global, "d".to_string(), Variable::new("D"))
+            .unwrap();
+        let names = Field::dummies(["a", "b", "c", "d"]);
+
+        let errors = unset_variables(&mut env, &names).unwrap_err();
+        assert_matches!(&errors[..], [e1, e2] => {
+            assert_eq!(e1.name, &Field::dummy("b"));
+            assert_eq!(e1.read_only_location, location_b);
+            assert_eq!(e2.name, &Field::dummy("c"));
+            assert_eq!(e2.read_only_location, location_c);
+        });
+        assert_eq!(env.variables.get("a"), None);
+        assert_eq!(
+            env.variables.get("b").unwrap().value,
+            Some(Value::scalar("B")),
+        );
+        assert_eq!(
+            env.variables.get("c").unwrap().value,
+            Some(Value::scalar("C")),
+        );
+        assert_eq!(env.variables.get("d"), None);
+    }
+
+    fn dummy_function(name: &str) -> Function {
+        Function::new(
+            name,
+            "{ :; }".parse::<FullCompoundCommand>().unwrap(),
+            Location::dummy(name),
+        )
+    }
+
+    #[test]
+    fn unsetting_one_function() {
+        let mut env = Env::new_virtual();
+        env.functions.define(dummy_function("foo")).unwrap();
+        env.functions.define(dummy_function("bar")).unwrap();
+        env.functions.define(dummy_function("baz")).unwrap();
+
+        unset_functions(&mut env, &Field::dummies(["foo"])).unwrap();
+        assert_eq!(env.functions.get("foo"), None);
+        assert_eq!(env.functions.get("bar").unwrap().name, "bar");
+        assert_eq!(env.functions.get("baz").unwrap().name, "baz");
+    }
+
+    #[test]
+    fn unsetting_many_functions() {
+        let mut env = Env::new_virtual();
+        env.functions.define(dummy_function("foo")).unwrap();
+        env.functions.define(dummy_function("bar")).unwrap();
+        env.functions.define(dummy_function("baz")).unwrap();
+
+        unset_functions(&mut env, &Field::dummies(["bar", "foo", "baz"])).unwrap();
+        assert_eq!(env.functions.get("foo"), None);
+        assert_eq!(env.functions.get("bar"), None);
+        assert_eq!(env.functions.get("baz"), None);
+    }
+
+    #[test]
+    fn unsetting_readonly_function() {
+        let mut env = Env::new_virtual();
+        env.functions.define(dummy_function("a")).unwrap();
+        let location_b = Location::dummy("readonly b");
+        env.functions
+            .define(dummy_function("b").make_read_only(location_b.clone()))
+            .unwrap();
+        let location_c = Location::dummy("readonly c");
+        env.functions
+            .define(dummy_function("c").make_read_only(location_c.clone()))
+            .unwrap();
+        env.functions.define(dummy_function("d")).unwrap();
+        let names = Field::dummies(["a", "b", "c", "d"]);
+
+        let errors = unset_functions(&mut env, &names).unwrap_err();
+        assert_matches!(&errors[..], [e1, e2] => {
+            assert_eq!(e1.name, &Field::dummy("b"));
+            assert_eq!(e1.read_only_location, location_b);
+            assert_eq!(e2.name, &Field::dummy("c"));
+            assert_eq!(e2.read_only_location, location_c);
+        });
+        assert_eq!(env.functions.get("a"), None);
+        assert_eq!(env.functions.get("b").unwrap().name, "b");
+        assert_eq!(env.functions.get("c").unwrap().name, "c");
+        assert_eq!(env.functions.get("d"), None);
+    }
+
+    // TODO unsetting_global_variable_hidden_by_local_variable: should unset the both
+    // TODO unsetting_readonly_global_variable_hidden_by_local_variable: should unset the local only
+}

--- a/yash-builtin/src/unset/syntax.rs
+++ b/yash-builtin/src/unset/syntax.rs
@@ -1,0 +1,166 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Parses the unset built-in command arguments.
+
+use crate::common::syntax::parse_arguments;
+use crate::common::syntax::OptionOccurrence;
+use crate::common::syntax::OptionSpec;
+use std::borrow::Cow;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::MessageBase;
+
+use super::Command;
+use super::Mode;
+
+/// Error in parsing command line arguments
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// An error occurred in the common parser.
+    #[error(transparent)]
+    CommonError(#[from] crate::common::syntax::Error<'static>),
+    // TODO MissingOperand
+}
+
+impl MessageBase for Error {
+    fn message_title(&self) -> Cow<str> {
+        self.to_string().into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        match self {
+            Error::CommonError(inner) => inner.main_annotation(),
+        }
+    }
+}
+
+/// Result of parsing command line arguments
+pub type Result = std::result::Result<Command, Error>;
+
+const OPTION_SPECS: &[OptionSpec] = &[
+    OptionSpec::new().short('f').long("functions"),
+    OptionSpec::new().short('v').long("variables"),
+];
+
+fn mode_for_option(option: &OptionOccurrence) -> Mode {
+    match option.spec.get_short() {
+        Some('f') => Mode::Functions,
+        Some('v') => Mode::Variables,
+        _ => unreachable!("{option:?}"),
+    }
+}
+
+/// Parses command line arguments for the unset built-in.
+pub fn parse(env: &Env, args: Vec<Field>) -> Result {
+    let parser_mode = crate::common::syntax::Mode::with_env(env);
+    let (options, operands) = parse_arguments(OPTION_SPECS, parser_mode, args)?;
+
+    Ok(Command {
+        mode: options.last().map(mode_for_option).unwrap_or_default(),
+        names: operands,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_arguments_non_posix() {
+        let env = Env::new_virtual();
+        let result = parse(&env, vec![]);
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Variables,
+                names: vec![],
+            })
+        );
+    }
+
+    // TODO no_arguments_posix: In the POSIXly-correct mode, the built-in
+    // requires at least one operand.
+
+    #[test]
+    fn v_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-v"]));
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Variables,
+                names: vec![],
+            })
+        );
+
+        // The same option can be specified multiple times.
+        let result = parse(&env, Field::dummies(["-vv", "--variables"]));
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Variables,
+                names: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn f_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-f"]));
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Functions,
+                names: vec![],
+            })
+        );
+
+        // The same option can be specified multiple times.
+        let result = parse(&env, Field::dummies(["-ff", "--functions"]));
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Functions,
+                names: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn v_and_f_option() {
+        // Specifying both -v and -f is an error.
+        // TODO Common argument parser should detect this.
+    }
+
+    #[test]
+    fn operands() {
+        let env = Env::new_virtual();
+        let args = Field::dummies(["foo", "bar"]);
+        let result = parse(&env, args.clone());
+        assert_eq!(
+            result,
+            Ok(Command {
+                mode: Mode::Variables,
+                names: args,
+            })
+        );
+    }
+}

--- a/yash-env/src/function.rs
+++ b/yash-env/src/function.rs
@@ -41,10 +41,50 @@ pub struct Function {
     /// Location of the function definition command that defined this function.
     pub origin: Location,
 
-    /// Whether this function is read-only or not.
+    /// Optional location where this function was made read-only.
     ///
-    /// A read-only function cannot be re-defined or unset.
-    pub is_read_only: bool,
+    /// If this function is not read-only, `read_only_location` is `None`.
+    /// Otherwise, `read_only_location` is the location of the simple command
+    /// that executed the `readonly` built-in that made this function read-only.
+    pub read_only_location: Option<Location>,
+}
+
+impl Function {
+    /// Creates a new function.
+    ///
+    /// This is a convenience function for constructing a `Function` object.
+    /// The `read_only_location` is set to `None`.
+    #[inline]
+    #[must_use]
+    pub fn new<N: Into<String>, C: Into<Rc<FullCompoundCommand>>>(
+        name: N,
+        body: C,
+        origin: Location,
+    ) -> Self {
+        Function {
+            name: name.into(),
+            body: body.into(),
+            origin,
+            read_only_location: None,
+        }
+    }
+
+    /// Makes the function read-only.
+    ///
+    /// This is a convenience function for doing
+    /// `self.read_only_location = Some(location)` in a method chain.
+    #[inline]
+    #[must_use]
+    pub fn make_read_only(mut self, location: Location) -> Self {
+        self.read_only_location = Some(location);
+        self
+    }
+
+    /// Whether this function is read-only or not.
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only_location.is_some()
+    }
 }
 
 /// Wrapper of [`Function`] for inserting into a hash set.
@@ -62,13 +102,13 @@ impl HashEntry {
         name: String,
         body: Rc<FullCompoundCommand>,
         origin: Location,
-        is_read_only: bool,
+        read_only_location: Option<Location>,
     ) -> HashEntry {
         HashEntry(Rc::new(Function {
             name,
             body,
             origin,
-            is_read_only,
+            read_only_location,
         }))
     }
 }

--- a/yash-env/src/function.rs
+++ b/yash-env/src/function.rs
@@ -34,8 +34,9 @@ pub struct Function {
 
     /// Command that is executed when the function is called.
     ///
-    /// This is wrapped in `Rc` so that a function can be defined and executed
-    /// without cloning the entire compound command.
+    /// This is wrapped in `Rc` so that we don't have to clone the entire
+    /// compound command when we define a function. The function definition
+    /// command only clones the `Rc` object from the abstract syntax tree.
     pub body: Rc<FullCompoundCommand>,
 
     /// Location of the function definition command that defined this function.
@@ -89,10 +90,14 @@ impl Function {
 
 /// Wrapper of [`Function`] for inserting into a hash set.
 ///
-/// A `HashEntry` wraps a `Function` in `Rc` so that the function can be
-/// referred to even after the function has been removed from the environment.
+/// A `HashEntry` wraps a `Function` in `Rc` so that the `Function` object can
+/// outlive the execution of the function which may redefine or unset the
+/// function itself. A simple command that executes the function clones the
+/// `Rc` object from the function set and retains it until the command
+/// terminates.
+///
 /// The `Hash` and `PartialEq` implementation for `HashEntry` only compares
-/// names.
+/// the names of the functions.
 #[derive(Clone, Debug, Eq)]
 pub struct HashEntry(pub Rc<Function>);
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -52,7 +52,7 @@ use self::system::SignalHandling;
 pub use self::system::System;
 use self::trap::Signal;
 use self::trap::TrapSet;
-use self::variable::ReadOnlyError;
+use self::variable::AssignError;
 use self::variable::Scope;
 use self::variable::Variable;
 use self::variable::VariableSet;
@@ -392,7 +392,7 @@ impl Env {
         scope: Scope,
         name: String,
         value: Variable,
-    ) -> Result<Option<Variable>, ReadOnlyError> {
+    ) -> Result<Option<Variable>, AssignError> {
         let value = match self.options.get(AllExport) {
             On => value.export(),
             Off => value,

--- a/yash-env/src/pwd.rs
+++ b/yash-env/src/pwd.rs
@@ -19,7 +19,7 @@
 use super::Env;
 use crate::system::AtFlags;
 use crate::system::AT_FDCWD;
-use crate::variable::ReadOnlyError;
+use crate::variable::AssignError;
 use crate::variable::Scope::Global;
 use crate::variable::Value::Scalar;
 use crate::variable::Variable;
@@ -45,7 +45,7 @@ fn same_files(a: &FileStat, b: &FileStat) -> bool {
 pub enum PreparePwdError {
     /// Error assigning to the `$PWD` variable
     #[error(transparent)]
-    AssignError(#[from] ReadOnlyError),
+    AssignError(#[from] AssignError),
 
     /// Error obtaining the current working directory path
     #[error("cannot obtain the current working directory path: {0}")]

--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -406,7 +406,7 @@ pub enum Scope {
 // TODO Add UnsetReadOnlyError that does not have the new_value field
 /// Error that occurs when assigning to an existing read-only variable.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
-#[error("variable `{name}` is read-only")]
+#[error("cannot assign to read-only variable `{name}`")]
 pub struct AssignError {
     /// Variable name.
     pub name: String,

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -67,7 +67,7 @@ pub async fn perform_assignment(
         read_only_location: None,
     };
     env.assign_variable(scope, name, value).map_err(|e| Error {
-        cause: ErrorCause::AssignReadOnly(e),
+        cause: ErrorCause::AssignError(e),
         location: assign.location.clone(),
     })?;
     Ok(exit_status)
@@ -158,7 +158,7 @@ mod tests {
             .now_or_never()
             .unwrap()
             .unwrap_err();
-        assert_matches!(e.cause, ErrorCause::AssignReadOnly(roe) => {
+        assert_matches!(e.cause, ErrorCause::AssignError(roe) => {
             assert_eq!(roe.name, "v");
             assert_eq!(roe.read_only_location, location);
             assert_eq!(roe.new_value.value, Some(Value::scalar("new")));

--- a/yash-semantics/src/command/compound_command/for_loop.rs
+++ b/yash-semantics/src/command/compound_command/for_loop.rs
@@ -91,7 +91,7 @@ pub async fn execute(
                 other => other?,
             },
             Err(error) => {
-                let cause = ErrorCause::AssignReadOnly(error);
+                let cause = ErrorCause::AssignError(error);
                 let location = name.origin;
                 let error = Error { cause, location };
                 return apply_errexit(error.handle(env).await, env);

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -148,7 +148,7 @@ pub fn search<E: SearchEnv>(env: &mut E, name: &str) -> Option<Target> {
     }
 
     if let Some(function) = env.functions().get(name) {
-        return Some(function.0.clone().into());
+        return Some(Rc::clone(function).into());
     }
 
     if let Some(builtin) = builtin {
@@ -196,7 +196,6 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use std::collections::HashSet;
-    use yash_env::function::HashEntry as FunctionEntry;
     use yash_syntax::source::Location;
     use yash_syntax::syntax::CompoundCommand;
     use yash_syntax::syntax::FullCompoundCommand;
@@ -231,11 +230,11 @@ mod tests {
         }
     }
 
-    fn full_compound_command(s: &str) -> Rc<FullCompoundCommand> {
-        Rc::new(FullCompoundCommand {
+    fn full_compound_command(s: &str) -> FullCompoundCommand {
+        FullCompoundCommand {
             command: CompoundCommand::Grouping(s.parse().unwrap()),
             redirs: vec![],
-        })
+        }
     }
 
     #[test]
@@ -255,12 +254,8 @@ mod tests {
                 execute: |_, _| unreachable!(),
             },
         );
-        env.functions.insert(FunctionEntry::new(
-            "foo".to_string(),
-            full_compound_command(""),
-            Location::dummy(""),
-            None,
-        ));
+        let function = Function::new("foo", full_compound_command(""), Location::dummy(""));
+        env.functions.define(function).unwrap();
 
         let target = search(&mut env, "bar");
         assert!(target.is_none(), "target = {target:?}");
@@ -283,16 +278,15 @@ mod tests {
     #[test]
     fn function_is_found_if_not_hidden_by_special_builtin() {
         let mut env = DummyEnv::default();
-        let function = FunctionEntry::new(
-            "foo".to_string(),
+        let function = Rc::new(Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        );
-        env.functions.insert(function.clone());
+        ));
+        env.functions.define(function.clone()).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Function(result)) => {
-            assert_eq!(result, function.0);
+            assert_eq!(result, function);
         });
     }
 
@@ -304,12 +298,12 @@ mod tests {
             execute: |_, _| unreachable!(),
         };
         env.builtins.insert("foo", builtin);
-        env.functions.insert(FunctionEntry::new(
-            "foo".to_string(),
+        let function = Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        ));
+        );
+        env.functions.define(function).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Builtin(result)) => {
             assert_eq!(result.r#type, builtin.r#type);
@@ -369,16 +363,15 @@ mod tests {
             },
         );
 
-        let function = FunctionEntry::new(
-            "foo".to_string(),
+        let function = Rc::new(Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        );
-        env.functions.insert(function.clone());
+        ));
+        env.functions.define(function.clone()).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Function(result)) => {
-            assert_eq!(result, function.0);
+            assert_eq!(result, function);
         });
     }
 
@@ -393,16 +386,15 @@ mod tests {
             },
         );
 
-        let function = FunctionEntry::new(
-            "foo".to_string(),
+        let function = Rc::new(Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        );
-        env.functions.insert(function.clone());
+        ));
+        env.functions.define(function.clone()).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Function(result)) => {
-            assert_eq!(result, function.0);
+            assert_eq!(result, function);
         });
     }
 
@@ -417,16 +409,15 @@ mod tests {
             },
         );
 
-        let function = FunctionEntry::new(
-            "foo".to_string(),
+        let function = Rc::new(Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        );
-        env.functions.insert(function.clone());
+        ));
+        env.functions.define(function.clone()).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Function(result)) => {
-            assert_eq!(result, function.0);
+            assert_eq!(result, function);
         });
     }
 
@@ -470,16 +461,15 @@ mod tests {
         env.path = Some(Variable::new("/bin").export());
         env.executables.insert("/bin/foo".to_string());
 
-        let function = FunctionEntry::new(
-            "foo".to_string(),
+        let function = Rc::new(Function::new(
+            "foo",
             full_compound_command("bar"),
             Location::dummy("location"),
-            None,
-        );
-        env.functions.insert(function.clone());
+        ));
+        env.functions.define(function.clone()).unwrap();
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Function(result)) => {
-            assert_eq!(result, function.0);
+            assert_eq!(result, function);
         });
     }
 

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -259,7 +259,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command(""),
             Location::dummy(""),
-            false,
+            None,
         ));
 
         let target = search(&mut env, "bar");
@@ -287,7 +287,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         );
         env.functions.insert(function.clone());
 
@@ -308,7 +308,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         ));
 
         assert_matches!(search(&mut env, "foo"), Some(Target::Builtin(result)) => {
@@ -373,7 +373,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         );
         env.functions.insert(function.clone());
 
@@ -397,7 +397,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         );
         env.functions.insert(function.clone());
 
@@ -421,7 +421,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         );
         env.functions.insert(function.clone());
 
@@ -474,7 +474,7 @@ mod tests {
             "foo".to_string(),
             full_compound_command("bar"),
             Location::dummy("location"),
-            false,
+            None,
         );
         env.functions.insert(function.clone());
 

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -139,7 +139,7 @@ impl ErrorCause {
         match self {
             CommandSubstError(_) => "error performing the command substitution",
             ArithError(_) => "error evaluating the arithmetic expansion",
-            AssignError(_) => "cannot assign to read-only variable",
+            AssignError(_) => "error assigning to variable",
             UnsetParameter => "unset parameter",
             EmptyExpansion(error) => error.message_or_default(),
             NonassignableParameter(_) => "cannot assign to parameter",
@@ -383,10 +383,13 @@ mod tests {
         };
         let message = Message::from(&error);
         assert_eq!(message.r#type, AnnotationType::Error);
-        assert_eq!(message.title, "cannot assign to read-only variable");
+        assert_eq!(message.title, "error assigning to variable");
         assert_eq!(message.annotations.len(), 2);
         assert_eq!(message.annotations[0].r#type, AnnotationType::Error);
-        assert_eq!(message.annotations[0].label, "variable `var` is read-only");
+        assert_eq!(
+            message.annotations[0].label,
+            "cannot assign to read-only variable `var`"
+        );
         assert_eq!(message.annotations[0].location, &error.location);
         assert_eq!(message.annotations[1].r#type, AnnotationType::Info);
         assert_eq!(

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -90,7 +90,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 use yash_env::semantics::ExitStatus;
 use yash_env::system::Errno;
-use yash_env::variable::ReadOnlyError;
+use yash_env::variable::AssignError;
 use yash_env::variable::Variable;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
@@ -115,7 +115,7 @@ pub enum ErrorCause {
 
     /// Assignment to a read-only variable.
     #[error(transparent)]
-    AssignReadOnly(#[from] ReadOnlyError),
+    AssignReadOnly(#[from] AssignError),
 
     /// Expansion of an unset parameter with the `nounset` option
     #[error("unset parameter")]
@@ -374,7 +374,7 @@ mod tests {
         let location = Location { code, range: 2..4 };
         let new_value = Variable::new("value").set_assigned_location(Location::dummy("assigned"));
         let error = Error {
-            cause: ErrorCause::AssignReadOnly(ReadOnlyError {
+            cause: ErrorCause::AssignReadOnly(AssignError {
                 name: "var".into(),
                 read_only_location: Location::dummy("ROL"),
                 new_value,

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -115,7 +115,7 @@ pub enum ErrorCause {
 
     /// Assignment to a read-only variable.
     #[error(transparent)]
-    AssignReadOnly(#[from] AssignError),
+    AssignError(#[from] AssignError),
 
     /// Expansion of an unset parameter with the `nounset` option
     #[error("unset parameter")]
@@ -139,7 +139,7 @@ impl ErrorCause {
         match self {
             CommandSubstError(_) => "error performing the command substitution",
             ArithError(_) => "error evaluating the arithmetic expansion",
-            AssignReadOnly(_) => "cannot assign to read-only variable",
+            AssignError(_) => "cannot assign to read-only variable",
             UnsetParameter => "unset parameter",
             EmptyExpansion(error) => error.message_or_default(),
             NonassignableParameter(_) => "cannot assign to parameter",
@@ -154,7 +154,7 @@ impl ErrorCause {
         match self {
             CommandSubstError(e) => e.desc().into(),
             ArithError(e) => e.to_string().into(),
-            AssignReadOnly(e) => e.to_string().into(),
+            AssignError(e) => e.to_string().into(),
             UnsetParameter => "unset parameter disallowed by the nounset option".into(),
             EmptyExpansion(e) => e.state.description().into(),
             NonassignableParameter(e) => e.to_string().into(),
@@ -170,7 +170,7 @@ impl ErrorCause {
         match self {
             CommandSubstError(_) => None,
             ArithError(e) => e.related_location(),
-            AssignReadOnly(e) => Some((
+            AssignError(e) => Some((
                 &e.read_only_location,
                 "the variable was made read-only here",
             )),
@@ -374,7 +374,7 @@ mod tests {
         let location = Location { code, range: 2..4 };
         let new_value = Variable::new("value").set_assigned_location(Location::dummy("assigned"));
         let error = Error {
-            cause: ErrorCause::AssignReadOnly(AssignError {
+            cause: ErrorCause::AssignError(AssignError {
                 name: "var".into(),
                 read_only_location: Location::dummy("ROL"),
                 new_value,

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -193,7 +193,7 @@ fn convert_error_cause(
             yash_arith::EvalError::ReverseShifting => ErrorCause::ArithError(ReverseShifting),
             yash_arith::EvalError::AssignmentToValue => ErrorCause::ArithError(AssignmentToValue),
             yash_arith::EvalError::GetVariableError(UnsetVariable) => ErrorCause::UnsetParameter,
-            yash_arith::EvalError::AssignVariableError(e) => ErrorCause::AssignReadOnly(e),
+            yash_arith::EvalError::AssignVariableError(e) => ErrorCause::AssignError(e),
         },
     }
 }

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use yash_arith::eval;
 use yash_env::option::Option::Unset;
 use yash_env::option::State::{Off, On};
-use yash_env::variable::ReadOnlyError;
+use yash_env::variable::AssignError;
 use yash_env::variable::Scope::Global;
 use yash_env::variable::Value::Scalar;
 use yash_env::variable::Variable;
@@ -144,7 +144,7 @@ struct UnsetVariable;
 /// It is used to reproduce a location contained in the error cause.
 #[must_use]
 fn convert_error_cause(
-    cause: yash_arith::ErrorCause<UnsetVariable, ReadOnlyError>,
+    cause: yash_arith::ErrorCause<UnsetVariable, AssignError>,
     source: &Rc<Code>,
 ) -> ErrorCause {
     use ArithError::*;
@@ -206,7 +206,7 @@ struct VarEnv<'a> {
 
 impl<'a> yash_arith::Env for VarEnv<'a> {
     type GetVariableError = UnsetVariable;
-    type AssignVariableError = ReadOnlyError;
+    type AssignVariableError = AssignError;
 
     #[rustfmt::skip]
     fn get_variable(&self, name: &str) -> Result<Option<&str>, UnsetVariable> {
@@ -227,7 +227,7 @@ impl<'a> yash_arith::Env for VarEnv<'a> {
         name: &str,
         value: String,
         range: Range<usize>,
-    ) -> Result<(), ReadOnlyError> {
+    ) -> Result<(), AssignError> {
         let code = Rc::new(Code {
             value: self.expression.to_string().into(),
             start_line_number: 1.try_into().unwrap(),

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -191,7 +191,7 @@ async fn assign(
         .assign_variable(Scope::Global, name, variable)
         .map_err(|e| {
             let location = e.new_value.last_assigned_location.as_ref().unwrap().clone();
-            let cause = ErrorCause::AssignReadOnly(e);
+            let cause = ErrorCause::AssignError(e);
             Error { cause, location }
         })?;
     Ok(value_phrase)
@@ -536,7 +536,7 @@ mod tests {
             .now_or_never()
             .unwrap();
         assert_matches!(result, Some(Err(error)) => {
-            assert_matches!(error.cause, ErrorCause::AssignReadOnly(e) => {
+            assert_matches!(error.cause, ErrorCause::AssignError(e) => {
                 assert_eq!(e.name, "var");
                 assert_eq!(e.read_only_location, Location::dummy("read-only"));
                 assert_eq!(e.new_value.value, Some(Value::scalar("foo")));

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -178,6 +178,11 @@ fn tilde_expansion() {
 }
 
 #[test]
+fn unset_builtin() {
+    run("unset-p.sh")
+}
+
+#[test]
 fn until_loop() {
     run("until-p.sh")
 }

--- a/yash/tests/scripted_test/arith-p.sh
+++ b/yash/tests/scripted_test/arith-p.sh
@@ -19,7 +19,6 @@ __IN__
 0 1 100 1 -1
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE -e 0 'unset variable is considered 0 (direct)'
 unset x
 echoraw $((x))
@@ -169,7 +168,6 @@ echoraw $((a=5))
 echoraw not reached
 __IN__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE -e 0 'unset variable is considered 0 (assignment)'
 unset x
 echoraw $((a=x)) && echoraw $a
@@ -357,7 +355,6 @@ __OUT__
 #__IN__
 #__OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE 'assignment in parameter expansion in arithmetic expansion'
 unset a
 echoraw $((${a=1}))

--- a/yash/tests/scripted_test/cd-p.sh
+++ b/yash/tests/scripted_test/cd-p.sh
@@ -218,7 +218,6 @@ __IN__
 $ORIGPWD/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'cd paths are ignored for operand starting with dot-dot (-L)' \
     3<<\__IN__ 5</dev/null 4<<__OUT__
 unset CDPATH
@@ -232,7 +231,6 @@ __IN__
 $ORIGPWD/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'cd paths are ignored for operand starting with dot-dot (-P)' \
     3<<\__IN__ 5</dev/null 4<<__OUT__
 unset CDPATH
@@ -270,7 +268,6 @@ __OUT__
 
 )
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" -d 'directory not found (with unset CDPATH, -L)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -282,7 +279,6 @@ __IN__
 $ORIGPWD
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" -d 'directory not found (with unset CDPATH, -P)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -310,7 +306,6 @@ test_O -d -e n 'non-existing file in operand component (-P)'
 cd -P ./_no_such_file_/../dev
 __IN__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'target pathname is canonicalized (-L)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -322,7 +317,6 @@ PWD=$ORIGPWD/dev
 $ORIGPWD/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'symbolic links are resolved (in operand, -P)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -334,7 +328,6 @@ PWD=$ORIGPWD/cdpath2/dev
 $ORIGPWD/cdpath2/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'symbolic links are resolved (in old PWD, -P)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -347,7 +340,6 @@ PWD=$ORIGPWD/cdpath2/dev
 $ORIGPWD/cdpath2/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'default option is -L' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -359,7 +351,6 @@ PWD=$ORIGPWD/dev
 $ORIGPWD/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'the last option wins (-L)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -371,7 +362,6 @@ PWD=$ORIGPWD/dev
 $ORIGPWD/dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'the last option wins (-P)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH
@@ -421,7 +411,6 @@ __IN__
 /dev
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 testcase "$LINENO" 'OLDPWD is set to old PWD (-L)' \
     3<<\__IN__ 5<&- 4<<__OUT__
 unset CDPATH

--- a/yash/tests/scripted_test/fsplit-p.sh
+++ b/yash/tests/scripted_test/fsplit-p.sh
@@ -66,7 +66,6 @@ __IN__
 4]
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE 'field splitting with unset IFS'
 unset IFS
 a='1 2	3

--- a/yash/tests/scripted_test/simple-p.sh
+++ b/yash/tests/scripted_test/simple-p.sh
@@ -8,7 +8,6 @@ test_x -e 11 'exit status of empty command with command substitution'
 $(exit 11)
 __IN__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE 'command words are expanded before assignments and redirections'
 unset a
 a=$(echo A 3>|f1) 3>|f1 echo "$(test -f f1 || echo file does not exist $a)"
@@ -55,7 +54,6 @@ __IN__
 [A"B"C][A'B'C]['"C"']
 __OUT__
 
-: TODO Needs the unset built-in <<\__OUT__
 test_oE 'assignment is persistent for empty command'
 unset a b x
 a=A

--- a/yash/tests/scripted_test/unset-p.sh
+++ b/yash/tests/scripted_test/unset-p.sh
@@ -1,0 +1,122 @@
+# unset-p.sh: test of the unset built-in for any POSIX-compliant shell
+
+posix="true"
+
+echo echo external a > a
+echo echo external b > b
+echo echo external c > c
+echo echo external d > d
+echo echo external x > x
+chmod a+x a b c d x
+setup 'PATH=.:$PATH'
+
+test_oE -e 0 'deleting existing variable (default)' -e
+a=1 b=2
+unset a
+echo ${a-unset} ${b-unset}
+__IN__
+unset 2
+__OUT__
+
+test_oE -e 0 'deleting non-existing variable (default)' -e
+a=1 b=2
+unset x
+echo ${a-unset} ${b-unset} ${x-unset}
+__IN__
+1 2 unset
+__OUT__
+
+test_oE -e 0 'deleting many variables (default)' -e
+a=1 b=2 c=3 d=4
+unset a b x c
+echo ${a-unset} ${b-unset} ${c-unset} ${d-unset} ${x-unset}
+__IN__
+unset unset unset 4 unset
+__OUT__
+
+test_oE -e 0 'only variable is deleted by default' -e
+a() { echo "$@"; }
+a=1
+unset a
+a ${a-unset}
+__IN__
+unset
+__OUT__
+
+test_oE -e 0 'deleting many variables (-v)' -e
+a=1 b=2 c=3 d=4
+unset -v a b x c
+echo ${a-unset} ${b-unset} ${c-unset} ${d-unset} ${x-unset}
+__IN__
+unset unset unset 4 unset
+__OUT__
+
+test_oE -e 0 'only variable is deleted (-v)' -e
+a() { echo "$@"; }
+a=1
+unset -v a
+a ${a-unset}
+__IN__
+unset
+__OUT__
+
+test_oE -e 0 'deleting existing function (-f)' -e
+a() { echo a; }
+b() { echo b; }
+unset -f b
+a
+b
+__IN__
+a
+external b
+__OUT__
+
+test_oE -e 0 'deleting non-existing function (-f)' -e
+a() { echo a; }
+unset -f b
+a
+b
+__IN__
+a
+external b
+__OUT__
+
+test_oE -e 0 'deleting many functions (-f)' -e
+a() { echo a; }
+b() { echo b; }
+c() { echo c; }
+d() { echo d; }
+unset -f a b x c
+a
+b
+c
+d
+x
+__IN__
+external a
+external b
+external c
+d
+external x
+__OUT__
+
+test_oE -e 0 'only function is deleted (-f)' -e
+a=1
+a() { echo a; }
+unset -f a
+echo ${a-unset}
+__IN__
+1
+__OUT__
+
+test_O -d -e n 'read-only variable cannot be deleted (default)'
+readonly a=
+unset a
+echo not reached # special built-in error kills non-interactive shell
+__IN__
+
+test_O -d -e n 'read-only variable cannot be deleted (-v)'
+readonly a=
+unset -v a
+echo not reached # special built-in error kills non-interactive shell
+__IN__


### PR DESCRIPTION
- [x] Split `ReadOnlyError` into `AssignReadOnlyError` and `UnsetReadOnlyError`
- [x] Implement `VariableSet::unset`
- [x] Refactor `yash_env::function` to make it more like `yash_env::variable`.
    - Use a hash map instead of a hash set
    - Make the hash map opaque
    - Reject modifying read-only functions (Return `DefineError` or `UnsetError`)
- [x] Implement the built-in command argument parser
- [x] Implement the built-in semantics
- [x] Integrate
