### PR TITLE
Unalias built-in (POSIX only)

### DIFF
--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -70,6 +70,7 @@ pub mod shift;
 pub mod source;
 pub mod trap;
 pub mod typeset;
+pub mod unalias;
 pub mod unset;
 pub mod wait;
 
@@ -237,6 +238,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Elective,
             execute: |env, args| Box::pin(typeset::main(env, args)),
+        },
+    ),
+    (
+        "unalias",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(unalias::main(env, args)),
         },
     ),
     (

--- a/yash-builtin/src/unalias.rs
+++ b/yash-builtin/src/unalias.rs
@@ -1,0 +1,89 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Unalias built-in
+//!
+//! The **`unalias`** built-in removes alias definitions.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! unalias name…
+//! ```
+//!
+//! ```sh
+//! unalias -a
+//! ```
+//!
+//! # Description
+//!
+//! The unalias built-in removes alias definitions as specified by the operands.
+//!
+//! # Options
+//!
+//! The **`-a`** (**`--all`**) option removes all alias definitions.
+//!
+//! # Operands
+//!
+//! Each operand must be the name of an alias to remove.
+//!
+//! # Errors
+//!
+//! It is an error if an operand names a non-existent alias.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Portability
+//!
+//! The unalias built-in is specified in POSIX.
+//!
+//! Some shells implement some built-in utilities as predefined aliases. Using
+//! `unalias -a` may make such built-ins unavailable.
+
+use crate::common::report_error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Parsed command arguments for the `unalias` built-in
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Command {
+    /// Remove specified aliases
+    Remove(Vec<Field>),
+    /// Remove all aliases
+    RemoveAll,
+}
+
+pub mod semantics;
+pub mod syntax;
+
+/// Entry point for executing the `unalias` built-in
+pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
+    match syntax::parse(env, args) {
+        Ok(command) => {
+            let errors = command.execute(env);
+
+            let mut result = crate::Result::default();
+            for error in errors {
+                result = result.max(report_error(env, &error).await);
+            }
+            result
+        }
+
+        Err(e) => report_error(env, e.to_message()).await,
+    }
+}

