### PR TITLE
Readonly builtin

### DIFF
--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -91,7 +91,7 @@ use crate::typeset::syntax::OptionSpec;
 use crate::typeset::syntax::PRINT_OPTION;
 use crate::typeset::to_message;
 use crate::typeset::Command;
-use crate::typeset::PrintVariablesContext;
+use crate::typeset::PrintContext;
 use crate::typeset::Scope::Global;
 use crate::typeset::VariableAttr::Export;
 use yash_env::option::State::On;
@@ -101,8 +101,8 @@ use yash_env::Env;
 /// List of portable options applicable to the export built-in
 pub static PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
 
-/// Variable printing context for the export built-in
-pub const PRINT_VARIABLES_CONTEXT: PrintVariablesContext<'static> = PrintVariablesContext {
+/// Printing context for the export built-in
+pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {
     builtin_name: "export",
     options_allowed: &[],
 };
@@ -124,7 +124,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result 
                     Command::SetFunctions(sf) => unreachable!("{sf:?}"),
                     Command::PrintFunctions(pf) => unreachable!("{pf:?}"),
                 }
-                match command.execute(env, &PRINT_VARIABLES_CONTEXT) {
+                match command.execute(env, &PRINT_CONTEXT) {
                     Ok(result) => output(env, &result).await,
                     Err(errors) => report_failure(env, to_message(&errors)).await,
                 }

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -99,7 +99,7 @@ use yash_env::semantics::Field;
 use yash_env::Env;
 
 /// List of portable options applicable to the export built-in
-pub static PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
+pub const PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
 
 /// Printing context for the export built-in
 pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -56,6 +56,10 @@
 //! Note that the commands do not include options to restore the attributes of
 //! the variables, such as the `-r` option to make variables read-only.
 //!
+//! For array variables, the export built-in invocation is preceded by a
+//! separate assignment command since the export built-in does not support
+//! assigning values to array variables.
+//!
 //! # Exit status
 //!
 //! Zero unless an error occurs.
@@ -104,6 +108,7 @@ pub const PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
 /// Printing context for the export built-in
 pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {
     builtin_name: "export",
+    builtin_is_significant: true,
     options_allowed: &[],
 };
 

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -26,10 +26,11 @@
 //!
 //! # Description
 //!
-//! The export built-in (without the `-p` option) exports each of the specified
-//! names to the environment, with optional values. If no names are given, or if
-//! the `-p` option is given, the names and values of all exported variables are
-//! displayed.
+//! The export built-in (without the `-p` option) exports variables of the
+//! specified names to the environment, with optional values. If no names are
+//! given, or if the `-p` option is given, the names and values of all exported
+//! variables are displayed. If the `-p` option is given with operands, only the
+//! specified variables are displayed.
 //!
 //! # Options
 //!
@@ -42,8 +43,18 @@
 //!
 //! # Operands
 //!
-//! The operands are names of shell variables to be exported. Each name may
-//! optionally be followed by `=` and a *value* to assign to the variable.
+//! The operands are the names of shell variables to be exported or printed.
+//! When exporting, each name may optionally be followed by `=` and a *value* to
+//! assign to the variable.
+//!
+//! # Standard output
+//!
+//! When exporting variables, the export built-in does not produce any output.
+//!
+//! When printing variables, the built-in prints simple commands that invoke the
+//! export built-in to reexport the variables with the same values.
+//! Note that the commands do not include options to restore the attributes of
+//! the variables, such as the `-r` option to make variables read-only.
 //!
 //! # Exit status
 //!
@@ -65,7 +76,11 @@
 //! # Implementation notes
 //!
 //! The implementation of this built-in depends on that of the
-//! [`typeset`](crate::typeset) built-in.
+//! [`typeset`](crate::typeset) built-in. The export built-in basically works
+//! like the typeset built-in with the `-gx` (`--global --export`) options,
+//! except that:
+//! - Printed commands name the export built-in instead of the typeset built-in.
+//! - Printed commands do not include options that modify variable attributes.
 
 use crate::common::output;
 use crate::common::report_error;

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -144,7 +144,7 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "readonly",
         Builtin {
             r#type: Special,
-            execute: |env, args| Box::pin(ready(readonly::main(env, args))),
+            execute: |env, args| Box::pin(readonly::main(env, args)),
         },
     ),
     (

--- a/yash-builtin/src/readonly.rs
+++ b/yash-builtin/src/readonly.rs
@@ -16,7 +16,172 @@
 
 //! Readonly built-in.
 //!
-//! TODO Elaborate
+//! The **`readonly`** built-in behaves differently depending on the arguments.
+//!
+//! # Making variables read-only
+//!
+//! If the `-p` (`--print`) or `-f` (`--functions`) option is not specified and
+//! there are any operands, the built-in makes the specified variables
+//! read-only.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! readonly name[=value]…
+//! ```
+//!
+//! ## Options
+//!
+//! None.
+//!
+//! ## Operands
+//!
+//! Operands specify the names and values of the variables to be made read-only.
+//! If an operand contains an equal sign (`=`), the operand is split into the
+//! name and value at the first equal sign. The value is assigned to the
+//! variable named by the name. Otherwise, the variable named by the operand is
+//! created without a value unless it is already defined, in which case the
+//! existing value is retained.
+//!
+//! If no operands are given, the built-in prints variables (see below).
+//!
+//! ## Standard output
+//!
+//! None.
+//!
+//! # Printing read-only variables
+//!
+//! If the `-p` (`--print`) option is specified and the `-f` (`--functions`)
+//! option is not specified, the built-in prints the names and values of the
+//! variables named by the operands in the format that can be evaluated as shell
+//! code to recreate the variables.
+//! <!-- TODO: link to the eval built-in -->
+//! If there are no operands and the `-f` (`--functions`) option is not
+//! specified, the built-in prints all read-only variables in the same format.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! readonly -p [name…]
+//! ```
+//!
+//! ```sh
+//! readonly
+//! ```
+//!
+//! # Options
+//!
+//! The **`-p`** (**`--print`**) option must be specified to print variables
+//! unless there are no operands.
+//!
+//! # Operands
+//!
+//! Operands specify the names of the variables to be printed. If no operands
+//! are given, all read-only variables are printed.
+//!
+//! ## Standard output
+//!
+//! A command string that invokes the readonly built-in to recreate the variable
+//! is printed for each read-only variable. Note that the command does not
+//! include options to restore the attributes of the variable, such as the `-x`
+//! option to make variables exported.
+//!
+//! Also note that evaluating the printed commands in the current context will
+//! fail (unless the variable is declared without a value) because the variable
+//! is already defined and read-only.
+//!
+//! # Making functions read-only
+//!
+//! If the `-f` (`--functions`) option is specified, the built-in makes the
+//! specified functions read-only.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! readonly -f name…
+//! ```
+//!
+//! ## Options
+//!
+//! The **`-f`** (**`--functions`**) option must be specified to make functions
+//! read-only.
+//!
+//! ## Operands
+//!
+//! Operands specify the names of the functions to be made read-only.
+//!
+//! ## Standard output
+//!
+//! None.
+//!
+//! # Printing read-only functions
+//!
+//! If the `-f` (`--functions`) and `-p` (`--print`) options are specified, the
+//! built-in prints the attributes and definitions of the shell functions named
+//! by the operands in the format that can be evaluated as shell code to
+//! recreate the functions.
+//! <!-- TODO: link to the eval built-in -->
+//! If there are no operands and the `-f` (`--functions`) option is specified,
+//! the built-in prints all read-only functions in the same format.
+//!
+//! ## Synopsis
+//!
+//! ```sh
+//! readonly -fp [name…]
+//! ```
+//!
+//! ```sh
+//! readonly -f
+//! ```
+//!
+//! ## Options
+//!
+//! The **`-f`** (**`--functions`**) and **`-p`** (**`--print`**) options must be
+//! specified to print functions. The `-p` option may be omitted if there are no
+//! operands.
+//!
+//! ## Operands
+//!
+//! Operands specify the names of the functions to be printed. If no operands
+//! are given, all read-only functions are printed.
+//!
+//! ## Standard output
+//!
+//! A command string of a function definition command is printed for each
+//! function, followed by a simple command invoking the readonly built-in to
+//! make the function read-only.
+//!
+//! Note that executing the printed commands in the current context will fail
+//! because the function is already defined and read-only.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Errors
+//!
+//! When making a variable read-only with a value, it is an error if the
+//! variable is already read-only.
+//!
+//! It is an error to specify a non-existing function for making it read-only.
+//!
+//! When printing variables or functions, it is an error if an operand names a
+//! non-existing variable or function.
+//!
+//! # Portability
+//!
+//! This built-in is part of the POSIX standard. Printing variables is portable
+//! only when the `-p` option is used without operands. Operations on functions
+//! with the `-f` option are non-portable extensions.
+//!
+//! # Implementation notes
+//!
+//! The implementation of this built-in depends on that of the
+//! [`typeset`](crate::typeset) built-in. The readonly built-in basically works
+//! like the typeset built-in with the `-r` (`--readonly`) option except that:
+//! - The `-g` (`--global`) option is also implied when operating on variables.
+//! - Printed commands name the readonly built-in instead of the typeset built-in.
+//! - Printed commands do not include options that modify variable attributes.
 
 use yash_env::builtin::Result;
 use yash_env::semantics::ExitStatus;

--- a/yash-builtin/src/readonly.rs
+++ b/yash-builtin/src/readonly.rs
@@ -92,6 +92,10 @@
 //! fail (unless the variable is declared without a value) because the variable
 //! is already defined and read-only.
 //!
+//! For array variables, the readonly built-in invocation is preceded by a
+//! separate assignment command since the readonly built-in does not support
+//! assigning values to array variables.
+//!
 //! # Making functions read-only
 //!
 //! If the `-f` (`--functions`) option is specified, the built-in makes the
@@ -209,6 +213,7 @@ pub const PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
 /// Printing context for the readonly built-in
 pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {
     builtin_name: "readonly",
+    builtin_is_significant: true,
     options_allowed: &[],
 };
 

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -134,6 +134,15 @@
 //! variables are read-only since the read-only variables cannot be assigned
 //! values.
 //!
+//! Below is an example of the output of the typeset built-in that displays the
+//! variable `foo` and the read-only array variable `bar`:
+//!
+//! ```sh
+//! typeset foo='some value that contains spaces'
+//! bar=(this is a readonly array)
+//! typeset -r bar
+//! ```
+//!
 //! # Modifying functions
 //!
 //! If the `-f` (`--functions`) option is specified, the `-p` (`--print`) option

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -463,7 +463,7 @@ impl Command {
             Self::SetVariables(command) => command.execute(env),
             Self::PrintVariables(command) => command.execute(&env.variables, print_context),
             Self::SetFunctions(command) => command.execute(&mut env.functions),
-            Self::PrintFunctions(command) => command.execute(&env.functions),
+            Self::PrintFunctions(command) => command.execute(&env.functions, print_context),
         }
     }
 }

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -82,7 +82,8 @@
 //! shell code to recreate the variables.
 //! <!-- TODO: link to the eval built-in -->
 //! If there are no operands and the `-f` (`--functions`) option is not
