### PR TITLE
Improve virtual process execution control

### DIFF
--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -184,7 +184,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeEr
 
     if is_alive(job.status) {
         let pgid = Pid::from_raw(-job.pid.as_raw());
-        env.system.kill(pgid, Signal::SIGCONT.into())?;
+        env.system.kill(pgid, Signal::SIGCONT.into()).await?;
 
         // We've just reported that the job is resumed, so there is no need to
         // report the same thing in the usual pre-prompt message.

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -143,7 +143,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<WaitStatus, 
     env.system.tcsetpgrp_without_block(tty, job.pid)?;
 
     let pgid = Pid::from_raw(-job.pid.as_raw());
-    env.system.kill(pgid, Signal::SIGCONT.into())?;
+    env.system.kill(pgid, Signal::SIGCONT.into()).await?;
 
     // Wait for the job to finish (or suspend again).
     let status = wait_while_running(env, job.pid).await?;

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -287,7 +287,6 @@ pub(crate) mod tests {
     use assert_matches::assert_matches;
     use futures_executor::LocalSpawner;
     use futures_util::task::LocalSpawnExt;
-    #[cfg(feature = "yash-semantics")]
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::future::Future;
@@ -297,9 +296,7 @@ pub(crate) mod tests {
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::INode;
     use yash_env::system::r#virtual::SystemState;
-    #[cfg(feature = "yash-semantics")]
     use yash_env::Env;
-    #[cfg(feature = "yash-semantics")]
     use yash_env::VirtualSystem;
 
     #[derive(Clone, Debug)]
@@ -317,7 +314,6 @@ pub(crate) mod tests {
     }
 
     /// Helper function to perform a test in a virtual system with an executor.
-    #[cfg(feature = "yash-semantics")]
     pub fn in_virtual_system<F, Fut>(f: F)
     where
         F: FnOnce(Env, Rc<RefCell<SystemState>>) -> Fut,

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -149,7 +149,7 @@ mod tests {
             let pid = subshell.start(&mut env).await.unwrap().0;
             let index = env.jobs.add(Job::new(pid));
             // Suspend the child process.
-            env.system.kill(pid, Some(Signal::SIGSTOP)).unwrap();
+            env.system.kill(pid, Some(Signal::SIGSTOP)).await.unwrap();
 
             // The job is suspended, so the function returns immediately.
             let result = wait_for_any_job_or_trap(&mut env).await;

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -671,8 +671,16 @@ mod tests {
             .await
             .unwrap();
 
-            parent_env.system.kill(child_pid, Some(SIGINT)).unwrap();
-            parent_env.system.kill(child_pid, Some(SIGQUIT)).unwrap();
+            parent_env
+                .system
+                .kill(child_pid, Some(SIGINT))
+                .await
+                .unwrap();
+            parent_env
+                .system
+                .kill(child_pid, Some(SIGQUIT))
+                .await
+                .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
             assert_eq!(child_result, WaitStatus::Exited(child_pid, 123));

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -320,6 +320,11 @@ pub trait System: Debug {
     /// This is a thin wrapper around the `setpgid` system call.
     fn setpgid(&mut self, pid: Pid, pgid: Pid) -> nix::Result<()>;
 
+    /// Returns the current foreground process group ID.
+    ///
+    /// This is a thin wrapper around the `tcgetpgrp` system call.
+    fn tcgetpgrp(&self, fd: Fd) -> nix::Result<Pid>;
+
     /// Switches the foreground process group.
     ///
     /// This is a thin wrapper around the `tcsetpgrp` system call.
@@ -906,6 +911,9 @@ impl System for SharedSystem {
     }
     fn setpgid(&mut self, pid: Pid, pgid: Pid) -> nix::Result<()> {
         self.0.borrow_mut().setpgid(pid, pgid)
+    }
+    fn tcgetpgrp(&self, fd: Fd) -> nix::Result<Pid> {
+        self.0.borrow().tcgetpgrp(fd)
     }
     fn tcsetpgrp(&mut self, fd: Fd, pgid: Pid) -> nix::Result<()> {
         self.0.borrow_mut().tcsetpgrp(fd, pgid)

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -355,6 +355,10 @@ impl System for RealSystem {
         nix::unistd::setpgid(pid, pgid)
     }
 
+    fn tcgetpgrp(&self, fd: Fd) -> nix::Result<Pid> {
+        nix::unistd::tcgetpgrp(fd.0)
+    }
+
     fn tcsetpgrp(&mut self, fd: Fd, pgid: Pid) -> nix::Result<()> {
         nix::unistd::tcsetpgrp(fd.0, pgid)
     }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -355,9 +355,9 @@ impl System for RealSystem {
     /// Creates a new child process.
     ///
     /// This implementation calls the `fork` system call and returns both in the
-    /// parent and child process. In the parent, the `run` function of the
-    /// returned `ChildProcess` ignores arguments and returns the child process
-    /// ID. In the child, the `run` function runs the task and exits the
+    /// parent and child process. In the parent, the returned
+    /// `ChildProcessStarter` ignores any arguments and returns the child
+    /// process ID. In the child, the starter runs the task and exits the
     /// process.
     fn new_child_process(&mut self) -> nix::Result<ChildProcessStarter> {
         use nix::unistd::ForkResult::*;

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -811,6 +811,17 @@ impl System for VirtualSystem {
         // TODO Support sessions
     }
 
+    /// Returns the current foreground process group ID.
+    ///
+    /// The current implementation does not yet support the concept of
+    /// controlling terminals and sessions. It accepts any open file descriptor.
+    fn tcgetpgrp(&self, fd: Fd) -> nix::Result<Pid> {
+        // Make sure the FD is open
+        self.with_open_file_description(fd, |_| Ok(()))?;
+
+        self.state.borrow().foreground.ok_or(Errno::ENOTTY)
+    }
+
     /// Switches the foreground process.
     ///
     /// The current implementation does not yet support the concept of

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -1011,7 +1011,10 @@ mod tests {
                     false,
                 )
                 .unwrap();
-            env.system.kill(env.main_pid, Some(Signal::SIGINT)).unwrap();
+            env.system
+                .kill(env.main_pid, Some(Signal::SIGINT))
+                .await
+                .unwrap();
             env.traps.enter_subshell(&mut env.system, true, false);
 
             let state = state.borrow();
@@ -1038,6 +1041,7 @@ mod tests {
                 .unwrap();
             env.system
                 .kill(env.main_pid, Some(Signal::SIGQUIT))
+                .await
                 .unwrap();
             env.traps.enter_subshell(&mut env.system, true, false);
 
@@ -1076,7 +1080,7 @@ mod tests {
             }
             env.traps.enable_stopper_handlers(&mut env.system).unwrap();
             for signal in [Signal::SIGTSTP, Signal::SIGTTIN, Signal::SIGTTOU] {
-                env.system.kill(env.main_pid, Some(signal)).unwrap();
+                env.system.kill(env.main_pid, Some(signal)).await.unwrap();
             }
             env.traps.enter_subshell(&mut env.system, false, true);
 

--- a/yash-semantics/src/tests.rs
+++ b/yash-semantics/src/tests.rs
@@ -22,7 +22,6 @@ use futures_util::task::LocalSpawnExt;
 use itertools::Itertools;
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::future::pending;
 use std::future::ready;
 use std::future::Future;
 use std::ops::ControlFlow::Break;
@@ -217,10 +216,13 @@ fn suspend_builtin_main(
     env: &mut Env,
     _args: Vec<Field>,
 ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
-    env.system
-        .kill(Pid::from_raw(0), Some(Signal::SIGSTOP))
-        .unwrap();
-    Box::pin(pending())
+    Box::pin(async move {
+        env.system
+            .kill(Pid::from_raw(0), Some(Signal::SIGSTOP))
+            .await
+            .unwrap();
+        yash_env::builtin::Result::default()
+    })
 }
 
 /// Returns a minimal implementation of the `suspend` built-in.


### PR DESCRIPTION
Fixes #340

<!--
- [ ] Add `SharedSystem.kill_async`
- [ ] Modify callers of `System.kill` to use `SharedSystem.kill_async`
-->
- [x] Don't run signaled or suspended processes
- [x] Make `System.kill` (and its dependent) asynchronous
- [x] Yield when a process's execution state is changed
- [x] Implement test `wait_for_signaled_child`
- [x] Remove finished jobs in the `fg` built-in
- [x] Implement the missing tests for the `fg` built-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced process management with asynchronous kill operations.
  - Improved job control by automatically removing completed jobs.

- **Bug Fixes**
  - Implemented test cases for foreground job resumption to ensure reliability.

- **Refactor**
  - Transitioned child process termination to asynchronous operations.

- **Tests**
  - Updated tests to support asynchronous process handling.

- **Documentation**
  - Conditional compilation adjustments for improved documentation clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->