### PR TITLE
Refactor error reporting in built-ins

### DIFF
--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -75,27 +75,23 @@
 //! continue built-in implementation.
 
 use crate::common::print_error_message;
-use crate::common::print_simple_error_message;
-use crate::common::BuiltinEnv;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
-use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
 
 // pub mod display;
 pub mod semantics;
 pub mod syntax;
 
 async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
-    let builtin_name = &env.stack.builtin_name();
-    let location = builtin_name.origin.clone();
-    print_simple_error_message(
-        env,
-        "cannot break",
-        Annotation::new(AnnotationType::Error, error.to_string().into(), &location),
-    )
-    .await
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: format!("cannot break: {}", error).into(),
+        annotations: vec![],
+    };
+    print_error_message(env, message).await
 }
 
 /// Entry point for executing the `break` built-in

--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -75,23 +75,17 @@
 //! continue built-in implementation.
 
 use crate::common::report_error;
+use crate::common::report_simple_error;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
-use yash_syntax::source::pretty::AnnotationType;
-use yash_syntax::source::pretty::Message;
 
 // pub mod display;
 pub mod semantics;
 pub mod syntax;
 
 async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
-    let message = Message {
-        r#type: AnnotationType::Error,
-        title: format!("cannot break: {}", error).into(),
-        annotations: vec![],
-    };
-    report_error(env, message).await
+    report_simple_error(env, &format!("cannot break: {}", error)).await
 }
 
 /// Entry point for executing the `break` built-in

--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -74,7 +74,7 @@
 //! Part of the break built-in implementation is shared with the
 //! continue built-in implementation.
 
-use crate::common::print_error_message;
+use crate::common::report_error;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
@@ -85,13 +85,13 @@ use yash_syntax::source::pretty::Message;
 pub mod semantics;
 pub mod syntax;
 
-async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
+async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
     let message = Message {
         r#type: AnnotationType::Error,
         title: format!("cannot break: {}", error).into(),
         annotations: vec![],
     };
-    print_error_message(env, message).await
+    report_error(env, message).await
 }
 
 /// Entry point for executing the `break` built-in
@@ -101,8 +101,8 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     match syntax::parse(env, args) {
         Ok(count) => match semantics::run(&env.stack, count) {
             Ok(result) => result,
-            Err(e) => print_semantics_error(env, &e).await,
+            Err(e) => report_semantics_error(env, &e).await,
         },
-        Err(e) => print_error_message(env, &e).await,
+        Err(e) => report_error(env, &e).await,
     }
 }

--- a/yash-builtin/src/break/semantics.rs
+++ b/yash-builtin/src/break/semantics.rs
@@ -54,14 +54,15 @@ pub fn run(stack: &Stack, max_count: NonZeroUsize) -> Result {
 mod tests {
     use super::*;
     use yash_env::semantics::Field;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::stack::StackFrameGuard;
 
     fn push_break_builtin(stack: &mut Stack) -> StackFrameGuard<'_> {
-        stack.push(Frame::Builtin {
+        stack.push(Frame::Builtin(Builtin {
             name: Field::dummy("break"),
             is_special: true,
-        })
+        }))
     }
 
     #[test]

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -144,8 +144,8 @@
 //! the above conditions are not met. The current implementation does it if and
 //! only if the final operand starts with `$PWD`.
 
-use crate::common::print_error_message;
-use crate::common::print_failure_message;
+use crate::common::report_error;
+use crate::common::report_failure;
 use crate::Result;
 use std::path::Path;
 use yash_env::semantics::Field;
@@ -200,14 +200,14 @@ fn get_pwd(env: &Env) -> String {
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,
-        Err(e) => return print_error_message(env, &e).await,
+        Err(e) => return report_error(env, &e).await,
     };
 
     let pwd = get_pwd(env);
 
     let (path, origin) = match target::target(env, &command, &pwd) {
         Ok(target) => target,
-        Err(e) => return print_failure_message(env, &e).await,
+        Err(e) => return report_failure(env, &e).await,
     };
 
     let short_path = shorten::shorten(&path, Path::new(&pwd), command.mode);

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -214,7 +214,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
 
     match chdir::chdir(env, short_path) {
         Ok(()) => {}
-        Err(e) => return chdir::print_failure(env, command.operand.as_ref(), &path, &e).await,
+        Err(e) => return chdir::report_failure(env, command.operand.as_ref(), &path, &e).await,
     }
 
     let new_pwd = assign::new_pwd(env, command.mode, &path);

--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -117,6 +117,7 @@ mod tests {
     use futures_util::FutureExt;
     use std::rc::Rc;
     use yash_env::semantics::Field;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
@@ -128,10 +129,10 @@ mod tests {
         let mut env = Env::with_system(system);
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,
             is_special: false,
-        });
+        }));
 
         set_oldpwd(&mut env, "/some/path".to_string())
             .now_or_never()
@@ -153,10 +154,10 @@ mod tests {
         let mut env = Env::with_system(system);
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,
             is_special: false,
-        });
+        }));
         env.assign_variable(Global, "OLDPWD".to_string(), Variable::new("/old/pwd"))
             .unwrap();
 
@@ -178,10 +179,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("cd"),
             is_special: false,
-        });
+        }));
         let read_only_location = Location::dummy("read-only");
         env.assign_variable(
             Global,
@@ -208,10 +209,10 @@ mod tests {
         let mut env = Env::with_system(system);
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,
             is_special: false,
-        });
+        }));
 
         set_pwd(&mut env, PathBuf::from("/some/path"))
             .now_or_never()
@@ -233,10 +234,10 @@ mod tests {
         let mut env = Env::with_system(system);
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,
             is_special: false,
-        });
+        }));
         env.assign_variable(Global, "PWD".to_string(), Variable::new("/old/path"))
             .unwrap();
 
@@ -259,10 +260,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let cd = Field::dummy("cd");
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,
             is_special: false,
-        });
+        }));
         let read_only_location = Location::dummy("read-only");
         env.assign_variable(
             Global,

--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -20,7 +20,6 @@ use super::Mode;
 use crate::common::arrange_message_and_divert;
 use std::path::Path;
 use std::path::PathBuf;
-use yash_env::io::Stderr;
 use yash_env::variable::AssignError;
 use yash_env::variable::Scope::Global;
 use yash_env::variable::Value::Scalar;

--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -17,7 +17,7 @@
 //! Part of the cd built-in that updates `$PWD` and `$OLDPWD`
 
 use super::Mode;
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use std::path::Path;
 use std::path::PathBuf;
 use yash_env::io::Stderr;
@@ -92,7 +92,7 @@ async fn handle_assign_error(env: &mut Env, error: AssignError) {
             &error.read_only_location,
         )],
     };
-    let (message, _divert) = builtin_message_and_divert(env, message);
+    let (message, _divert) = arrange_message_and_divert(env, message);
     env.system.print_error(&message).await;
 }
 

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -16,21 +16,27 @@
 
 //! Part of the cd built-in that invokes the underlying system call
 
-use crate::common::print_failure_message;
-use crate::common::AsStderr;
-use crate::common::BuiltinEnv;
+use crate::common::builtin_message_and_divert;
+use std::borrow::Cow;
 use std::ffi::CString;
 use std::ffi::NulError;
 use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
 use thiserror::Error;
+use yash_env::io::Stderr;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+#[cfg(doc)]
+use yash_env::stack::Stack;
 use yash_env::system::Errno;
+#[cfg(doc)]
+use yash_env::system::SharedSystem;
 use yash_env::Env;
 use yash_env::System;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
+use yash_syntax::source::Location;
 
 /// Error invoking the underlying system call
 #[derive(Debug, Clone, Eq, Error, PartialEq)]
@@ -55,28 +61,46 @@ pub fn chdir(env: &mut Env, path: &Path) -> Result<(), Error> {
     Ok(env.system.chdir(&c_path)?)
 }
 
