### PR TITLE
Typeset built-in for variables

### DIFF
--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -57,6 +57,7 @@ pub mod r#return;
 pub mod set;
 pub mod shift;
 pub mod trap;
+pub mod typeset;
 pub mod unset;
 pub mod wait;
 

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -69,7 +69,7 @@ use yash_env::stack::{Frame, Stack};
 use yash_env::Env;
 
 use std::future::ready;
-use Type::{Mandatory, Special};
+use Type::{Elective, Mandatory, Special};
 
 /// Array of all the implemented built-in utilities.
 ///
@@ -165,6 +165,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: |env, args| Box::pin(trap::main(env, args)),
+        },
+    ),
+    (
+        "typeset",
+        Builtin {
+            r#type: Elective,
+            execute: |env, args| Box::pin(typeset::main(env, args)),
         },
     ),
     (

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -253,3 +253,131 @@
 //! # Implementation notes
 //!
 //! TBD
+
+use yash_env::option::State;
+use yash_env::semantics::Field;
+
+pub mod syntax;
+
+/// Attribute that can be set on a variable
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum VariableAttr {
+    /// The variable is read-only.
+    ReadOnly,
+    /// The variable is exported to the environment.
+    Export,
+}
+
+/// Scope in which a variable is defined or selected
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Scope {
+    /// Operates on global scope.
+    ///
+    /// When defining variables: If an existing variable is visible in the
+    /// current scope, the variable is updated. Otherwise, a new variable is
+    /// created in the base context.
+    ///
+    /// When printing variables: All visible variables are printed.
+    Global,
+
+    /// Operates on local scope.
+    ///
+    /// When defining variables: The variable is defined in the local context of
+    /// the current function.
+    ///
+    /// When printing variables: Only variables defined in the local context of
+    /// the current function are printed.
+    Local,
+}
+
+/// Set of information to define variables
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetVariables {
+    /// Names and optional values of the variables to be defined
+    pub variables: Vec<Field>,
+    /// Attributes to be set on the variables
+    pub attrs: Vec<(VariableAttr, State)>,
+    /// Scope in which the variables are defined
+    pub scope: Scope,
+}
+
+/// Set of information to print variables
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrintVariables {
+    /// Names of the variables to be printed
+    ///
+    /// If empty, all variables are printed.
+    pub variables: Vec<Field>,
+    /// Attributes to select the variables to be printed
+    pub attrs: Vec<(VariableAttr, State)>,
+    /// Scope in which the variables are printed
+    pub scope: Scope,
+}
+
+/// Attribute that can be set on a function
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum FunctionAttr {
+    /// The function is read-only.
+    ReadOnly,
+}
+
+/// Set of information to modify functions
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetFunctions {
+    /// Names of the functions to be modified
+    pub functions: Vec<Field>,
+    /// Attributes to be set on the functions
+    pub attrs: Vec<(FunctionAttr, State)>,
+}
+
+/// Set of information to print functions
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrintFunctions {
+    /// Names of the functions to be printed
+    ///
+    /// If empty, all functions are printed.
+    pub functions: Vec<Field>,
+    /// Attributes to select the functions to be printed
+    pub attrs: Vec<(FunctionAttr, State)>,
+}
+
+/// Set of information that specifies the behavior of the typeset built-in
+///
+/// The [`syntax::parse`] function returns a value of this type after parsing
+/// the arguments of the built-in.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Command {
+    SetVariables(SetVariables),
+    PrintVariables(PrintVariables),
+    SetFunctions(SetFunctions),
+    PrintFunctions(PrintFunctions),
+}
+
+impl From<SetVariables> for Command {
+    fn from(v: SetVariables) -> Self {
+        Self::SetVariables(v)
+    }
+}
+
+impl From<PrintVariables> for Command {
+    fn from(v: PrintVariables) -> Self {
+        Self::PrintVariables(v)
+    }
+}
+
+impl From<SetFunctions> for Command {
+    fn from(v: SetFunctions) -> Self {
+        Self::SetFunctions(v)
+    }
+}
+
+impl From<PrintFunctions> for Command {
+    fn from(v: PrintFunctions) -> Self {
+        Self::PrintFunctions(v)
+    }
+}
+
+// TODO the main function

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -258,11 +258,12 @@ use crate::common::{output, report_error, report_failure};
 use thiserror::Error;
 use yash_env::option::State;
 use yash_env::semantics::Field;
-use yash_env::variable::AssignError;
+use yash_env::variable::{AssignError, Variable};
 use yash_env::Env;
 use yash_syntax::source::pretty::{Annotation, AnnotationType, Message, MessageBase};
 use yash_syntax::source::Location;
 
+mod print_variables;
 mod set_variables;
 pub mod syntax;
 
@@ -274,6 +275,18 @@ pub enum VariableAttr {
     ReadOnly,
     /// The variable is exported to the environment.
     Export,
+}
+
+impl VariableAttr {
+    /// Tests if the attribute is set on a variable
+    #[must_use]
+    pub fn test(&self, var: &Variable) -> State {
+        let is_on = match self {
+            VariableAttr::ReadOnly => var.is_read_only(),
+            VariableAttr::Export => var.is_exported,
+        };
+        State::from(is_on)
+    }
 }
 
 /// Scope in which a variable is defined or selected