-//! specified, the built-in prints all shell variables in the same format.
+//! specified, the built-in prints all shell variables in the same format in
+//! alphabetical order.
 //!
 //! ## Synopsis
 //!
@@ -158,7 +159,7 @@
 //! are given, the built-in prints functions (see below).
 //!
 //! Note that the built-in operates on existing shell functions only. It cannot
-//! create new functions or change the contents of existing functions.
+//! create new functions or change the body of existing functions.
 //!
 //! ## Standard output
 //!
@@ -172,7 +173,8 @@
 //! recreate the functions.
 //! <!-- TODO: link to the eval built-in -->
 //! If there are no operands and the `-f` (`--functions`) option is specified,
-//! the built-in prints all shell functions in the same format.
+//! the built-in prints all shell functions in the same format in alphabetical
+//! order.
 //!
 //! ## Synopsis
 //!
@@ -221,6 +223,8 @@
 //! The read-only attribute cannot be removed from a variable or function. If a
 //! variable is already read-only, you cannot assign a value to it.
 //!
+//! It is an error to modify a non-existing function.
+//!
 //! When printing variables or functions, it is an error if an operand names a
 //! non-existing variable or function.
 //!
@@ -253,12 +257,12 @@
 //! # Implementation notes
 //!
 //! The implementation of this built-in is also used by the
