### PR TITLE
Refactor Context and PositionalParams

### DIFF
--- a/yash-env/src/variable/guard.rs
+++ b/yash-env/src/variable/guard.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::ContextType;
+use super::Context;
 use super::VariableSet;
 use crate::Env;
 use std::ops::Deref;
@@ -30,12 +30,12 @@ pub struct ContextGuard<'a> {
 }
 
 impl VariableSet {
-    /// Pushes a new empty context to this variable set.
+    /// Pushes a new context to this variable set.
     ///
     /// This function returns a scope guard that will pop the context when dropped.
     #[inline]
-    pub fn push_context(&mut self, context_type: ContextType) -> ContextGuard<'_> {
-        self.push_context_impl(context_type);
+    pub fn push_context(&mut self, context: Context) -> ContextGuard<'_> {
+        self.push_context_impl(context);
         ContextGuard { stack: self }
     }
 
@@ -86,8 +86,8 @@ impl Env {
     /// `self.variables.push_context(context_type)`, but returns an
     /// `EnvContextGuard` that allows re-borrowing the `Env`.
     #[inline]
-    pub fn push_context(&mut self, context_type: ContextType) -> EnvContextGuard<'_> {
-        self.variables.push_context_impl(context_type);
+    pub fn push_context(&mut self, context: Context) -> EnvContextGuard<'_> {
+        self.variables.push_context_impl(context);
         EnvContextGuard { env: self }
     }
 
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn scope_guard() {
         let mut env = Env::new_virtual();
-        let mut guard = env.variables.push_context(ContextType::Regular);
+        let mut guard = env.variables.push_context(Context::default());
         guard
             .get_or_new("foo", Scope::Global)
             .assign("", None)
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn env_scope_guard() {
         let mut env = Env::new_virtual();
-        let mut guard = env.push_context(ContextType::Regular);
+        let mut guard = env.push_context(Context::default());
         guard
             .variables
             .get_or_new("foo", Scope::Global)

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -36,7 +36,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::semantics::Result;
 #[cfg(doc)]
-use yash_env::variable::ContextType;
+use yash_env::variable::Context;
 use yash_env::variable::Scope;
 use yash_env::Env;
 use yash_syntax::syntax;
@@ -85,8 +85,8 @@ use yash_syntax::syntax::Assign;
 ///
 /// If the target is a function, redirections are performed in the same way as a
 /// regular built-in. Then, assignments are performed in a
-/// [volatile](ContextType::Volatile) variable context and exported. Next, a
-/// [regular](ContextType::Regular) context is
+/// [volatile](Context::Volatile) variable context and exported. Next, a
+/// [regular](Context::Regular) context is
 /// [pushed](yash_env::variable::VariableSet::push_context) to allow local
 /// variable assignment during the function execution. The remaining fields not
 /// used in the command search become positional parameters in the new context.

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -31,7 +31,7 @@ use yash_env::semantics::Field;
 use yash_env::semantics::Result;
 use yash_env::stack::Builtin as FrameBuiltin;
 use yash_env::stack::Frame;
-use yash_env::variable::ContextType;
+use yash_env::variable::Context;
 use yash_env::Env;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
@@ -78,7 +78,7 @@ pub async fn execute_builtin(
         }
         // TODO Reject elective and extension built-ins in POSIX mode
         Mandatory | Elective | Extension | Substitutive => {
-            let mut env = env.push_context(ContextType::Volatile);
+            let mut env = env.push_context(Context::Volatile);
             perform_assignments(&mut env, assigns, true, xtrace.as_mut()).await?;
             trace_and_execute(&mut env, fields, builtin.execute, xtrace).await
         }

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -35,7 +35,7 @@ use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
 use yash_env::system::Errno;
-use yash_env::variable::ContextType;
+use yash_env::variable::Context;
 use yash_env::Env;
 use yash_env::System;
 use yash_syntax::source::Location;
@@ -59,7 +59,7 @@ pub async fn execute_external_utility(
         return e.handle(env).await;
     };
 
-    let mut env = env.push_context(ContextType::Volatile);
+    let mut env = env.push_context(Context::Volatile);
     perform_assignments(&mut env, assigns, true, xtrace.as_mut()).await?;
 
     trace_fields(xtrace.as_mut(), &fields);

--- a/yash-semantics/src/command/simple_command/function.rs
+++ b/yash-semantics/src/command/simple_command/function.rs
@@ -30,7 +30,6 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::Field;
 use yash_env::semantics::Result;
 use yash_env::variable::ContextType;
-use yash_env::variable::Value;
 use yash_env::Env;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
@@ -60,8 +59,8 @@ pub async fn execute_function(
     let params = inner.variables.positional_params_mut();
     let mut i = fields.into_iter();
     let field = i.next().unwrap();
-    params.last_assigned_location = Some(field.origin);
-    params.value = Some(Value::array(i.map(|f| f.value)));
+    params.last_modified_location = Some(field.origin);
+    params.values = i.map(|f| f.value).collect();
 
     // TODO Update control flow stack
     let result = function.body.execute(&mut inner).await;

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -156,7 +156,7 @@ pub mod tests {
 
     pub fn env_with_positional_params_and_ifs() -> yash_env::Env {
         let mut env = yash_env::Env::new_virtual();
-        env.variables.positional_params_mut().value = Some(Value::array(["a", "c"]));
+        env.variables.positional_params_mut().values = vec!["a".to_string(), "c".to_string()];
         env.variables
             .get_or_new("IFS", Scope::Global)
             .assign("&?!", None)

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -436,7 +436,8 @@ mod tests {
     #[test]
     fn assign_array_word() {
         let mut env = yash_env::Env::new_virtual();
-        env.variables.positional_params_mut().value = Some(Value::array(["1", "2  2", "3"]));
+        env.variables.positional_params_mut().values =
+            vec!["1".to_string(), "2  2".to_string(), "3".to_string()];
         env.variables
             .get_or_new("IFS", Scope::Global)
             .assign("~", None)

--- a/yash/src/lib.rs
+++ b/yash/src/lib.rs
@@ -37,7 +37,6 @@ async fn print_version(env: &mut env::Env) -> i32 {
 async fn parse_and_print(mut env: env::Env) -> i32 {
     use env::option::Option::{Interactive, Monitor};
     use env::option::State::On;
-    use env::variable::Value::Array;
     use semantics::trap::run_exit_trap;
     use semantics::Divert;
     use semantics::ExitStatus;
@@ -70,7 +69,7 @@ async fn parse_and_print(mut env: env::Env) -> i32 {
     }
 
     env.arg0 = run.arg0;
-    env.variables.positional_params_mut().value = Some(Array(run.positional_params));
+    env.variables.positional_params_mut().values = run.positional_params;
 
     if env.options.get(Interactive) == On {
         env.traps.enable_terminator_handlers(&mut env.system).ok();


### PR DESCRIPTION
This pull request refactors the Context and PositionalParams structs to improve code clarity and reduce unnecessary overhead. Specifically, it replaces the use of Variable for positional parameters with a distinct type, PositionalParams, and merges ContextType into Context as an enum. The new Context::Regular variant contains a PositionalParams, while the Context::Volatile variant does not. These changes make the code more intuitive and efficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of positional parameters in the application.
- **Refactor**
	- Improved code clarity and maintainability by modifying how positional parameters are managed.
- **Tests**
	- Updated test cases to reflect changes in the handling of positional parameters.
- **Bug Fixes**
	- Fixed issues related to the incorrect handling of positional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->