### PR TITLE
Export built-in

### DIFF
--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -1,0 +1,115 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Export built-in
+//!
+//! The **`export`** built-in exports shell variables to the environment.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! export [-p] [name[=value]…]
+//! ```
+//!
+//! # Description
+//!
+//! The export built-in (without the `-p` option) exports each of the specified
+//! names to the environment, with optional values. If no names are given, or if
+//! the `-p` option is given, the names and values of all exported variables are
+//! displayed.
+//!
+//! # Options
+//!
+//! The **`-p`** (**`--print`**) option causes the shell to display the names and
+//! values of all exported variables in a format that can be reused as input to
+//! restore the state of these variables. When used with operands, the option
+//! limits the output to the specified variables.
+//!
+//! (TODO: Other non-portable options)
+//!
+//! # Operands
+//!
+//! The operands are names of shell variables to be exported. Each name may
+//! optionally be followed by `=` and a *value* to assign to the variable.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Errors
+//!
+//! When exporting a variable with a value, it is an error if the variable is
+//! read-only.
+//!
+//! When printing variables, it is an error if an operand names a non-existing
+//! variable.
+//!
+//! # Portability
+//!
+//! This built-in is part of the POSIX standard. Printing variables is portable
+//! only when the `-p` option is used without operands.
+//!
+//! # Implementation notes
+//!
+//! The implementation of this built-in depends on that of the
+//! [`typeset`](crate::typeset) built-in.
+
+use crate::common::output;
+use crate::common::report_error;
+use crate::common::report_failure;
+use crate::typeset::syntax::interpret;
+use crate::typeset::syntax::parse;
+use crate::typeset::syntax::OptionSpec;
+use crate::typeset::syntax::PRINT_OPTION;
+use crate::typeset::to_message;
+use crate::typeset::Command;
+use crate::typeset::Scope::Global;
+use crate::typeset::VariableAttr::Export;
+use yash_env::option::State::On;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// List of portable options applicable to the export built-in
+pub static PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
+
+/// Entry point of the export built-in
+pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result {
+    match parse(PORTABLE_OPTIONS, args) {
+        Ok((options, operands)) => match interpret(options, operands) {
+            Ok(mut command) => {
+                match &mut command {
+                    Command::SetVariables(sv) => {
+                        sv.attrs.push((Export, On));
+                        sv.scope = Global;
+                    }
+                    // TODO print as export rather than typeset
+                    Command::PrintVariables(pv) => {
+                        pv.attrs.push((Export, On));
+                        pv.scope = Global;
+                    }
+                    Command::SetFunctions(sf) => unreachable!("{sf:?}"),
+                    Command::PrintFunctions(pf) => unreachable!("{pf:?}"),
+                }
+                match command.execute(env) {
+                    Ok(result) => output(env, &result).await,
+                    Err(errors) => report_failure(env, to_message(&errors)).await,
+                }
+            }
+            Err(error) => report_error(env, &error).await,
+        },
+        Err(error) => report_error(env, &error).await,
+    }
+}

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -76,6 +76,7 @@ use crate::typeset::syntax::OptionSpec;
 use crate::typeset::syntax::PRINT_OPTION;
 use crate::typeset::to_message;
 use crate::typeset::Command;
+use crate::typeset::PrintVariablesContext;
 use crate::typeset::Scope::Global;
 use crate::typeset::VariableAttr::Export;
 use yash_env::option::State::On;
@@ -84,6 +85,11 @@ use yash_env::Env;
 
 /// List of portable options applicable to the export built-in
 pub static PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
+
+/// Variable printing context for the export built-in
+pub const PRINT_VARIABLES_CONTEXT: PrintVariablesContext<'static> = PrintVariablesContext {
+    builtin_name: "export",
+};
 
 /// Entry point of the export built-in
 pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result {
@@ -95,7 +101,6 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result 
                         sv.attrs.push((Export, On));
                         sv.scope = Global;
                     }
-                    // TODO print as export rather than typeset
                     Command::PrintVariables(pv) => {
                         pv.attrs.push((Export, On));
                         pv.scope = Global;
@@ -103,7 +108,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result 
                     Command::SetFunctions(sf) => unreachable!("{sf:?}"),
                     Command::PrintFunctions(pf) => unreachable!("{pf:?}"),
                 }