-//! [`export`](crate::export) built-in. Functions that are common to both
-//! built-ins are parameterized to support the different behaviors of the
-//! built-ins. By customizing the contents of [`Command`] and the
-//! [`PrintVariablesContext`] passed to [`Command::execute`], you can even
-//! implement a new built-in that behaves differently from both `typeset` and
-//! `export`.
+//! [`export`](crate::export) and [`readonly`](crate::readonly) built-ins.
+//! Functions that are common to these built-ins and the typeset built-in are
+//! parameterized to support the different behaviors of the built-ins. By
+//! customizing the contents of [`Command`] and the [`PrintVariablesContext`]
+//! passed to [`Command::execute`], you can even implement a new built-in that
+//! behaves differently from all of them.
 
 use self::syntax::OptionSpec;
 use crate::common::{output, report_error, report_failure};

--- a/yash-builtin/src/typeset/print_variables.rs
+++ b/yash-builtin/src/typeset/print_variables.rs
@@ -577,7 +577,7 @@ mod tests {
         }
 
         #[test]
-        fn attrs_to_print() {
+        fn options_allowed() {
             let mut vars = VariableSet::new();
             let mut a = vars.get_or_new("a", Scope::Global.into());
             a.assign("A", None).unwrap();

--- a/yash-builtin/src/typeset/print_variables.rs
+++ b/yash-builtin/src/typeset/print_variables.rs
@@ -23,7 +23,7 @@ impl PrintVariables {
     pub fn execute(
         self,
         variables: &VariableSet,
-        context: &PrintVariablesContext,
+        context: &PrintContext,
     ) -> Result<String, Vec<ExecuteError>> {
         let mut output = String::new();
         let mut errors = Vec::new();
@@ -57,7 +57,7 @@ fn print_one(
     name: &str,
     var: &Variable,
     filter_attrs: &[(VariableAttr, State)],
-    context: &PrintVariablesContext,
+    context: &PrintContext,
     output: &mut String,
 ) {
     // Skip if the variable does not match the filter.
@@ -151,7 +151,7 @@ mod tests {
             scope: Scope::Global,
         };
 
-        let output = pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap();
+        let output = pv.execute(&vars, &PRINT_CONTEXT).unwrap();
         assert_eq!(output, "typeset foo=value\n")
     }
 
@@ -174,7 +174,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset first=1\n\
              typeset second=2\n\
              typeset third=3\n",
@@ -193,7 +193,7 @@ mod tests {
             scope: Scope::Global,
         };
 
-        let result = pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap();
+        let result = pv.execute(&vars, &PRINT_CONTEXT).unwrap();
         assert_eq!(result, "a=(1 '2  2' 3)\n");
     }
 
@@ -207,7 +207,7 @@ mod tests {
             scope: Scope::Global,
         };
 
-        let result = pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap();
+        let result = pv.execute(&vars, &PRINT_CONTEXT).unwrap();
         assert_eq!(result, "typeset x\n");
     }
 
@@ -228,7 +228,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset 'valueless$'\n\
              typeset 'scalar$'='=;'\n\
              'array$'=('~' \"'\" '*?')\n",
@@ -254,7 +254,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&inner, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&inner, &PRINT_CONTEXT).unwrap(),
             "typeset global='global value'\n\
              typeset local='local value'\n",
         );
@@ -278,7 +278,7 @@ mod tests {
             attrs: vec![],
             scope: Scope::Local,
         };
-        let output = pv.execute(&inner, &PRINT_VARIABLES_CONTEXT).unwrap();
+        let output = pv.execute(&inner, &PRINT_CONTEXT).unwrap();
         assert_eq!(output, "typeset local='local value'\n");
 
         let pv = PrintVariables {
@@ -287,7 +287,7 @@ mod tests {
             scope: Scope::Local,
         };
         assert_eq!(
-            pv.execute(&inner, &PRINT_VARIABLES_CONTEXT).unwrap_err(),
+            pv.execute(&inner, &PRINT_CONTEXT).unwrap_err(),
             [ExecuteError::PrintUnsetVariable(Field::dummy("global"))]
         );
     }
@@ -315,7 +315,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&inner, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&inner, &PRINT_CONTEXT).unwrap(),
             // sorted by name
             "typeset one=1\n\
              typeset three=3\n\
@@ -346,7 +346,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&inner, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&inner, &PRINT_CONTEXT).unwrap(),
             // sorted by name
             "typeset three=3\n\
              typeset two=2\n",
