### PR TITLE
Fg & bg built-ins

### DIFF
--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -86,6 +86,7 @@ use crate::common::to_single_message;
 use std::borrow::Cow;
 use std::fmt::Display;
 use thiserror::Error;
+use yash_env::io::Fd;
 use yash_env::job::fmt::Marker;
 use yash_env::job::fmt::Report;
 use yash_env::job::id::parse;
@@ -103,7 +104,6 @@ use yash_env::System;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::MessageBase;
-use yash_syntax::syntax::Fd;
 
 /// Errors that may occur when resuming a job
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -178,6 +178,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeEr
     };
     let line = format!("[{}] {}\n", report.number(), job.name);
     env.system.write_all(Fd::STDOUT, line.as_bytes()).await?;
+    drop(line);
 
     if is_alive(job.status) {
         let pgid = Pid::from_raw(-job.pid.as_raw());

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -1,0 +1,79 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Bg built-in
+//!
+//! The **`bg`** built-in resumes a suspended job in the background.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! bg [job_id…]
+//! ```
+//!
+//! # Description
+//!
+//! The built-in resumes the specified jobs by sending the `SIGCONT` signal to
+//! them.
+//!
+//! # Options
+//!
+//! None.
+//!
+//! # Operands
+//!
+//! Operands specify which jobs to resume. See the module documentation of
+//! [`yash_env::job::id`] for the format of job IDs. If omitted, the built-in
+//! resumes the [current job](JobSet::current_job).
+//!
+//! (TODO: allow omitting the leading `%`)
+//!
+//! # Standard output
+//!
+//! The built-in writes the job number and name of each resumed job to the
+//! standard output.
+//!
+//! # Errors
+//!
+//! This built-in can be used only when the [`Monitor`] option is set.
+//!
+//! It is an error if the specified job is not found.
+//!
+//! # Exit status
+//!
+//! Zero unless an error occurs.
+//!
+//! # Portability
+//!
+//! Many implementations allow omitting the leading `%` from job IDs, though it
+//! is not required by POSIX.
+//!
+//! # Implementation notes
+//!
+//! This implementation sends the `SIGCONT` signal even to jobs that are already
+//! running.
+//!
+//! [`Monitor`]: yash_env::option::Monitor
+
+#[cfg(doc)]
+use yash_env::job::JobSet;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Entry point of the `bg` built-in
+pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
+    todo!()
+}

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -188,7 +188,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
                 Err(error) => report_simple_failure(env, &error.to_string()).await,
             }
         } else {
-            todo!("there is no job, error")
+            report_simple_failure(env, "there is no job").await
         }
     } else {
         let mut errors = Vec::new();
@@ -325,7 +325,18 @@ mod tests {
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
     }
 
-    // TODO main_without_operands_fails_if_there_is_no_current_job
+    #[test]
+    fn main_without_operands_fails_if_there_is_no_current_job() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Box::new(system.clone()));
+
+        let result = main(&mut env, vec![]).now_or_never().unwrap();
+        assert_eq!(result, crate::Result::from(ExitStatus::FAILURE));
+
+        assert_stderr(&system.state, |stderr| {
+            assert!(stderr.contains("there is no job"), "{stderr:?}");
+        });
+    }
 
     #[test]
     fn main_with_operands_resumes_specified_jobs() {

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -68,12 +68,141 @@
 //!
 //! [`Monitor`]: yash_env::option::Monitor
 
+use crate::common::report_error;
+use crate::common::report_failure;
+use crate::common::report_simple_failure;
+use crate::common::syntax::parse_arguments;
+use crate::common::syntax::Mode;
+use crate::common::to_single_message;
+use std::borrow::Cow;
+use std::fmt::Display;
+use thiserror::Error;
+use yash_env::job::fmt::Marker;
+use yash_env::job::fmt::Report;
+use yash_env::job::id::parse;
+use yash_env::job::id::FindError;
+use yash_env::job::id::ParseError;
 #[cfg(doc)]
 use yash_env::job::JobSet;
+use yash_env::job::Pid;
 use yash_env::semantics::Field;
+use yash_env::system::Errno;
+use yash_env::trap::Signal;
 use yash_env::Env;
+use yash_env::System;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::MessageBase;
+use yash_syntax::syntax::Fd;
+
+/// Errors that may occur when resuming a job
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+enum ResumeError {
+    #[error("target job is not job-controlled")]
+    Unmonitored,
+    #[error("system error: {0}")]
+    SystemError(#[from] Errno),
+}
+
+/// Errors that may occur when processing an operand
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+enum OperandErrorKind {
+    /// The operand is not a job ID.
+    #[error(transparent)]
+    InvalidJobId(#[from] ParseError),
+    /// The job ID does not specify a single job.
+    #[error(transparent)]
+    UnidentifiedJob(#[from] FindError),
+    /// The job cannot be resumed.
+    #[error(transparent)]
+    CannotResume(#[from] ResumeError),
+}
+
+/// An operand and the error that occurred when processing it
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+struct OperandError(Field, OperandErrorKind);
+
+impl Display for OperandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.0.value, self.1)
+    }
+}
+
+impl MessageBase for OperandError {
+    fn message_title(&self) -> Cow<str> {
+        "cannot resume job".into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        let label = format!("{}: {}", self.0.value, self.1).into();
+        Annotation::new(AnnotationType::Error, label, &self.0.origin)
+    }
+}
+
+/// Resumes the job at the specified index.
+///
+/// This function panics if there is no job at the specified index.
+async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeError> {
+    let job = env.jobs.get_mut(index).unwrap();
+    if !job.job_controlled {
+        return Err(ResumeError::Unmonitored);
+    }
+
+    let report = Report {
+        index,
+        marker: Marker::None,
+        job: &job,
+    };
+    let line = format!("[{}] {}\n", report.number(), job.name);
+    env.system.write_all(Fd::STDOUT, line.as_bytes()).await?;
+
+    let pgid = Pid::from_raw(-job.pid.as_raw());
+    env.system.kill(pgid, Signal::SIGCONT.into())?;
+    // TODO Don't kill if the job is already dead.
+
+    // TODO env.jobs.set_current_job(index).ok();
+    // TODO Update the job status but reset the status_changed flag.
+    Ok(())
+}
+
+/// Resumes the job specified by the operand.
+async fn resume_job_by_id(env: &mut Env, job_id: &str) -> Result<(), OperandErrorKind> {
+    let job_id = parse(job_id)?;
+    let index = job_id.find(&env.jobs)?;
+    resume_job_by_index(env, index).await?;
+    Ok(())
+}
 
 /// Entry point of the `bg` built-in
-pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
-    todo!()
+pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
+    let (options, operands) = match parse_arguments(&[], Mode::with_env(env), args) {
+        Ok(result) => result,
+        Err(error) => return report_error(env, &error).await,
+    };
+    debug_assert_eq!(options, []);
+
+    if operands.is_empty() {
+        if let Some(index) = env.jobs.current_job() {
+            match resume_job_by_index(env, index).await {
+                Ok(()) => crate::Result::default(),
+                Err(error) => report_simple_failure(env, &error.to_string()).await,
+            }
+        } else {
+            todo!("there is no job, error")
+        }
+    } else {
+        let mut errors = Vec::new();
+        for operand in operands {
+            match resume_job_by_id(env, &operand.value).await {
+                Ok(()) => {}
+                Err(error) => errors.push(OperandError(operand, error)),
+            }
+        }
+        match to_single_message(&{ errors }) {
+            None => crate::Result::default(),
+            Some(message) => report_failure(env, message).await,
+        }
+    }
 }
+
+// TODO test

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -105,9 +105,11 @@ use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::MessageBase;
 
+// Some definitions in this module are shared with the `fg` built-in.
+
 /// Errors that may occur when resuming a job
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
-enum ResumeError {
+pub(crate) enum ResumeError {
     #[error("target job is not controlled by the current shell environment")]
     Unowned,
     #[error("target job is not job-controlled")]
@@ -118,7 +120,7 @@ enum ResumeError {
 
 /// Errors that may occur when processing an operand
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
-enum OperandErrorKind {
+pub(crate) enum OperandErrorKind {
     /// The operand is not a job ID.
     #[error(transparent)]
     InvalidJobId(#[from] ParseError),
@@ -152,7 +154,7 @@ impl MessageBase for OperandError {
 }
 
 /// Tests if the specified wait status indicates that the job is still alive.
-const fn is_alive(status: WaitStatus) -> bool {
+pub(crate) const fn is_alive(status: WaitStatus) -> bool {
     !matches!(
         status,
         WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _)

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -1,0 +1,86 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2023 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Fg built-in
+//!
+//! The **`fg`** resumes a suspended job in the foreground.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! fg [job_id]
+//! ```
+//!
+//! # Description
+//!
+//! The built-in brings the specified job to the foreground and resumes its
+//! execution by sending the `SIGCONT` signal to it. The built-in then waits for
+//! the job to finish (or suspend again).
+//!
+//! If the job gets suspended again, it is set as the [current
+//! job](JobSet::current_job).
+//!
+//! # Options
+//!
+//! None.
+//!
+//! # Operands
+//!
+//! Operand *job_id* specifies which job to resume. See the module documentation
+//! of [`yash_env::job::id`] for the format of job IDs. If omitted, the built-in
+//! resumes the [current job](JobSet::current_job).
+//!
+//! (TODO: allow omitting the leading `%`)
+//! (TODO: allow multiple operands)
+//!
+//! # Standard output
+//!
+//! The built-in writes the selected job name to the standard output.
+//!
+//! (TODO: print the job number as well)
+//!
+//! # Errors
+//!
+//! This built-in can be used only when the [`Monitor`] option is set.
+//!
+//! It is an error if the specified job is not found.
+//!
+//! # Exit status
+//!
+//! The built-in returns the exit status of the resumed job. On error, it
+//! returns a non-zero exit status.
+//!
+//! # Portability
+//!
+//! Many implementations allow omitting the leading `%` from job IDs and
+//! specifying multiple job IDs at once, though this is not required by POSIX.
+//!
+//! # Implementation notes
+//!
+//! This implementation sends the `SIGCONT` signal even if the job is already
+//! running.
+//!
+//! [`Monitor`]: yash_env::option::Monitor
+
+#[cfg(doc)]
+use yash_env::job::JobSet;
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Entry point of the `fg` built-in
+pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
+    todo!()
+}

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -54,9 +54,11 @@
 //!
 //! # Errors
 //!
-//! This built-in can be used only when the [`Monitor`] option is set.
+//! This built-in can be used only when the shell is in the foreground.
+//! Otherwise, the shell will be suspended.
 //!
-//! It is an error if the specified job is not found.
+//! The built-in fails if the specified job is not found, not job-controlled, or
+//! not [owned] by the current shell environment.
 //!
 //! # Exit status
 //!
@@ -70,17 +72,252 @@
 //!
 //! # Implementation notes
 //!
-//! This implementation sends the `SIGCONT` signal even if the job is already
-//! running.
+//! This implementation sends the `SIGCONT` signal even to jobs that are already
+//! running. The signal is not sent to jobs that have already terminated, to
+//! prevent unrelated processes that happen to have the same process IDs as the
+//! jobs from receiving the signal.
 //!
-//! [`Monitor`]: yash_env::option::Monitor
+//! [owned]: yash_env::job::Job::is_owned
 
+use crate::bg::is_alive;
+use crate::bg::OperandErrorKind;
+use crate::bg::ResumeError;
+use crate::common::report_error;
+use crate::common::report_simple_failure;
+use crate::common::syntax::parse_arguments;
+use crate::common::syntax::Mode;
+use yash_env::io::Fd;
+use yash_env::job::id::parse;
 #[cfg(doc)]
 use yash_env::job::JobSet;
+use yash_env::job::Pid;
+use yash_env::job::WaitStatus;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::system::Errno;
+use yash_env::system::System as _;
+use yash_env::system::SystemEx as _;
+use yash_env::trap::Signal;
 use yash_env::Env;
 
+/// Waits for the specified job to finish (or suspend again).
+async fn wait_while_running(env: &mut Env, pid: Pid) -> Result<WaitStatus, Errno> {
+    loop {
+        let status = env.wait_for_subshell(pid).await?;
+        match status {
+            WaitStatus::Continued(_) | WaitStatus::StillAlive => (),
+            _ => return Ok(status),
+        }
+    }
+}
+
+/// Resumes the job at the specified index.
+///
+/// This function puts the target job in the foreground and sends the `SIGCONT`
+/// signal to it. It then waits for the job to finish (or suspend again).
+///
+/// This function panics if there is no job at the specified index.
+async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<WaitStatus, ResumeError> {
+    let tty = env.get_tty()?;
+
+    let job = env.jobs.get(index).unwrap();
+    if !job.is_owned {
+        return Err(ResumeError::Unowned);
+    }
+    if !job.job_controlled {
+        return Err(ResumeError::Unmonitored);
+    }
+
+    let line = format!("{}\n", job.name);
+    env.system.write_all(Fd::STDOUT, line.as_bytes()).await?;
+    drop(line);
+
+    if !is_alive(job.status) {
+        return Ok(job.status);
+    }
+
+    // TODO Should we save/restore the terminal state?
+
+    // Make sure to put the target job in the foreground before sending the
+    // SIGCONT signal, or the job may be immediately re-suspended.
+    env.system.tcsetpgrp_without_block(tty, job.pid)?;
+
+    let pgid = Pid::from_raw(-job.pid.as_raw());
+    env.system.kill(pgid, Signal::SIGCONT.into())?;
+
+    // Wait for the job to finish (or suspend again).
+    let status = wait_while_running(env, job.pid).await?;
+
+    // Move the shell back to the foreground.
+    env.system.tcsetpgrp_with_block(tty, env.main_pgid)?;
+
+    Ok(status)
+}
+
+/// Resumes the job specified by the operand.
+async fn resume_job_by_id(env: &mut Env, job_id: &str) -> Result<WaitStatus, OperandErrorKind> {
+    let job_id = parse(job_id)?;
+    let index = job_id.find(&env.jobs)?;
+    Ok(resume_job_by_index(env, index).await?)
+}
+
 /// Entry point of the `fg` built-in
-pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
-    todo!()
+pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
+    let (options, operands) = match parse_arguments(&[], Mode::with_env(env), args) {
+        Ok(result) => result,
+        Err(error) => return report_error(env, &error).await,
+    };
+    debug_assert_eq!(options, []);
+
+    let result = if operands.is_empty() {
+        if let Some(index) = env.jobs.current_job() {
+            resume_job_by_index(env, index).await.map_err(Into::into)
+        } else {
+            return report_simple_failure(env, "there is no job").await;
+        }
+    } else if operands.len() > 1 {
+        // TODO Support multiple operands
+        return report_simple_failure(env, "too many operands").await;
+    } else {
+        resume_job_by_id(env, &operands[0].value).await
+    };
+
+    match result {
+        Ok(WaitStatus::Exited(_, exit_status)) => crate::Result::from(ExitStatus(exit_status)),
+        Ok(WaitStatus::Signaled(_, signal, _)) | Ok(WaitStatus::Stopped(_, signal)) => {
+            crate::Result::from(ExitStatus::from(signal))
+        }
+        Ok(wait_status) => unreachable!("unexpected wait status: {wait_status:?}"),
+        Err(error) => report_simple_failure(env, &error.to_string()).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::assert_stderr;
+    use crate::tests::stub_tty;
+    use futures_util::FutureExt as _;
+    use yash_env::job::Job;
+    use yash_env::system::r#virtual::Process;
+    use yash_env::system::r#virtual::ProcessState;
+    use yash_env::VirtualSystem;
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn resume_job_by_index_moves_job_to_foreground() {
+        // TODO Test resume_job_by_index_moves_job_to_foreground
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn resume_job_by_index_sends_sigcont() {
+        // TODO Test resume_job_by_index_sends_sigcont
+    }
+
+    #[test]
+    fn resume_job_by_index_prints_job_name() {
+        // TODO Test resume_job_by_index_prints_job_name
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn resume_job_by_index_returns_after_job_exits() {
+        // TODO Test resume_job_by_index_returns_after_job_exits
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn resume_job_by_index_returns_after_job_suspends() {
+        // TODO Test resume_job_by_index_returns_after_job_suspends
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn resume_job_by_index_moves_shell_back_to_foreground() {
+        // TODO resume_job_by_index_moves_shell_back_to_foreground
+    }
+
+    #[test]
+    fn resume_job_by_index_sends_no_sigcont_to_dead_process() {
+        let system = VirtualSystem::new();
+        stub_tty(&system.state);
+        let mut env = Env::with_system(Box::new(system.clone()));
+        let pid = Pid::from_raw(123);
+        let mut job = Job::new(pid);
+        job.job_controlled = true;
+        job.status = WaitStatus::Exited(pid, 0);
+        let index = env.jobs.add(job);
+        // This process (irrelevant to the job) happens to have the same PID as the job.
+        let mut process = Process::with_parent_and_group(system.process_id, pid);
+        _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        {
+            let mut state = system.state.borrow_mut();
+            state.processes.insert(pid, process);
+        }
+
+        resume_job_by_index(&mut env, index)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let state = system.state.borrow();
+        // The process should not be resumed.
+        assert_eq!(
+            state.processes[&pid].state(),
+            ProcessState::Stopped(Signal::SIGSTOP),
+        );
+    }
+
+    #[test]
+    fn resume_job_by_index_rejects_unowned_job() {
+        let system = VirtualSystem::new();
+        stub_tty(&system.state);
+        let mut env = Env::with_system(Box::new(system));
+        let mut job = Job::new(Pid::from_raw(123));
+        job.job_controlled = true;
+        job.is_owned = false;
+        let index = env.jobs.add(job);
+
+        let result = resume_job_by_index(&mut env, index).now_or_never().unwrap();
+        assert_eq!(result, Err(ResumeError::Unowned));
+    }
+
+    #[test]
+    fn resume_job_by_index_rejects_unmonitored_job() {
+        let system = VirtualSystem::new();
+        stub_tty(&system.state);
+        let mut env = Env::with_system(Box::new(system));
+        let index = env.jobs.add(Job::new(Pid::from_raw(123)));
+
+        let result = resume_job_by_index(&mut env, index).now_or_never().unwrap();
+        assert_eq!(result, Err(ResumeError::Unmonitored));
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn main_without_operands_resumes_current_job() {
+        // TODO Test main_without_operands_resumes_current_job
+    }
+
+    #[test]
+    fn main_without_operands_fails_if_there_is_no_current_job() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Box::new(system.clone()));
+
+        let result = main(&mut env, vec![]).now_or_never().unwrap();
+        assert_eq!(result, crate::Result::from(ExitStatus::FAILURE));
+
+        assert_stderr(&system.state, |stderr| {
+            assert!(stderr.contains("there is no job"), "{stderr:?}");
+        });
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn main_with_operand_resumes_specified_job() {
+        // TODO Test main_with_operands_resumes_specified_job
+    }
+
+    // TODO error cases with operands
 }

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -292,10 +292,10 @@ pub(crate) mod tests {
     use std::cell::RefCell;
     use std::future::Future;
     use std::pin::Pin;
-    #[cfg(feature = "yash-semantics")]
     use std::rc::Rc;
     use std::str::from_utf8;
     use yash_env::system::r#virtual::FileBody;
+    use yash_env::system::r#virtual::INode;
     use yash_env::system::r#virtual::SystemState;
     #[cfg(feature = "yash-semantics")]
     use yash_env::Env;
@@ -347,6 +347,14 @@ pub(crate) mod tests {
             shared_system.select(false).unwrap();
             SystemState::select_all(&state);
         }
+    }
+
+    pub fn stub_tty(state: &RefCell<SystemState>) {
+        state
+            .borrow_mut()
+            .file_system
+            .save("/dev/tty", Rc::new(RefCell::new(INode::new([]))))
+            .unwrap();
     }
 
     /// Helper function for asserting on the content of /dev/stdout.

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -47,6 +47,7 @@
 //! - `wait`
 
 pub mod alias;
+pub mod bg;
 pub mod r#break;
 pub mod cd;
 pub mod colon;
@@ -58,6 +59,7 @@ pub mod eval;
 pub mod exec;
 pub mod exit;
 pub mod export;
+pub mod fg;
 pub mod getopts;
 pub mod jobs;
 pub mod pwd;
@@ -113,6 +115,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         },
     ),
     (
+        "bg",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(bg::main(env, args)),
+        },
+    ),
+    (
         "break",
         Builtin {
             r#type: Special,
@@ -161,6 +170,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Special,
             execute: |env, args| Box::pin(export::main(env, args)),
+        },
+    ),
+    (
+        "fg",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(fg::main(env, args)),
         },
     ),
     (

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -130,13 +130,25 @@ pub struct Report<'a> {
     pub job: &'a Job,
 }
 
+impl Report<'_> {
+    /// Returns the job number of the job.
+    ///
+    /// The job number is a positive integer that is one greater than the index
+    /// of the job in its containing job set. Rather than the raw index, the job
+    /// number should be displayed to the user.
+    #[must_use]
+    pub fn number(&self) -> usize {
+        self.index + 1
+    }
+}
+
 /// Formats a job status report.
 ///
 /// The `fmt` method will **panic** if `self.index` does not name an existing
 /// job in `self.jobs`.
 impl Display for Report<'_> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let number = self.index + 1;
+        let number = self.number();
         let marker = self.marker;
         let status = FormatStatus(self.job.status);
         let name = &self.job.name;

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -94,6 +94,11 @@ fn asynchronous_list() {
 }
 
 #[test]
+fn bg_builtin() {
+    run_with_pty("bg-p.sh")
+}
+
+#[test]
 fn break_builtin() {
     run("break-p.sh")
 }

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -149,6 +149,11 @@ fn export_builtin() {
 }
 
 #[test]
+fn fg_builtin() {
+    run_with_pty("fg-p.sh")
+}
+
+#[test]
 fn fnmatch() {
     run("fnmatch-p.sh")
 }

--- a/yash/tests/scripted_test/bg-p.sh
+++ b/yash/tests/scripted_test/bg-p.sh
@@ -1,0 +1,103 @@
+# bg-p.sh: test of the bg built-in for any POSIX-compliant shell
+
+posix="true"
+
+# The "sleep 0" commands in the test cases below are a hack to ensure that the
+# shell receives SIGCHLD and takes in the latest status of the background jobs.
+# Without this, the "wait" built-in may return before the background jobs are
+# actually resumed.
+
+cat >job1 <<\__END__
+exec sh -c 'kill -s STOP $$; echo'
+__END__
+
+chmod a+x job1
+ln job1 job2
+
+test_O -d -e n 'bg cannot be used when job control is disabled' +m
+:&
+bg
+__IN__
+
+test_oE 'default operand chooses most recently suspended job' -m
+:&
+sh -c 'kill -s STOP $$; echo 1'
+bg >/dev/null
+sleep 0
+wait
+__IN__
+1
+__OUT__
+
+: TODO Needs the kill built-in <<\__IN__
+test_OE 'already running job is ignored' -m
+while kill -s CONT $$; do sleep 1; done &
+bg >/dev/null
+kill %
+__IN__
+
+test_OE -e 17 'resumed job is awaitable' -m
+sh -c 'kill -s STOP $$; exit 17'
+bg >/dev/null
+sleep 0
+wait %
+__IN__
+
+test_O -e n 'resumed job is in background' -m
+sh -c 'kill -s STOP $$; trap "" TTIN; head -n 1 /dev/tty'
+# The shell is ignoring SIGTTIN, so the "head" command will just fail with EIO
+# when it tries to read from the terminal in the background.
+bg >/dev/null
+sleep 0
+wait %
+__IN__
+
+test_oE 'specifying job ID' -m
+./job1
+./job2
+echo -
+bg %./job1 >/dev/null
+bg %./job2 >/dev/null
+sleep 0
+wait
+__IN__
+-
+
+
+__OUT__
+
+test_oE 'specifying more than one job ID' -m
+./job1
+./job2
+echo -
+bg %./job1 %./job2 >/dev/null
+sleep 0
+wait
+__IN__
+-
+
+
+__OUT__
+
+test_OE -e 0 'bg prints resumed job' -m
+sleep 1&
+bg >bg.out
+grep -qx '\[[[:digit:]][[:digit:]]*][[:blank:]]*sleep 1' bg.out
+__IN__
+
+test_OE -e 0 'exit status of bg' -m
+sh -c 'kill -s STOP $$; exit 17'
+bg >/dev/null
+__IN__
+
+test_O -d -e n 'no existing job' -m
+bg
+__IN__
+
+test_O -d -e n 'no such job' -m
+sh -c 'kill -s STOP $$'
+bg %_no_such_job_
+exit_status=$?
+fg >/dev/null
+exit $exit_status
+__IN__

--- a/yash/tests/scripted_test/fg-p.sh
+++ b/yash/tests/scripted_test/fg-p.sh
@@ -1,0 +1,78 @@
+# fg-p.sh: test of the fg built-in for any POSIX-compliant shell
+
+posix="true"
+
+cat >job1 <<\__END__
+exec sh -c 'echo 1; kill -s STOP $$; echo 2'
+__END__
+
+cat >job2 <<\__END__
+exec sh -c 'echo a; kill -s STOP $$; echo b'
+__END__
+
+chmod a+x job1
+chmod a+x job2
+
+mkfifo fifo
+
+test_O -d -e n 'fg cannot be used when job control is disabled' +m
+:&
+fg
+__IN__
+
+test_oE 'default operand chooses most recently suspended job' -m
+:&
+sh -c 'kill -s STOP $$; echo 1'
+fg >/dev/null
+__IN__
+1
+__OUT__
+
+: TODO Needs to find a way to test this <<\__IN__
+test_oE 'resumed job is in foreground' -m
+sh -c 'kill -s STOP $$; ...'
+fg >/dev/null
+__IN__
+
+: TODO Needs the kill built-in <<\__IN__
+test_x -e 127 'resumed job is disowned unless suspended again' -m
+cat fifo >/dev/null &
+exec 3>fifo
+kill -s STOP %
+exec 3>&-
+fg >/dev/null
+wait $!
+__IN__
+
+test_oE 'specifying job ID' -m
+./job1
+./job2
+fg %./job1 >/dev/null
+fg %./job2 >/dev/null
+__IN__
+1
+a
+2
+b
+__OUT__
+
+test_oE 'fg prints resumed job' -m
+./job1
+fg
+__IN__
+1
+./job1
+2
+__OUT__
+
+test_O -d -e n 'no existing job' -m
+fg
+__IN__
+
+test_O -d -e n 'no such job' -m
+sh -c 'kill -s STOP $$'
+fg %_no_such_job_
+exit_status=$?
+fg >/dev/null
+exit $exit_status
+__IN__


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `bg` built-in command for resuming suspended jobs in the background.
	- Introduced `fg` built-in command for resuming suspended jobs in the foreground.

- **Enhancements**
	- Improved job status handling with `expected_status` field and methods.
	- Enhanced job reporting with new `number` method in `Report` struct.

- **Tests**
	- Added new tests for `bg` and `fg` built-in commands.
	- Included comprehensive test suites `bg-p.sh` and `fg-p.sh` for POSIX compliance.

- **Bug Fixes**
	- Fixed signal handling in `send_signal_to_processes` function to check results before raising signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->