-/// Prints an error message to the standard error.
-pub async fn print_failure<E>(
-    env: &mut E,
+/// Creates a message that describes the failure.
+///
+/// This function expects
+/// [`env.stack.current_builtin()`](Stack::current_builtin) to return `Some(_)`.
+/// If it returns `None`, the function will annotate the message with a dummy
+/// location.
+///
+/// See [`builtin_message_and_divert`] for the second return value.
+#[must_use]
+pub fn failure_message(
+    env: &Env,
     operand: Option<&Field>,
     path: &Path,
     error: &Error,
-) -> crate::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
-    let field = operand.unwrap_or_else(|| env.builtin_name());
-    let location = field.origin.clone();
-
-    let error = Annotation::new(AnnotationType::Error, error.to_string().into(), &location);
-
-    let info_label = format!("target directory is {path:?}").into();
-    let info = Annotation::new(AnnotationType::Info, info_label, &location);
-
+) -> (String, yash_env::semantics::Result) {
+    let label = Cow::Owned(format!("{path:?}: {error}"));
+    let location = operand
+        .or_else(|| env.stack.current_builtin().map(|builtin| &builtin.name))
+        .map(|field| Cow::Borrowed(&field.origin))
+        .unwrap_or_else(|| Cow::Owned(Location::dummy("")));
+    let error = Annotation::new(AnnotationType::Error, label, &location);
     let message = Message {
         r#type: AnnotationType::Error,
         title: "cannot change the working directory".into(),
-        annotations: vec![error, info],
+        annotations: vec![error],
     };
-    print_failure_message(env, message).await
+    builtin_message_and_divert(env, message)
+}
+
+/// Prints an error message to the standard error.
+///
+/// This function constructs a message with [`failure_message`] and prints it
+/// with [`SharedSystem::print_error`].
+pub async fn report_failure(
+    env: &mut Env,
+    operand: Option<&Field>,
+    path: &Path,
+    error: &Error,
+) -> crate::Result {
+    let (message, divert) = failure_message(env, operand, path, error);
+    env.system.print_error(&message).await;
+    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -23,7 +23,6 @@ use std::ffi::NulError;
 use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
 use thiserror::Error;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 #[cfg(doc)]

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -16,7 +16,7 @@
 
 //! Part of the cd built-in that invokes the underlying system call
 
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use std::borrow::Cow;
 use std::ffi::CString;
 use std::ffi::NulError;
@@ -68,7 +68,7 @@ pub fn chdir(env: &mut Env, path: &Path) -> Result<(), Error> {
 /// If it returns `None`, the function will annotate the message with a dummy
 /// location.
 ///
-/// See [`builtin_message_and_divert`] for the second return value.
+/// See [`arrange_message_and_divert`] for the second return value.
 #[must_use]
 pub fn failure_message(
     env: &Env,
@@ -87,7 +87,7 @@ pub fn failure_message(
         title: "cannot change the working directory".into(),
         annotations: vec![error],
     };
-    builtin_message_and_divert(env, message)
+    arrange_message_and_divert(env, message)
 }
 
 /// Prints an error message to the standard error.

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -19,7 +19,6 @@
 use super::target::Origin;
 use crate::common::arrange_message_and_divert;
 use std::path::Path;
-use yash_env::io::Stderr;
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_syntax::source::pretty::AnnotationType;

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -17,7 +17,7 @@
 //! Part of the cd built-in that prints the new working directory
 
 use super::target::Origin;
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use std::path::Path;
 use yash_env::io::Stderr;
 use yash_env::system::Errno;
@@ -59,6 +59,6 @@ async fn handle_print_error(env: &mut Env, errno: Errno) {
         title: format!("cannot print new $PWD: {}", errno).into(),
         annotations: vec![],
     };
-    let (message, _divert) = builtin_message_and_divert(env, message);
+    let (message, _divert) = arrange_message_and_divert(env, message);
     env.system.print_error(&message).await;
 }

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -17,15 +17,14 @@
 //! Part of the cd built-in that prints the new working directory
 
 use super::target::Origin;
-use crate::common::AsStdout;
 use crate::common::BuiltinEnv;
-use crate::common::Stdout;
 use std::path::Path;
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
+use yash_syntax::syntax::Fd;
 
 impl Origin {
     /// Whether the built-in should print the target directory path.
@@ -45,8 +44,8 @@ pub async fn print_path(env: &mut Env, path: &Path, origin: &Origin) {
     }
 
     let line = format!("{}\n", path.display());
-    match env.as_stdout().try_print(&line).await {
-        Ok(()) => (),
+    match env.system.write_all(Fd::STDOUT, line.as_bytes()).await {
+        Ok(_) => (),
         Err(errno) => handle_print_error(env, errno).await,
     }
 }

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -17,11 +17,11 @@
 //! Part of the cd built-in that prints the new working directory
 
 use super::target::Origin;
-use crate::common::BuiltinEnv;
+use crate::common::builtin_message_and_divert;
 use std::path::Path;
+use yash_env::io::Stderr;
 use yash_env::system::Errno;
 use yash_env::Env;
-use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
 use yash_syntax::syntax::Fd;
@@ -54,15 +54,11 @@ pub async fn print_path(env: &mut Env, path: &Path, origin: &Origin) {
 ///
 /// The message is only a warning because it does not affect the exit status.
 async fn handle_print_error(env: &mut Env, errno: Errno) {
-    let builtin_name = env.stack.builtin_name();
     let message = Message {
         r#type: AnnotationType::Warning,
         title: format!("cannot print new $PWD: {}", errno).into(),
-        annotations: vec![Annotation::new(
-            AnnotationType::Info,
-            format!("error occurred in the {} built-in", builtin_name.value).into(),
-            &builtin_name.origin,
-        )],
+        annotations: vec![],
     };
-    yash_env::io::print_message(&mut env.system, message).await;
+    let (message, _divert) = builtin_message_and_divert(env, message);
+    env.system.print_error(&message).await;
 }

--- a/yash-builtin/src/cd/target.rs
+++ b/yash-builtin/src/cd/target.rs
@@ -18,7 +18,6 @@
 
 use super::Command;
 use super::Mode;
-use crate::common::BuiltinEnv;
 use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
@@ -153,8 +152,11 @@ pub fn target(env: &Env, command: &Command, pwd: &str) -> Result<(PathBuf, Origi
     // Step 1 & 2: substitute $HOME and $OLDPWD
     let (mut curpath, mut origin) = match &command.operand {
         None => {
-            let home = get_scalar(env, "HOME").ok_or_else(|| TargetError::UnsetHome {
-                location: env.builtin_name().origin.clone(),
+            let home = get_scalar(env, "HOME").ok_or_else(|| {
+                let builtin = env.stack.current_builtin();
+                let location =
+                    builtin.map_or_else(|| Location::dummy(""), |b| b.name.origin.clone());
+                TargetError::UnsetHome { location }
             })?;
             (PathBuf::from(home), Origin::Home)
         }
@@ -194,8 +196,8 @@ pub fn target(env: &Env, command: &Command, pwd: &str) -> Result<(PathBuf, Origi
             target: curpath,
             location: {
                 let field = command.operand.as_ref();
-                let field = field.unwrap_or_else(|| env.builtin_name());
-                field.origin.clone()
+                let field = field.or_else(|| env.stack.current_builtin().map(|b| &b.name));
+                field.map_or_else(|| Location::dummy(""), |f| f.origin.clone())
             },
         }
     })?;

--- a/yash-builtin/src/cd/target.rs
+++ b/yash-builtin/src/cd/target.rs
@@ -244,6 +244,7 @@ pub fn target(env: &Env, command: &Command, pwd: &str) -> Result<(PathBuf, Origi
 mod tests {
     use super::*;
     use yash_env::semantics::Field;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::variable::Scope;
     use yash_env::variable::Variable;
@@ -275,10 +276,10 @@ mod tests {
         };
         let arg0 = Field::dummy("cd");
         let location = arg0.origin.clone();
-        let env = env.push_frame(Frame::Builtin {
+        let env = env.push_frame(Frame::Builtin(Builtin {
             name: arg0,
             is_special: false,
-        });
+        }));
 
         let e = target(&env, &command, "").unwrap_err();
         assert_eq!(e, TargetError::UnsetHome { location });
@@ -293,10 +294,10 @@ mod tests {
         };
         let arg0 = Field::dummy("cd");
         let location = arg0.origin.clone();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: arg0,
             is_special: false,
-        });
+        }));
         env.assign_variable(Scope::Global, "HOME".to_string(), Variable::new(""))
             .unwrap();
 

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -103,7 +103,7 @@ pub fn builtin_message_and_divert<'e: 'm, 'm>(
 /// # }.now_or_never().unwrap();
 /// ```
 #[inline]
-pub async fn print_failure_message<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
+pub async fn report_failure<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
 where
     M: Into<Message<'a>> + 'a,
 {
@@ -134,7 +134,7 @@ where
 /// # }.now_or_never().unwrap();
 /// ```
 #[inline]
-pub async fn print_error_message<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
+pub async fn report_error<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
 where
     M: Into<Message<'a>> + 'a,
 {
@@ -146,9 +146,9 @@ where
 /// Prints a simple error message.
 ///
 /// This function constructs a [`Message`] from the given title and annotation,
-/// and calls [`print_error_message`].
+/// and calls [`report_error`].
 #[inline]
-pub async fn print_simple_error_message(
+pub async fn report_simple_error(
     env: &mut Env,
     title: &str,
     annotation: Annotation<'_>,
@@ -158,19 +158,19 @@ pub async fn print_simple_error_message(
         title: title.into(),
         annotations: vec![annotation],
     };
-    print_error_message(env, message).await
+    report_error(env, message).await
 }
 
 /// Prints a simple error message for a command syntax error.
 ///
-/// This function calls [`print_simple_error_message`] with a predefined title
-/// and an [`Annotation`] constructed with the given label and location.
+/// This function calls [`report_simple_error`] with a predefined title and an
+/// [`Annotation`] constructed with the given label and location.
 pub async fn syntax_error(
     env: &mut Env,
     label: &str,
     location: &Location,
 ) -> yash_env::builtin::Result {
-    print_simple_error_message(
+    report_simple_error(
         env,
         "command argument syntax error",
         Annotation::new(AnnotationType::Error, label.into(), location),

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -69,8 +69,8 @@ impl BuiltinEnv for Stack {
     fn builtin_name(&self) -> &Field {
         self.iter()
             .filter_map(|frame| {
-                if let Frame::Builtin { name, .. } = frame {
-                    Some(name)
+                if let Frame::Builtin(builtin) = frame {
+                    Some(&builtin.name)
                 } else {
                     None
                 }
@@ -86,8 +86,8 @@ impl BuiltinEnv for Stack {
     fn is_executing_special_builtin(&self) -> bool {
         self.iter()
             .filter_map(|frame| {
-                if let &Frame::Builtin { is_special, .. } = frame {
-                    Some(is_special)
+                if let Frame::Builtin(builtin) = frame {
+                    Some(builtin.is_special)
                 } else {
                     None
                 }
@@ -364,12 +364,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use yash_env::stack::Builtin;
 
     #[test]
     fn builtin_name_in_stack() {
         let name = Field::dummy("my built-in");
         let is_special = false;
-        let stack = Stack::from(vec![Frame::Builtin { name, is_special }]);
+        let stack = Stack::from(vec![Frame::Builtin(Builtin { name, is_special })]);
         // TODO Test with a stack containing a frame other than Frame::Builtin
         assert_eq!(stack.builtin_name().value, "my built-in");
     }
@@ -384,7 +385,7 @@ mod tests {
     fn is_executing_special_builtin_true_in_stack() {
         let name = Field::dummy("my built-in");
         let is_special = true;
-        let stack = Stack::from(vec![Frame::Builtin { name, is_special }]);
+        let stack = Stack::from(vec![Frame::Builtin(Builtin { name, is_special })]);
         assert!(stack.is_executing_special_builtin());
     }
 
@@ -392,7 +393,7 @@ mod tests {
     fn is_executing_special_builtin_false_in_stack() {
         let name = Field::dummy("my built-in");
         let is_special = false;
-        let stack = Stack::from(vec![Frame::Builtin { name, is_special }]);
+        let stack = Stack::from(vec![Frame::Builtin(Builtin { name, is_special })]);
         assert!(!stack.is_executing_special_builtin());
     }
 

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -47,7 +47,7 @@ pub mod syntax;
 /// The [`Divert`] value indicates whether the caller should divert the
 /// execution flow. If the current built-in is a special built-in, the second
 /// return value is `Break(Divert::Interrupt(None))`; otherwise, `Continue(())`.
-/// 
+///
 /// You should always use this function (or another function defined in this
 /// module which calls this function) to construct an error or warning message
 /// in a built-in. This ensures that the message contains the built-in name
@@ -57,7 +57,7 @@ pub mod syntax;
 /// [`crate::Result::with_exit_status_and_divert`] to return the divert value
 /// along with an exit status.
 #[must_use]
-pub fn builtin_message_and_divert<'e: 'm, 'm>(
+pub fn arrange_message_and_divert<'e: 'm, 'm>(
     env: &'e Env,
     mut message: Message<'m>,
 ) -> (String, yash_env::semantics::Result) {
@@ -95,7 +95,7 @@ pub fn builtin_message_and_divert<'e: 'm, 'm>(
 ///
 /// ```
 /// # use futures_util::future::FutureExt;
-/// # use yash_builtin::common::builtin_message_and_divert;
+/// # use yash_builtin::common::arrange_message_and_divert;
 /// # use yash_env::builtin::Result;
 /// # use yash_env::io::Stderr;
 /// # use yash_env::semantics::ExitStatus;
@@ -103,7 +103,7 @@ pub fn builtin_message_and_divert<'e: 'm, 'm>(
 /// # async {
 /// # let mut env = yash_env::Env::new_virtual();
 /// # let message = Message { r#type: AnnotationType::Error, title: "".into(), annotations: vec![] };
-/// let (message, divert) = builtin_message_and_divert(&env, message);
+/// let (message, divert) = arrange_message_and_divert(&env, message);
 /// env.system.print_error(&message).await;
 /// Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 /// # }.now_or_never().unwrap();
@@ -113,7 +113,7 @@ pub async fn report_failure<'a, M>(env: &mut Env, message: M) -> yash_env::built
 where
     M: Into<Message<'a>> + 'a,
 {
-    let (message, divert) = builtin_message_and_divert(env, message.into());
+    let (message, divert) = arrange_message_and_divert(env, message.into());
     env.system.print_error(&message).await;
     yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }
@@ -126,7 +126,7 @@ where
 ///
 /// ```
 /// # use futures_util::future::FutureExt;
-/// # use yash_builtin::common::builtin_message_and_divert;
+/// # use yash_builtin::common::arrange_message_and_divert;
 /// # use yash_env::builtin::Result;
 /// # use yash_env::io::Stderr;
 /// # use yash_env::semantics::ExitStatus;
@@ -134,7 +134,7 @@ where
 /// # async {
 /// # let mut env = yash_env::Env::new_virtual();
 /// # let message = Message { r#type: AnnotationType::Error, title: "".into(), annotations: vec![] };
-/// let (message, divert) = builtin_message_and_divert(&env, message);
+/// let (message, divert) = arrange_message_and_divert(&env, message);
 /// env.system.print_error(&message).await;
 /// Result::with_exit_status_and_divert(ExitStatus::ERROR, divert)
 /// # }.now_or_never().unwrap();
@@ -144,7 +144,7 @@ pub async fn report_error<'a, M>(env: &mut Env, message: M) -> yash_env::builtin
 where
     M: Into<Message<'a>> + 'a,
 {
-    let (message, divert) = builtin_message_and_divert(env, message.into());
+    let (message, divert) = arrange_message_and_divert(env, message.into());
     env.system.print_error(&message).await;
     yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::ERROR, divert)
 }
@@ -153,7 +153,7 @@ where
 ///
 /// This function constructs a [`Message`] with the given title and prints it
 /// using [`report_error`]. The message has no annotations except for the
-/// built-in name which is added by [`builtin_message_and_divert`].
+/// built-in name which is added by [`arrange_message_and_divert`].
 pub async fn report_simple_error(env: &mut Env, title: &str) -> yash_env::builtin::Result {
     let message = Message {
         r#type: AnnotationType::Error,
@@ -199,7 +199,7 @@ pub async fn output(env: &mut Env, content: &str) -> yash_env::builtin::Result {
                 title: format!("error printing results to stdout: {errno}").into(),
                 annotations: vec![],
             };
-            let (message, divert) = builtin_message_and_divert(env, message);
+            let (message, divert) = arrange_message_and_divert(env, message);
             env.system.print_error(&message).await;
             yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
         }
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn divert_without_builtin() {
         let env = Env::new_virtual();
-        let (_message, divert) = builtin_message_and_divert(&env, dummy_message());
+        let (_message, divert) = arrange_message_and_divert(&env, dummy_message());
         assert_eq!(divert, Continue(()));
     }
 
@@ -236,7 +236,7 @@ mod tests {
             is_special: true,
         }));
 
-        let (_message, divert) = builtin_message_and_divert(&env, dummy_message());
+        let (_message, divert) = arrange_message_and_divert(&env, dummy_message());
         assert_eq!(divert, Break(Divert::Interrupt(None)));
     }
 
@@ -248,7 +248,7 @@ mod tests {
             is_special: false,
         }));
 
-        let (_message, divert) = builtin_message_and_divert(&env, dummy_message());
+        let (_message, divert) = arrange_message_and_divert(&env, dummy_message());
         assert_eq!(divert, Continue(()));
     }
 }

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -143,39 +143,23 @@ where
     yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::ERROR, divert)
 }
 
-/// Prints a simple error message.
-///
-/// This function constructs a [`Message`] from the given title and annotation,
-/// and calls [`report_error`].
-#[inline]
-pub async fn report_simple_error(
-    env: &mut Env,
-    title: &str,
-    annotation: Annotation<'_>,
-) -> yash_env::builtin::Result {
-    let message = Message {
-        r#type: AnnotationType::Error,
-        title: title.into(),
-        annotations: vec![annotation],
-    };
-    report_error(env, message).await
-}
-
 /// Prints a simple error message for a command syntax error.
 ///
-/// This function calls [`report_simple_error`] with a predefined title and an
-/// [`Annotation`] constructed with the given label and location.
+/// This function constructs a [`Message`] with a predefined title and an
+/// [`Annotation`] created from the given label and location, and calls
+/// [`report_error`].
 pub async fn syntax_error(
     env: &mut Env,
     label: &str,
     location: &Location,
 ) -> yash_env::builtin::Result {
-    report_simple_error(
-        env,
-        "command argument syntax error",
-        Annotation::new(AnnotationType::Error, label.into(), location),
-    )
-    .await
+    let annotation = Annotation::new(AnnotationType::Error, label.into(), location);
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: "command argument syntax error".into(),
+        annotations: vec![annotation],
+    };
+    report_error(env, message).await
 }
 
 /// Prints a text to the standard output.

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -185,20 +185,6 @@ impl AsStderr for yash_env::Env {
     }
 }
 
-impl AsStderr for String {
-    type Stderr = String;
-    fn as_stderr(&mut self) -> &mut Self::Stderr {
-        self
-    }
-}
-
-impl<'a, 'b> AsStderr for (&'a mut String, &'b mut String) {
-    type Stderr = String;
-    fn as_stderr(&mut self) -> &mut Self::Stderr {
-        self.1
-    }
-}
-
 /// Extension of [`Stdout`] that handles errors.
 #[async_trait(?Send)]
 pub trait Print {

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -36,20 +36,26 @@ use yash_syntax::source::Location;
 
 pub mod syntax;
 
-/// Converts the given message into a string.
+/// Convenience function for constructing an error message and a divert value.
 ///
 /// If the environment is currently executing a built-in
 /// ([`Stack::current_builtin`]), an annotation indicating the built-in name is
-/// appended to the message. The message is then converted into a string using
-/// [`yash_env::io::to_string`].
+/// appended to the given message. The message is then converted into a string
+/// using [`yash_env::io::to_string`] and returned along with an optional divert
+/// value.
 ///
-/// This function returns an optional [`Divert`] value indicating whether the
-/// caller should divert the execution flow. If the environment is currently
-/// executing a special built-in, the divert value is `Divert::Interrupt(None)`;
-/// otherwise, `None`.
+/// The [`Divert`] value indicates whether the caller should divert the
+/// execution flow. If the current built-in is a special built-in, the second
+/// return value is `Break(Divert::Interrupt(None))`; otherwise, `Continue(())`.
+/// 
+/// You should always use this function (or another function defined in this
+/// module which calls this function) to construct an error or warning message
+/// in a built-in. This ensures that the message contains the built-in name
+/// in a unified format.
 ///
-/// Note that this function does not print the message. Use
-/// [`SharedSystem::print_error`].
+/// Use [`SharedSystem::print_error`] to print the returned message and
+/// [`crate::Result::with_exit_status_and_divert`] to return the divert value
+/// along with an exit status.
 #[must_use]
 pub fn builtin_message_and_divert<'e: 'm, 'm>(
     env: &'e Env,

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -316,27 +316,6 @@ where
     yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::ERROR, result)
 }
 
-/// Prints a simple failure message.
-///
-/// This function constructs a [`Message`] from the given title and annotation,
-/// and calls [`print_failure_message`].
-#[inline]
-pub async fn print_simple_failure_message<E>(
-    env: &mut E,
-    title: &str,
-    annotation: Annotation<'_>,
-) -> yash_env::builtin::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
-    let message = Message {
-        r#type: AnnotationType::Error,
-        title: title.into(),
-        annotations: vec![annotation],
-    };
-    print_failure_message(env, message).await
-}
-
 /// Prints a simple error message.
 ///
 /// This function constructs a [`Message`] from the given title and annotation,

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -307,9 +307,8 @@ where
 /// This function uses [`print_message`] and returns a result with exit status
 /// [`ExitStatus::ERROR`].
 #[inline]
-pub async fn print_error_message<'a, E, M>(env: &mut E, message: M) -> yash_env::builtin::Result
+pub async fn print_error_message<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
 where
-    E: BuiltinEnv + AsStderr,
     M: Into<Message<'a>> + 'a,
 {
     let result = print_message(env, message).await;
@@ -321,14 +320,11 @@ where
 /// This function constructs a [`Message`] from the given title and annotation,
 /// and calls [`print_error_message`].
 #[inline]
-pub async fn print_simple_error_message<E>(
-    env: &mut E,
+pub async fn print_simple_error_message(
+    env: &mut Env,
     title: &str,
     annotation: Annotation<'_>,
-) -> yash_env::builtin::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
+) -> yash_env::builtin::Result {
     let message = Message {
         r#type: AnnotationType::Error,
         title: title.into(),
@@ -341,14 +337,11 @@ where
 ///
 /// This function calls [`print_simple_error_message`] with a predefined title
 /// and an [`Annotation`] constructed with the given label and location.
-pub async fn syntax_error<E>(
-    env: &mut E,
+pub async fn syntax_error(
+    env: &mut Env,
     label: &str,
     location: &Location,
-) -> yash_env::builtin::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
+) -> yash_env::builtin::Result {
     print_simple_error_message(
         env,
         "command argument syntax error",

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -186,33 +186,6 @@ impl AsStderr for yash_env::Env {
     }
 }
 
-/// Extension of [`Stdout`] that handles errors.
-#[async_trait(?Send)]
-pub trait Print {
-    /// Prints a string to the standard output.
-    ///
-    /// If an error occurs while printing, an error message is printed to the
-    /// standard error and a non-zero exit status is returned.
-    async fn print(&mut self, text: &str) -> yash_env::builtin::Result;
-}
-
-#[async_trait(?Send)]
-impl<T: BuiltinEnv + AsStdout + AsStderr> Print for T {
-    async fn print(&mut self, text: &str) -> yash_env::builtin::Result {
-        match self.as_stdout().try_print(text).await {
-            Ok(()) => yash_env::builtin::Result::default(),
-            Err(errno) => {
-                let message = Message {
-                    r#type: AnnotationType::Error,
-                    title: format!("error printing results to stdout: {errno}").into(),
-                    annotations: vec![],
-                };
-                print_failure_message(self, message).await
-            }
-        }
-    }
-}
-
 /// Prints a message.
 ///
 /// This function prepares a [`Message`] by inserting an annotation indicating

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -143,6 +143,20 @@ where
     yash_env::builtin::Result::with_exit_status_and_divert(ExitStatus::ERROR, divert)
 }
 
+/// Prints a simple error message.
+///
+/// This function constructs a [`Message`] with the given title and prints it
+/// using [`report_error`]. The message has no annotations except for the
+/// built-in name which is added by [`builtin_message_and_divert`].
+pub async fn report_simple_error(env: &mut Env, title: &str) -> yash_env::builtin::Result {
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: title.into(),
+        annotations: vec![],
+    };
+    report_error(env, message).await
+}
+
 /// Prints a simple error message for a command syntax error.
 ///
 /// This function constructs a [`Message`] with a predefined title and an

--- a/yash-builtin/src/common/syntax.rs
+++ b/yash-builtin/src/common/syntax.rs
@@ -558,8 +558,7 @@ pub fn parse_arguments<'a>(
 /// This is a helper object for constructing an error message from a list of
 /// conflicting option occurrences. An instance of this type can be created
 /// using [`new`](Self::new) or [`pick_from_indexes`](Self::pick_from_indexes)
-/// and printed with
-/// [`print_error_message`](crate::common::print_error_message).
+/// and printed with [`report_error`](crate::common::report_error).
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 #[error("conflicting options")]
 pub struct ConflictingOptionError<'a> {

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -78,27 +78,23 @@
 //! This module re-exports [`super::break::syntax`].
 
 use crate::common::print_error_message;
-use crate::common::print_simple_error_message;
-use crate::common::BuiltinEnv;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
-use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
 
 // pub mod display;
 pub mod semantics;
 pub use super::r#break::syntax;
 
 async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
-    let builtin_name = &env.stack.builtin_name();
-    let location = builtin_name.origin.clone();
-    print_simple_error_message(
-        env,
-        "cannot continue",
-        Annotation::new(AnnotationType::Error, error.to_string().into(), &location),
-    )
-    .await
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: format!("cannot continue: {}", error).into(),
+        annotations: vec![],
+    };
+    print_error_message(env, message).await
 }
 
 /// Entry point for executing the `continue` built-in

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -78,23 +78,17 @@
 //! This module re-exports [`super::break::syntax`].
 
 use crate::common::report_error;
+use crate::common::report_simple_error;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
-use yash_syntax::source::pretty::AnnotationType;
-use yash_syntax::source::pretty::Message;
 
 // pub mod display;
 pub mod semantics;
 pub use super::r#break::syntax;
 
 async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
-    let message = Message {
-        r#type: AnnotationType::Error,
-        title: format!("cannot continue: {}", error).into(),
-        annotations: vec![],
-    };
-    report_error(env, message).await
+    report_simple_error(env, &format!("cannot continue: {}", error)).await
 }
 
 /// Entry point for executing the `continue` built-in

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -77,7 +77,7 @@
 //! break built-in implementation.
 //! This module re-exports [`super::break::syntax`].
 
-use crate::common::print_error_message;
+use crate::common::report_error;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
@@ -88,13 +88,13 @@ use yash_syntax::source::pretty::Message;
 pub mod semantics;
 pub use super::r#break::syntax;
 
-async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
+async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
     let message = Message {
         r#type: AnnotationType::Error,
         title: format!("cannot continue: {}", error).into(),
         annotations: vec![],
     };
-    print_error_message(env, message).await
+    report_error(env, message).await
 }
 
 /// Entry point for executing the `continue` built-in
@@ -104,9 +104,9 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     match syntax::parse(env, args) {
         Ok(count) => match semantics::run(&env.stack, count) {
             Ok(result) => result,
-            Err(e) => print_semantics_error(env, &e).await,
+            Err(e) => report_semantics_error(env, &e).await,
         },
-        Err(e) => print_error_message(env, &e).await,
+        Err(e) => report_error(env, &e).await,
     }
 }
 

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -127,6 +127,7 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::Env;
     use yash_env::VirtualSystem;
@@ -142,10 +143,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(
@@ -165,10 +166,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(
@@ -187,10 +188,10 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(
@@ -209,10 +210,10 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -232,10 +233,10 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["3"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -256,10 +257,10 @@ mod tests {
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["5"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -277,10 +278,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["0"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -303,10 +304,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["999999999999999999999999999999"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -324,10 +325,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1", "1"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -347,10 +348,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         let mut env = env.push_frame(Frame::Loop);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["--", "1"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/continue/semantics.rs
+++ b/yash-builtin/src/continue/semantics.rs
@@ -43,14 +43,15 @@ pub fn run(stack: &Stack, max_count: NonZeroUsize) -> Result {
 mod tests {
     use super::*;
     use yash_env::semantics::Field;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::stack::StackFrameGuard;
 
     fn push_continue_builtin(stack: &mut Stack) -> StackFrameGuard<'_> {
-        stack.push(Frame::Builtin {
+        stack.push(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
-        })
+        }))
     }
 
     #[test]

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -128,6 +128,7 @@ mod tests {
     use crate::tests::assert_stderr;
     use futures_util::FutureExt;
     use std::rc::Rc;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::VirtualSystem;
 
@@ -167,10 +168,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["-1"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -187,10 +188,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["foo"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -207,10 +208,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["999999999999999999999999999999"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -230,10 +231,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1", "2"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -80,8 +80,8 @@
 //! leading `%`, the built-in assumes one silently, which is not portable.
 
 use crate::common::output;
-use crate::common::print_error_message;
-use crate::common::print_failure_message;
+use crate::common::report_error;
+use crate::common::report_failure;
 use crate::common::syntax::parse_arguments;
 use crate::common::syntax::Mode;
 use crate::common::syntax::OptionSpec;
@@ -164,7 +164,7 @@ fn find_error_message(error: FindError, operand: &Field) -> Message {
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let (options, operands) = match parse_arguments(OPTIONS, Mode::with_env(env), args) {
         Ok(result) => result,
-        Err(error) => return print_error_message(env, &error).await,
+        Err(error) => return report_error(env, &error).await,
     };
 
     let mut accumulator = Accumulator {
@@ -197,7 +197,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
             match job_id.find(&env.jobs) {
                 Ok(index) => accumulator.report(index, &env.jobs[index]),
                 Err(error) => {
-                    return print_failure_message(env, find_error_message(error, &operand)).await
+                    return report_failure(env, find_error_message(error, &operand)).await
                 }
             }
         }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -232,6 +232,7 @@ mod tests {
     use yash_env::job::Pid;
     use yash_env::job::WaitStatus;
     use yash_env::semantics::ExitStatus;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::trap::Signal;
@@ -401,10 +402,10 @@ mod tests {
         env.jobs.add(Job::new(Pid::from_raw(2)));
 
         let args = Field::dummies(["%2"]);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("jobs"),
             is_special: false,
-        });
+        }));
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
@@ -428,10 +429,10 @@ mod tests {
         env.jobs.add(Job::new(Pid::from_raw(100)));
 
         let args = Field::dummies(["%?first", "%echo"]);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("jobs"),
             is_special: false,
-        });
+        }));
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
@@ -451,10 +452,10 @@ mod tests {
         job.name = "exit 0".to_string();
         let i10 = env.jobs.add(job);
 
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("jobs"),
             is_special: false,
-        });
+        }));
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert_matches!(env.jobs.get(i10), Some(&Job { status, .. }) => {
@@ -488,10 +489,10 @@ mod tests {
         let mut env = Env::with_system(system);
         let i72 = env.jobs.add(Job::new(Pid::from_raw(72)));
 
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("jobs"),
             is_special: false,
-        });
+        }));
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert!(env.jobs[i72].status_changed);

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -79,12 +79,12 @@
 //! A portable job ID must start with a `%`. If an operand does not have a
 //! leading `%`, the built-in assumes one silently, which is not portable.
 
+use crate::common::output;
 use crate::common::print_error_message;
 use crate::common::print_failure_message;
 use crate::common::syntax::parse_arguments;
 use crate::common::syntax::Mode;
 use crate::common::syntax::OptionSpec;
-use crate::common::Print;
 use std::fmt::Write;
 use yash_env::builtin::Result;
 use yash_env::job::id::parse;
@@ -203,7 +203,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
         }
     }
 
-    let result = env.print(&accumulator.print).await;
+    let result = output(env, &accumulator.print).await;
 
     if result.exit_status().is_successful() {
         for index in accumulator.indices_reported {

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -16,7 +16,23 @@
 
 //! Implementation of the shell built-in utilities.
 //!
-//! TODO Elaborate
+//! Each built-in utility is implemented in the submodule named after the
+//! utility. The submodule contains the `main` function that implements the
+//! built-in utility. The submodule many also export other items that are used
+//! by the `main` function. The module documentation for each submodule
+//! describes the specification of the built-in utility.
+//!
+//! The [`common`] module provides common functions that are used for
+//! implementing built-in utilities.
+//!
+//! # Stack
+//!
+//! Many built-ins in this crate use [`Stack::current_builtin`] to obtain the
+//! command word that invoked the built-in. It is used to report the command
+//! location in error messages, switch the behavior of the built-in depending on
+//! the command, etc. For the built-ins to work correctly, the
+//! [stack](Env::stack) should contain a [built-in frame](Frame::Builtin) so
+//! that `Stack::current_builtin` provides the correct command word.
 //!
 //! # Optional dependency
 //!
@@ -46,6 +62,10 @@ pub mod wait;
 
 #[doc(no_inline)]
 pub use yash_env::builtin::*;
+#[cfg(doc)]
+use yash_env::stack::{Frame, Stack};
+#[cfg(doc)]
+use yash_env::Env;
 
 use std::future::ready;
 use Type::{Mandatory, Special};

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -73,7 +73,7 @@
 //! The result for the `-P` option is obtained with [`System::getcwd`].
 
 use crate::common::print_error_message;
-use crate::common::print_simple_failure_message;
+use crate::common::print_failure_message;
 use crate::common::BuiltinEnv;
 use crate::common::Print;
 use yash_env::builtin::Result;
@@ -83,6 +83,7 @@ use yash_env::Env;
 use yash_env::System;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
 
 /// Choice of the behavior of the built-in
 #[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -106,12 +107,13 @@ pub mod syntax;
 async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
     let builtin_name = &env.stack.builtin_name();
     let location = builtin_name.origin.clone();
-    print_simple_failure_message(
-        env,
-        "cannot compute the working directory path",
-        Annotation::new(AnnotationType::Error, error.to_string().into(), &location),
-    )
-    .await
+    let annotation = Annotation::new(AnnotationType::Error, error.to_string().into(), &location);
+    let message = Message {
+        r#type: AnnotationType::Error,
+        title: "cannot compute the working directory path".into(),
+        annotations: vec![annotation],
+    };
+    print_failure_message(env, message).await
 }
 
 /// Entry point for executing the `pwd` built-in

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -72,11 +72,13 @@
 //!
 //! The result for the `-P` option is obtained with [`System::getcwd`].
 
+use crate::common::builtin_message_and_divert;
 use crate::common::output;
 use crate::common::print_error_message;
-use crate::common::print_failure_message;
-use crate::common::BuiltinEnv;
+use std::borrow::Cow;
 use yash_env::builtin::Result;
+use yash_env::io::Stderr;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::Env;
 #[cfg(doc)]
@@ -84,6 +86,7 @@ use yash_env::System;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
+use yash_syntax::source::Location;
 
 /// Choice of the behavior of the built-in
 #[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -104,16 +107,20 @@ pub enum Mode {
 pub mod semantics;
 pub mod syntax;
 
-async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
-    let builtin_name = &env.stack.builtin_name();
-    let location = builtin_name.origin.clone();
+async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Result {
+    let location = env.stack.current_builtin().map_or_else(
+        || Cow::Owned(Location::dummy("")),
+        |field| Cow::Borrowed(&field.name.origin),
+    );
     let annotation = Annotation::new(AnnotationType::Error, error.to_string().into(), &location);
     let message = Message {
         r#type: AnnotationType::Error,
         title: "cannot compute the working directory path".into(),
         annotations: vec![annotation],
     };
-    print_failure_message(env, message).await
+    let (message, divert) = builtin_message_and_divert(env, message);
+    env.system.print_error(&message).await;
+    Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }
 
 /// Entry point for executing the `pwd` built-in
@@ -123,7 +130,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     match syntax::parse(env, args) {
         Ok(mode) => match semantics::compute(env, mode) {
             Ok(result) => output(env, &result).await,
-            Err(e) => print_semantics_error(env, &e).await,
+            Err(e) => report_semantics_error(env, &e).await,
         },
         Err(e) => print_error_message(env, &e).await,
     }

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -74,7 +74,7 @@
 
 use crate::common::builtin_message_and_divert;
 use crate::common::output;
-use crate::common::print_error_message;
+use crate::common::report_error;
 use std::borrow::Cow;
 use yash_env::builtin::Result;
 use yash_env::io::Stderr;
@@ -132,6 +132,6 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
             Ok(result) => output(env, &result).await,
             Err(e) => report_semantics_error(env, &e).await,
         },
-        Err(e) => print_error_message(env, &e).await,
+        Err(e) => report_error(env, &e).await,
     }
 }

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -72,10 +72,10 @@
 //!
 //! The result for the `-P` option is obtained with [`System::getcwd`].
 
