### PR TITLE
Handle conflicting options in unset built-in

### DIFF
--- a/yash-builtin/src/break/syntax.rs
+++ b/yash-builtin/src/break/syntax.rs
@@ -34,7 +34,7 @@ use yash_syntax::source::pretty::MessageBase;
 pub enum Error {
     /// An error occurred in the common parser.
     #[error(transparent)]
-    CommonError(#[from] crate::common::syntax::Error<'static>),
+    CommonError(#[from] crate::common::syntax::ParseError<'static>),
 
     /// More than one operand is given.
     #[error("too many operands")]

--- a/yash-builtin/src/cd/syntax.rs
+++ b/yash-builtin/src/cd/syntax.rs
@@ -36,7 +36,7 @@ use yash_syntax::source::pretty::MessageBase;
 pub enum Error {
     /// An error occurred in the common parser.
     #[error(transparent)]
-    CommonError(#[from] crate::common::syntax::Error<'static>),
+    CommonError(#[from] crate::common::syntax::ParseError<'static>),
 
     /// The operand is an empty string.
     // TODO: EmptyOperand(Field),

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -20,7 +20,8 @@
 //! built-in implementations. These traits abstract the environment and reduce
 //! dependency on it.
 //!
-//! This module contains some utility functions for printing error messages.
+//! This module contains some utility functions for printing error messages and
+//! a submodule for [parsing command line arguments](syntax).
 
 use async_trait::async_trait;
 use std::ops::ControlFlow::{self, Break, Continue};

--- a/yash-builtin/src/pwd/syntax.rs
+++ b/yash-builtin/src/pwd/syntax.rs
@@ -34,7 +34,7 @@ use yash_syntax::source::pretty::MessageBase;
 pub enum Error {
     /// An error occurred in the common parser.
     #[error(transparent)]
-    CommonError(#[from] crate::common::syntax::Error<'static>),
+    CommonError(#[from] crate::common::syntax::ParseError<'static>),
 
     /// One or more operands are given.
     #[error("unexpected operand")]

--- a/yash-builtin/src/unset/syntax.rs
+++ b/yash-builtin/src/unset/syntax.rs
@@ -35,7 +35,7 @@ use super::Mode;
 pub enum Error {
     /// An error occurred in the common parser.
     #[error(transparent)]
-    CommonError(#[from] crate::common::syntax::Error<'static>),
+    CommonError(#[from] crate::common::syntax::ParseError<'static>),
 
     /// The `-f` and `-v` options are used together.
     #[error(transparent)]


### PR DESCRIPTION
This pull request follows up #301.

This pull request makes the unset built-in reject the `-f` and `-v` options specified at once.
In doing so, `OptionOccurrence` is modified to include the location and a utility named `ConflictingOptionError` is added that reports the conflicting options.