-                match command.execute(env) {
+                match command.execute(env, &PRINT_VARIABLES_CONTEXT) {
                     Ok(result) => output(env, &result).await,
                     Err(errors) => report_failure(env, to_message(&errors)).await,
                 }

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -89,6 +89,7 @@ pub static PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
 /// Variable printing context for the export built-in
 pub const PRINT_VARIABLES_CONTEXT: PrintVariablesContext<'static> = PrintVariablesContext {
     builtin_name: "export",
+    options_allowed: &[],
 };
 
 /// Entry point of the export built-in

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -50,6 +50,7 @@ pub mod r#continue;
 #[cfg(feature = "yash-semantics")]
 pub mod exec;
 pub mod exit;
+pub mod export;
 pub mod jobs;
 pub mod pwd;
 pub mod readonly;
@@ -116,6 +117,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: |env, args| Box::pin(exit::main(env, args)),
+        },
+    ),
+    (
+        "export",
+        Builtin {
+            r#type: Special,
+            execute: |env, args| Box::pin(export::main(env, args)),
         },
     ),
     (

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -252,7 +252,13 @@
 //!
 //! # Implementation notes
 //!
-//! TBD
+//! The implementation of this built-in is also used by the
+//! [`export`](crate::export) built-in. Functions that are common to both
+//! built-ins are parameterized to support the different behaviors of the
+//! built-ins. By customizing the contents of [`Command`] and the
+//! [`PrintVariablesContext`] passed to [`Command::execute`], you can even
+//! implement a new built-in that behaves differently from both `typeset` and
+//! `export`.
 
 use self::syntax::OptionSpec;
 use crate::common::{output, report_error, report_failure};

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -254,6 +254,7 @@
 //!
 //! TBD
 
+use self::syntax::OptionSpec;
 use crate::common::{output, report_error, report_failure};
 use thiserror::Error;
 use yash_env::function::Function;
@@ -340,15 +341,22 @@ pub struct PrintVariables {
 }
 
 /// Set of information used when printing variables
+///
+/// [`PrintVariables::execute`] prints a list of commands that invoke a built-in
+/// to recreate the variables. This context is used to determine the name of the
+/// built-in and the attributes possibly indicated as options to the built-in.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PrintVariablesContext<'a> {
     /// Name of the built-in printed as the command name
     pub builtin_name: &'a str,
+    /// Options that may be printed for the built-in
+    pub options_allowed: &'a [OptionSpec<'a>],
 }
 
 /// Variable printing context for the typeset built-in
 pub const PRINT_VARIABLES_CONTEXT: PrintVariablesContext<'static> = PrintVariablesContext {
     builtin_name: "typeset",