+use crate::common::output;
 use crate::common::print_error_message;
 use crate::common::print_failure_message;
 use crate::common::BuiltinEnv;
-use crate::common::Print;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
@@ -122,7 +122,7 @@ async fn print_semantics_error(env: &mut Env, error: &semantics::Error) -> Resul
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     match syntax::parse(env, args) {
         Ok(mode) => match semantics::compute(env, mode) {
-            Ok(result) => env.print(&result).await,
+            Ok(result) => output(env, &result).await,
             Err(e) => print_semantics_error(env, &e).await,
         },
         Err(e) => print_error_message(env, &e).await,

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -77,7 +77,6 @@ use crate::common::output;
 use crate::common::report_error;
 use std::borrow::Cow;
 use yash_env::builtin::Result;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::Env;

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -72,7 +72,7 @@
 //!
 //! The result for the `-P` option is obtained with [`System::getcwd`].
 
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use crate::common::output;
 use crate::common::report_error;
 use std::borrow::Cow;
@@ -118,7 +118,7 @@ async fn report_semantics_error(env: &mut Env, error: &semantics::Error) -> Resu
         title: "cannot compute the working directory path".into(),
         annotations: vec![annotation],
     };
-    let (message, divert) = builtin_message_and_divert(env, message);
+    let (message, divert) = arrange_message_and_divert(env, message);
     env.system.print_error(&message).await;
     Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }

