### PR TITLE
Eval built-in

### DIFF
--- a/yash-builtin/src/eval.rs
+++ b/yash-builtin/src/eval.rs
@@ -1,0 +1,106 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Eval built-in
+//!
+//! The **`eval`** built-in evaluates the arguments as shell commands.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! eval [command…]
+//! ```
+//!
+//! # Description
+//!
+//! This built-in parses and executes the argument as a shell script in
+//! the current shell environment.
+//!
+//! # Options
+//!
+//! None.
+//!
+//! (TODO: non-portable options)
+//!
+//! # Operands
+//!
+//! The operand is a command string to be evaluated.
+//! If more than one operand is given, they are concatenated with spaces
+//! between them to form a single command string.
+//!
+//! # Errors
+//!
+//! During parsing and execution, any syntax error or runtime error may
+//! occur.
+//!
+//! # Exit status
+//!
+//! The exit status of the `eval` built-in is the exit status of the last
+//! command executed in the command string.
+//! If there is no command in the string, the exit status is zero.
+//! In case of a syntax error, the exit status is 2 ([`ExitStatus::ERROR`]).
+//!
+//! # Portability
+//!
+//! POSIX does not require the eval built-in to conform to the Utility Syntax
+//! Guidelines, which means portable scripts cannot use any options or the `--`
+//! separator for the built-in.
+
+use crate::Result;
+use std::num::NonZeroU64;
+#[cfg(doc)]
+use yash_env::semantics::ExitStatus;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_semantics::ReadEvalLoop;
+use yash_syntax::input::Memory;
+use yash_syntax::parser::lex::Lexer;
+use yash_syntax::source::Source;
+
+/// Entry point of the `eval` built-in execution
+pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
+    let command = match join(args) {
+        Some(command) => command,
+        None => return Result::default(),
+    };
+
+    // Parse and execute the command string
+    let input = Box::new(Memory::new(&command.value));
+    let start_line_number = NonZeroU64::new(1).unwrap();
+    let source = Source::Eval {
+        original: command.origin,
+    };
+    let mut lexer = Lexer::new(input, start_line_number, source);
+    let divert = ReadEvalLoop::new(env, &mut lexer).run().await;
+    Result::with_exit_status_and_divert(env.exit_status, divert)
+}
+
+/// Joins the arguments to make a single command string.
+fn join(args: Vec<Field>) -> Option<Field> {
+    let mut args = args.into_iter();
+    let mut command = args.next()?;
+    command.value.reserve_exact(
+        args.as_slice()
+            .iter()
+            .map(|arg| 1 + arg.value.len())
+            .sum::<usize>(),
+    );
+    for arg in args {
+        command.value.push(' ');
+        command.value.push_str(&arg.value);
+    }
+    Some(command)
+}

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -49,6 +49,8 @@ pub mod colon;
 pub mod common;
 pub mod r#continue;
 #[cfg(feature = "yash-semantics")]
+pub mod eval;
+#[cfg(feature = "yash-semantics")]
 pub mod exec;
 pub mod exit;
 pub mod export;
@@ -110,6 +112,14 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: |env, args| Box::pin(r#continue::main(env, args)),
+        },
+    ),
+    #[cfg(feature = "yash-semantics")]
+    (
+        "eval",
+        Builtin {
+            r#type: Special,
+            execute: |env, args| Box::pin(eval::main(env, args)),
         },
     ),
     #[cfg(feature = "yash-semantics")]

--- a/yash-builtin/src/readonly.rs
+++ b/yash-builtin/src/readonly.rs
@@ -55,9 +55,8 @@
 //!
 //! If the `-p` (`--print`) option is specified and the `-f` (`--functions`)
 //! option is not specified, the built-in prints the names and values of the
-//! variables named by the operands in the format that can be evaluated as shell
-//! code to recreate the variables.
-//! <!-- TODO: link to the eval built-in -->
+//! variables named by the operands in the format that can be
+//! [evaluated](crate::eval) as shell code to recreate the variables.
 //! If there are no operands and the `-f` (`--functions`) option is not
 //! specified, the built-in prints all read-only variables in the same format.
 //!
@@ -124,9 +123,8 @@
 //!
 //! If the `-f` (`--functions`) and `-p` (`--print`) options are specified, the
 //! built-in prints the attributes and definitions of the shell functions named