@@ -399,8 +412,8 @@ impl Command {
     pub fn execute(self, env: &mut Env) -> Result<String, Vec<ExecuteError>> {
         match self {
             Self::SetVariables(command) => command.execute(env),
-            Self::PrintVariables(command) => todo!("{command:?}"), // command.execute(env),
-            Self::SetFunctions(command) => todo!("{command:?}"),   // command.execute(env),
+            Self::PrintVariables(command) => command.execute(&env.variables),
+            Self::SetFunctions(command) => todo!("{command:?}"), // command.execute(env),
             Self::PrintFunctions(command) => todo!("{command:?}"), // command.execute(env),
         }
     }

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -264,6 +264,7 @@ use yash_syntax::source::pretty::{Annotation, AnnotationType, Message, MessageBa
 use yash_syntax::source::Location;
 
 mod print_variables;
+mod set_functions;
 mod set_variables;
 pub mod syntax;
 
@@ -413,7 +414,7 @@ impl Command {
         match self {
             Self::SetVariables(command) => command.execute(env),
             Self::PrintVariables(command) => command.execute(&env.variables),
-            Self::SetFunctions(command) => todo!("{command:?}"), // command.execute(env),
+            Self::SetFunctions(command) => command.execute(&mut env.functions),
             Self::PrintFunctions(command) => todo!("{command:?}"), // command.execute(env),
         }
     }

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -1,0 +1,255 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Typeset built-in
+//!
+//! The built-in behaves differently depending on the arguments.
+//!
+//! # Defining variables
+//!
+//! If the `-p` (`--print`) or `-f` (`--functions`) option is not specified and
+//! there are any operands, the built-in defines shell variables named by the
+//! operands.
+//!
+//! Other options may be specified to set the scope and attributes of the
+//! variables.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! typeset [-grx] [+rx] name[=value]...
+//! ```
+//!
+//! ## Options
+//!
+//! By default, the built-in creates or updates variables in the current
+//! context.  If the **`-g`** (**`--global`**) option is specified, the built-in
+//! affects existing variables visible in the current scope (which may reside in
+//! an outer context) or creates new variables in the base context. See the
+//! documentation in [`yash_env::variable`] for details on the variable scope.
+//!
+//! The following options may be specified to set the attributes of the
+//! variables:
+//!
+//! - **`-r`** (**`--readonly`**): Makes the variables read-only.
+//! - **`-x`** (**`--export`**): Exports the variables to the environment.
+//!
+//! To remove the attributes, specify the corresponding option with a plus sign
+//! (`+`) instead of a minus sign (`-`). For example, the following commands
+//! stop exporting the variable `foo`:
+//!
+//! ```sh
+//! typeset +x foo
+//! typeset ++export foo
+//! ```
+//!
+//! Note that the read-only attribute cannot be removed, so the `+r` option is
+//! of no use.
+//!
+//! ## Operands
+//!
+//! Operands specify the names and values of the variables to be defined. If an
+//! operand contains an equal sign (`=`), the operand is split into the name and
+//! value at the first equal sign. The value is assigned to the variable named
+//! by the name. Otherwise, the variable named by the operand is created without
+//! a value unless it is already defined, in which case the existing value is
+//! retained.
+//!
+//! If no operands are given, the built-in prints variables (see below).
+//!
+//! ## Standard output
+//!
+//! None.
+//!
+//! # Printing variables
+//!
+//! If the `-p` (`--print`) option is specified and the `-f` (`--functions`)
+//! option is not specified, the built-in prints the attributes and values of
+//! the variables named by the operands in the format that can be evaluated as
+//! shell code to recreate the variables.
+//! <!-- TODO: link to the eval built-in -->
+//! If there are no operands and the `-f` (`--functions`) option is not
+//! specified, the built-in prints all shell variables in the same format.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! typeset -p [-grx] [+rx] [name...]
+//! ```
+//!
+//! ```sh
+//! typeset [-grx] [+rx]
+//! ```
+//!
+//! ## Options
+//!
+//! The **`-p`** (**`--print`**) option must be specified to print variables
+//! when there are any operands. Otherwise, the built-in defines variables. The
+//! option may be omitted if there are no operands.
+//!
+//! By default, the built-in prints variables in the current context. If the
+//! **`-g`** (**`--global`**) option is specified, the built-in prints variables
+//! visible in the current scope (which may reside in an outer context).
+//!
+//! The following options may be specified to select which variables to print.
+//! Variables that do not match the selection criteria are ignored.
+//!
+//! - **`-r`** (**`--readonly`**): Prints read-only variables.
+//! - **`-x`** (**`--export`**): Prints exported variables.
+//!
+//! If these options are negated by prefixing a plus sign (`+`) instead of a
+//! minus sign (`-`), the built-in prints variables that do not have the
+//! corresponding attribute.
+//!
+//! ## Operands
+//!
+//! Operands specify the names of the variables to be printed. If no operands
+//! are given, the built-in prints all variables that match the selection
+//! criteria.
+//!
+//! ## Standard output
+//!
+//! A command string that invokes the typeset built-in to recreate the variable
+//! is printed for each variable.
+//!
+//! Note that evaluating the printed commands in the current context may fail if
+//! variables are read-only since the read-only variables cannot be assigned
+//! values.
+//!
+//! # Modifying functions
+//!
+//! If the `-f` (`--functions`) option is specified, the `-p` (`--print`) option
+//! is not specified, and there are any operands, the built-in modifies the
+//! attributes of shell functions named by the operands.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! typeset -f [-r] [+r] name...
+//! ```
+//!
+//! ## Options
+//!
+//! The **`-f`** (**`--functions`**) option is required to modify functions.
+//! Otherwise, the built-in defines variables.
+//!
+//! The **`-r`** (**`--readonly`**) option makes the functions read-only. If the
+//! option is not specified, the built-in does nothing.
+//!
+//! The built-in accepts the `+r` (`++readonly`) option, but it is of no use
+//! since the read-only attribute cannot be removed.
+//!
+//! ## Operands
+//!
+//! Operands specify the names of the functions to be modified. If no operands
+//! are given, the built-in prints functions (see below).
+//!
+//! Note that the built-in operates on existing shell functions only. It cannot
+//! create new functions or change the contents of existing functions.
+//!
+//! ## Standard output
+//!
+//! None.
+//!
+//! # Printing functions
+//!
+//! If the `-f` (`--functions`) and `-p` (`--print`) options are specified, the
+//! built-in prints the attributes and definitions of the shell functions named
+//! by the operands in the format that can be evaluated as shell code to
+//! recreate the functions.
+//! <!-- TODO: link to the eval built-in -->
+//! If there are no operands and the `-f` (`--functions`) option is specified,
+//! the built-in prints all shell functions in the same format.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! typeset -fp [-r] [+r] [name...]
+//! ```
+//!
+//! ```sh
+//! typeset -f [-r] [+r]
+//! ```
+//!
+//! ## Options
+//!
+//! The the **`-f`** (**`--functions`**) and **`-p`** (**`--print`**) options
+//! must be specified to print functions when there are any operands. Otherwise,
+//! the built-in modifies functions. The `-p` (`--print`) option may be omitted
+//! if there are no operands.
+//!
+//! The **`-r`** (**`--readonly`**) option can be specified to limit the output
+//! to read-only functions. If this option is negated as `+r` (`++readonly`),
+//! the built-in prints functions that are not read-only. If the option is not
+//! specified, the built-in prints all functions.
+//!
+//! ## Operands
+//!
+//! Operands specify the names of the functions to be printed. If no operands
+//! are given, the built-in prints all functions that match the selection
+//! criteria.
+//!
+//! ## Standard output
+//!
+//! A command string of a function definition command is printed for each
+//! function, which may be followed by an invocation of the typeset built-in to
+//! set the attributes of the function.
+//!
+//! Note that evaluating the printed commands in the current shell environment
+//! may fail if functions are read-only since the read-only functions cannot be
+//! redefined.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Errors
+//!
+//! The read-only attribute cannot be removed from a variable or function. If a
+//! variable is already read-only, you cannot assign a value to it.
+//!
+//! When printing variables or functions, it is an error if the operand contains
+//! an equal sign (`=`) or names a non-existing variable or function.
+//!
+//! # Portability
+//!
+//! The typeset built-in is not specified by POSIX and many shells implement it
+//! differently. This implementation is based on common characteristics seen in
+//! other shells, but it is not fully compatible with any of them.
+//!
+//! Some implementations allow operating on variables and functions at the same
+//! time. This implementation does not.
+//!
+//! This implementation requires the `-g` (`--global`) option to print variables
+//! defined in outer contexts. Other implementations may print such variables by
+//! default.
+//!
+//! This implementation allows hiding a read-only variable defined in an outer
+//! context by introducing a variable with the same name in the current context.
+//! This may not be allowed in other implementations.
+//!
+//! Historical versions of yash used to perform assignments when operands of the
+//! form `name=value` are given even if the `-p` option is specified. This
+//! implementation regards such usage as an error.
+//!
+//! Historical versions of yash used the `-X` (`--unexport`) option to negate
+//! the `-x` (`--export`) option. This is now deprecated because its behavior is
+//! incompatible with other implementations. Use the `+x` (`++export`) option
+//! instead.
+//!
+//! # Implementation notes
+//!
+//! TBD

--- a/yash-builtin/src/typeset/print_variables.rs
+++ b/yash-builtin/src/typeset/print_variables.rs
@@ -1,0 +1,508 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use std::fmt::Write;
+use yash_env::variable::{Value, VariableSet};
+
+impl PrintVariables {
+    /// Executes the command.
+    pub fn execute(self, variables: &VariableSet) -> Result<String, Vec<ExecuteError>> {
+        let mut output = String::new();
+        let mut errors = Vec::new();
+
+        if self.variables.is_empty() {
+            let mut variables = variables.iter(self.scope.into()).collect::<Vec<_>>();
+            // TODO Honor the collation order in the locale.
+            variables.sort_unstable_by_key(|&(name, _)| name);
+            for (name, var) in variables {
+                print_one(name, var, &self.attrs, &mut output);
+            }
+        } else {
+            for name in self.variables {
+                match variables.get(&name.value) {
+                    Some(var) => print_one(&name.value, var, &self.attrs, &mut output),
+                    None => errors.push(ExecuteError::PrintUnsetVariable(name)),
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(output)
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Formats a variable for printing.
+fn print_one(
+    name: &str,
+    var: &Variable,
+    filter_attrs: &[(VariableAttr, State)],
+    output: &mut String,
+) {
+    // Skip if the variable does not match the filter.
+    if filter_attrs
+        .iter()
+        .any(|&(attr, state)| attr.test(var) != state)
+    {
+        return;
+    }
+
+    // Do the formatting.
+    let options = AttributeOption { var };
+    let quoted_name = yash_quote::quoted(name);
+    match &var.value {
+        Some(value @ Value::Scalar(_)) => writeln!(
+            output,
+            "typeset {}{}={}",
+            options,
+            quoted_name,
+            value.quote()
+        )
+        .unwrap(),
+
+        Some(value @ Value::Array(_)) => {
+            writeln!(output, "{}={}", quoted_name, value.quote()).unwrap();
+
+            let options = options.to_string();
+            if !options.is_empty() {
+                writeln!(output, "typeset {}{}", options, quoted_name).unwrap();
+            }
+        }
+
+        None => writeln!(output, "typeset {}{}", options, quoted_name).unwrap(),
+    }
+}
+
+/// `Display` implementor for printing command line options that reproduce the
+/// variable attributes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AttributeOption<'a> {
+    var: &'a Variable,
+}
+
+impl std::fmt::Display for AttributeOption<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.var.is_read_only() {
+            f.write_str("-r ")?;
+        }
+        if self.var.is_exported {
+            f.write_str("-x ")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yash_env::option::{Off, On};
+    use yash_env::variable::ContextType;
+
+    #[test]
+    fn printing_one_variable() {
+        let mut vars = VariableSet::new();
+        vars.get_or_new("foo", Scope::Global.into())
+            .assign("value", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["foo"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        let output = pv.execute(&vars).unwrap();
+        assert_eq!(output, "typeset foo=value\n")
+    }
+
+    #[test]
+    fn printing_multiple_variables() {
+        let mut vars = VariableSet::new();
+        vars.get_or_new("first", Scope::Global.into())
+            .assign("1", None)
+            .unwrap();
+        vars.get_or_new("second", Scope::Global.into())
+            .assign("2", None)
+            .unwrap();
+        vars.get_or_new("third", Scope::Global.into())
+            .assign("3", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["first", "second", "third"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset first=1\n\
+             typeset second=2\n\
+             typeset third=3\n",
+        );
+    }
+
+    #[test]
+    fn printing_array_variable() {
+        let mut vars = VariableSet::new();
+        vars.get_or_new("a", Scope::Global.into())
+            .assign(Value::array(["1", "2  2", "3"]), None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["a"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(pv.execute(&vars).unwrap(), "a=(1 '2  2' 3)\n");
+    }
+
+    #[test]
+    fn printing_valueless_variable() {
+        let mut vars = VariableSet::new();
+        vars.get_or_new("x", Scope::Global.into());
+        let pv = PrintVariables {
+            variables: Field::dummies(["x"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(pv.execute(&vars).unwrap(), "typeset x\n");
+    }
+
+    #[test]
+    fn quoting_variable_names_and_values() {
+        let mut vars = VariableSet::new();
+        vars.get_or_new("valueless$", Scope::Global.into());
+        vars.get_or_new("scalar$", Scope::Global.into())
+            .assign("=;", None)
+            .unwrap();
+        vars.get_or_new("array$", Scope::Global.into())
+            .assign(Value::array(["~", "'", "*?"]), None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["valueless$", "scalar$", "array$"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset 'valueless$'\n\
+             typeset 'scalar$'='=;'\n\
+             'array$'=('~' \"'\" '*?')\n",
+        );
+    }
+
+    #[test]
+    fn printing_global_and_local_variables_at_once() {
+        let mut outer = VariableSet::new();
+        outer
+            .get_or_new("global", Scope::Global.into())
+            .assign("global value", None)
+            .unwrap();
+        let mut inner = outer.push_context(ContextType::Regular);
+        inner
+            .get_or_new("local", Scope::Local.into())
+            .assign("local value", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["global", "local"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&inner).unwrap(),
+            "typeset global='global value'\n\
+             typeset local='local value'\n",
+        );
+    }
+
+    #[test]
+    #[ignore = "needs VariableSet::get_scoped"]
+    fn printing_local_variables_only() {
+        let mut outer = VariableSet::new();
+        outer
+            .get_or_new("global", Scope::Global.into())
+            .assign("global value", None)
+            .unwrap();
+        let mut inner = outer.push_context(ContextType::Regular);
+        inner
+            .get_or_new("local", Scope::Local.into())
+            .assign("local value", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: Field::dummies(["global", "local"]),
+            attrs: vec![],
+            scope: Scope::Local,
+        };
+
+        let output = pv.execute(&inner).unwrap();
+        assert_eq!(output, "typeset local='local value'\n");
+    }
+
+    #[test]
+    fn printing_all_global_and_local_variables() {
+        let mut outer = VariableSet::new();
+        outer
+            .get_or_new("one", Scope::Global.into())
+            .assign("1", None)
+            .unwrap();
+        let mut inner = outer.push_context(ContextType::Regular);
+        inner
+            .get_or_new("two", Scope::Local.into())
+            .assign("2", None)
+            .unwrap();
+        inner
+            .get_or_new("three", Scope::Local.into())
+            .assign("3", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&inner).unwrap(),
+            // sorted by name
+            "typeset one=1\n\
+             typeset three=3\n\
+             typeset two=2\n",
+        );
+    }
+
+    #[test]
+    fn printing_all_local_variables() {
+        let mut outer = VariableSet::new();
+        outer
+            .get_or_new("one", Scope::Global.into())
+            .assign("1", None)
+            .unwrap();
+        let mut inner = outer.push_context(ContextType::Regular);
+        inner
+            .get_or_new("two", Scope::Local.into())
+            .assign("2", None)
+            .unwrap();
+        inner
+            .get_or_new("three", Scope::Local.into())
+            .assign("3", None)
+            .unwrap();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![],
+            scope: Scope::Local,
+        };
+
+        assert_eq!(
+            pv.execute(&inner).unwrap(),
+            // sorted by name
+            "typeset three=3\n\
+             typeset two=2\n",
+        );
+    }
+
+    #[test]
+    fn printing_attributes_of_valueless_variables() {
+        let mut vars = VariableSet::new();
+        let mut x = vars.get_or_new("x", Scope::Global.into());
+        x.export(true);
+        let mut y = vars.get_or_new("y", Scope::Global.into());
+        y.make_read_only(Location::dummy("y location"));
+        let mut z = vars.get_or_new("z", Scope::Global.into());
+        z.export(true);
+        z.make_read_only(Location::dummy("z location"));
+        let pv = PrintVariables {
+            variables: Field::dummies(["x", "y", "z"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -x x\n\
+             typeset -r y\n\
+             typeset -r -x z\n",
+        );
+    }
+
+    #[test]
+    fn printing_attributes_of_scalar_variables() {
+        let mut vars = VariableSet::new();
+        let mut x = vars.get_or_new("x", Scope::Global.into());
+        x.assign("X", None).unwrap();
+        x.export(true);
+        let mut y = vars.get_or_new("y", Scope::Global.into());
+        y.assign("Y", None).unwrap();
+        y.make_read_only(Location::dummy("y location"));
+        let mut z = vars.get_or_new("z", Scope::Global.into());
+        z.assign("Z", None).unwrap();
+        z.export(true);
+        z.make_read_only(Location::dummy("z location"));
+        let pv = PrintVariables {
+            variables: Field::dummies(["x", "y", "z"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -x x=X\n\
+             typeset -r y=Y\n\
+             typeset -r -x z=Z\n",
+        );
+    }
+
+    #[test]
+    fn printing_attributes_of_array_variables() {
+        let mut vars = VariableSet::new();
+        let mut x = vars.get_or_new("x", Scope::Global.into());
+        x.assign(Value::array(["X"]), None).unwrap();
+        x.export(true);
+        let mut y = vars.get_or_new("y", Scope::Global.into());
+        y.assign(Value::array(["Y"]), None).unwrap();
+        y.make_read_only(Location::dummy("y location"));
+        let mut z = vars.get_or_new("z", Scope::Global.into());
+        z.assign(Value::array(["Z"]), None).unwrap();
+        z.export(true);
+        z.make_read_only(Location::dummy("z location"));
+        let pv = PrintVariables {
+            variables: Field::dummies(["x", "y", "z"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "x=(X)\n\
+             typeset -x x\n\
+             y=(Y)\n\
+             typeset -r y\n\
+             z=(Z)\n\
+             typeset -r -x z\n",
+        );
+    }
+
+    fn variables_with_different_attributes() -> VariableSet {
+        let mut vars = VariableSet::new();
+        let mut a = vars.get_or_new("a", Scope::Global.into());
+        a.export(true);
+        let mut b = vars.get_or_new("b", Scope::Global.into());
+        b.make_read_only(Location::dummy("b location"));
+        let mut c = vars.get_or_new("c", Scope::Global.into());
+        c.export(true);
+        c.make_read_only(Location::dummy("c location"));
+        vars.get_or_new("d", Scope::Global.into());
+        vars
+    }
+
+    #[test]
+    fn selecting_readonly_variables() {
+        let vars = variables_with_different_attributes();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![(VariableAttr::ReadOnly, On)],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -r b\n\
+             typeset -r -x c\n",
+        );
+    }
+
+    #[test]
+    fn selecting_non_readonly_variables() {
+        let vars = variables_with_different_attributes();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![(VariableAttr::ReadOnly, Off)],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -x a\n\
+             typeset d\n",
+        );
+    }
+
+    #[test]
+    fn selecting_exported_variables() {
+        let vars = variables_with_different_attributes();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![(VariableAttr::Export, On)],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -x a\n\
+             typeset -r -x c\n",
+        );
+    }
+
+    #[test]
+    fn selecting_non_exported_variables() {
+        let vars = variables_with_different_attributes();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![(VariableAttr::Export, Off)],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&vars).unwrap(),
+            "typeset -r b\n\
+             typeset d\n",
+        );
+    }
+
+    #[test]
+    fn selecting_with_multiple_filtering_attributes() {
+        let vars = variables_with_different_attributes();
+        let pv = PrintVariables {
+            variables: vec![],
+            attrs: vec![(VariableAttr::ReadOnly, On), (VariableAttr::Export, Off)],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(pv.execute(&vars).unwrap(), "typeset -r b\n");
+    }
+
+    #[test]
+    fn variable_not_found() {
+        let foo = Field::dummy("foo");
+        let bar = Field::dummy("bar");
+        let pv = PrintVariables {
+            variables: vec![foo.clone(), bar.clone()],
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+
+        assert_eq!(
+            pv.execute(&VariableSet::new()).unwrap_err(),
+            [
+                ExecuteError::PrintUnsetVariable(foo),
+                ExecuteError::PrintUnsetVariable(bar)
+            ]
+        );
+    }
+}

--- a/yash-builtin/src/typeset/set_functions.rs
+++ b/yash-builtin/src/typeset/set_functions.rs
@@ -1,0 +1,26 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use yash_env::function::FunctionSet;
+
+impl SetFunctions {
+    /// Executes the command.
+    pub fn execute(self, functions: &mut FunctionSet) -> Result<String, Vec<ExecuteError>> {
+        _ = functions;
+        todo!()
+    }
+}

--- a/yash-builtin/src/typeset/set_variables.rs
+++ b/yash-builtin/src/typeset/set_variables.rs
@@ -1,0 +1,376 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use yash_env::variable::Value;
+
+impl From<Scope> for yash_env::variable::Scope {
+    fn from(value: Scope) -> Self {
+        match value {
+            Scope::Local => Self::Local,
+            Scope::Global => Self::Global,
+        }
+    }
+}
+
+impl SetVariables {
+    /// Executes the command.
+    pub fn execute(self, env: &mut Env) -> Result<String, Vec<ExecuteError>> {
+        let mut errors = Vec::new();
+
+        'field: for mut field in self.variables {
+            // Split the field into the name and the value.
+            let mut value_to_assign = None;
+            if let Some((name, value)) = field.value.split_once('=') {
+                value_to_assign = Some(Value::scalar(value));
+
+                // Make the name out of the field value.
+                field.value.truncate(name.len());
+            }
+            let name = field.value.clone();
+
+            let mut variable = env.get_or_create_variable(name, self.scope.into());
+
+            // Assign the value to the variable.
+            if let Some(value) = value_to_assign {
+                if let Err(error) = variable.assign(value, field.origin.clone()) {
+                    errors.push(error.into());
+                    continue;
+                }
+            }
+
+            // Apply the attributes to the variable.
+            for &(attr, state) in &self.attrs {
+                match (attr, state) {
+                    (VariableAttr::ReadOnly, State::On) => {
+                        variable.make_read_only(field.origin.clone())
+                    }
+                    (VariableAttr::ReadOnly, State::Off) => {
+                        if let Some(read_only_location) = variable.read_only_location.clone() {
+                            errors.push(ExecuteError::UndoReadOnlyVariable(UndoReadOnlyError {
+                                name: field,
+                                read_only_location,
+                            }));
+                            continue 'field;
+                        }
+                    }
+                    (VariableAttr::Export, State::On) => variable.export(true),
+                    (VariableAttr::Export, State::Off) => variable.export(false),
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(String::new())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use yash_env::option::Option::AllExport;
+    use yash_env::variable::{ContextType, Variable};
+    use yash_syntax::source::Location;
+
+    #[test]
+    fn setting_local_variables() {
+        let mut outer = Env::new_virtual();
+        let mut inner = outer.push_context(ContextType::Regular);
+        let baz_location = Location::dummy("baz assigned");
+        let mut baz = inner.get_or_create_variable("baz", Scope::Local.into());
+        baz.assign("BAZ", baz_location.clone()).unwrap();
+        let sv = SetVariables {
+            variables: Field::dummies(["foo=FOO", "bar", "baz"]),
+            attrs: vec![],
+            scope: Scope::Local,
+        };
+        let foo_location = sv.variables[0].origin.clone();
+
+        let result = sv.execute(&mut inner);
+
+        assert_eq!(result, Ok("".to_string()));
+        // $foo now has the value assigned by `execute`
+        let foo = inner.variables.get("foo").unwrap();
+        assert_eq!(foo.value, Some(Value::scalar("FOO")));
+        assert_eq!(foo.last_assigned_location, Some(foo_location));
+        assert_eq!(foo.read_only_location, None);
+        // $bar now exists but has no value
+        let bar = inner.variables.get("bar").unwrap();
+        assert_eq!(bar.value, None);
+        assert_eq!(bar.last_assigned_location, None);
+        assert_eq!(bar.read_only_location, None);
+        // $baz retains the previous value since `execute` assigned nothing
+        let baz = inner.variables.get("baz").unwrap();
+        assert_eq!(baz.value, Some(Value::scalar("BAZ")));
+        assert_eq!(baz.last_assigned_location, Some(baz_location));
+        assert_eq!(baz.read_only_location, None);
+        // All the variables are local, so they aren't visible from the outer context
+        Env::pop_context(inner);
+        assert_eq!(outer.variables.get("foo"), None);
+        assert_eq!(outer.variables.get("bar"), None);
+        assert_eq!(outer.variables.get("baz"), None);
+    }
+
+    #[test]
+    fn setting_global_variables() {
+        let mut outer = Env::new_virtual();
+        let baz_location = Location::dummy("assign");
+        let mut baz = outer.get_or_create_variable("baz", Scope::Global.into());
+        baz.assign("BAZ", baz_location.clone()).unwrap();
+        let mut inner = outer.push_context(ContextType::Regular);
+        let sv = SetVariables {
+            variables: Field::dummies(["foo=FOO", "bar", "baz"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+        let foo_location = sv.variables[0].origin.clone();
+
+        let result = sv.execute(&mut inner);
+
+        assert_eq!(result, Ok("".to_string()));
+        // All the variables are global, so they are visible from the outer context
+        Env::pop_context(inner);
+        // $foo now has the value assigned by `execute`
+        let foo = outer.variables.get("foo").unwrap();
+        assert_eq!(foo.value, Some(Value::scalar("FOO")));
+        assert_eq!(foo.last_assigned_location, Some(foo_location));
+        assert_eq!(foo.read_only_location, None);
+        // $bar now exists but has no value
+        let bar = outer.variables.get("bar").unwrap();
+        assert_eq!(bar.value, None);
+        assert_eq!(bar.last_assigned_location, None);
+        assert_eq!(bar.read_only_location, None);
+        // $baz retains the previous value since `execute` assigned nothing
+        let baz = outer.variables.get("baz").unwrap();
+        assert_eq!(baz.value, Some(Value::scalar("BAZ")));
+        assert_eq!(baz.last_assigned_location, Some(baz_location));
+        assert_eq!(baz.read_only_location, None);
+    }
+
+    #[test]
+    fn setting_variables_readonly() {
+        let mut env = Env::new_virtual();
+        let sv = SetVariables {
+            variables: Field::dummies(["foo", "bar=BAR"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::On)],
+            scope: Scope::Local,
+        };
+        let foo_location = sv.variables[0].origin.clone();
+        let bar_location = sv.variables[1].origin.clone();
+
+        let result = sv.execute(&mut env);
+
+        assert_eq!(result, Ok("".to_string()));
+        let foo = env.variables.get("foo").unwrap();
+        assert_eq!(foo.value, None);
+        assert_eq!(foo.last_assigned_location.as_ref(), None);
+        assert_eq!(foo.read_only_location.as_ref(), Some(&foo_location));
+        let bar = env.variables.get("bar").unwrap();
+        assert_eq!(bar.value, Some(Value::scalar("BAR")));
+        assert_eq!(bar.last_assigned_location.as_ref(), Some(&bar_location));
+        assert_eq!(bar.read_only_location.as_ref(), Some(&bar_location));
+    }
+
+    #[test]
+    fn exporting_variables() {
+        let mut env = Env::new_virtual();
+        let sv = SetVariables {
+            variables: Field::dummies(["foo", "bar=BAR"]),
+            attrs: vec![(VariableAttr::Export, State::On)],
+            scope: Scope::Local,
+        };
+
+        let result = sv.execute(&mut env);
+
+        assert_eq!(result, Ok("".to_string()));
+        let foo = env.variables.get("foo").unwrap();
+        assert_eq!(foo.value, None);
+        assert!(foo.is_exported);
+        let bar = env.variables.get("bar").unwrap();
+        assert_eq!(bar.value, Some(Value::scalar("BAR")));
+        assert!(bar.is_exported);
+    }
+
+    #[test]
+    fn cancelling_exportation() {
+        let mut env = Env::new_virtual();
+        let mut var = env.get_or_create_variable("bar", Scope::Global.into());
+        var.assign("BAR", None).unwrap();
+        var.export(true);
+        let sv = SetVariables {
+            variables: Field::dummies(["foo", "bar=NEW_BAR"]),
+            attrs: vec![(VariableAttr::Export, State::Off)],
+            scope: Scope::Local,
+        };
+
+        let result = sv.execute(&mut env);
+
+        assert_eq!(result, Ok("".to_string()));
+        let foo = env.variables.get("foo").unwrap();
+        assert_eq!(foo.value, None);
+        assert!(!foo.is_exported);
+        let bar = env.variables.get("bar").unwrap();
+        assert_eq!(bar.value, Some(Value::scalar("NEW_BAR")));
+        assert!(!bar.is_exported);
+    }
+
+    #[test]
+    fn exportation_with_allexport_option() {
+        let mut env = Env::new_virtual();
+        env.options.set(AllExport, State::On);
+
+        let sv = SetVariables {
+            variables: Field::dummies(["foo=FOO"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+        let result = sv.execute(&mut env);
+        assert_eq!(result, Ok("".to_string()));
+        assert!(env.variables.get("foo").unwrap().is_exported);
+
+        let sv = SetVariables {
+            variables: Field::dummies(["foo=BAR"]),
+            attrs: vec![(VariableAttr::Export, State::Off)],
+            scope: Scope::Global,
+        };
+        let result = sv.execute(&mut env);
+        assert_eq!(result, Ok("".to_string()));
+        assert!(!env.variables.get("foo").unwrap().is_exported);
+    }
+
+    #[test]
+    fn unsetting_readonly_attribute() {
+        let mut env = Env::new_virtual();
+        let ro_location = Location::dummy("assign readonly");
+        let mut ro = env.get_or_create_variable("ro", Scope::Global.into());
+        ro.assign("readonly value", ro_location.clone()).unwrap();
+        ro.make_read_only(ro_location.clone());
+        let ro = ro.clone();
+        let w_location = Location::dummy("assign writable");
+        let mut w = env.get_or_create_variable("w", Scope::Global.into());
+        w.assign("writable value", w_location).unwrap();
+        let w = w.clone();
+        let sv = SetVariables {
+            variables: Field::dummies(["ro", "w=foo"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::Off)],
+            scope: Scope::Global,
+        };
+        let ro_arg_location = sv.variables[0].origin.clone();
+        let w_location = sv.variables[1].origin.clone();
+
+        let errors = sv.execute(&mut env).unwrap_err();
+
+        assert_matches!(&errors[..], [ExecuteError::UndoReadOnlyVariable(error)] => {
+            assert_eq!(error.name.value, "ro");
+            assert_eq!(error.name.origin, ro_arg_location);
+            assert_eq!(error.read_only_location, ro_location);
+        });
+        assert_eq!(env.variables.get("ro"), Some(&ro));
+        // No error for variable `w`
+        assert_eq!(
+            env.variables.get("w"),
+            Some(&Variable {
+                value: Some(Value::scalar("foo")),
+                last_assigned_location: Some(w_location),
+                ..w
+            })
+        );
+    }
+
+    #[test]
+    fn overwriting_readonly_variables() {
+        let mut env = Env::new_virtual();
+        let ro_location = Location::dummy("assign readonly");
+        let mut ro = env.get_or_create_variable("ro", Scope::Global.into());
+        ro.assign("readonly value", ro_location.clone()).unwrap();
+        ro.make_read_only(ro_location.clone());
+        let ro = ro.clone();
+
+        let sv = SetVariables {
+            variables: Field::dummies(["ro=foo"]),
+            attrs: vec![],
+            scope: Scope::Global,
+        };
+        let assigned_location = sv.variables[0].origin.clone();
+
+        let errors = sv.execute(&mut env).unwrap_err();
+        assert_matches!(&errors[..], [ExecuteError::AssignReadOnlyVariable(error)] => {
+            assert_eq!(error.new_value, Value::scalar("foo"));
+            assert_eq!(error.assigned_location.as_ref(), Some(&assigned_location));
+            assert_eq!(error.read_only_location, ro_location);
+        });
+        assert_eq!(env.variables.get("ro"), Some(&ro));
+    }
+
+    #[test]
+    fn hiding_readonly_variables() {
+        let mut outer = Env::new_virtual();
+        let assign_location = Location::dummy("assign");
+        let mut var = outer.get_or_create_variable("var", Scope::Global.into());
+        var.assign("VAR", assign_location.clone()).unwrap();
+        var.make_read_only(assign_location.clone());
+        let mut inner = outer.push_context(ContextType::Regular);
+        let sv = SetVariables {
+            variables: Field::dummies(["var=NEW"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::Off)],
+            scope: Scope::Local,
+        };
+        let new_location = sv.variables[0].origin.clone();
+
+        let result = sv.execute(&mut inner);
+
+        assert_eq!(result, Ok("".to_string()));
+        let var = inner.variables.get("var").unwrap();
+        assert_eq!(var.value, Some(Value::scalar("NEW")));
+        assert_eq!(var.last_assigned_location, Some(new_location));
+        assert_eq!(var.read_only_location, None);
+        Env::pop_context(inner);
+        let var = outer.variables.get("var").unwrap();
+        assert_eq!(var.value, Some(Value::scalar("VAR")));
+        assert_eq!(var.last_assigned_location.as_ref(), Some(&assign_location));
+        assert_eq!(var.read_only_location.as_ref(), Some(&assign_location));
+    }
+
+    #[test]
+    fn combination_of_readonly_attributes() {
+        let mut env = Env::new_virtual();
+        let sv = SetVariables {
+            variables: Field::dummies(["foo=FOO"]),
+            attrs: vec![
+                (VariableAttr::ReadOnly, State::On),
+                (VariableAttr::ReadOnly, State::Off),
+            ],
+            scope: Scope::Local,
+        };
+        let foo_location = sv.variables[0].origin.clone();
+
+        let errors = sv.execute(&mut env).unwrap_err();
+
+        assert_matches!(&errors[..], [ExecuteError::UndoReadOnlyVariable(error)] => {
+            assert_eq!(error.name.value, "foo");
+            assert_eq!(error.name.origin, foo_location);
+            assert_eq!(error.read_only_location, foo_location);
+        });
+        let var = env.variables.get("foo").unwrap();
+        assert_eq!(var.value, Some(Value::scalar("FOO")));
+        assert_eq!(var.last_assigned_location.as_ref(), Some(&foo_location));
+        assert_eq!(var.read_only_location.as_ref(), Some(&foo_location));
+    }
+}

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -1,0 +1,19 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub fn parse() {
+    todo!()
+}

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -14,6 +14,774 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub fn parse() {
-    todo!()
+//! Command line argument parser for the typeset built-in
+//!
+//! There are two main functions in this module: [`parse`] and [`interpret`].
+//! The former parses command line arguments into [`OptionOccurrence`]s and
+//! operands, and the latter interprets them into a [`Command`].
+
+use super::*;
+use std::borrow::Cow;
+use std::iter::Peekable;
+use thiserror::Error;
+use yash_env::option::State;
+use yash_env::semantics::Field;
+use yash_syntax::source::pretty::{Annotation, AnnotationType, MessageBase};
+use yash_syntax::source::Location;
+
+/// Attribute that can be set on a variable or function
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Attr {
+    ReadOnly,
+    Export,
+}
+
+/// Dummy error returned when an `Attr` cannot be converted to a `FunctionAttr`
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct UnsupportedAttr;
+
+impl TryFrom<Attr> for VariableAttr {
+    // An attribute that cannot be converted to a variable attribute may be
+    // added in the future, so we don't use `Infallible` here.
+    // type Error = Infallible;
+    type Error = UnsupportedAttr;
+
+    fn try_from(attr: Attr) -> Result<Self, Self::Error> {
+        match attr {
+            Attr::ReadOnly => Ok(Self::ReadOnly),
+            Attr::Export => Ok(Self::Export),
+        }
+    }
+}
+
+impl TryFrom<Attr> for FunctionAttr {
+    type Error = UnsupportedAttr;
+
+    fn try_from(attr: Attr) -> Result<Self, Self::Error> {
+        match attr {
+            Attr::ReadOnly => Ok(Self::ReadOnly),
+            Attr::Export => Err(UnsupportedAttr),
+        }
+    }
+}
+
+/// Specification of an option
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OptionSpec<'a> {
+    /// Short option name
+    pub short: char,
+    /// Long option name (not including the leading `--`)
+    pub long: &'a str,
+    /// Attribute specified by this option
+    pub attr: Option<Attr>,
+}
+
+impl std::fmt::Display for OptionSpec<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "-{}/--{}", self.short, self.long)
+    }
+}
+
+/// Specification of the `-f`/`--functions` option
+pub const FUNCTIONS_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'f',
+    long: "functions",
+    attr: None,
+};
+/// Specification of the `-g`/`--global` option
+pub const GLOBAL_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'g',
+    long: "global",
+    attr: None,
+};
+/// Specification of the `-p`/`--print` option
+pub const PRINT_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'p',
+    long: "print",
+    attr: None,
+};
+/// Specification of the `-r`/`--readonly` option
+pub const READONLY_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'r',
+    long: "readonly",
+    attr: Some(Attr::ReadOnly),
+};
+/// Specification of the `-x`/`--export` option
+pub const EXPORT_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'x',
+    long: "export",
+    attr: Some(Attr::Export),
+};
+/// Specification of the `-X`/`--unexport` option
+///
+/// This option is deprecated.
+pub const UNEXPORT_OPTION: OptionSpec<'static> = OptionSpec {
+    short: 'X',
+    long: "unexport",
+    attr: None,
+};
+
+/// List of all option specifications applicable to the typeset built-in
+pub static ALL_OPTIONS: &[OptionSpec<'static>] = &[
+    FUNCTIONS_OPTION,
+    GLOBAL_OPTION,
+    PRINT_OPTION,
+    READONLY_OPTION,
+    EXPORT_OPTION,
+    UNEXPORT_OPTION,
+];
+
+/// Occurrence of an option
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OptionOccurrence<'a> {
+    /// Specification for this option
+    pub spec: &'a OptionSpec<'a>,
+    /// Whether this option is negated
+    pub state: State,
+    /// Location of the field containing this option
+    pub location: Location,
+}
+
+/// Error in command line parsing
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
+pub enum ParseError {
+    /// Short option that is not defined in the option specs
+    #[error("unknown option {0:?}")]
+    UnknownShortOption(char, Field),
+
+    /// Long option that is not defined in the option specs
+    #[error("unknown option {:?}", .0.value)]
+    UnknownLongOption(Field),
+
+    /// Long option that matches the prefix of more than one option name.
+    #[error("ambiguous option name {:?}", .0.value)]
+    AmbiguousLongOption(Field),
+
+    /// Negated short option that is not an attribute
+    #[error("option {0:?} cannot be canceled with '+'")]
+    UncancelableShortOption(char, Field),
+
+    /// Negated long option that is not an attribute
+    #[error("option {:?} cannot be canceled with '++'", .0.value)]
+    UncancelableLongOption(Field),
+}
+
+impl ParseError {
+    /// Returns the field containing the option that caused this error.
+    #[must_use]
+    pub fn field(&self) -> &Field {
+        match self {
+            ParseError::UnknownShortOption(_, field)
+            | ParseError::UnknownLongOption(field)
+            | ParseError::AmbiguousLongOption(field)
+            | ParseError::UncancelableShortOption(_, field)
+            | ParseError::UncancelableLongOption(field) => field,
+        }
+    }
+}
+
+impl MessageBase for ParseError {
+    fn message_title(&self) -> Cow<str> {
+        self.to_string().into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        let field = self.field();
+        Annotation::new(
+            AnnotationType::Error,
+            field.value.as_str().into(),
+            &field.origin,
+        )
+    }
+}
+
+/// Tries to parse the next field in `args`.
+///
+/// Returns `Ok(true)` if the next field contained a short option, in which case
+/// the parsed field is consumed from the iterator.
+fn try_parse_short<'a, I: Iterator<Item = Field>>(
+    option_specs: &'a [OptionSpec<'a>],
+    args: &mut Peekable<I>,
+    option_occurrences: &mut Vec<OptionOccurrence<'a>>,
+) -> Result<bool, ParseError> {
+    let field = match args.peek() {
+        Some(field) => field,
+        None => return Ok(false),
+    };
+    let mut chars = field.value.chars();
+    let negate = match chars.next() {
+        Some('-') => false,
+        Some('+') => true,
+        _ => return Ok(false),
+    };
+    match chars.next() {
+        Some('-') if !negate => return Ok(false),
+        Some('+') if negate => return Ok(false),
+        None => return Ok(false),
+        _ => (),
+    }
+
+    let field = args.next().unwrap();
+    for c in field.value.chars().skip(1) {
+        let spec = match option_specs.iter().find(|spec| spec.short == c) {
+            Some(spec) => spec,
+            None => return Err(ParseError::UnknownShortOption(c, field)),
+        };
+        if negate && spec.attr.is_none() {
+            return Err(ParseError::UncancelableShortOption(c, field));
+        }
+        option_occurrences.push(OptionOccurrence {
+            spec,
+            state: if negate { State::Off } else { State::On },
+            location: field.origin.clone(),
+        });
+    }
+    Ok(true)
+}
+
+/// Tries to parse and consume the next field in `args`.
+fn try_parse_long<'a, I: Iterator<Item = Field>>(
+    option_specs: &'a [OptionSpec<'a>],
+    args: &mut Peekable<I>,
+) -> Result<Option<OptionOccurrence<'a>>, ParseError> {
+    let field = match args.peek() {
+        Some(field) => field,
+        None => return Ok(None),
+    };
+
+    let (name, negate) = if let Some(name) = field.value.strip_prefix("--") {
+        if name.is_empty() {
+            return Ok(None);
+        }
+        (name, false)
+    } else if let Some(name) = field.value.strip_prefix("++") {
+        (name, true)
+    } else {
+        return Ok(None);
+    };
+
+    let mut option_specs = option_specs
+        .iter()
+        .filter(|spec| spec.long.starts_with(name));
+    let spec = option_specs.next();
+    let spec2 = option_specs.next();
+    let field = args.next().unwrap();
+    match spec {
+        None => Err(ParseError::UnknownLongOption(field)),
+        Some(_spec) if spec2.is_some() => Err(ParseError::AmbiguousLongOption(field)),
+        Some(spec) if negate && spec.attr.is_none() => {
+            Err(ParseError::UncancelableLongOption(field))
+        }
+        Some(spec) => Ok(Some(OptionOccurrence {
+            spec,
+            state: if negate { State::Off } else { State::On },
+            location: field.origin,
+        })),
+    }
+}
+
+/// Parses command line arguments.
+///
+/// The first argument is a list of option specifications that should be
+/// recognized by the parser. The second argument is a list of command line
+/// arguments to be parsed.
+///
+/// Returns a pair of option occurrences and operands, which can be passed to
+/// [`interpret`] to get a [`Command`].
+pub fn parse<'a>(
+    option_specs: &'a [OptionSpec<'a>],
+    // TODO: mode: Mode, (disabling long options & options after operands)
+    args: Vec<Field>,
+) -> Result<(Vec<OptionOccurrence<'a>>, Vec<Field>), ParseError> {
+    let mut args = args.into_iter().peekable();
+    let mut options = Vec::new();
+    loop {
+        if try_parse_short(option_specs, &mut args, &mut options)? {
+            continue;
+        }
+        if let Some(result) = try_parse_long(option_specs, &mut args)? {
+            options.push(result);
+        } else {
+            break; // TODO option after operand
+        }
+    }
+    let operands = args.collect();
+    Ok((options, operands))
+}
+
+/// Error in interpreting command line arguments
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
+pub enum InterpretError<'a> {
+    /// Short option that cannot be used with the `-f` option
+    #[error("option {} is inapplicable for function", .clashing.spec)]
+    OptionInapplicableForFunction {
+        /// Occurrence of the option that conflicts with the `-f` option
+        clashing: OptionOccurrence<'a>,
+        /// Occurrence of the `-f` option
+        function: OptionOccurrence<'a>,
+    },
+}
+
+impl MessageBase for InterpretError<'_> {
+    fn message_title(&self) -> Cow<str> {
+        self.to_string().into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        match self {
+            InterpretError::OptionInapplicableForFunction { clashing, .. } => Annotation::new(
+                AnnotationType::Error,
+                format!("the {} option ...", clashing.spec).into(),
+                &clashing.location,
+            ),
+        }
+    }
+
+    fn additional_annotations<'a, T: Extend<Annotation<'a>>>(&'a self, results: &mut T) {
+        match self {
+            InterpretError::OptionInapplicableForFunction { function, .. } => {
+                results.extend([Annotation::new(
+                    AnnotationType::Error,
+                    "... cannot be used for -f/--functions".into(),
+                    &function.location,
+                )])
+            }
+        }
+    }
+}
+
+/// Interprets options and operands into a command.
+///
+/// You can pass the result of [`parse`] to this function to get a command.
+///
+/// If `options` contain an `OptionSpec` that is not contained in
+/// [`ALL_OPTIONS`], this function will panic.
+pub fn interpret(
+    options: Vec<OptionOccurrence>,
+    operands: Vec<Field>,
+) -> Result<Command, InterpretError> {
+    let mut functions_option_index = None;
+    let mut global_option_index = None;
+    let mut print = operands.is_empty();
+    let mut attrs = Vec::new();
+    for (index, option) in options.iter().enumerate() {
+        match option.spec.short {
+            'f' => functions_option_index = Some(index),
+            'g' => global_option_index = Some(index),
+            'p' => print = true,
+            'X' => attrs.push((index, Attr::Export, !option.state)),
+            _ => attrs.push((index, option.spec.attr.unwrap(), option.state)),
+        }
+    }
+
+    if let Some(functions_option_index) = functions_option_index {
+        if let Some(global_option_index) = global_option_index {
+            return Err(InterpretError::OptionInapplicableForFunction {
+                clashing: options[global_option_index].clone(),
+                function: options[functions_option_index].clone(),
+            });
+        }
+
+        let functions = operands;
+        let attrs = attrs
+            .into_iter()
+            .map(|(index, attr, state)| Ok((attr.try_into().or(Err(index))?, state)))
+            .collect::<Result<Vec<(FunctionAttr, State)>, usize>>()
+            .map_err(|attr_index| InterpretError::OptionInapplicableForFunction {
+                clashing: options[attr_index].clone(),
+                function: options[functions_option_index].clone(),
+            })?;
+
+        if print {
+            Ok((PrintFunctions { functions, attrs }).into())
+        } else {
+            Ok((SetFunctions { functions, attrs }).into())
+        }
+    } else {
+        let variables = operands;
+        let attrs = attrs
+            .into_iter()
+            .map(|(_index, attr, state)| Ok((attr.try_into()?, state)))
+            .collect::<Result<Vec<(VariableAttr, State)>, UnsupportedAttr>>()
+            .expect("all attributes should be convertible to VariableAttr");
+        let scope = match global_option_index {
+            Some(_) => Scope::Global,
+            None => Scope::Local,
+        };
+
+        if print {
+            let pv = PrintVariables {
+                variables,
+                attrs,
+                scope,
+            };
+            Ok(pv.into())
+        } else {
+            let sv = SetVariables {
+                variables,
+                attrs,
+                scope,
+            };
+            Ok(sv.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn parse_empty_arguments() {
+        let result = parse(&[], vec![]).unwrap();
+        assert_eq!(result, (vec![], vec![]));
+    }
+
+    #[test]
+    fn parse_some_operands_without_options() {
+        let vars = Field::dummies(["foo", "bar"]);
+        let result = parse(&[], vars.clone()).unwrap();
+        assert_eq!(result, (vec![], vars));
+    }
+
+    #[test]
+    fn parse_short_print_option_without_operands() {
+        let result = parse(ALL_OPTIONS, Field::dummies(["-p"])).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &PRINT_OPTION);
+            assert_eq!(option.state, State::On);
+            assert_eq!(option.location, Location::dummy("-p"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_long_print_option_without_operands() {
+        let result = parse(ALL_OPTIONS, Field::dummies(["--print"])).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &PRINT_OPTION);
+            assert_eq!(option.state, State::On);
+            assert_eq!(option.location, Location::dummy("--print"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_print_option_with_operands() {
+        let vars = Field::dummies(["foo", "var"]);
+        let mut args = Field::dummies(["-p"]);
+        args.extend(vars.iter().cloned());
+        let result = parse(ALL_OPTIONS, args).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &PRINT_OPTION);
+            assert_eq!(option.state, State::On);
+            assert_eq!(option.location, Location::dummy("-p"));
+        });
+        assert_eq!(result.1, vars);
+    }
+
+    #[test]
+    fn parse_abbreviated_long_option() {
+        let result = parse(ALL_OPTIONS, Field::dummies(["--pri"])).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &PRINT_OPTION);
+            assert_eq!(option.state, State::On);
+            assert_eq!(option.location, Location::dummy("--pri"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_negated_short_export_option() {
+        let result = parse(ALL_OPTIONS, Field::dummies(["+x"])).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &EXPORT_OPTION);
+            assert_eq!(option.state, State::Off);
+            assert_eq!(option.location, Location::dummy("+x"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_negated_long_export_option() {
+        let result = parse(ALL_OPTIONS, Field::dummies(["++export"])).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &EXPORT_OPTION);
+            assert_eq!(option.state, State::Off);
+            assert_eq!(option.location, Location::dummy("++export"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_unknown_short_option() {
+        assert_eq!(
+            parse(&[], Field::dummies(["-p"])),
+            Err(ParseError::UnknownShortOption('p', Field::dummy("-p"))),
+        );
+    }
+
+    #[test]
+    fn parse_unknown_long_option() {
+        assert_eq!(
+            parse(&[], Field::dummies(["--print"])),
+            Err(ParseError::UnknownLongOption(Field::dummy("--print"))),
+        );
+    }
+
+    #[test]
+    fn parse_negated_short_print_option() {
+        assert_eq!(
+            parse(ALL_OPTIONS, Field::dummies(["+p"])),
+            Err(ParseError::UncancelableShortOption('p', Field::dummy("+p"))),
+        );
+    }
+
+    #[test]
+    fn parse_negated_long_print_option() {
+        assert_eq!(
+            parse(ALL_OPTIONS, Field::dummies(["++print"])),
+            Err(ParseError::UncancelableLongOption(Field::dummy("++print"))),
+        );
+    }
+
+    #[test]
+    fn parse_ambiguous_long_option() {
+        pub const EXPAND_OPTION: OptionSpec<'static> = OptionSpec {
+            short: 'x',
+            long: "expand",
+            attr: None,
+        };
+        assert_eq!(
+            parse(&[EXPORT_OPTION, EXPAND_OPTION], Field::dummies(["++exp"])),
+            Err(ParseError::AmbiguousLongOption(Field::dummy("++exp"))),
+        );
+    }
+
+    #[test]
+    fn interpret_empty_arguments() {
+        let result = interpret(vec![], vec![]).unwrap();
+        assert_matches!(result, Command::PrintVariables(pv) => {
+            assert_eq!(pv.variables, []);
+            assert_eq!(pv.attrs, []);
+            assert_eq!(pv.scope, Scope::Local);
+        });
+    }
+
+    #[test]
+    fn interpret_some_operands_without_options() {
+        let vars = Field::dummies(["foo", "bar"]);
+        let result = interpret(vec![], vars.clone()).unwrap();
+        assert_matches!(result, Command::SetVariables(sv) => {
+            assert_eq!(sv.variables, vars);
+            assert_eq!(sv.attrs, []);
+            assert_eq!(sv.scope, Scope::Local);
+        });
+    }
+
+    fn dummy_option_occurrence<'a>(spec: &'a OptionSpec<'a>, state: State) -> OptionOccurrence<'a> {
+        OptionOccurrence {
+            spec,
+            state,
+            location: Location::dummy(""),
+        }
+    }
+
+    #[test]
+    fn interpret_functions_option_without_operands() {
+        let result = interpret(
+            vec![dummy_option_occurrence(&FUNCTIONS_OPTION, State::On)],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintFunctions(pf)) => {
+            assert_eq!(pf.functions, []);
+            assert_eq!(pf.attrs, []);
+        });
+    }
+
+    #[test]
+    fn interpret_functions_option_with_operands() {
+        let functions = Field::dummies(["foo", "bar"]);
+        let result = interpret(
+            vec![dummy_option_occurrence(&FUNCTIONS_OPTION, State::On)],
+            functions.clone(),
+        );
+        assert_matches!(result, Ok(Command::SetFunctions(sf)) => {
+            assert_eq!(sf.functions, functions);
+            assert_eq!(sf.attrs, []);
+        });
+    }
+
+    #[test]
+    fn interpret_global_option_without_operands() {
+        let result = interpret(
+            vec![dummy_option_occurrence(&GLOBAL_OPTION, State::On)],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintVariables(pv)) => {
+            assert_eq!(pv.variables, []);
+            assert_eq!(pv.attrs, []);
+            assert_eq!(pv.scope, Scope::Global);
+        });
+    }
+
+    #[test]
+    fn interpret_global_option_with_operands() {
+        let vars = Field::dummies(["foo", "var"]);
+        let result = interpret(
+            vec![dummy_option_occurrence(&GLOBAL_OPTION, State::On)],
+            vars.clone(),
+        );
+        assert_matches!(result, Ok(Command::SetVariables(sv)) => {
+            assert_eq!(sv.variables, vars);
+            assert_eq!(sv.attrs, []);
+            assert_eq!(sv.scope, Scope::Global);
+        });
+    }
+
+    #[test]
+    fn interpret_print_option_without_operands() {
+        let result = interpret(
+            vec![dummy_option_occurrence(&PRINT_OPTION, State::On)],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintVariables(pv)) => {
+            assert_eq!(pv.variables, []);
+            assert_eq!(pv.attrs, []);
+            assert_eq!(pv.scope, Scope::Local);
+        });
+    }
+
+    #[test]
+    fn interpret_print_option_with_operands() {
+        let vars = Field::dummies(["foo", "var"]);
+        let result = interpret(
+            vec![dummy_option_occurrence(&PRINT_OPTION, State::On)],
+            vars.clone(),
+        );
+        assert_matches!(result, Ok(Command::PrintVariables(pv)) => {
+            assert_eq!(pv.variables, vars);
+            assert_eq!(pv.attrs, []);
+            assert_eq!(pv.scope, Scope::Local);
+        });
+    }
+
+    #[test]
+    fn interpret_negated_export_option_without_operands() {
+        let result = interpret(
+            vec![dummy_option_occurrence(&EXPORT_OPTION, State::Off)],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintVariables(pv)) => {
+            assert_eq!(pv.variables, []);
+            assert_eq!(pv.attrs, [(VariableAttr::Export, State::Off)]);
+            assert_eq!(pv.scope, Scope::Local);
+        });
+    }
+
+    #[test]
+    fn interpret_negated_export_option_with_operands() {
+        let vars = Field::dummies(["foo", "bar"]);
+        let result = interpret(
+            vec![dummy_option_occurrence(&EXPORT_OPTION, State::Off)],
+            vars.clone(),
+        );
+        assert_matches!(result, Ok(Command::SetVariables(sv)) => {
+            assert_eq!(sv.variables, vars);
+            assert_eq!(sv.attrs, [(VariableAttr::Export, State::Off)]);
+            assert_eq!(sv.scope, Scope::Local);
+        });
+    }
+
+    #[test]
+    fn interpret_function_names_for_printing() {
+        let functions = Field::dummies(["foo", "bar"]);
+        let result = interpret(
+            vec![
+                dummy_option_occurrence(&FUNCTIONS_OPTION, State::On),
+                dummy_option_occurrence(&PRINT_OPTION, State::On),
+            ],
+            functions.clone(),
+        );
+        assert_matches!(result, Ok(Command::PrintFunctions(pf)) => {
+            assert_eq!(pf.functions, functions);
+            assert_eq!(pf.attrs, []);
+        });
+    }
+
+    #[test]
+    fn interpret_function_attributes_for_printing() {
+        let result = interpret(
+            vec![
+                dummy_option_occurrence(&FUNCTIONS_OPTION, State::On),
+                dummy_option_occurrence(&PRINT_OPTION, State::On),
+                dummy_option_occurrence(&READONLY_OPTION, State::Off),
+            ],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintFunctions(pf)) => {
+            assert_eq!(pf.functions, vec![]);
+            assert_eq!(pf.attrs, [(FunctionAttr::ReadOnly, State::Off)]);
+        });
+    }
+
+    #[test]
+    fn interpret_function_attributes_for_setting() {
+        let functions = Field::dummies(["func"]);
+        let result = interpret(
+            vec![
+                dummy_option_occurrence(&FUNCTIONS_OPTION, State::On),
+                dummy_option_occurrence(&READONLY_OPTION, State::On),
+            ],
+            functions.clone(),
+        );
+        assert_matches!(result, Ok(Command::SetFunctions(sf)) => {
+            assert_eq!(sf.functions, functions);
+            assert_eq!(sf.attrs, [(FunctionAttr::ReadOnly, State::On)]);
+        });
+    }
+
+    #[test]
+    fn interpret_inapplicable_attribute_option_for_functions() {
+        let f_option = dummy_option_occurrence(&FUNCTIONS_OPTION, State::On);
+        let x_option = dummy_option_occurrence(&EXPORT_OPTION, State::On);
+        let result = interpret(vec![f_option.clone(), x_option.clone()], vec![]);
+        assert_eq!(
+            result,
+            Err(InterpretError::OptionInapplicableForFunction {
+                clashing: x_option,
+                function: f_option,
+            }),
+        );
+    }
+
+    #[test]
+    fn interpret_global_option_with_functions_option() {
+        let f_option = dummy_option_occurrence(&FUNCTIONS_OPTION, State::On);
+        let g_option = dummy_option_occurrence(&GLOBAL_OPTION, State::On);
+        let result = interpret(vec![f_option.clone(), g_option.clone()], vec![]);
+        assert_eq!(
+            result,
+            Err(InterpretError::OptionInapplicableForFunction {
+                clashing: g_option,
+                function: f_option,
+            }),
+        );
+    }
+
+    #[test]
+    fn interpret_unexport_option_for_variables() {
+        let result = interpret(
+            vec![dummy_option_occurrence(&UNEXPORT_OPTION, State::On)],
+            vec![],
+        );
+        assert_matches!(result, Ok(Command::PrintVariables(pv)) => {
+            assert_eq!(pv.variables, vec![]);
+            assert_eq!(pv.attrs, [(VariableAttr::Export, State::Off)]);
+            assert_eq!(pv.scope, Scope::Local);
+        });
+    }
 }

--- a/yash-env/src/option.rs
+++ b/yash-env/src/option.rs
@@ -73,6 +73,27 @@ impl Not for State {
     }
 }
 
+/// Converts a Boolean to a state
+impl From<bool> for State {
+    fn from(is_on: bool) -> Self {
+        if is_on {
+            On
+        } else {
+            Off
+        }
+    }
+}
+
+/// Converts a state to a Boolean
+impl From<State> for bool {
+    fn from(state: State) -> Self {
+        match state {
+            On => true,
+            Off => false,
+        }
+    }
+}
+
 /// Shell option
 #[derive(Clone, Copy, Debug, EnumSetType, Eq, Hash, PartialEq)]
 #[enumset(no_super_impls)]


### PR DESCRIPTION
This pull request implements the `typeset` built-in for modifying and showing variables.
Operations on functions are not handled in this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new built-in utility "typeset" for defining and manipulating shell variables and functions.
	- Added the ability to print variable attributes and values.
	- Implemented variable assignment and attribute application with error handling.
	- Introduced a new module for parsing command line arguments for the `typeset` command.
- **Bug Fixes**
	- Added conversion functions between boolean values and the `State` enum to prevent type errors.
- **Tests**
	- Added several tests to cover the new functionality and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->