@@ -370,7 +370,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -x x\n\
              typeset -r y\n\
              typeset -r -x z\n",
@@ -397,7 +397,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -x x=X\n\
              typeset -r y=Y\n\
              typeset -r -x z=Z\n",
@@ -424,7 +424,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "x=(X)\n\
              typeset -x x\n\
              y=(Y)\n\
@@ -457,7 +457,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -r b\n\
              typeset -r -x c\n",
         );
@@ -473,7 +473,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -x a\n\
              typeset d\n",
         );
@@ -489,7 +489,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -x a\n\
              typeset -r -x c\n",
         );
@@ -505,7 +505,7 @@ mod tests {
         };
 
         assert_eq!(
-            pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap(),
+            pv.execute(&vars, &PRINT_CONTEXT).unwrap(),
             "typeset -r b\n\
              typeset d\n",
         );
@@ -520,7 +520,7 @@ mod tests {
             scope: Scope::Global,
         };
 
-        let result = pv.execute(&vars, &PRINT_VARIABLES_CONTEXT).unwrap();
+        let result = pv.execute(&vars, &PRINT_CONTEXT).unwrap();
         assert_eq!(result, "typeset -r b\n");
     }
 
@@ -534,11 +534,8 @@ mod tests {
             scope: Scope::Global,
         };
 