--- a/yash-builtin/src/unalias/semantics.rs
+++ b/yash-builtin/src/unalias/semantics.rs
@@ -1,0 +1,168 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Core runtime behavior of the `unalias` built-in
+
+use super::Command;
+use std::borrow::Cow;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::MessageBase;
+
+/// Errors that can occur while executing the `unalias` built-in
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum Error {
+    /// The operand names a non-existent alias.
+    #[error("no such alias `{0}`")]
+    UndefinedAlias(Field),
+}
+
+impl MessageBase for Error {
+    fn message_title(&self) -> Cow<str> {
+        "cannot remove alias".into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        match self {
+            Error::UndefinedAlias(alias) => Annotation::new(
+                AnnotationType::Error,
+                format!("no such alias `{alias}`").into(),
+                &alias.origin,
+            ),
+        }
+    }
+}
+
+impl Command {
+    /// Executes the `unalias` built-in.
+    ///
+    /// Returns a list of errors that occurred while executing the built-in.
+    #[must_use]
+    pub fn execute(self, env: &mut Env) -> Vec<Error> {
+        match self {
+            Command::RemoveAll => {
+                env.aliases.clear();
+                vec![]
+            }
+            Command::Remove(operands) => operands
+                .into_iter()
+                .filter(|operand| !env.aliases.remove(operand.value.as_str()))
+                .map(Error::UndefinedAlias)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yash_syntax::alias::HashEntry;
+    use yash_syntax::source::Location;
+
+    #[test]
+    fn remove_all() {
+        let mut env = Env::new_virtual();
+        env.aliases.insert(HashEntry::new(
+            "foo".into(),
+            "FOO".into(),
+            false,
+            Location::dummy("foo location"),
+        ));
+        env.aliases.insert(HashEntry::new(
+            "bar".into(),
+            "BAR".into(),
+            false,
+            Location::dummy("bar location"),
+        ));
+
+        let errors = Command::RemoveAll.execute(&mut env);
+
+        assert_eq!(errors, []);
+        assert_eq!(env.aliases.len(), 0, "remaining: {:?}", env.aliases);
+    }
+
+    #[test]
+    fn remove_some() {
+        let mut env = Env::new_virtual();
+        env.aliases.insert(HashEntry::new(
+            "foo".into(),
+            "FOO".into(),
+            false,
+            Location::dummy("foo location"),
+        ));
+        let bar = HashEntry::new(
+            "bar".into(),
+            "BAR".into(),
+            false,
+            Location::dummy("bar location"),
+        );
+        env.aliases.insert(bar.clone());
+        env.aliases.insert(HashEntry::new(
+            "baz".into(),
+            "BAZ".into(),
+            false,
+            Location::dummy("baz location"),
+        ));
+        let names = Field::dummies(["foo", "baz"]);
+
+        let errors = Command::Remove(names).execute(&mut env);
+
+        assert_eq!(errors, []);
+        let aliases = env.aliases.into_iter().collect::<Vec<_>>();
+        assert_eq!(aliases, [bar]);
+    }
+
+    #[test]
+    fn remove_undefined() {
+        let mut env = Env::new_virtual();
+        env.aliases.insert(HashEntry::new(
+            "foo".into(),
+            "FOO".into(),
+            false,
+            Location::dummy("foo location"),
+        ));
+        let bar = HashEntry::new(
+            "bar".into(),
+            "BAR".into(),
+            false,
+            Location::dummy("bar location"),
+        );
+        env.aliases.insert(bar.clone());
+        env.aliases.insert(HashEntry::new(
+            "baz".into(),
+            "BAZ".into(),
+            false,
+            Location::dummy("baz location"),
+        ));
+        let names = Field::dummies(["foo", "gar", "baz", "qux"]);
+
+        let errors = Command::Remove(names).execute(&mut env);
+
+        assert_eq!(
+            errors,
+            [
+                Error::UndefinedAlias(Field::dummy("gar")),
+                Error::UndefinedAlias(Field::dummy("qux")),
+            ]
+        );
+        // Despite the errors, the existing aliases are removed.
+        let aliases = env.aliases.into_iter().collect::<Vec<_>>();
+        assert_eq!(aliases, [bar]);
+    }
+}

--- a/yash-builtin/src/unalias/syntax.rs
+++ b/yash-builtin/src/unalias/syntax.rs
@@ -1,0 +1,129 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command line argument parsing for the `unalias` built-in
+
+use super::Command;
+use crate::common::syntax::parse_arguments;
+use crate::common::syntax::Mode;
+use crate::common::syntax::OptionSpec;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::Message;
+use yash_syntax::source::Location;
+
+/// List of all options supported by the `unalias` built-in
+pub const OPTION_SPECS: &[OptionSpec] = &[OptionSpec::new().short('a')];
+
+/// Errors that can occur while parsing command line arguments
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum Error {
+    /// An error occurred while parsing arguments.
+    #[error(transparent)]
+    CommonError(#[from] crate::common::syntax::ParseError<'static>),
+
+    /// The `-a` option was specified with other operands.
+    #[error("cannot specify `-a` with other operands")]
+    ExclusiveOptionAndOperand(Location),
+
+    /// No option or operand was specified.
+    #[error("no option or operand specified")]
+    MissingArgument,
+}
+
+impl Error {
+    /// Converts the error into a [`Message`].
+    pub fn to_message(&self) -> Message {
+        let (title, annotations) = match self {
+            Error::CommonError(e) => return e.into(),
+
+            Error::ExclusiveOptionAndOperand(location) => (
+                "cannot specify `-a` with other operands".into(),
+                vec![Annotation::new(
+                    AnnotationType::Error,
+                    "cannot specify `-a` with other operands".into(),
+                    location,
+                )],
+            ),
+
+            Error::MissingArgument => ("no option or operand specified".into(), vec![]),
+        };
+
+        Message {
+            r#type: AnnotationType::Error,
+            title,
+            annotations,
+        }
+    }
+}
+
+/// Parses command line arguments for the `unalias` built-in.
+pub fn parse(env: &Env, args: Vec<Field>) -> Result<Command, Error> {
+    let mode = Mode::with_env(env);
+    let (mut options, operands) = parse_arguments(OPTION_SPECS, mode, args)?;
+
+    for option in &options {
+        debug_assert_eq!(option.spec.get_short(), Some('a'));
+    }
+
+    match (options.pop(), operands.is_empty()) {
+        (None, true) => Err(Error::MissingArgument),
+        (None, false) => Ok(Command::Remove(operands)),
+        (Some(_), true) => Ok(Command::RemoveAll),
+        (Some(option), false) => Err(Error::ExclusiveOptionAndOperand(option.location)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-a"]));
+        assert_eq!(result, Ok(Command::RemoveAll));
+    }
+
+    #[test]
+    fn operands() {
+        let env = Env::new_virtual();
+        let operands = Field::dummies(["foo", "bar"]);
+        let result = parse(&env, operands.clone());
+        assert_eq!(result, Ok(Command::Remove(operands)));
+    }
+
+    #[test]
+    fn missing_arguments() {
+        let env = Env::new_virtual();
+        let result = parse(&env, vec![]);
+        assert_eq!(result, Err(Error::MissingArgument));
+    }
+
+    #[test]
+    fn option_and_operand() {
+        let env = Env::new_virtual();
+        let args = Field::dummies(["-a", "foo"]);
+        let result = parse(&env, args);
+        assert_eq!(
+            result,
+            Err(Error::ExclusiveOptionAndOperand(Location::dummy("-a"))),
+        );
+    }
+}

--- a/yash/tests/scripted_test/alias-p.sh
+++ b/yash/tests/scripted_test/alias-p.sh
@@ -31,26 +31,22 @@ __IN__
 BCD
 __OUT__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE -e 0 'removing specific alias - exit status'
 alias true=false
 unalias true
 __IN__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE -e 0 'removing specific alias - removal'
 alias true=false
 unalias true
 true
 __IN__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE -e 0 'removing multiple aliases - exit status'
 alias true=a cat=b echo=c
 unalias true cat echo
 __IN__
 
-: TODO Needs the unalias built-in <<\__OUT__
 test_oE -e 0 'removing multiple aliases - removal'
 alias true=a cat=b echo=c
 unalias true cat echo
@@ -60,13 +56,11 @@ __IN__
 ok
 __OUT__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE -e 0 'removing all aliases - exit status'
 alias a=a b=b c=c
 unalias -a
 __IN__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE 'removing all aliases - removal'
 alias a=a b=b c=c
 unalias -a
@@ -77,7 +71,6 @@ test_OE -e 0 'printing specific alias'
 alias a | grep -q '^a='
 __IN__
 
-: TODO Needs the unalias built-in <<\__OUT__
 test_oE -e 0 'reusing printed alias (simple)'
 save="$(alias a)"
 unalias a
@@ -87,7 +80,6 @@ __IN__
 ABC
 __OUT__
 
-: TODO Needs the unalias built-in <<\__OUT__
 test_oE -e 0 'reusing printed alias (complex quotation)'
 alias a='printf %s\\n \"['\\\'{'\\'}\\\'']\"'
 save="$(alias a)"
@@ -98,7 +90,6 @@ __IN__
 "['{\}']"
 __OUT__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_OE -e 0 'printing all aliases'
 alias b=b c=c e='echo OK'
 alias >save_alias_1
@@ -121,13 +112,11 @@ __IN__
 ABC
 __OUT__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_O -d -e n 'printing undefined alias is error'
 unalias -a
 alias a
 __IN__
 
-: TODO Needs the unalias built-in <<\__IN__
 test_O -d -e n 'removing undefined alias is error'
 alias true=false
 unalias true

--- a/yash/tests/scripted_test/quote-p.sh
+++ b/yash/tests/scripted_test/quote-p.sh
@@ -428,7 +428,6 @@ __IN__
 echo ]]
 __OUT__
 
-: TODO Needs the unalias built-in <<\__OUT__
 test_oE 'aliases are ignored in command substitution in double quotes'
 alias echo=')'
 f() { bracket "$(echo x)"; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated a new `unalias` built-in command for removing existing aliases.

- **Enhancements**
  - Improved error handling for non-existent aliases within the `unalias` command.

- **Documentation**
  - Added descriptions and usage information for the `unalias` built-in command.

- **Tests**
  - Implemented new test cases for the `unalias` functionality, covering scenarios such as removing specific aliases and handling undefined aliases.

- **Bug Fixes**
  - Resolved issues related to alias removal in scripted tests, leading to more reliable behavior when using the `unalias` command in scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->