--- a/yash-builtin/src/return.rs
+++ b/yash-builtin/src/return.rs
@@ -146,6 +146,7 @@ mod tests {
     use futures_util::FutureExt;
     use std::rc::Rc;
     use yash_env::semantics::ExitStatus;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::VirtualSystem;
 
@@ -211,10 +212,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["-1"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -231,10 +232,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["foo"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -251,10 +252,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["999999999999999999999999999999"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -274,10 +275,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1", "2"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -123,7 +123,7 @@
 //! place of an option-operand separator. This behavior is not portable either.
 
 use crate::common::output;
-use crate::common::print_error_message;
+use crate::common::report_error;
 use std::fmt::Write;
 use yash_env::builtin::Result;
 #[cfg(doc)]
@@ -222,7 +222,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
             Result::new(ExitStatus::SUCCESS)
         }
 
-        Err(error) => print_error_message(env, &error).await,
+        Err(error) => report_error(env, &error).await,
     }
 }
 

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -122,9 +122,9 @@
 //! Many (but not all) shells specially treat `+`, especially when it appears in
 //! place of an option-operand separator. This behavior is not portable either.
 
+use crate::common::output;
 use crate::common::print_error_message;
 use crate::common::BuiltinEnv;
-use crate::common::Print;
 use std::fmt::Write;
 use yash_env::builtin::Result;
 #[cfg(doc)]
@@ -190,7 +190,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
                     writeln!(print, "{}={}", name, value.quote()).unwrap();
                 }
             }
