### PR TITLE
getopts built-in

### DIFF
--- a/yash-builtin/src/getopts.rs
+++ b/yash-builtin/src/getopts.rs
@@ -174,3 +174,5 @@
 //! modify the `$OPTIND` variable until the built-in finishes parsing all
 //! options. The implementation may be changed in the future to check these
 //! conditions.
+
+pub mod model;

--- a/yash-builtin/src/getopts.rs
+++ b/yash-builtin/src/getopts.rs
@@ -1,0 +1,176 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Getopts built-in
+//!
+//! The **`getopts`** built-in is used to parse options in shell scripts.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! getopts option_spec variable_name [argument…]
+//! ```
+//!
+//! # Description
+//!
+//! The getopts built-in parses single-character options in the specified
+//! arguments according to the specified option specification, and assigns the
+//! parsed options to the specified variable. This built-in is meant to be used
+//! in the condition of a `while` loop to iterate over the options in the
+//! arguments. Every invocation of the built-in parses the next option in the
+//! arguments. The built-in returns a non-zero exit status when there are no more
+//! options to parse.
+//!
+//! The shell uses the `$OPTIND` variable to keep track of the current position
+//! in the arguments. When the shell starts, the variable is initialized to `1`.
+//! The built-in updates the variable to the index of the next argument to parse.
+//! When all arguments are parsed, the built-in sets the variable to the index of
+//! the first operand after the options, or to the number of arguments plus one
+//! if there are no operands.
+//!
+//! When the built-in parses an option, it sets the specified variable to the
+//! option name. If the option takes an argument, the built-in also sets the
+//! `$OPTARG` variable to the argument.
+//!
+//! If the built-in encounters an option that is not listed in the option
+//! specification, the specified variable is set to `?`. Additionally, if the
+//! option specification starts with a colon (`:`), the built-in sets the
+//! `$OPTARG` variable to the encountered option character. Otherwise, the
+//! built-in unsets the `$OPTARG` variable and prints an error message to the
+//! standard error describing the invalid option.
+//!
+//! If the built-in encounters an option that takes an argument but the argument
+//! is missing, the error handling is similar to the case of an invalid option.
+//! If the option specification starts with a colon, the built-in sets the
+//! the specified variable to `:` (not `?`) and sets the `$OPTARG` variable to
+//! the option character. Otherwise, the built-in sets the specified variable to
+//! `?`, unsets the `$OPTARG` variable, and prints an error message to the
+//! standard error describing the missing argument.
+//!
+//! In repeated invocations of the built-in, you must pass the same arguments to
+//! the built-in. You must not modify the `$OPTIND` variable between
+//! invocations, either. Otherwise, the built-in may not be able to parse the
+//! options correctly.
+//!
+//! To start parsing a new set of options, you must reset the `$OPTIND` variable
+//! to `1` before invoking the built-in.
+//!
+//! # Options
+//!
+//! None.
+//!
+//! # Operands
+//!
+//! The first operand is the option specification. It is a string that contains
+//! the option characters the built-in parses. If a character is followed by a
+//! colon (`:`), the option takes an argument. If the option specification
+//! starts with a colon, the built-in does not print an error message when it
+//! encounters an invalid option or an option that is missing an argument.
+//!
+//! The second operand is the name of the variable to which the built-in assigns
+//! the parsed option. In case of an invalid option or an option that is missing
+//! an argument, the built-in assigns `?` or `:` to the variable (see above).
+//!
+//! The remaining operands are the arguments to parse. If there are no operands,
+//! the built-in parses the positional parameters.
+//!
+//! # Errors
+//!
+//! The built-in may print an error message to the standard error when it
+//! encounters an invalid option or an option that is missing an argument (see
+//! the description above). However, this is not considered an error of the
+//! built-in itself.
+//!
+//! It is an error if `$OPTIND`, `$OPTARG`, or the specified variable is
+//! read-only.
+//!
+//! # Exit status
+//!
+//! The built-in returns an exit status of zero if it parses an option,
+//! regardless of whether the option is valid or not. When there are no more
+//! options to parse, the built-in returns a non-zero exit status.
+//!
+//! The exit status is non-zero on error.
+//!
+//! # Examples
+//!
+//! In the following example, the getopts built-in parses three kinds of options
+//! (`-a`, `-b`, and `-c`), of which only `-b` takes an argument. In case of an
+//! error, the built-in prints an error message to the standard error, so the
+//! script just exits with a non-zero exit status when `$opt` is set to `?`.
+//!
+//! ```sh
+//! a=false c=false
+//! while getopts ab:c opt; do
+//!     case "$opt" in
+//!         a) a=true ;;
+//!         b) b="$OPTARG" ;;
+//!         c) c=true ;;
+//!         '?') exit 1 ;;
+//!     esac
+//! done
+//! shift "$((OPTIND - 1))"
+//!
+//! if "$a"; then printf 'The -a option was specified\n'; fi
+//! if [ "${b+set}" ]; then printf 'The -b option was specified with argument %s\n' "$b"; fi
+//! if "$c"; then printf 'The -c option was specified\n'; fi
+//! printf 'The remaining operands are: %s\n' "$*"
+//! ```
+//!
+//! If you prefer to print an error message yourself, put a colon at the
+//! beginning of the option specification like this:
+//!
+//! ```sh
+//! while getopts :ab:c opt; do
+//!     case "$opt" in
+//!         a) a=true ;;
+//!         b) b="$OPTARG" ;;
+//!         c) c=true ;;
+//!         '?') printf 'Invalid option: -%s\n' "$OPTARG" >&2; exit 1 ;;
+//!         :) printf 'Option -%s requires an argument\n' "$OPTARG" >&2; exit 1 ;;
+//!     esac
+//! done
+//! ```
+//!
+//! # Portability
+//!
+//! The getopts built-in is specified by POSIX. Only ASCII alphanumeric
+//! characters are allowed for option names, though this implementation allows
+//! any characters but `:`.
+//!
+//! Although POSIX requires the built-in to support the Utility Syntax
+//! Guidelines 3 to 10, some implementations do not support the `--` separator
+//! placed before operands to the built-in itself, that is, between the built-in
+//! name `getopts` and the first operand *option_spec*.
+//!
+//! The value of the `$OPTIND` variable is not portable until the built-in
+//! finishes parsing all options. In this implementation, the value may
+//! temporarily contain two integers separated by a colon. The first integer is
+//! the index of the next argument to parse, and the second is the index of the
+//! character in the argument to parse. Other implementations may use a
+//! different scheme. Some sets `$OPTIND` to the index of the just-parsed
+//! argument and uses a hidden variable to keep track of the character index.
+//!
+//! The behavior is unspecified if you modify the `$OPTIND` variable between
+//! invocations of the built-in or to a value other than `1`.
+//!
+//! # Implementation notes
+//!
+//! The current implementation does not aggressively check that you pass the
+//! same arguments to the built-in in repeated invocations or that you do not
+//! modify the `$OPTIND` variable until the built-in finishes parsing all
+//! options. The implementation may be changed in the future to check these
+//! conditions.