-        let error = pv
-            .execute(&VariableSet::new(), &PRINT_VARIABLES_CONTEXT)
-            .unwrap_err();
         assert_eq!(
-            error,
+            pv.execute(&VariableSet::new(), &PRINT_CONTEXT).unwrap_err(),
             [
                 ExecuteError::PrintUnsetVariable(foo),
                 ExecuteError::PrintUnsetVariable(bar)
@@ -565,9 +562,9 @@ mod tests {
                 attrs: vec![],
                 scope: Scope::Global,
             };
-            let context = PrintVariablesContext {
+            let context = PrintContext {
                 builtin_name: "export",
-                ..PRINT_VARIABLES_CONTEXT
+                ..PRINT_CONTEXT
             };
 
             assert_eq!(
@@ -600,9 +597,9 @@ mod tests {
                 scope: Scope::Global,
             };
 
-            let context = PrintVariablesContext {
+            let context = PrintContext {
                 options_allowed: &[READONLY_OPTION],
-                ..PRINT_VARIABLES_CONTEXT
+                ..PRINT_CONTEXT
             };
             assert_eq!(
                 pv.clone().execute(&vars, &context).unwrap(),
@@ -612,9 +609,9 @@ mod tests {
                  typeset -r d=D\n",
             );
 
-            let context = PrintVariablesContext {
+            let context = PrintContext {
                 options_allowed: &[EXPORT_OPTION],
-                ..PRINT_VARIABLES_CONTEXT
+                ..PRINT_CONTEXT
             };
             assert_eq!(
                 pv.clone().execute(&vars, &context).unwrap(),
@@ -624,9 +621,9 @@ mod tests {
                  typeset -x d=D\n",
             );
 
-            let context = PrintVariablesContext {
+            let context = PrintContext {
                 options_allowed: &[],
-                ..PRINT_VARIABLES_CONTEXT
+                ..PRINT_CONTEXT
             };
             assert_eq!(
                 pv.execute(&vars, &context).unwrap(),

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -158,6 +158,11 @@ fn quotation() {
 }
 
 #[test]
+fn readonly_builtin() {
+    run("readonly-p.sh")
+}
+
+#[test]
 fn redirection() {
     run("redir-p.sh")
 }

--- a/yash/tests/scripted_test/readonly-p.sh
+++ b/yash/tests/scripted_test/readonly-p.sh
@@ -1,0 +1,32 @@
+# readonly-p.sh: test of the readonly built-in for any POSIX-compliant shell
+
+posix="true"
+
+test_o -d -e n 'making one variable read-only'
+readonly a=bar
+echo $a
+a=X && test "$a" = bar
+__IN__
+bar
+__OUT__
+
+test_o -d -e n 'making many variables read-only'
+a=X b=B c=X
+readonly a=A b c=C
+echo $a $b $c
+a=X || b=Y || c=Z && test "$a/$b/$c" = A/B/C
+__IN__
+A B C
+__OUT__
+
+# This test is in readonly-y.tst because it fails on some existing shells
+# because of pre-defined read-only variables.
+#test_x 'reusing printed read-only variables'
+
+test_O -d -e n 'read-only variable cannot be re-assigned'
+readonly a=1
+readonly a=2
+# The readonly built-in fails because of the readonly variable.
+# Since it is a special built-in, the non-interactive shell exits.
+echo not reached
+__IN__

--- a/yash/tests/scripted_test/readonly-p.sh
+++ b/yash/tests/scripted_test/readonly-p.sh
@@ -5,17 +5,29 @@ posix="true"
 test_o -d -e n 'making one variable read-only'
 readonly a=bar
 echo $a
-a=X && test "$a" = bar
+a=X # This should fail, and the shell should exit.
+echo not reached
 __IN__
 bar
 __OUT__
 
-test_o -d -e n 'making many variables read-only'
+test_o -d 'making many variables read-only'
 a=X b=B c=X
 readonly a=A b c=C
 echo $a $b $c
-a=X || b=Y || c=Z && test "$a/$b/$c" = A/B/C
+(
+    a=X # This should fail, and the subshell should exit.
+    echo not reached
+) || (
+    b=Y # This should fail, and the subshell should exit.
+    echo not reached
+) || (
+    c=Z # This should fail, and the subshell should exit.
+    echo not reached
+) ||
+echo $a $b $c # This should print the values passed to the readonly built-in.
 __IN__
+A B C
 A B C
 __OUT__
 

--- a/yash/tests/scripted_test/typeset-y.sh
+++ b/yash/tests/scripted_test/typeset-y.sh
@@ -52,7 +52,6 @@ __IN__
 a=unset b=unset
 __OUT__
 
-: TODO Needs the readonly built-in <<\__OUT__
 test_oE -e 0 'printing all variables (no option)' -e
 typeset >/dev/null
 typeset | grep -q '^typeset -x PATH='
@@ -146,7 +145,6 @@ __OUT__
 
 )
 
-: TODO Needs the readonly built-in <<\__OUT__
 test_oE -e 0 'printing all variables (-p)' -e
 typeset -p >/dev/null
 typeset -p | grep -q '^typeset -x PATH='


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `export` and `readonly` built-in commands with clarified behavior and additional documentation.
  - Improved the `typeset` built-in to print variables and functions in alphabetical order and handle array variables more effectively.

- **Documentation**
  - Added detailed documentation for `readonly` built-in covering behavior, options, operands, and standard output.

- **Refactor**
  - Renamed `PRINT_VARIABLES_CONTEXT` to `PRINT_CONTEXT` across various modules for consistency.
  - Updated `typeset` built-in implementation to support different behaviors and introduced `PrintContext` for command details.

- **Tests**
  - Added new test cases for `readonly` and `typeset` built-ins to ensure compliance with POSIX standards.
  - Introduced `readonly-p.sh` and updated `typeset-y.sh` test scripts for comprehensive testing of shell built-ins.

- **Bug Fixes**
  - Fixed issues related to the `readonly` built-in to prevent re-assignment of read-only variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->