-//! by the operands in the format that can be evaluated as shell code to
-//! recreate the functions.
-//! <!-- TODO: link to the eval built-in -->
+//! by the operands in the format that can be [evaluated](crate::eval) as shell
+//! code to recreate the functions.
 //! If there are no operands and the `-f` (`--functions`) option is specified,
 //! the built-in prints all read-only functions in the same format.
 //!

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -78,9 +78,8 @@
 //!
 //! If the `-p` (`--print`) option is specified and the `-f` (`--functions`)
 //! option is not specified, the built-in prints the attributes and values of
-//! the variables named by the operands in the format that can be evaluated as
-//! shell code to recreate the variables.
-//! <!-- TODO: link to the eval built-in -->
+//! the variables named by the operands in the format that can be
+//! [evaluated](crate::eval) as shell code to recreate the variables.
 //! If there are no operands and the `-f` (`--functions`) option is not
 //! specified, the built-in prints all shell variables in the same format in
 //! alphabetical order.
@@ -182,9 +181,8 @@
 //!
 //! If the `-f` (`--functions`) and `-p` (`--print`) options are specified, the
 //! built-in prints the attributes and definitions of the shell functions named
-//! by the operands in the format that can be evaluated as shell code to
-//! recreate the functions.
-//! <!-- TODO: link to the eval built-in -->
+//! by the operands in the format that can be [evaluated](crate::eval) as shell
+//! code to recreate the functions.
 //! If there are no operands and the `-f` (`--functions`) option is specified,
 //! the built-in prints all shell functions in the same format in alphabetical
 //! order.

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -72,7 +72,7 @@ pub enum Frame {
 
     /// Trap
     Trap(crate::trap::Condition),
-    // TODO dot script, eval
+    // TODO dot script, function
 }
 
 impl From<Builtin> for Frame {

--- a/yash-syntax/src/source.rs
+++ b/yash-syntax/src/source.rs
@@ -30,25 +30,25 @@ use std::num::NonZeroU64;
 use std::ops::Range;
 use std::rc::Rc;
 
-/// Origin of source code.
+/// Origin of source code
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Source {
-    /// Source code of unknown origin.
+    /// Source code of unknown origin
     ///
     /// Normally you should not use this value, but it may be useful for quick debugging.
     Unknown,
 
-    /// Standard input.
+    /// Standard input
     Stdin,
 
-    /// Command string specified with the `-c` option on the shell startup.
+    /// Command string specified with the `-c` option on the shell startup
     CommandString,
 
-    /// File specified on the shell startup.
+    /// File specified on the shell startup
     CommandFile { path: String },
 
-    /// Alias substitution.
+    /// Alias substitution
     ///
     /// This applies to a code fragment that replaced another as a result of alias substitution.
     Alias {
@@ -58,13 +58,16 @@ pub enum Source {
         alias: Rc<Alias>,
     },
 
-    /// Command substitution.
+    /// Command substitution
     CommandSubst { original: Location },
 
-    /// Arithmetic expansion.
+    /// Arithmetic expansion
     Arith { original: Location },
 
-    /// Trap command.
+    /// Command string executed by the `eval` built-in
+    Eval { original: Location },
+
+    /// Trap command
     Trap {
         /// Trap condition name, typically the signal name.
         condition: String,
@@ -144,6 +147,7 @@ impl Source {
             Alias { .. } => "<alias>",
             CommandSubst { .. } => "<command_substitution>",
             Arith { .. } => "<arith>",
+            Eval { .. } => "<eval>",
             Trap { condition, .. } => condition,
         }
     }

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -123,6 +123,14 @@ impl super::Source {
                     original,
                 )));
             }