-            env.print(&print).await
+            output(env, &print).await
         }
 
         Ok(syntax::Parse::PrintOptionsHumanReadable) => {
@@ -199,7 +199,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
                 let state = env.options.get(option);
                 writeln!(print, "{option:16} {state}").unwrap();
             }
-            env.print(&print).await
+            output(env, &print).await
         }
 
         Ok(syntax::Parse::PrintOptionsMachineReadable) => {
@@ -212,7 +212,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
                 };
                 writeln!(print, "{skip}set {flag}o {option}").unwrap();
             }
-            env.print(&print).await
+            output(env, &print).await
         }
 
         Ok(syntax::Parse::Modify {

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -240,7 +240,6 @@ mod tests {
     use yash_env::option::Option::*;
     use yash_env::option::OptionSet;
     use yash_env::option::State::*;
-    use yash_env::stack::Frame;
     use yash_env::system::SignalHandling;
     use yash_env::trap::Signal::SIGTSTP;
     use yash_env::variable::Scope;
@@ -377,7 +376,7 @@ xtrace           off
         let location = name.origin.clone();
         let is_special = true;
         let mut env = Env::new_virtual();
-        let mut env = env.push_frame(Frame::Builtin { name, is_special });
+        let mut env = env.push_frame(yash_env::stack::Builtin { name, is_special }.into());
         let args = Field::dummies(["a", "b", "z"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -124,7 +124,6 @@
 
 use crate::common::output;
 use crate::common::print_error_message;
-use crate::common::BuiltinEnv;
 use std::fmt::Write;
 use yash_env::builtin::Result;
 #[cfg(doc)]
@@ -168,10 +167,10 @@ fn modify(
 
     // Modify positional parameters
     if let Some(fields) = positional_params {
-        let location = env.builtin_name().origin.clone();
+        let location = env.stack.current_builtin().map(|b| b.name.origin.clone());
         let params = env.variables.positional_params_mut();
         params.value = Some(Array(fields.into_iter().map(|f| f.value).collect()));
-        params.last_assigned_location = Some(location);
+        params.last_assigned_location = location;
     }
 }
 

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -65,7 +65,6 @@ use crate::common::arrange_message_and_divert;
 use crate::common::syntax_error;
 use std::borrow::Cow;
 use yash_env::builtin::Result;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::variable::Value;

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -153,6 +153,7 @@ mod tests {
     use std::vec;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
@@ -160,10 +161,10 @@ mod tests {
     #[test]
     fn shifting_without_operand() {
         let mut env = Env::new_virtual();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
         env.variables.positional_params_mut().value = Some(Value::array(["1", "2", "3"]));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
@@ -193,10 +194,10 @@ mod tests {
     #[test]
     fn shifting_with_operand() {
         let mut env = Env::new_virtual();
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
         env.variables.positional_params_mut().value =
             Some(Value::array(["1", "2", "3", "4", "5", "6", "7"]));
 
@@ -230,10 +231,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
 
         let actual_result = main(&mut env, vec![]).now_or_never().unwrap();
         let expected_result = Result::with_exit_status_and_divert(
@@ -254,10 +255,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
         env.variables.positional_params_mut().value = Some(Value::array(["1", "2", "3"]));
 
         let args = Field::dummies(["4"]);
@@ -281,10 +282,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
         // TODO Enable POSIX mode
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1.5"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();
@@ -304,10 +305,10 @@ mod tests {
         let system = Box::new(VirtualSystem::new());
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["1", "2"]);
 
         let actual_result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -61,7 +61,7 @@
 //! parameters](yash_env::variable::VariableSet::positional_params_mut) to be an
 //! array. If it is not an array, the built-in panics.
 
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use crate::common::syntax_error;
 use std::borrow::Cow;
 use yash_env::builtin::Result;
@@ -141,7 +141,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
             title: "cannot shift positional parameters".into(),
             annotations,
         };
-        let (message, divert) = builtin_message_and_divert(env, message);
+        let (message, divert) = arrange_message_and_divert(env, message);
         env.system.print_error(&message).await;
         return Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert);
     }

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -18,7 +18,7 @@
 //!
 //! TODO Elaborate
 
-use crate::common::print_error_message;
+use crate::common::report_error;
 use crate::common::syntax::parse_arguments;
 use crate::common::syntax::Mode;
 use std::fmt::Write;
@@ -55,7 +55,7 @@ pub async fn print_traps(env: &mut Env) -> Result {
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let (_options, mut operands) = match parse_arguments(&[], Mode::with_env(env), args) {
         Ok(result) => result,
-        Err(error) => return print_error_message(env, &error).await,
+        Err(error) => return report_error(env, &error).await,
     };
 
     match operands.len() {

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -99,6 +99,7 @@ mod tests {
     use std::rc::Rc;
     use yash_env::io::Fd;
     use yash_env::semantics::Divert;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::system::SignalHandling;
     use yash_env::trap::Signal;
@@ -200,10 +201,10 @@ mod tests {
         system.current_process_mut().close_fd(Fd::STDOUT);
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(system);
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
-        });
+        }));
         let args = Field::dummies(["echo", "INT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
 

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -21,7 +21,6 @@
 use crate::common::print_error_message;
 use crate::common::syntax::parse_arguments;
 use crate::common::syntax::Mode;
-use crate::common::Print;
 use std::fmt::Write;
 use yash_env::builtin::Result;
 use yash_env::semantics::ExitStatus;
@@ -49,7 +48,7 @@ pub async fn print_traps(env: &mut Env) -> Result {
         };
         writeln!(output, "trap -- {} {}", quoted(command), cond).ok();
     }
-    env.print(&output).await
+    crate::common::output(env, &output).await
 }
 
 /// Entry point for executing the `trap` built-in

--- a/yash-builtin/src/unset.rs
+++ b/yash-builtin/src/unset.rs
@@ -69,7 +69,7 @@
 //! implementation unsets the both. This is not portable. Old versions of yash
 //! used to unset the local variable only.
 
-use crate::common::print_error_message;
+use crate::common::report_error;
 use crate::Result;
 use yash_env::semantics::Field;
 use yash_env::Env;
@@ -104,7 +104,7 @@ pub mod syntax;
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,
-        Err(e) => return print_error_message(env, &e).await,
+        Err(e) => return report_error(env, &e).await,
     };
 
     match command.mode {

--- a/yash-builtin/src/unset.rs
+++ b/yash-builtin/src/unset.rs
@@ -110,12 +110,12 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     match command.mode {
         Mode::Variables => match semantics::unset_variables(env, &command.names) {
             Ok(()) => Result::default(),
-            Err(errors) => semantics::print_variables_error(env, &errors).await,
+            Err(errors) => semantics::report_variables_error(env, &errors).await,
         },
 
         Mode::Functions => match semantics::unset_functions(env, &command.names) {
             Ok(()) => Result::default(),
-            Err(errors) => semantics::print_functions_error(env, &errors).await,
+            Err(errors) => semantics::report_functions_error(env, &errors).await,
         },
     }
 }

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -18,7 +18,6 @@
 
 use crate::common::arrange_message_and_divert;
 use thiserror::Error;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 #[cfg(doc)]

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -16,11 +16,13 @@
 
 //! Defines the behavior of the unset built-in.
 
-use crate::common::print_failure_message;
-use crate::common::AsStderr;
-use crate::common::BuiltinEnv;
+use crate::common::builtin_message_and_divert;
 use thiserror::Error;
+use yash_env::io::Stderr;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+#[cfg(doc)]
+use yash_env::system::SharedSystem;
 use yash_env::variable::Scope::Global;
 use yash_env::Env;
 use yash_syntax::source::pretty::Annotation;
@@ -75,13 +77,14 @@ pub fn unset_variables<'a>(
     }
 }
 
-pub async fn print_variables_error<E>(
-    env: &mut E,
-    errors: &[UnsetVariablesError<'_>],
-) -> crate::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
+/// Creates a message that describes the errors.
+///
+/// See [`builtin_message_and_divert`] for the second return value.
+#[must_use]
+pub fn unset_variables_error_message(
+    env: &Env,
+    errors: &[UnsetVariablesError],
+) -> (String, yash_env::semantics::Result) {
     let annotations = errors
         .iter()
         .flat_map(|error| {
@@ -104,7 +107,20 @@ where
         title: "cannot unset variable".into(),
         annotations,
     };
-    print_failure_message(env, message).await
+    builtin_message_and_divert(env, message)
+}
+
+/// Prints an error message to the standard error.
+///
+/// This function constructs a message with [`unset_variables_error_message`]
+/// and prints it with [`SharedSystem::print_error`].
+pub async fn report_variables_error(
+    env: &mut Env,
+    errors: &[UnsetVariablesError<'_>],
+) -> crate::Result {
+    let (message, divert) = unset_variables_error_message(env, errors);
+    env.system.print_error(&message).await;
+    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }
 
 /// Error returned by [`unset_functions`].
@@ -143,13 +159,14 @@ pub fn unset_functions<'a>(
     }
 }
 
-pub async fn print_functions_error<E>(
-    env: &mut E,
+/// Creates a message that describes the errors.
+///
+/// See [`builtin_message_and_divert`] for the second return value.
+#[must_use]
+pub fn unset_functions_error_message(
+    env: &mut Env,
     errors: &[UnsetFunctionsError<'_>],
-) -> crate::Result
-where
-    E: BuiltinEnv + AsStderr,
-{
+) -> (String, yash_env::semantics::Result) {
     let annotations = errors
         .iter()
         .flat_map(|error| {
@@ -172,7 +189,20 @@ where
         title: "cannot unset function".into(),
         annotations,
     };
-    print_failure_message(env, message).await
+    builtin_message_and_divert(env, message)
+}
+
+/// Prints an error message to the standard error.
+///
+/// This function constructs a message with [`unset_functions_error_message`]
+/// and prints it with [`SharedSystem::print_error`].
+pub async fn report_functions_error(
+    env: &mut Env,
+    errors: &[UnsetFunctionsError<'_>],
+) -> crate::Result {
+    let (message, divert) = unset_functions_error_message(env, errors);
+    env.system.print_error(&message).await;
+    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }
 
 #[cfg(test)]

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -16,7 +16,7 @@
 
 //! Defines the behavior of the unset built-in.
 
-use crate::common::builtin_message_and_divert;
+use crate::common::arrange_message_and_divert;
 use thiserror::Error;
 use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
@@ -79,7 +79,7 @@ pub fn unset_variables<'a>(
 
 /// Creates a message that describes the errors.
 ///
-/// See [`builtin_message_and_divert`] for the second return value.
+/// See [`arrange_message_and_divert`] for the second return value.
 #[must_use]
 pub fn unset_variables_error_message(
     env: &Env,
@@ -107,7 +107,7 @@ pub fn unset_variables_error_message(
         title: "cannot unset variable".into(),
         annotations,
     };
-    builtin_message_and_divert(env, message)
+    arrange_message_and_divert(env, message)
 }
 
 /// Prints an error message to the standard error.
@@ -161,7 +161,7 @@ pub fn unset_functions<'a>(
 
 /// Creates a message that describes the errors.
 ///
-/// See [`builtin_message_and_divert`] for the second return value.
+/// See [`arrange_message_and_divert`] for the second return value.
 #[must_use]
 pub fn unset_functions_error_message(
     env: &mut Env,
@@ -189,7 +189,7 @@ pub fn unset_functions_error_message(
         title: "cannot unset function".into(),
         annotations,
     };
-    builtin_message_and_divert(env, message)
+    arrange_message_and_divert(env, message)
 }
 
 /// Prints an error message to the standard error.

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -231,6 +231,7 @@ mod tests {
     use std::ops::ControlFlow::Continue;
     use std::rc::Rc;
     use yash_env::job::Job;
+    use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::subshell::Subshell;
     use yash_env::system::r#virtual::ProcessState;
@@ -398,10 +399,10 @@ mod tests {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("wait"),
             is_special: false,
-        });
+        }));
         let args = Field::dummies(["abc"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -414,10 +415,10 @@ mod tests {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
-        let mut env = env.push_frame(Frame::Builtin {
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("wait"),
             is_special: false,
-        });
+        }));
         let args = Field::dummies(["0"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -76,7 +76,7 @@
 //! The exact value of an exit status resulting from a signal is
 //! implementation-dependent.
 
-use crate::common::print_error_message;
+use crate::common::report_error;
 use crate::common::syntax::parse_arguments;
 use crate::common::syntax::Mode;
 use std::num::ParseIntError;
@@ -193,8 +193,8 @@ async fn wait_for_each_job(env: &mut Env, job_specs: Vec<Field>) -> Result {
     for job_spec in job_specs {
         let pid = match job_spec.value.parse() {
             Ok(pid) if pid > 0 => Pid::from_raw(pid),
-            Ok(_) => return print_error_message(env, &JobSpecError::NonPositive(job_spec)).await,
-            Err(e) => return print_error_message(env, &JobSpecError::ParseInt(job_spec, e)).await,
+            Ok(_) => return report_error(env, &JobSpecError::NonPositive(job_spec)).await,
+            Err(e) => return report_error(env, &JobSpecError::ParseInt(job_spec, e)).await,
         };
 
         exit_status = if let Some(index) = env.jobs.find_by_pid(pid) {
@@ -211,7 +211,7 @@ async fn wait_for_each_job(env: &mut Env, job_specs: Vec<Field>) -> Result {
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let (_options, operands) = match parse_arguments(&[], Mode::with_env(env), args) {
         Ok(result) => result,
-        Err(error) => return print_error_message(env, &error).await,
+        Err(error) => return report_error(env, &error).await,
     };
 
     if operands.is_empty() {

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -63,13 +63,6 @@ pub trait Stderr {
     }
 }
 
-#[async_trait(?Send)]
-impl Stderr for String {
-    async fn print_error(&mut self, message: &str) {
-        self.push_str(message)
-    }
-}
-
 /// Convenience function for printing an error message.
 ///
 /// This function converts the `error` into a [`Message`] which in turn is

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -16,6 +16,9 @@
 
 //! Type definitions for I/O.
 
+#[cfg(doc)]
+use crate::system::SharedSystem;
+use crate::Env;
 use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::snippet::Snippet;
 use async_trait::async_trait;
@@ -61,6 +64,20 @@ pub trait Stderr {
     fn should_print_error_in_color(&self) -> bool {
         false
     }
+}
+
+/// Convenience function for converting an error message into a string.
+///
+/// The returned string may contain ANSI color escape sequences if the given
+/// `env` allows it. The string will end with a newline.
+///
+/// To print the returned string to the standard error, you can use
+/// [`SharedSystem::print_error`].
+#[must_use]
+pub fn to_string(env: &Env, message: Message<'_>) -> String {
+    let mut s = Snippet::from(&message);
+    s.opt.color = env.system.should_print_error_in_color();
+    format!("{}\n", DisplayList::from(s))
 }
 
 /// Convenience function for printing an error message.

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -263,6 +263,22 @@ impl Env {
         None
     }
 
+    /// Whether error messages should be printed in color
+    ///
+    /// This function decides whether messages printed to the standard error
+    /// should contain ANSI color escape sequences. The result is true only if
+    /// the standard error is a terminal.
+    ///
+    /// The current implementaion simply checks if the standard error is a
+    /// terminal. This will be changed in the future to support user
+    /// configuration.
+    #[must_use]
+    fn should_print_error_in_color(&self) -> bool {
+        // TODO Enable color depending on user config (force/auto/never)
+        // TODO Check if the terminal really supports color (needs terminfo)
+        self.system.isatty(Fd::STDERR) == Ok(true)
+    }
+
     /// Returns a file descriptor to the controlling terminal.
     ///
     /// This function returns `self.tty` if it is `Some` FD. Otherwise, it

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -216,17 +216,6 @@ impl Env {
         let _ = self.prepare_pwd();
     }
 
-    /// Convenience function that prints the given error message.
-    ///
-    /// This function prints the `message` to the standard error of this
-    /// environment, ignoring any errors that may happen.
-    ///
-    /// No formatting takes place in this function. Use [`io::print_message`] or
-    /// [`io::print_error`] to format a message before printing.
-    pub async fn print_error(&mut self, message: &str) {
-        let _: Result<_, _> = self.system.write_all(Fd::STDERR, message.as_bytes()).await;
-    }
-
     /// Waits for some signals to be caught in the current process.
     ///
     /// Returns an array of signals caught.

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -23,7 +23,6 @@ use crate::xtrace::XTrace;
 use crate::Handle;
 use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -23,6 +23,7 @@ use crate::xtrace::XTrace;
 use crate::Handle;
 use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
+use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
@@ -40,7 +41,7 @@ async fn perform_redirs(
     let mut xtrace = XTrace::from_options(&env.options);
     let result = env.perform_redirs(redirs, xtrace.as_mut()).await;
     let xtrace = finish(env, xtrace).await;
-    env.print_error(&xtrace).await;
+    env.system.print_error(&xtrace).await;
     result
 }
 

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -52,7 +52,7 @@ pub async fn execute(env: &mut Env, body: Rc<List>, location: &Location) -> Resu
         }
         Err(errno) => {
             print_error(
-                &mut env.system,
+                env,
                 "cannot start subshell".into(),
                 errno.desc().into(),
                 location,

--- a/yash-semantics/src/command/function_definition.rs
+++ b/yash-semantics/src/command/function_definition.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
 use std::rc::Rc;
 use yash_env::function::Function;
+use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::Env;
@@ -65,7 +66,7 @@ async fn define_function(env: &mut Env, def: &syntax::FunctionDefinition) -> Res
         }
         Err(error) => {
             // TODO Use pretty::Message and annotate_snippet
-            env.print_error(&error.to_string()).await;
+            env.system.print_error(&error.to_string()).await;
             env.exit_status = ExitStatus::ERROR;
         }
     }

--- a/yash-semantics/src/command/function_definition.rs
+++ b/yash-semantics/src/command/function_definition.rs
@@ -24,7 +24,6 @@ use async_trait::async_trait;
 use std::ops::ControlFlow::Continue;
 use std::rc::Rc;
 use yash_env::function::Function;
-use yash_env::io::Stderr;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::Env;

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -84,7 +84,7 @@ async fn execute_async(env: &mut Env, and_or: &Rc<AndOrList>, async_flag: &Locat
         }
         Err(errno) => {
             print_error(
-                &mut env.system,
+                env,
                 "cannot start a subshell to run an asynchronous command".into(),
                 errno.desc().into(),
                 async_flag,

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::io::Fd;
+use yash_env::io::Stderr;
 use yash_env::job::Job;
 use yash_env::job::Pid;
 use yash_env::job::WaitStatus::Stopped;
@@ -145,11 +146,12 @@ async fn execute_job_controlled_pipeline(
         }
         Err(errno) => {
             // TODO print error location using yash_env::io::print_error
-            env.print_error(&format!(
-                "cannot start a subshell in the pipeline: {}\n",
-                errno.desc()
-            ))
-            .await;
+            env.system
+                .print_error(&format!(
+                    "cannot start a subshell in the pipeline: {}\n",
+                    errno.desc()
+                ))
+                .await;
             Break(Divert::Interrupt(Some(ExitStatus::NOEXEC)))
         }
     }
@@ -198,11 +200,12 @@ async fn shift_or_fail(env: &mut Env, pipes: &mut PipeSet, has_next: bool) -> Re
         Ok(()) => Continue(()),
         Err(errno) => {
             // TODO print error location using yash_env::io::print_error
-            env.print_error(&format!(
-                "cannot connect pipes in the pipeline: {}\n",
-                errno.desc()
-            ))
-            .await;
+            env.system
+                .print_error(&format!(
+                    "cannot connect pipes in the pipeline: {}\n",
+                    errno.desc()
+                ))
+                .await;
             Break(Divert::Interrupt(Some(ExitStatus::NOEXEC)))
         }
     }
@@ -217,11 +220,12 @@ async fn connect_pipe_and_execute_command(
         Ok(()) => (),
         Err(errno) => {
             // TODO print error location using yash_env::io::print_error
-            env.print_error(&format!(
-                "cannot connect pipes in the pipeline: {}\n",
-                errno.desc()
-            ))
-            .await;
+            env.system
+                .print_error(&format!(
+                    "cannot connect pipes in the pipeline: {}\n",
+                    errno.desc()
+                ))
+                .await;
             return Break(Divert::Interrupt(Some(ExitStatus::NOEXEC)));
         }
     }
@@ -240,11 +244,12 @@ async fn pid_or_fail(
         }
         Err(errno) => {
             // TODO print error location using yash_env::io::print_error
-            env.print_error(&format!(
-                "cannot start a subshell in the pipeline: {}\n",
-                errno.desc()
-            ))
-            .await;
+            env.system
+                .print_error(&format!(
+                    "cannot start a subshell in the pipeline: {}\n",
+                    errno.desc()
+                ))
+                .await;
             Break(Divert::Interrupt(Some(ExitStatus::NOEXEC)))
         }
     }

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -22,7 +22,6 @@ use itertools::Itertools;
 use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::io::Fd;
-use yash_env::io::Stderr;
 use yash_env::job::Job;
 use yash_env::job::Pid;
 use yash_env::job::WaitStatus::Stopped;

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -85,7 +85,7 @@ pub async fn execute_absent_target(
             }
             Err(errno) => {
                 print_error(
-                    &mut env.system,
+                    env,
                     "cannot start subshell to perform redirection".into(),
                     errno.desc().into(),
                     &first_redir_location,

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -67,7 +67,7 @@ pub async fn execute_external_utility(
 
     if path.to_bytes().is_empty() {
         print_error(
-            &mut env.system,
+            &mut env,
             format!("cannot execute external utility {:?}", name.value).into(),
             "utility not found".into(),
             &name.origin,
@@ -105,7 +105,7 @@ pub async fn execute_external_utility(
         }
         Err(errno) => {
             print_error(
-                &mut env.system,
+                &mut env,
                 format!("cannot execute external utility {:?}", name.value).into(),
                 errno.desc().into(),
                 &name.origin,
@@ -168,7 +168,7 @@ pub async fn replace_current_process(
         }
     }
     print_error(
-        &mut env.system,
+        env,
         format!("cannot execute external utility {path:?}").into(),
         errno.desc().into(),
         &location,

--- a/yash-semantics/src/handle.rs
+++ b/yash-semantics/src/handle.rs
@@ -43,7 +43,7 @@ pub trait Handle {
 #[async_trait(?Send)]
 impl Handle for yash_syntax::parser::Error {
     async fn handle(&self, env: &mut Env) -> super::Result {
-        print_message(&mut env.system, self).await;
+        print_message(env, self).await;
         Break(Divert::Interrupt(Some(ExitStatus::ERROR)))
     }
 }
@@ -57,7 +57,7 @@ impl Handle for yash_syntax::parser::Error {
 #[async_trait(?Send)]
 impl Handle for crate::expansion::Error {
     async fn handle(&self, env: &mut Env) -> super::Result {
-        print_message(&mut env.system, self).await;
+        print_message(env, self).await;
         Break(Divert::Interrupt(Some(ExitStatus::ERROR)))
     }
 }
@@ -77,7 +77,7 @@ impl Handle for crate::expansion::Error {
 #[async_trait(?Send)]
 impl Handle for crate::redir::Error {
     async fn handle(&self, env: &mut Env) -> super::Result {
-        print_message(&mut env.system, self).await;
+        print_message(env, self).await;
         env.exit_status = ExitStatus::ERROR;
         Continue(())
     }

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -36,7 +36,6 @@
 use crate::expansion::expand_text;
 use crate::Handle;
 use std::fmt::Write;
-use yash_env::io::Stderr;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::semantics::Field;
@@ -205,8 +204,8 @@ pub async fn finish(env: &mut Env, xtrace: Option<XTrace>) -> String {
     }
 }
 
-/// Convenience function for [finish]ing and [print](Stderr::print_error)ing an
-/// (optional) `XTrace`.
+/// Convenience function for [finish]ing and
+/// [print](yash_env::SharedSystem::print_error)ing an (optional) `XTrace`.
 pub async fn print<X: Into<Option<XTrace>>>(env: &mut Env, xtrace: X) {
     async fn inner(env: &mut Env, xtrace: Option<XTrace>) {
         let s = finish(env, xtrace).await;

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -36,6 +36,7 @@
 use crate::expansion::expand_text;
 use crate::Handle;
 use std::fmt::Write;
+use yash_env::io::Stderr;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::semantics::Field;
@@ -204,12 +205,12 @@ pub async fn finish(env: &mut Env, xtrace: Option<XTrace>) -> String {
     }
 }
 
-/// Convenience function for [finish]ing and [print](Env::print_error)ing an
+/// Convenience function for [finish]ing and [print](Stderr::print_error)ing an
 /// (optional) `XTrace`.
 pub async fn print<X: Into<Option<XTrace>>>(env: &mut Env, xtrace: X) {
     async fn inner(env: &mut Env, xtrace: Option<XTrace>) {
         let s = finish(env, xtrace).await;
-        env.print_error(&s).await;
+        env.system.print_error(&s).await;
     }
     inner(env, xtrace.into()).await
 }

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -77,6 +77,9 @@ impl std::fmt::Debug for Annotation<'_> {
 
 impl<'a> Annotation<'a> {
     /// Creates a new annotation.
+    ///
+    /// This function makes a borrow of `location.code.value` and stores it in
+    /// `self.code`. If it has been mutually borrowed, this function panics.
     pub fn new(r#type: AnnotationType, label: Cow<'a, str>, location: &'a Location) -> Self {
         Annotation {
             r#type,

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -35,7 +35,6 @@ async fn print_version(env: &mut env::Env) -> i32 {
 }
 
 async fn parse_and_print(mut env: env::Env) -> i32 {
-    use env::io::Stderr;
     use env::option::Option::{Interactive, Monitor};
     use env::option::State::On;
     use env::variable::Value::Array;

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -29,9 +29,8 @@ pub mod startup;
 // mod runner;
 
 async fn print_version(env: &mut env::Env) -> i32 {
-    use builtin::common::Print;
     let version = env!("CARGO_PKG_VERSION");
-    let result = &env.print(&format!("yash {}\n", version)).await;
+    let result = builtin::common::output(env, &format!("yash {}\n", version)).await;
     result.exit_status().0
 }
 

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -36,6 +36,7 @@ async fn print_version(env: &mut env::Env) -> i32 {
 }
 
 async fn parse_and_print(mut env: env::Env) -> i32 {
+    use env::io::Stderr;
     use env::option::Option::{Interactive, Monitor};
     use env::option::State::On;
     use env::variable::Value::Array;
@@ -53,7 +54,7 @@ async fn parse_and_print(mut env: env::Env) -> i32 {
         Ok(Parse::Run(run)) => run,
         Err(e) => {
             let arg0 = std::env::args().next().unwrap_or_else(|| "yash".to_owned());
-            env.print_error(&format!("{}: {}\n", arg0, e)).await;
+            env.system.print_error(&format!("{}: {}\n", arg0, e)).await;
             return ExitStatus::ERROR.0;
         }
     };
@@ -95,7 +96,7 @@ async fn parse_and_print(mut env: env::Env) -> i32 {
         Ok(input) => input,
         Err(e) => {
             let arg0 = std::env::args().next().unwrap_or_else(|| "yash".to_owned());
-            env.print_error(&format!("{}: {}\n", arg0, e)).await;
+            env.system.print_error(&format!("{}: {}\n", arg0, e)).await;
             return ExitStatus::FAILURE.0;
         }
     };


### PR DESCRIPTION
This is a major refactoring of error reporting in yash-builtin. The goal
is to make error reporting functions more composable and reusable.

The most notable change is the introduction of the
`arrange_message_and_divert` function, which only constructs a message
without printing it. Printing the error message requires a mutable
reference to the environment, which may conflict with shared references
in the message that borrow locations from the variable set, stack, or
some other part of the environment. The conflict forced the caller to
temporarily clone the locations onto the local stack, which was not very
efficient. The new function only requires a shared reference to the
environment, so the caller can borrow the locations directly from the
environment.

Another notable change is the removal of the `Stderr`, `Stdout` and
`BuiltinEnv` traits. The abstraction introduced by these traits was not
very useful because most use cases of these traits were only applicable
to `Env` and `SharedSystem`. The traits are now replaced by the direct
use of `Env` and `SharedSystem`. This change reduces complexity and
makes the API easier to use.

----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Improved error reporting across the application by introducing more consistent and descriptive naming conventions. This change enhances the clarity of error messages, making it easier for users to understand and resolve issues.
- Refactor: Updated the built-in command implementation in the shell, enhancing the overall structure and readability of the code.
- Refactor: Simplified the printing and error handling logic in the shell built-in utilities module, making the code more maintainable.
- Refactor: Enhanced the error handling and reporting in the `unset` command, providing more detailed error messages to users.
- Refactor: Updated the `shift` built-in command to provide more detailed error messages, improving user understanding of issues.
- Refactor: Removed unnecessary dependencies and consolidated similar functions in the `common` module, simplifying the codebase.
- Refactor: Updated the `print_version` and `parse_and_print` functions to use new error handling and output functions, improving the consistency of the codebase.
- Documentation: Added comprehensive documentation to the shell built-in utilities module, making it easier for developers to understand and work with the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->