--- a/yash-builtin/src/getopts/model.rs
+++ b/yash-builtin/src/getopts/model.rs
@@ -1,0 +1,439 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Main domain model of the getopts built-in
+
+use std::num::NonZeroUsize;
+use thiserror::Error;
+
+/// Type of an option
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OptionType {
+    /// Option without an argument
+    NoArgument,
+    /// Option that takes an argument
+    TakesArgument,
+    /// Option not listed in the option specification
+    Unknown,
+}
+
+/// Option specification
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OptionSpec<'a> {
+    raw: &'a str,
+}
+
+/// Creates an option specification from a raw string representation.
+impl<'a, S: AsRef<str> + ?Sized> From<&'a S> for OptionSpec<'a> {
+    #[inline(always)]
+    fn from(raw: &'a S) -> Self {
+        Self { raw: raw.as_ref() }
+    }
+}
+
+impl OptionSpec<'_> {
+    /// Returns the raw string representation of the option specification.
+    #[inline(always)]
+    #[must_use]
+    pub fn as_raw(&self) -> &str {
+        self.raw
+    }
+
+    /// Returns the type of the option.
+    #[must_use]
+    pub fn judge(&self, option: char) -> OptionType {
+        if option == ':' {
+            return OptionType::Unknown;
+        }
+
+        let mut iter = self.raw.chars();
+        match iter.find(|&c| c == option) {
+            None => OptionType::Unknown,
+            Some(c) => {
+                debug_assert_eq!(c, option);
+                if iter.next() == Some(':') {
+                    OptionType::TakesArgument
+                } else {
+                    OptionType::NoArgument
+                }
+            }
+        }
+    }
+}
+
+/// Result of parsing an option
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Result {
+    /// Option character
+    pub option: char,
+
+    /// Argument to the option
+    pub argument: Option<String>,
+
+    /// Index of the next argument to parse
+    ///
+    /// The index starts from 1 and may go beyond the number of arguments.
+    pub next_arg_index: NonZeroUsize,
+
+    /// Index of the next character to parse in the argument at `next_arg_index`
+    ///
+    /// The hyphen character (`-`) is not included in the count. For example, if
+    /// `next_char_index` is 1, the next character to parse is the first option
+    /// character just following the leading hyphen character.
+    pub next_char_index: NonZeroUsize,
+
+    /// Error that occurred when parsing the option
+    pub error: Option<Error>,
+}
+
+/// Error that may occur when parsing an option
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum Error {
+    /// The option is not listed in the option specification.
+    #[error("invalid option")]
+    UnknownOption,
+    /// The option takes an argument but the argument is missing.
+    #[error("missing argument")]
+    MissingArgument,
+}
+
+/// Parses an option from the specified arguments.
+///
+/// If the next argument is an option, returns the parsed option.
+/// Otherwise, returns `None`.
+pub fn next<S, I>(
+    args: I,
+    spec: OptionSpec,
+    arg_index: NonZeroUsize,
+    char_index: NonZeroUsize,
+) -> Option<Result>
+where
+    S: AsRef<str>,
+    I: IntoIterator<Item = S>,
+{
+    let mut args = args.into_iter().skip(arg_index.get() - 1);
+    let arg = args.next()?;
+    let body = arg.as_ref().strip_prefix('-')?;
+    if body == "-" {
+        debug_assert_eq!(arg.as_ref(), "--");
+        return None;
+    }
+
+    let mut chars = body.chars().skip(char_index.get() - 1);
+    let option = chars.next()?;
+
+    /// Computes the increment of the argument index.
+    /// Only used when `option` does not take an argument.
+    fn arg_index_incr<I: Iterator<Item = char>>(mut chars: I) -> usize {
+        if chars.next().is_some() {
+            0 // The next option is in the same argument, so no increment.
+        } else {
+            1 // No more options in the current argument, so increment.
+        }
+    }
+
+    let (argument, arg_index_incr, error) = match spec.judge(option) {
+        OptionType::Unknown => (None, arg_index_incr(chars), Some(Error::UnknownOption)),
+        OptionType::NoArgument => (None, arg_index_incr(chars), None),
+        OptionType::TakesArgument => {
+            let remainder = chars.collect::<String>();
+            if !remainder.is_empty() {
+                (Some(remainder), 1, None)
+            } else if let Some(arg) = args.next() {
+                (Some(arg.as_ref().to_owned()), 2, None)
+            } else {
+                (None, 1, Some(Error::MissingArgument))
+            }
+        }
+    };
+
+    // Rust's slices cannot be as large as `usize::MAX`, so we can safely unwrap here.
+    let next_arg_index = arg_index.checked_add(arg_index_incr).unwrap();
+    let next_char_index = if arg_index_incr == 0 {
+        char_index.checked_add(1).unwrap()
+    } else {
+        NonZeroUsize::MIN
+    };
+
+    Some(Result {
+        option,
+        argument,
+        next_arg_index,
+        next_char_index,
+        error,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn judge_options_without_arguments() {
+        let spec = OptionSpec::from("abc:def");
+        assert_eq!(spec.judge('a'), OptionType::NoArgument);
+        assert_eq!(spec.judge('b'), OptionType::NoArgument);
+        assert_eq!(spec.judge('d'), OptionType::NoArgument);
+        assert_eq!(spec.judge('e'), OptionType::NoArgument);
+        assert_eq!(spec.judge('f'), OptionType::NoArgument);
+    }
+
+    #[test]
+    fn judge_options_that_take_argument() {
+        let spec = OptionSpec::from("abc:de:f:");
+        assert_eq!(spec.judge('c'), OptionType::TakesArgument);
+        assert_eq!(spec.judge('e'), OptionType::TakesArgument);
+        assert_eq!(spec.judge('f'), OptionType::TakesArgument);
+    }
+
+    #[test]
+    fn judge_unknown_options() {
+        let spec = OptionSpec::from("abc:df:");
+        assert_eq!(spec.judge('x'), OptionType::Unknown);
+        assert_eq!(spec.judge('e'), OptionType::Unknown);
+
+        // Colon is always unknown
+        assert_eq!(spec.judge(':'), OptionType::Unknown);
+    }
+
+    fn non_zero(i: usize) -> NonZeroUsize {
+        NonZeroUsize::new(i).unwrap()
+    }
+
+    #[test]
+    fn next_with_empty_arguments() {
+        let args = [] as [&str; 0];
+        let result = next(args, "a".into(), non_zero(1), non_zero(1));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn next_with_single_hyphen() {
+        let result = next(["-"], "a".into(), non_zero(1), non_zero(1));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn next_with_non_option_argument() {
+        let result = next([""], "a".into(), non_zero(1), non_zero(1));
+        assert_eq!(result, None);
+        let result = next(["abc"], "a".into(), non_zero(1), non_zero(1));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn next_with_double_hyphen_separator() {
+        let result = next(["--"], "a".into(), non_zero(1), non_zero(1));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn next_with_single_option() {
+        assert_eq!(
+            next(["-a"], "a".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-x"], "x".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'x',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_many_options_in_single_argument() {
+        assert_eq!(
+            next(["-abc"], "abc".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: None,
+                next_arg_index: non_zero(1),
+                next_char_index: non_zero(2),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-abc"], "abc".into(), non_zero(1), non_zero(2)),
+            Some(Result {
+                option: 'b',
+                argument: None,
+                next_arg_index: non_zero(1),
+                next_char_index: non_zero(3),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-abc"], "abc".into(), non_zero(1), non_zero(3)),
+            Some(Result {
+                option: 'c',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_many_option_arguments() {
+        assert_eq!(
+            next(["-a", "-b", "-c"], "abc".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-a", "-b", "-c"], "abc".into(), non_zero(2), non_zero(1)),
+            Some(Result {
+                option: 'b',
+                argument: None,
+                next_arg_index: non_zero(3),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-a", "-b", "-c"], "abc".into(), non_zero(3), non_zero(1)),
+            Some(Result {
+                option: 'c',
+                argument: None,
+                next_arg_index: non_zero(4),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_unknown_option() {
+        assert_eq!(
+            next(["-a"], "".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: Some(Error::UnknownOption),
+            })
+        );
+
+        assert_eq!(
+            next(["-x"], "a".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'x',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: Some(Error::UnknownOption),
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_option_argument_in_same_argument() {
+        assert_eq!(
+            next(["-abc"], "a:bc".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: Some("bc".into()),
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-abc"], "ab:c".into(), non_zero(1), non_zero(2)),
+            Some(Result {
+                option: 'b',
+                argument: Some("c".into()),
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_option_argument_in_next_argument() {
+        assert_eq!(
+            next(["-a", "bc"], "a:bc".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: Some("bc".into()),
+                next_arg_index: non_zero(3),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+
+        assert_eq!(
+            next(["-ab", "-c"], "ab:c".into(), non_zero(1), non_zero(2)),
+            Some(Result {
+                option: 'b',
+                argument: Some("-c".into()),
+                next_arg_index: non_zero(3),
+                next_char_index: non_zero(1),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn next_with_missing_option_argument() {
+        assert_eq!(
+            next(["-a"], "a:".into(), non_zero(1), non_zero(1)),
+            Some(Result {
+                option: 'a',
+                argument: None,
+                next_arg_index: non_zero(2),
+                next_char_index: non_zero(1),
+                error: Some(Error::MissingArgument),
+            })
+        );
+
+        assert_eq!(
+            next(["-a", "-ab"], "ab:".into(), non_zero(2), non_zero(2)),
+            Some(Result {
+                option: 'b',
+                argument: None,
+                next_arg_index: non_zero(3),
+                next_char_index: non_zero(1),
+                error: Some(Error::MissingArgument),
+            })
+        );
+    }
+}

--- a/yash-builtin/src/getopts/report.rs
+++ b/yash-builtin/src/getopts/report.rs
@@ -1,0 +1,584 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Reporting the result to the environment
+
+use super::indexes_to_optind;
+use super::model;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::variable::AssignError;
+use yash_env::variable::Scope;
+use yash_env::variable::UnsetError;
+use yash_env::variable::Value;
+use yash_env::Env;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
+use yash_syntax::source::Location;
+
+/// Error in reporting the result to the environment
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum Error {
+    /// Error in assigning to a read-only variable
+    #[error("cannot update read-only variable `{name}`")]
+    AssignReadOnlyError {
+        /// Name of the variable that was being assigned
+        name: String,
+        /// Value that was being assigned
+        new_value: Value,
+        /// Location of the failed assignment
+        assigned_location: Option<Location>,
+        /// Location where the variable was made read-only
+        read_only_location: Location,
+    },
+
+    /// Error in unsetting a read-only variable
+    #[error("cannot unset read-only variable `{name}`")]
+    UnsetReadOnlyError {
+        /// Name of the variable that was being unset
+        name: String,
+        /// Location where the variable was made read-only
+        read_only_location: Location,
+    },
+}
+
+impl From<UnsetError<'_>> for Error {
+    fn from(e: UnsetError) -> Self {
+        Error::UnsetReadOnlyError {
+            name: e.name.to_owned(),
+            read_only_location: e.read_only_location.clone(),
+        }
+    }
+}
+
+impl Error {
+    #[must_use]
+    fn with_name_and_assign_error(name: String, e: AssignError) -> Self {
+        Error::AssignReadOnlyError {
+            name,
+            new_value: e.new_value,
+            assigned_location: e.assigned_location,
+            read_only_location: e.read_only_location,
+        }
+    }
+
+    /// Converts this error to a printable message.
+    pub fn to_message(&self) -> Message {
+        let mut annotations = Vec::new();
+
+        match self {
+            Error::AssignReadOnlyError {
+                name,
+                new_value,
+                assigned_location,
+                read_only_location,
+            } => {
+                if let Some(location) = assigned_location {
+                    annotations.push(Annotation::new(
+                        AnnotationType::Info,
+                        format!(
+                            "the built-in needs to update the variable to `{}`",
+                            new_value.quote()
+                        )
+                        .into(),
+                        location,
+                    ));
+                }
+
+                annotations.push(Annotation::new(
+                    AnnotationType::Info,
+                    format!("`{name}` was made read-only here").into(),
+                    read_only_location,
+                ));
+            }
+
+            Error::UnsetReadOnlyError {
+                name,
+                read_only_location,
+            } => {
+                annotations.push(Annotation::new(
+                    AnnotationType::Info,
+                    format!("`{name}` was made read-only here").into(),
+                    read_only_location,
+                ));
+            }
+        }
+
+        Message {
+            r#type: AnnotationType::Error,
+            title: self.to_string().into(),
+            annotations,
+        }
+    }
+}
+
+impl model::Result {
+    /// Updates variables to reflect the result and returns an error message to
+    /// be printed to the standard error.
+    ///
+    /// The `colon` parameter must be `true` if and only if the option
+    /// specification starts with a colon (`:`).
+    ///
+    /// This method updates `$OPTIND`, `$OPTARG`, and the variable named by
+    /// `var_name` to reflect the result. If the result is an error and `colon`
+    /// is `false`, this method returns an error message. Otherwise, this method
+    /// returns an empty string.
+    pub fn report(self, env: &mut Env, colon: bool, var_name: Field) -> Result<String, Error> {
+        let location = env.stack.current_builtin().map(|b| b.name.origin.clone());
+
+        let (var_value, optarg, message) = match self.error {
+            None => (self.option.to_string(), self.argument, String::new()),
+
+            Some(model::Error::UnknownOption) if colon => (
+                "?".to_string(),
+                Some(self.option.to_string()),
+                String::new(),
+            ),
+
+            Some(model::Error::MissingArgument) if colon => (
+                ":".to_string(),
+                Some(self.option.to_string()),
+                String::new(),
+            ),
+
+            Some(model::Error::UnknownOption) => {
+                let message = format!("{}: invalid option `-{}`\n", env.arg0, self.option);
+                ("?".to_string(), None, message)
+            }
+
+            Some(model::Error::MissingArgument) => {
+                let message = format!(
+                    "{}: option `-{}` requires an argument\n",
+                    env.arg0, self.option
+                );
+                ("?".to_string(), None, message)
+            }
+        };
+
+        env.get_or_create_variable(var_name.value.clone(), Scope::Global)
+            .assign(var_value, var_name.origin)
+            .map_err(|e| Error::with_name_and_assign_error(var_name.value.clone(), e))?;
+
+        if let Some(value) = optarg {
+            env.get_or_create_variable("OPTARG", Scope::Global)
+                .assign(value, location.clone())
+                .map_err(|e| Error::with_name_and_assign_error("OPTARG".to_string(), e))?;
+        } else {
+            env.variables.unset(Scope::Global, "OPTARG")?;
+        }
+
+        let optind = indexes_to_optind(self.next_arg_index, self.next_char_index);
+        env.get_or_create_variable("OPTIND", Scope::Global)
+            .assign(optind, location)
+            .map_err(|e| Error::with_name_and_assign_error("OPTIND".to_string(), e))?;
+
+        Ok(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use std::num::NonZeroUsize;
+    use yash_env::stack::Builtin;
+    use yash_env::stack::Frame;
+    use yash_env::variable::Value;
+    use yash_env::variable::Variable;
+    use yash_syntax::source::Location;
+
+    fn non_zero(i: usize) -> NonZeroUsize {
+        NonZeroUsize::new(i).unwrap()
+    }
+
+    fn env_with_dummy_arg0_and_optarg() -> Env {
+        let mut env = Env::new_virtual();
+        env.arg0 = "some/arg0".to_string();
+        env.get_or_create_variable("OPTARG", Scope::Global)
+            .assign("DUMMY", None)
+            .unwrap();
+        env
+    }
+
+    fn assert_variable_scalar(env: &Env, name: &str, value: &str) {
+        assert_matches!(
+            &env.variables.get(name),
+            Some(Variable { value: Some(Value::Scalar(s)), .. }) if s == value,
+            "expected ${name} == {value:?}",
+        );
+    }
+
+    fn assert_variable_none(env: &Env, name: &str) {
+        assert_matches!(env.variables.get(name), None, "expected ${name} unset");
+    }
+
+    #[test]
+    fn report_standard_result() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert_eq!(message, "");
+        assert_variable_scalar(&env, "opt_var", "a");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_none(&env, "OPTARG");
+    }
+
+    #[test]
+    fn name_and_location_of_reported_variable() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'b',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+        let var_name = Field {
+            value: "RESULT_VARIABLE".to_string(),
+            origin: Location::dummy("my dummy location"),
+        };
+
+        let _message = result.report(&mut env, false, var_name.clone()).unwrap();
+
+        let var = env.variables.get(&var_name.value).unwrap();
+        assert_matches!(&var.value, Some(Value::Scalar(s)) if s == "b");
+        assert_eq!(var.last_assigned_location, Some(var_name.origin));
+    }
+
+    #[test]
+    fn location_of_reported_optind() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let location = Location::dummy("invocation location");
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
+            name: Field {
+                value: "my_builtin".to_string(),
+                origin: location.clone(),
+            },
+            is_special: false,
+        }));
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let _message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        let optind = env.variables.get("OPTIND").unwrap();
+        assert_matches!(&optind.value, Some(Value::Scalar(s)) if s == "2");
+        assert_eq!(optind.last_assigned_location, Some(location));
+    }
+
+    #[test]
+    fn location_of_reported_optarg() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let location = Location::dummy("invocation location");
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
+            name: Field {
+                value: "my_builtin".to_string(),
+                origin: location.clone(),
+            },
+            is_special: false,
+        }));
+        let result = model::Result {
+            option: 'a',
+            argument: Some("some argument".to_string()),
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let _message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        let optind = env.variables.get("OPTARG").unwrap();
+        assert_matches!(&optind.value, Some(Value::Scalar(s)) if s == "some argument");
+        assert_eq!(optind.last_assigned_location, Some(location));
+    }
+
+    #[test]
+    fn report_with_option_argument() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: Some("foo".to_string()),
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert_eq!(message, "");
+        assert_variable_scalar(&env, "opt_var", "a");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_scalar(&env, "OPTARG", "foo");
+    }
+
+    #[test]
+    fn report_with_next_char_index_other_than_one() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(4),
+            next_char_index: non_zero(3),
+            error: None,
+        };
+
+        let message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert_eq!(message, "");
+        assert_variable_scalar(&env, "opt_var", "a");
+        assert_variable_scalar(&env, "OPTIND", "4:3");
+        assert_variable_none(&env, "OPTARG");
+    }
+
+    #[test]
+    fn report_unknown_option_with_colon() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: Some(model::Error::UnknownOption),
+        };
+
+        let message = result
+            .report(&mut env, true, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert_eq!(message, "");
+        assert_variable_scalar(&env, "opt_var", "?");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_scalar(&env, "OPTARG", "a");
+    }
+
+    #[test]
+    fn report_unknown_option_without_colon() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: Some(model::Error::UnknownOption),
+        };
+
+        let message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert!(message.starts_with(&env.arg0), "message = {message:?}");
+        assert!(message.contains("-a"), "message = {message:?}");
+        assert!(message.contains("invalid"), "message = {message:?}");
+        assert_variable_scalar(&env, "opt_var", "?");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_none(&env, "OPTARG");
+    }
+
+    #[test]
+    fn report_missing_argument_with_colon() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: Some(model::Error::MissingArgument),
+        };
+
+        let message = result
+            .report(&mut env, true, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert_eq!(message, "");
+        assert_variable_scalar(&env, "opt_var", ":");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_scalar(&env, "OPTARG", "a");
+    }
+
+    #[test]
+    fn report_missing_argument_without_colon() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: Some(model::Error::MissingArgument),
+        };
+
+        let message = result
+            .report(&mut env, false, Field::dummy("opt_var"))
+            .unwrap();
+
+        assert!(message.starts_with(&env.arg0), "message = {message:?}");
+        assert!(message.contains("-a"), "message = {message:?}");
+        assert!(message.contains("argument"), "message = {message:?}");
+        assert_variable_scalar(&env, "opt_var", "?");
+        assert_variable_scalar(&env, "OPTIND", "2");
+        assert_variable_none(&env, "OPTARG");
+    }
+
+    #[test]
+    fn report_with_readonly_optind() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let invocation_location = Location::dummy("invocation location");
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
+            name: Field {
+                value: "my_builtin".to_string(),
+                origin: invocation_location.clone(),
+            },
+            is_special: false,
+        }));
+        let mut optind = env.get_or_create_variable("OPTIND", Scope::Global);
+        let read_only_location = Location::dummy("read-only location");
+        optind.make_read_only(read_only_location.clone());
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let result = result.report(&mut env, false, Field::dummy("opt_var"));
+
+        assert_eq!(
+            result,
+            Err(Error::AssignReadOnlyError {
+                name: "OPTIND".to_string(),
+                new_value: Value::scalar("2"),
+                assigned_location: Some(invocation_location),
+                read_only_location,
+            })
+        );
+    }
+
+    #[test]
+    fn report_with_readonly_optarg_to_be_assigned() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let invocation_location = Location::dummy("invocation location");
+        let mut env = env.push_frame(Frame::Builtin(Builtin {
+            name: Field {
+                value: "my_builtin".to_string(),
+                origin: invocation_location.clone(),
+            },
+            is_special: false,
+        }));
+        let mut optarg = env.get_or_create_variable("OPTARG", Scope::Global);
+        let read_only_location = Location::dummy("read-only location");
+        optarg.make_read_only(read_only_location.clone());
+        let result = model::Result {
+            option: 'a',
+            argument: Some("some argument".to_string()),
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let result = result.report(&mut env, false, Field::dummy("opt_var"));
+
+        assert_eq!(
+            result,
+            Err(Error::AssignReadOnlyError {
+                name: "OPTARG".to_string(),
+                new_value: Value::scalar("some argument"),
+                assigned_location: Some(invocation_location),
+                read_only_location,
+            })
+        );
+    }
+
+    #[test]
+    fn report_with_readonly_optarg_to_be_unset() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let mut optarg = env.get_or_create_variable("OPTARG", Scope::Global);
+        let read_only_location = Location::dummy("read-only location");
+        optarg.make_read_only(read_only_location.clone());
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+
+        let result = result.report(&mut env, false, Field::dummy("opt_var"));
+
+        assert_eq!(
+            result,
+            Err(Error::UnsetReadOnlyError {
+                name: "OPTARG".to_string(),
+                read_only_location,
+            })
+        );
+    }
+
+    #[test]
+    fn report_with_readonly_option_var() {
+        let mut env = env_with_dummy_arg0_and_optarg();
+        let mut optarg = env.get_or_create_variable("var", Scope::Global);
+        let read_only_location = Location::dummy("read-only location");
+        optarg.make_read_only(read_only_location.clone());
+        let result = model::Result {
+            option: 'a',
+            argument: None,
+            next_arg_index: non_zero(2),
+            next_char_index: non_zero(1),
+            error: None,
+        };
+        let var_location = Location::dummy("var location");
+        let var = Field {
+            value: "var".to_string(),
+            origin: var_location.clone(),
+        };
+
+        let result = result.report(&mut env, false, var);
+
+        assert_eq!(
+            result,
+            Err(Error::AssignReadOnlyError {
+                name: "var".to_string(),
+                new_value: Value::scalar("a"),
+                assigned_location: Some(var_location),
+                read_only_location,
+            })
+        );
+    }
+}

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -56,6 +56,7 @@ pub mod eval;
 pub mod exec;
 pub mod exit;
 pub mod export;
+pub mod getopts;
 pub mod jobs;
 pub mod pwd;
 pub mod readonly;

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -158,6 +158,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         },
     ),
     (
+        "getopts",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(getopts::main(env, args)),
+        },
+    ),
+    (
         "jobs",
         Builtin {
             r#type: Mandatory,

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -132,6 +132,11 @@ fn function() {
 }
 
 #[test]
+fn getopts_builtin() {
+    run("getopts-p.sh")
+}
+
+#[test]
 fn grouping() {
     run("grouping-p.sh")
 }

--- a/yash/tests/scripted_test/getopts-p.sh
+++ b/yash/tests/scripted_test/getopts-p.sh
@@ -1,0 +1,252 @@
+# getopts-p.sh: test of the getopts built-in for any POSIX-compliant shell
+
+posix="true"
+
+test_o 'default OPTIND is 1'
+printf '%s\n' "$OPTIND"
+__IN__
+1
+__OUT__
+
+test_o 'OPTIND and OPTARG are not exported by default'
+getopts a: o -a arg
+getopts a: o -a arg
+sh -c 'echo ${OPTIND-unset} ${OPTARG-unset}'
+__IN__
+1 unset
+__OUT__
+
+test_o 'operand variable is updated to parsed option on each invocation'
+getopts ab:c o -a -b arg -c
+printf '1[%s]\n' "$o"
+getopts ab:c o -a -b arg -c
+printf '2[%s]\n' "$o"
+getopts ab:c o -a -b arg -c
+printf '3[%s]\n' "$o"
+__IN__
+1[a]
+2[b]
+3[c]
+__OUT__
+
+test_x -e 0 'exit status is zero after option is parsed' -e
+getopts ab:c o -a -b arg -c
+getopts ab:c o -a -b arg -c
+getopts ab:c o -a -b arg -c
+__IN__
+
+test_x -e n 'exit status is non-zero after parsing all options' -e
+getopts ab:c o -a -b arg -c
+getopts ab:c o -a -b arg -c
+getopts ab:c o -a -b arg -c
+getopts ab:c o -a -b arg -c
+__IN__
+
+test_o 'OPTARG is set when option argument is parsed: empty'
+getopts a: o -a ''
+echo "[$OPTARG]"
+__IN__
+[]
+__OUT__
+
+test_o 'OPTARG is set when option argument is parsed: non-empty separate'
+getopts a: o -a '-x  foo'
+echo "[$OPTARG]"
+__IN__
+[-x  foo]
+__OUT__
+
+test_o 'OPTARG is set when option argument is parsed: non-empty adjoined'
+getopts a: o -a'  foo'
+echo "[$OPTARG]"
+__IN__
+[  foo]
+__OUT__
+
+test_o 'OPTARG is unset when option without argument is parsed'
+getopts a o -a
+echo "${OPTARG-un}${OPTARG-set}"
+__IN__
+unset
+__OUT__
+
+test_o 'operand variable is set to "?" on unknown option'
+getopts '' o -a
+printf '[%s]\n' "$o"
+__IN__
+[?]
+__OUT__
+
+test_o 'OPTARG is set to the option on unknown option (with :)'
+getopts : o -a
+printf '[%s]\n' "$OPTARG"
+__IN__
+[a]
+__OUT__
+
+test_E 'no error message on unknown option (with :)'
+getopts : o -a
+__IN__
+
+test_o 'OPTARG is unset on unknown option (without :)'
+getopts '' o -a
+printf '%s\n' "${OPTARG-un}${OPTARG-set}"
+__IN__
+unset
+__OUT__
+
+test_x -d 'error message is printed on unknown option (without :)'
+getopts '' o -a
+__IN__
+
+test_o 'operand variable is set to ":" on missing option argument (with :)'
+getopts :a: v -a
+printf '[%s]\n' "$v"
+__IN__
+[:]
+__OUT__
+
+test_o 'OPTARG is set to the option on missing option argument (with :)'
+getopts :a: v -a
+printf '[%s]\n' "$OPTARG"
+__IN__
+[a]
+__OUT__
+
+test_o 'operand variable is set to "?" on missing option argument (without :)'
+getopts a: v -a
+printf '[%s]\n' "$v"
+__IN__
+[?]
+__OUT__
+
+test_o 'OPTARG is unset on missing option argument (without :)'
+getopts a: v -a
+printf '%s\n' "${OPTARG-un}${OPTARG-set}"
+__IN__
+unset
+__OUT__
+
+test_x -d 'error message is printed on missing option argument (without :)'
+getopts a: v -a
+__IN__
+
+test_o 'operand variable is set to "?" after parsing all options'
+getopts a x -a
+getopts a x -a
+printf '[%s]\n' "$x"
+__IN__
+[?]
+__OUT__
+
+test_o 'OPTARG is unset after parsing all options'
+getopts a x -a
+getopts a x -a
+printf '%s\n' "${OPTARG-un}${OPTARG-set}"
+__IN__
+unset
+__OUT__
+
+test_o 'options can be grouped after single hyphen'
+getopts abc o -abc
+printf '1[%s]\n' "$o"
+getopts abc o -abc
+printf '2[%s]\n' "$o"
+getopts abc o -abc
+printf '3[%s]\n' "$o"
+getopts abc o -abc
+printf '4[%s]\n' "$o"
+__IN__
+1[a]
+2[b]
+3[c]
+4[?]
+__OUT__
+
+test_x -e n 'single hyphen is not option'
+getopts '' x -
+__IN__
+
+test_o 'double hyphen separates options and operands'
+getopts ab x -a -- -b
+printf '1[%s]\n' "$x"
+getopts ab x -a -- -b ||
+printf '2[%d]\n' "$OPTIND"
+__IN__
+1[a]
+2[3]
+__OUT__
+
+test_o 'OPTIND is first operand index after parsing all options: no operand, no --'
+getopts '' x
+printf '%d\n' "$OPTIND"
+__IN__
+1
+__OUT__
+
+test_o 'OPTIND is first operand index after parsing all options: one operand, no --'
+getopts '' x operand
+printf '%d\n' "$OPTIND"
+__IN__
+1
+__OUT__
+
+test_o 'OPTIND is first operand index after parsing all options: no operand, with --'
+getopts '' x --
+printf '%d\n' "$OPTIND"
+__IN__
+2
+__OUT__
+
+test_o 'OPTIND is first operand index after parsing all options: one operand, with --'
+getopts '' x -- operand
+printf '%d\n' "$OPTIND"
+__IN__
+2
+__OUT__
+
+test_o 'resetting OPTIND to parse another arguments'
+getopts ab p -a -b
+getopts ab p -a -b
+getopts ab p -a -b
+OPTIND=1
+getopts xy q -x -y
+printf '1[%s]\n' "$q"
+getopts xy q -x -y
+printf '2[%s]\n' "$q"
+getopts xy q -x -y
+printf '3[%d]\n' "$OPTIND"
+__IN__
+1[x]
+2[y]
+3[3]
+__OUT__
+
+test_o 'positional parameters are parsed by default' -s -- -a -b arg -c
+getopts ab:c o
+printf '1[%s]\n' "$o"
+getopts ab:c o
+printf '2[%s]\n' "$o"
+getopts ab:c o
+printf '3[%s]\n' "$o"
+__IN__
+1[a]
+2[b]
+3[c]
+__OUT__
+
+test_o 'option characters are alphanumeric'
+getopts ab:01: o -a -b arg -1 -2 -0
+printf '1[%s]\n' "$o"
+getopts ab:01: o -a -b arg -1 -2 -0
+printf '2[%s]\n' "$o"
+getopts ab:01: o -a -b arg -1 -2 -0
+printf '3[%s]\n' "$o"
+getopts ab:01: o -a -b arg -1 -2 -0
+printf '4[%s]\n' "$o"
+__IN__
+1[a]
+2[b]
+3[1]
+4[0]
+__OUT__


### PR DESCRIPTION
This is a mostly correct implementation of the getopts built-in.
The implementation is incorrect in that it does not update `$OPTIND` to the expected value after seeing the `--` separator.