+            Eval { original } => {
+                // TODO Use Extend::extend_one
+                result.extend(std::iter::once(Annotation::new(
+                    AnnotationType::Info,
+                    "command passed to the eval built-in here".into(),
+                    original,
+                )));
+            }
             Trap { origin, .. } => {
                 // TODO Use Extend::extend_one
                 result.extend(std::iter::once(Annotation::new(

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -97,6 +97,11 @@ fn continue_builtin() {
 }
 
 #[test]
+fn eval_builtin() {
+    run("eval-p.sh")
+}
+
+#[test]
 fn exec_builtin() {
     run("exec-p.sh")
 }

--- a/yash/tests/scripted_test/break-p.sh
+++ b/yash/tests/scripted_test/break-p.sh
@@ -381,9 +381,8 @@ for i in 1; do
 done
 __IN__
 
-: TODO Needs the eval built-in <<\__IN__
 # This is a questionable case. Is this really a "lexically enclosing" loop as
-# defined in POSIX? Most shells (other than mksh) support this case.
+# defined in POSIX? Most shells do support this case.
 test_OE 'breaking out of eval'
 for i in 1; do
     eval break

--- a/yash/tests/scripted_test/continue-p.sh
+++ b/yash/tests/scripted_test/continue-p.sh
@@ -435,9 +435,8 @@ for i in 1; do
 done
 __IN__
 
-: TODO Needs the eval built-in <<\__OUT__
 # This is a questionable case. Is this really a "lexically enclosing" loop as
-# defined in POSIX? Most shells (other than mksh) support this case.
+# defined in POSIX? Most shells do support this case.
 test_oE 'continuing out of eval'
 for i in 1 2; do
     echo $i

--- a/yash/tests/scripted_test/eval-p.sh
+++ b/yash/tests/scripted_test/eval-p.sh
@@ -1,0 +1,42 @@
+# eval-p.sh: test of the eval built-in for any POSIX-compliant shell
+
+posix="true"
+
+test_OE -e 0 'evaluating no operands'
+false
+eval
+__IN__
+
+test_OE -e 0 'evaluating null operands'
+false
+eval '' '' ''
+__IN__
+
+test_oE -e 0 'evaluating some commands'
+eval 'echo foo; echo bar'
+__IN__
+foo
+bar
+__OUT__
+
+test_oE -e 0 'operands are concatenated with spaces in-between'
+eval 'echo foo' 'echo bar'
+eval 'echo 1"' '' '"2'
+__IN__
+foo echo bar
+1  2
+__OUT__
+
+test_OE -e 23 'exit status of evaluation'
+eval '(exit 23)'
+__IN__
+
+test_oE -e 0 'effect on environment in evaluation'
+a=foo
+eval 'a=bar'
+echo $a
+eval exit
+echo not reached
+__IN__
+bar
+__OUT__

--- a/yash/tests/scripted_test/export-p.sh
+++ b/yash/tests/scripted_test/export-p.sh
@@ -21,7 +21,6 @@ __IN__
 2 A B C
 __OUT__
 
-: TODO Needs the eval built-in <<\__OUT__
 test_oE -e 0 'reusing printed exported variables'
 export a=A
 e="$(export -p)"

--- a/yash/tests/scripted_test/return-p.sh
+++ b/yash/tests/scripted_test/return-p.sh
@@ -174,7 +174,6 @@ __IN__
 Z 2
 __OUT__
 
-: TODO Needs the eval built-in <<\__IN__
 test_OE 'returning out of eval'
 fn() {
     eval return

--- a/yash/tests/scripted_test/typeset-y.sh
+++ b/yash/tests/scripted_test/typeset-y.sh
@@ -317,11 +317,10 @@ __IN__
 function "f=/'g"() { :; }
 __OUT__
 
-: TODO Needs the eval built-in <<\__OUT__
 test_oE 'printing function with command substitution with subshell (-fp)' -e
 eval "$(
     print_foo() {
-	echo "$((echo foo) )"
+        echo "$((echo foo) )"
     }
     typeset -fp print_foo
 )"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `eval` built-in command for evaluating arguments as shell commands within the current environment.
  - Added new test script `eval-p.sh` to ensure POSIX compliance of the `eval` command.

- **Documentation**
  - Updated documentation to include direct links to the `eval` function for relevant built-in commands.
  - Clarified behavior in documentation for printing and evaluating shell variables and functions.

- **Bug Fixes**
  - Adjusted comments in test scripts to reflect broader shell support for certain POSIX-defined behaviors.

- **Refactor**
  - Updated comments and removed unnecessary periods for consistency in the `Source` enum.
  - Removed outdated "TODO" sections and clarified existing comments in test scripts.

- **Tests**
  - Enhanced scripted tests to cover various scenarios involving the `eval` command.
  - Adjusted indentation in a test function for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->