+    options_allowed: self::syntax::ALL_OPTIONS,
 };
 
 /// Attribute that can be set on a function

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -571,8 +571,11 @@ impl std::fmt::Display for ExecuteError {
 ///
 /// The first error's title is used as the message title. The other errors are
 /// added as annotations.
+///
+/// This is a utility for printing errors returned by [`Command::execute`].
+/// The returned message can be passed to [`report_failure`].
 #[must_use]
-fn to_message(errors: &[ExecuteError]) -> Message {
+pub fn to_message(errors: &[ExecuteError]) -> Message {
     let mut message = Message::from(&errors[0]);
     let other_errors = errors[1..].iter().map(ExecuteError::main_annotation);
     message.annotations.extend(other_errors);

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -122,7 +122,7 @@ pub const UNEXPORT_OPTION: OptionSpec<'static> = OptionSpec {
 };
 
 /// List of all option specifications applicable to the typeset built-in
-pub static ALL_OPTIONS: &[OptionSpec<'static>] = &[
+pub const ALL_OPTIONS: &[OptionSpec<'static>] = &[
     FUNCTIONS_OPTION,
     GLOBAL_OPTION,
     PRINT_OPTION,

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -107,6 +107,11 @@ fn exit_builtin() {
 }
 
 #[test]
+fn export_builtin() {
+    run("export-p.sh")
+}
+
+#[test]
 fn fnmatch() {
     run("fnmatch-p.sh")
 }

--- a/yash/tests/scripted_test/export-p.sh
+++ b/yash/tests/scripted_test/export-p.sh
@@ -35,7 +35,10 @@ __OUT__
 
 test_oE 'exporting with assignments'
 a=A export b=B
+# POSIX requires $a to persist after the export built-in,
+# but it is unspecified whether $a is exported.
 echo $a
+# $a does not affect $b being exported.
 sh -c 'echo $b'
 __IN__
 A
@@ -45,5 +48,7 @@ __OUT__
 test_O -d -e n 'read-only variable cannot be re-assigned'
 readonly a=1
 export a=2
-echo not reached # special built-in error kills non-interactive shell
+# The export built-in fails because of the readonly variable.
+# Since it is a special built-in, the non-interactive shell exits.
+echo not reached
 __IN__

--- a/yash/tests/scripted_test/export-p.sh
+++ b/yash/tests/scripted_test/export-p.sh
@@ -1,0 +1,49 @@
+# export-p.sh: test of the export built-in for any POSIX-compliant shell
+
+posix="true"
+
+test_oE -e 0 'exporting one variable' -e
+export a=bar
+echo 1 $a
+sh -c 'echo 2 $a'
+__IN__
+1 bar
+2 bar
+__OUT__
+
+test_oE -e 0 'exporting many variables' -e
+a=X b=B c=X
+export a=A b c=C
+echo 1 $a $b $c
+sh -c 'echo 2 $a $b $c'
+__IN__
+1 A B C
+2 A B C
+__OUT__
+
+: TODO Needs the eval built-in <<\__OUT__
+test_oE -e 0 'reusing printed exported variables'
+export a=A
+e="$(export -p)"
+unset a
+a=X
+eval "$e"
+sh -c 'echo $a'
+__IN__
+A
+__OUT__
+
+test_oE 'exporting with assignments'
+a=A export b=B
+echo $a
+sh -c 'echo $b'
+__IN__
+A
+B
+__OUT__
+
+test_O -d -e n 'read-only variable cannot be re-assigned'
+readonly a=1
+export a=2
+echo not reached # special built-in error kills non-interactive shell
+__IN__

--- a/yash/tests/scripted_test/simple-p.sh
+++ b/yash/tests/scripted_test/simple-p.sh
@@ -154,7 +154,6 @@ __IN__
 f12 created
 __OUT__
 
-: TODO Needs the export built-in <<\__OUT__
 test_o 'assignment-like command argument'
 export foo=F
 sh -c 'echo $1 $foo' X foo=bar

--- a/yash/tests/scripted_test/typeset-y.sh
+++ b/yash/tests/scripted_test/typeset-y.sh
@@ -52,7 +52,7 @@ __IN__
 a=unset b=unset
 __OUT__
 
-: TODO Needs the export and readonly built-ins <<\__OUT__
+: TODO Needs the readonly built-in <<\__OUT__
 test_oE -e 0 'printing all variables (no option)' -e
 typeset >/dev/null
 typeset | grep -q '^typeset -x PATH='
@@ -146,7 +146,7 @@ __OUT__
 
 )
 
-: TODO Needs the export and readonly built-ins <<\__OUT__
+: TODO Needs the readonly built-in <<\__OUT__
 test_oE -e 0 'printing all variables (-p)' -e
 typeset -p >/dev/null
 typeset -p | grep -q '^typeset -x PATH='


### PR DESCRIPTION
- [x] Core implementation
- [x] Print in the form of `export name=value` rather than `typeset -x name=value`
- [x] Scripted tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `export` built-in command for the yash shell, enhancing variable management capabilities.
  - Users can now export variables, making them available in subshells and to child processes.

- **Enhancements**
  - Improved the `typeset` command with additional context handling for variable attributes and options.

- **Testing**
  - Added comprehensive tests for the `export` command to ensure POSIX compliance and correct behavior in various scenarios.
  - Updated existing tests to reflect the integration of the `export` command and removal of outdated TODOs.

- **Documentation**
  - Included comments and documentation within the codebase to clarify the usage and behavior of the new `export` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->