### PR TITLE
Replace `WaitStatus` with `ProcessState` in public API

### DIFF
--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -246,9 +246,9 @@ mod tests {
     use crate::tests::assert_stdout;
     use futures_util::FutureExt as _;
     use yash_env::job::Job;
+    use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::system::r#virtual::Process;
-    use yash_env::system::r#virtual::ProcessState;
     use yash_env::VirtualSystem;
 
     #[test]

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -70,12 +70,12 @@
 //! prevent unrelated processes that happen to have the same process IDs as the
 //! jobs from receiving the signal.
 //!
-//! The built-in sets the [expected status] of the resumed jobs to
-//! [`WaitStatus::Continued`] so that the status changes are not reported again
+//! The built-in sets the [expected state] of the resumed jobs to
+//! [`ProcessState::Running`] so that the status changes are not reported again
 //! on the next command prompt.
 //!
 //! [owned]: yash_env::job::Job::is_owned
-//! [expected status]: yash_env::job::Job::expected_status
+//! [expected state]: yash_env::job::Job::expected_state
 
 use crate::common::report_error;
 use crate::common::report_failure;
@@ -95,7 +95,7 @@ use yash_env::job::id::ParseError;
 #[cfg(doc)]
 use yash_env::job::JobSet;
 use yash_env::job::Pid;
-use yash_env::job::WaitStatus;
+use yash_env::job::ProcessState;
 use yash_env::semantics::Field;
 use yash_env::system::Errno;
 use yash_env::trap::Signal;
@@ -180,7 +180,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeEr
 
         // We've just reported that the job is resumed, so there is no need to
         // report the same thing in the usual pre-prompt message.
-        job.expect(WaitStatus::Continued(job.pid));
+        job.expect(ProcessState::Running);
     }
 
     // The resumed job becomes the current job. This is only relevant when all
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn resume_job_by_index_sets_expected_status() {
+    fn resume_job_by_index_sets_expected_state() {
         let system = VirtualSystem::new();
         let mut env = Env::with_system(Box::new(system.clone()));
         let pid = Pid::from_raw(123);
@@ -321,7 +321,7 @@ mod tests {
         _ = resume_job_by_index(&mut env, index).now_or_never().unwrap();
 
         let job = env.jobs.get(index).unwrap();
-        assert_eq!(job.expected_status, Some(WaitStatus::Continued(pid)));
+        assert_eq!(job.expected_state, Some(ProcessState::Running));
     }
 
     #[test]

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -211,12 +211,12 @@ mod tests {
     use std::ops::ControlFlow::Continue;
     use std::rc::Rc;
     use yash_env::job::Job;
+    use yash_env::job::ProcessState;
     use yash_env::option::Option::Monitor;
     use yash_env::option::State::On;
     use yash_env::subshell::JobControl;
     use yash_env::subshell::Subshell;
     use yash_env::system::r#virtual::Process;
-    use yash_env::system::r#virtual::ProcessState;
     use yash_env::VirtualSystem;
 
     async fn suspend(env: &mut Env) {

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -207,7 +207,6 @@ mod tests {
     use crate::tests::assert_stdout;
     use crate::tests::in_virtual_system;
     use crate::tests::stub_tty;
-    use assert_matches::assert_matches;
     use futures_util::FutureExt as _;
     use std::cell::Cell;
     use std::ops::ControlFlow::Continue;
@@ -247,12 +246,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state;
             let index = env.jobs.add(job);
 
             resume_job_by_index(&mut env, index).await.unwrap();
@@ -273,12 +271,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state;
             job.name = "my job name".to_owned();
             let index = env.jobs.add(job);
 
@@ -301,12 +298,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state;
             let index = env.jobs.add(job);
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
@@ -332,12 +328,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state;
             let index = env.jobs.add(job);
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
@@ -362,12 +357,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state;
             let index = env.jobs.add(job);
 
             _ = resume_job_by_index(&mut env, index).await.unwrap();
@@ -446,12 +440,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid1 =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state1;
             env.jobs.add(job);
             // current job
             let subshell = Subshell::new(|env, _| {
@@ -461,12 +454,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid2 =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state2;
             let index2 = env.jobs.add(job);
             env.jobs.set_current_job(index2).unwrap();
 
@@ -507,12 +499,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid1 =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state1;
             job.name = "previous job".to_string();
             let index1 = env.jobs.add(job);
             // current job
@@ -523,12 +514,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let subshell_status = subshell.start_and_wait(&mut env).await.unwrap();
-            let pid2 =
-                assert_matches!(subshell_status, WaitStatus::Stopped(pid, Signal::SIGSTOP) => pid);
+            let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
-            job.state = ProcessState::from_wait_status(subshell_status).unwrap().1;
+            job.state = subshell_state2;
             let index2 = env.jobs.add(job);
             env.jobs.set_current_job(index2).unwrap();
 

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -104,10 +104,10 @@ use yash_env::Env;
 /// Waits for the specified job to finish (or suspend again).
 async fn wait_while_running(env: &mut Env, pid: Pid) -> Result<WaitStatus, Errno> {
     loop {
-        let status = env.wait_for_subshell(pid).await?;
-        match status {
+        let (pid, state) = env.wait_for_subshell(pid).await?;
+        match state.to_wait_status(pid) {
             WaitStatus::Continued(_) | WaitStatus::StillAlive => (),
-            _ => return Ok(status),
+            status => return Ok(status),
         }
     }
 }

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -106,7 +106,7 @@ async fn wait_while_running(env: &mut Env, pid: Pid) -> Result<ProcessState, Err
         let (_pid, state) = env.wait_for_subshell(pid).await?;
         match state {
             ProcessState::Running => (),
-            ProcessState::Stopped(_) | ProcessState::Exited(_) | ProcessState::Signaled(_) => {
+            ProcessState::Stopped(_) | ProcessState::Exited(_) | ProcessState::Signaled { .. } => {
                 return Ok(state)
             }
         }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -41,7 +41,7 @@
 //! [`yash_env::job::fmt`] module. You can use two options to change the output.
 //!
 //! The **`-l`** (**`--verbose`**) option uses the alternate format, which
-//! inserts the process ID before each job status. The **`-p`**
+//! inserts the process ID before each job state. The **`-p`**
 //! (**`--pgid-only`**) option only prints the process ID of each job.
 //!
 //! ## Filtering

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -297,12 +297,18 @@ mod tests {
         let i14 = env.jobs.add(job);
 
         let mut job = Job::new(Pid::from_raw(15));
-        job.state = ProcessState::Signaled(Signal::SIGINT /*, false*/);
+        job.state = ProcessState::Signaled {
+            signal: Signal::SIGINT,
+            core_dump: false,
+        };
         job.name = "echo signaled".to_string();
         let i15 = env.jobs.add(job);
 
         let mut job = Job::new(Pid::from_raw(16));
-        job.state = ProcessState::Signaled(Signal::SIGQUIT /*, true*/);
+        job.state = ProcessState::Signaled {
+            signal: Signal::SIGQUIT,
+            core_dump: true,
+        };
         job.name = "echo core dumped".to_string();
         let i16 = env.jobs.add(job);
 

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -212,7 +212,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
         for index in accumulator.indices_reported {
             let mut job = env.jobs.get_mut(index).unwrap();
             if job.state.is_alive() {
-                job.status_reported();
+                job.state_reported();
             } else {
                 env.jobs.remove(index);
             }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -121,7 +121,6 @@ impl Accumulator {
     /// Processes one job.
     ///
     /// 1. Formats a job report in `self.print` so it can be printed later.
-    /// 1. Clears the `status_changed` flag of the job.
     /// 1. Remembers the job index in `self.indices_reported` so the job can be
     ///    removed later.
     fn report(&mut self, index: usize, job: &Job) {
@@ -468,7 +467,7 @@ mod tests {
     }
 
     #[test]
-    fn report_clears_status_changed_flag() {
+    fn report_clears_state_changed_flag() {
         let mut env = Env::new_virtual();
         let mut job = Job::new(Pid::from_raw(42));
         job.name = "echo first".to_string();
@@ -482,12 +481,12 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
 
-        assert!(env.jobs[i42].status_changed);
-        assert!(!env.jobs[i72].status_changed);
+        assert!(env.jobs[i42].state_changed);
+        assert!(!env.jobs[i72].state_changed);
     }
 
     #[test]
-    fn status_changed_flag_not_cleared_in_case_of_error() {
+    fn state_changed_flag_not_cleared_in_case_of_error() {
         let mut system = Box::new(VirtualSystem::new());
         system.current_process_mut().close_fd(Fd::STDOUT);
         let mut env = Env::with_system(system);
@@ -499,7 +498,7 @@ mod tests {
         }));
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
-        assert!(env.jobs[i72].status_changed);
+        assert!(env.jobs[i72].state_changed);
     }
 
     #[test]

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -102,7 +102,8 @@ mod tests {
     use std::pin::pin;
     use std::task::Poll;
     use yash_env::job::Job;
-    use yash_env::job::WaitStatus;
+    use yash_env::job::ProcessState;
+    use yash_env::semantics::ExitStatus;
     use yash_env::subshell::Subshell;
     use yash_env::trap::Action;
     use yash_env::variable::Value;
@@ -135,8 +136,8 @@ mod tests {
             assert_eq!(result, Ok(()));
             // The job status is updated.
             assert_eq!(
-                env.jobs.get(index).unwrap().status,
-                WaitStatus::Exited(pid, 0),
+                env.jobs.get(index).unwrap().state,
+                ProcessState::Exited(ExitStatus::default()),
             );
         });
     }
@@ -156,8 +157,8 @@ mod tests {
             assert_eq!(result, Ok(()));
             // The job status is updated.
             assert_eq!(
-                env.jobs.get(index).unwrap().status,
-                WaitStatus::Stopped(pid, Signal::SIGSTOP),
+                env.jobs.get(index).unwrap().state,
+                ProcessState::Stopped(Signal::SIGSTOP),
             );
         });
     }

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -78,7 +78,7 @@ pub async fn wait_for_any_job_or_trap(env: &mut Env) -> Result<(), Error> {
 
             Ok(Some((pid, state))) => {
                 // Some job has changed its state.
-                env.jobs.update_status(state.to_wait_status(pid));
+                env.jobs.update_status(pid, state);
                 return Ok(());
             }
 

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -30,7 +30,7 @@
 //! child process, the caller should pass it to [`JobSet::update_status`], which
 //! modifies the status of the corresponding job. The `state_changed` flag of
 //! the job is set when the job is updated and should be
-//! [reset when reported](JobRefMut::status_reported).
+//! [reset when reported](JobRefMut::state_reported).
 //!
 //! The job set remembers the selection of two special jobs called the "current
 //! job" and "previous job." The previous job is chosen automatically, so there
@@ -216,7 +216,7 @@ impl JobRefMut<'_> {
     ///
     /// Normally, this method should be called when the shell printed a job
     /// status report.
-    pub fn status_reported(&mut self) {
+    pub fn state_reported(&mut self) {
         self.0.state_changed = false
     }
 }
@@ -573,7 +573,7 @@ impl JobSet {
     /// iterator. Otherwise, the job remains in the set.
     ///
     /// You can reset the `state_changed` flag of a job
-    /// ([`JobRefMut::status_reported`]) regardless of whether you choose to
+    /// ([`JobRefMut::state_reported`]) regardless of whether you choose to
     /// remove it or not.
     ///
     /// This function is a simplified version of [`JobSet::extract_if`] that
@@ -592,7 +592,7 @@ impl JobSet {
     /// iterator. Otherwise, the job remains in the set.
     ///
     /// You can reset the `state_changed` flag of a job
-    /// ([`JobRefMut::status_reported`]) regardless of whether you choose to
+    /// ([`JobRefMut::state_reported`]) regardless of whether you choose to
     /// remove it or not.
     ///
     /// If the returned iterator is dropped before iterating all jobs, the
@@ -885,7 +885,7 @@ mod tests {
         let mut i = set.extract_if(|index, mut job| {
             assert_ne!(index, i23);
             if index % 2 == 0 {
-                job.status_reported();
+                job.state_reported();
             }
             index == 0 || job.pid == Pid::from_raw(26)
         });
@@ -916,7 +916,7 @@ mod tests {
         let i30 = set.add(Job::new(Pid::from_raw(30)));
         assert_eq!(set.get(i20).unwrap().state, ProcessState::Running);
 
-        set.get_mut(i20).unwrap().status_reported();
+        set.get_mut(i20).unwrap().state_reported();
         assert_eq!(set.get(i20).unwrap().state_changed, false);
 
         assert_eq!(set.update_status(status), Some(i20));

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -43,8 +43,7 @@
 
 use crate::semantics::ExitStatus;
 use crate::trap::Signal;
-#[doc(no_inline)]
-pub use nix::sys::wait::WaitStatus;
+use nix::sys::wait::WaitStatus;
 #[doc(no_inline)]
 pub use nix::unistd::Pid;
 use slab::Slab;

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -107,6 +107,28 @@ impl ProcessState {
     }
 }
 
+/// Error value indicating that the process is running.
+///
+/// This error value may be returned by [`TryFrom<ProcessState>::try_from`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RunningProcess;
+
+/// Converts `ProcessState` to `ExitStatus`.
+///
+/// For the `Running` state, the conversion fails with [`RunningProcess`].
+impl TryFrom<ProcessState> for ExitStatus {
+    type Error = RunningProcess;
+    fn try_from(state: ProcessState) -> Result<Self, RunningProcess> {
+        match state {
+            ProcessState::Exited(exit_status) => Ok(exit_status),
+            ProcessState::Signaled(signal) | ProcessState::Stopped(signal) => {
+                Ok(ExitStatus::from(signal))
+            }
+            ProcessState::Running => Err(RunningProcess),
+        }
+    }
+}
+
 /// Trait for adding some methods to [`WaitStatus`]
 pub trait WaitStatusEx {
     /// Returns true if the status indicates that the process is finished.

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -128,18 +128,6 @@ impl TryFrom<ProcessState> for ExitStatus {
     }
 }
 
-/// Trait for adding some methods to [`WaitStatus`]
-pub trait WaitStatusEx {
-    /// Returns true if the status indicates that the process is finished.
-    fn is_finished(&self) -> bool;
-}
-
-impl WaitStatusEx for WaitStatus {
-    fn is_finished(&self) -> bool {
-        matches!(*self, WaitStatus::Exited(..) | WaitStatus::Signaled(..))
-    }
-}
-
 /// Set of one or more processes executing a pipeline
 ///
 /// In the current implementation, a job contains the process ID of one child

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -26,10 +26,10 @@
 //! job](JobSet::remove). Note that the job set may reuse the index of a removed
 //! job for another job added later.
 //!
-//! When the [wait system call](crate::System::wait) returns a new status of a
+//! When the [wait system call](crate::System::wait) returns a new state of a
 //! child process, the caller should pass it to [`JobSet::update_status`], which
-//! modifies the status of the corresponding job. The `state_changed` flag of
-//! the job is set when the job is updated and should be
+//! modifies the state of the corresponding job. The `state_changed` flag of the
+//! job is set when the job is updated and should be
 //! [reset when reported](JobRefMut::state_reported).
 //!
 //! The job set remembers the selection of two special jobs called the "current
@@ -76,6 +76,9 @@ impl ProcessState {
     }
 
     /// Converts `ProcessState` to `WaitStatus`.
+    ///
+    /// This function returns a type defined in the `nix` crate, which is not
+    /// covered by the semantic versioning policy of this crate.
     #[must_use]
     pub fn to_wait_status(self, pid: Pid) -> WaitStatus {
         match self {
@@ -93,6 +96,9 @@ impl ProcessState {
     /// If the given `WaitStatus` represents a change in the process state, this
     /// function returns the new state with the process ID. Otherwise, it
     /// returns `None`.
+    ///
+    /// The `WaitStatus` type is defined in the `nix` crate, which is not
+    /// covered by the semantic versioning policy of this crate.
     #[must_use]
     pub fn from_wait_status(status: WaitStatus) -> Option<(Pid, Self)> {
         match status {
@@ -159,9 +165,9 @@ pub struct Job {
     /// See [`JobRefMut::expect`] and [`JobSet::update_status`] for details.
     pub expected_state: Option<ProcessState>,
 
-    /// Indicator of status change
+    /// Indicator of state change
     ///
-    /// This flag is true if the `status` has been changed since the status was
+    /// This flag is true if the `state` has been changed since the state was
     /// last reported to the user.
     pub state_changed: bool,
 

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -233,7 +233,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "needs the core dumped flag in ProcessState::Signaled"]
     fn report_standard() {
         let index = 0;
         let marker = Marker::CurrentJob;
@@ -258,7 +257,10 @@ mod tests {
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[6]   Stopped(SIGSTOP)     echo ok");
 
-        job.state = ProcessState::Signaled(Signal::SIGQUIT /*, true */);
+        job.state = ProcessState::Signaled {
+            signal: Signal::SIGQUIT,
+            core_dump: true,
+        };
         job.name = "exit 0".to_string();
         let report = Report { index, marker, job };
         assert_eq!(

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -21,14 +21,14 @@
 //! job status report printed between commands in an interactive shell.
 //!
 //! The format includes the job number, an optional marker representing the
-//! current or previous job, the current status, and the job name, in this
-//! order. An example of a formatted job is:
+//! current or previous job, the current state, and the job name, in this order.
+//! An example of a formatted job is:
 //!
 //! ```text
 //! [2] + Running              cat foo bar | grep baz
 //! ```
 //!
-//! The process ID is inserted before the current status when the alternate mode
+//! The process ID is inserted before the current state when the alternate mode
 //! flag (`#`) is used:
 //!
 //! ```text
@@ -55,6 +55,8 @@
 //! ```
 
 use super::Job;
+#[cfg(doc)]
+use super::JobSet;
 use super::ProcessState;
 use crate::semantics::ExitStatus;
 use std::fmt::Display;
@@ -125,14 +127,15 @@ impl Display for Marker {
 
 /// Wrapper for implementing job status formatting
 ///
-/// This type is a thin wrapper of a job that implements the `Display` trait to
-/// format a job status report. See the [module documentation](self) for details.
+/// This wrapper contains the information necessary to format a job status
+/// report, which can be produced by the `Display` trait's method.
+/// See the [module documentation](self) for details.
 #[derive(Clone, Copy, Debug)]
 pub struct Report<'a> {
     /// Index of the job
     ///
     /// This value should be the index at which the job appears in its
-    /// containing job set.
+    /// containing [`JobSet`].
     ///
     /// Note that the index is the job number minus one.
     pub index: usize,
@@ -148,8 +151,8 @@ impl Report<'_> {
     /// Returns the job number of the job.
     ///
     /// The job number is a positive integer that is one greater than the index
-    /// of the job in its containing job set. Rather than the raw index, the job
-    /// number should be displayed to the user.
+    /// of the job in its containing [`JobSet`]. Rather than the raw index, the job
+    /// number is included in the formatted report.
     #[must_use]
     pub fn number(&self) -> usize {
         self.index + 1
@@ -157,9 +160,6 @@ impl Report<'_> {
 }
 
 /// Formats a job status report.
-///
-/// The `fmt` method will **panic** if `self.index` does not name an existing
-/// job in `self.jobs`.
 impl Display for Report<'_> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let number = self.number();

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -341,7 +341,7 @@ impl Env {
         loop {
             if let Some((pid, state)) = self.system.wait(target)? {
                 let status = state.to_wait_status(pid);
-                self.jobs.update_status(status);
+                self.jobs.update_status(pid, state);
                 return Ok(status);
             }
             self.wait_for_signal(Signal::SIGCHLD).await;
@@ -377,7 +377,7 @@ impl Env {
     /// lost when you call this function.
     pub fn update_all_subshell_statuses(&mut self) {
         while let Ok(Some((pid, state))) = self.system.wait(Pid::from_raw(-1)) {
-            self.jobs.update_status(state.to_wait_status(pid));
+            self.jobs.update_status(pid, state);
         }
     }
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -314,7 +314,7 @@ impl Env {
 
     /// Waits for a subshell to terminate, suspend, or resume.
     ///
-    /// This function waits for a subshell to change its execution status. The
+    /// This function waits for a subshell to change its execution state. The
     /// `target` parameter specifies which child to wait for:
     ///
     /// - `-1`: any child
@@ -322,7 +322,7 @@ impl Env {
     /// - `pid`: the child whose process ID is `pid`
     /// - `-pgid`: any child in the process group whose process group ID is `pgid`
     ///
-    /// When [`self.system.wait`](System::wait) returned a new status of the
+    /// When [`self.system.wait`](System::wait) returned a new state of the
     /// target, it is sent to `self.jobs` ([`JobSet::update_status`]) before
     /// being returned from this function.
     ///

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -18,7 +18,6 @@
 
 use crate::Env;
 use nix::sys::signal::Signal;
-use nix::sys::wait::WaitStatus;
 use std::ffi::c_int;
 use std::ops::ControlFlow::{self, Break};
 use std::process::ExitCode;
@@ -117,26 +116,6 @@ impl From<Signal> for ExitStatus {
 impl Termination for ExitStatus {
     fn report(self) -> ExitCode {
         (self.0 as u8).into()
-    }
-}
-
-/// Error returned when a [`WaitStatus`] could not be converted to an
-/// [`ExitStatus`]
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct StillAliveError;
-
-/// Converts a `WaitStatus` to an `ExitStatus` if the status is `Exited`,
-/// `Signaled`, or `Stopped`.
-impl TryFrom<WaitStatus> for ExitStatus {
-    type Error = StillAliveError;
-    fn try_from(status: WaitStatus) -> std::result::Result<Self, StillAliveError> {
-        match status {
-            WaitStatus::Exited(_, exit_status) => Ok(ExitStatus(exit_status)),
-            WaitStatus::Signaled(_, signal, _) | WaitStatus::Stopped(_, signal) => {
-                Ok(ExitStatus::from(signal))
-            }
-            _ => Err(StillAliveError),
-        }
     }
 }
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -245,7 +245,7 @@ where
             let is_done = match state {
                 ProcessState::Running => false,
                 ProcessState::Stopped(_) => job_control.is_some(),
-                ProcessState::Exited(_) | ProcessState::Signaled(_) => true,
+                ProcessState::Exited(_) | ProcessState::Signaled { .. } => true,
             };
             if is_done {
                 break Ok((pid, state));

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -27,7 +27,7 @@
 //! properly.
 
 use crate::job::Pid;
-use crate::job::WaitStatus;
+use crate::job::ProcessState;
 use crate::stack::Frame;
 use crate::system::ChildProcessTask;
 use crate::system::SigSet;
@@ -226,10 +226,10 @@ where
     /// subshell is job-controlled, the function also returns when the job is
     /// suspended.
     ///
-    /// If the subshell started successfully, the return value is the wait
-    /// status of the subshell, which is `Exited`, `Signaled`, or `Stopped`. If
-    /// there was an error starting the subshell, this function returns the
-    /// error.
+    /// If the subshell started successfully, the return value is the process ID
+    /// and the process state of the subshell, which is `Exited`, `Signaled`, or
+    /// `Stopped`. If there was an error starting the subshell, this function
+    /// returns the error.
     ///
     /// If you set [`job_control`](Self::job_control) to
     /// `JobControl::Foreground` and job control is effective as per
@@ -238,15 +238,17 @@ where
     ///
     /// When a job-controlled subshell suspends, this function does not add it
     /// to `env.jobs`. You have to do it for yourself if necessary.
-    pub async fn start_and_wait(self, env: &mut Env) -> nix::Result<WaitStatus> {
+    pub async fn start_and_wait(self, env: &mut Env) -> nix::Result<(Pid, ProcessState)> {
         let (pid, job_control) = self.start(env).await?;
         let result = loop {
             let (pid, state) = env.wait_for_subshell(pid).await?;
-            let wait_status = state.to_wait_status(pid);
-            match wait_status {
-                WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _) => break Ok(wait_status),
-                WaitStatus::Stopped(_, _) if job_control.is_some() => break Ok(wait_status),
-                _ => (),
+            let is_done = match state {
+                ProcessState::Running => false,
+                ProcessState::Stopped(_) => job_control.is_some(),
+                ProcessState::Exited(_) | ProcessState::Signaled(_) => true,
+            };
+            if is_done {
+                break Ok((pid, state));
             }
         };
 
@@ -311,7 +313,6 @@ impl<'a> Drop for MaskGuard<'a> {
 mod tests {
     use super::*;
     use crate::job::Job;
-    use crate::job::ProcessState;
     use crate::option::Option::{Interactive, Monitor};
     use crate::option::State::On;
     use crate::semantics::ExitStatus;
@@ -605,8 +606,8 @@ mod tests {
                     Continue(())
                 })
             });
-            let result = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_matches!(result, WaitStatus::Exited(_pid, 42));
+            let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(process_state, ProcessState::Exited(ExitStatus(42)));
         });
     }
 
@@ -623,8 +624,8 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let result = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_matches!(result, WaitStatus::Exited(_pid, 123));
+            let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(process_state, ProcessState::Exited(ExitStatus(123)));
             assert_eq!(state.borrow().foreground, Some(env.main_pgid));
         });
     }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -35,6 +35,7 @@ use super::System;
 use super::TimeSpec;
 use crate::io::Fd;
 use crate::job::Pid;
+use crate::job::ProcessState;
 use crate::SignalHandling;
 use nix::libc::DIR;
 use nix::libc::{S_IFDIR, S_IFMT, S_IFREG};
@@ -385,10 +386,10 @@ impl System for RealSystem {
         }
     }
 
-    fn wait(&mut self, target: Pid) -> nix::Result<super::WaitStatus> {
+    fn wait(&mut self, target: Pid) -> nix::Result<Option<(Pid, ProcessState)>> {
         use nix::sys::wait::WaitPidFlag;
         let options = WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED | WaitPidFlag::WNOHANG;
-        nix::sys::wait::waitpid(target, options.into())
+        nix::sys::wait::waitpid(target, options.into()).map(ProcessState::from_wait_status)
     }
 
     fn execve(

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -68,6 +68,7 @@ use super::TimeSpec;
 use super::AT_FDCWD;
 use crate::io::Fd;
 use crate::job::Pid;
+use crate::job::ProcessState;
 use crate::job::WaitStatus;
 use crate::system::ChildProcessStarter;
 use crate::SignalHandling;

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -271,10 +271,10 @@ impl Process {
     /// process are closed.
     ///
     /// This function returns whether the state did change. If true, the
-    /// [`state_has_changed`](Self::state_has_changed) flag is set and  the
-    /// caller must notify the status update by sending `SIGCHLD` to the parent
+    /// [`state_has_changed`](Self::state_has_changed) flag is set and the
+    /// caller must notify the state change by sending `SIGCHLD` to the parent
     /// process.
-    #[must_use = "You must send SIGCHLD to the parent"]
+    #[must_use = "You must send SIGCHLD to the parent if set_state returns true"]
     pub fn set_state(&mut self, state: ProcessState) -> bool {
         let old_state = std::mem::replace(&mut self.state, state);
 

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -396,7 +396,7 @@ impl<'a> IntoIterator for &'a TrapSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::system::r#virtual::ProcessState;
+    use crate::job::ProcessState;
     use crate::tests::in_virtual_system;
     use crate::System;
     use std::collections::HashMap;

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -22,6 +22,7 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::io::print_error;
 use yash_env::job::Job;
+use yash_env::job::ProcessState;
 use yash_env::job::WaitStatus::Stopped;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
@@ -39,10 +40,10 @@ pub async fn execute(env: &mut Env, body: Rc<List>, location: &Location) -> Resu
     let subshell = subshell.job_control(JobControl::Foreground);
     match subshell.start_and_wait(env).await {
         Ok(wait_status) => {
-            if let Stopped(pid, _signal) = wait_status {
+            if let Stopped(pid, signal) = wait_status {
                 let mut job = Job::new(pid);
                 job.job_controlled = true;
-                job.status = wait_status;
+                job.state = ProcessState::Stopped(signal);
                 job.name = body.to_string();
                 env.jobs.add(job);
             }
@@ -88,7 +89,6 @@ mod tests {
     use std::pin::Pin;
     use std::rc::Rc;
     use yash_env::job::ProcessState;
-    use yash_env::job::WaitStatus;
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::option::State::On;
     use yash_env::trap::Signal;
@@ -208,7 +208,7 @@ mod tests {
             let job = env.jobs.iter().next().unwrap().1;
             assert_eq!(job.pid, pid);
             assert!(job.job_controlled);
-            assert_eq!(job.status, WaitStatus::Stopped(pid, Signal::SIGSTOP));
+            assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
             assert!(job.status_changed);
             assert_eq!(job.name, "suspend foo");
         })

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -87,10 +87,10 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::rc::Rc;
+    use yash_env::job::ProcessState;
     use yash_env::job::WaitStatus;
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::option::State::On;
-    use yash_env::system::r#virtual::ProcessState;
     use yash_env::trap::Signal;
     use yash_env::VirtualSystem;
     use yash_syntax::syntax::CompoundCommand;

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -209,7 +209,7 @@ mod tests {
             assert_eq!(job.pid, pid);
             assert!(job.job_controlled);
             assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
-            assert!(job.status_changed);
+            assert!(job.state_changed);
             assert_eq!(job.name, "suspend foo");
         })
     }

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -131,7 +131,7 @@ mod tests {
     use futures_util::FutureExt;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use yash_env::job::WaitStatus;
+    use yash_env::job::ProcessState;
     use yash_env::option::Option::Monitor;
     use yash_env::option::State::On;
     use yash_env::system::r#virtual::FileBody;
@@ -210,7 +210,7 @@ mod tests {
             let job = env.jobs.get(0).unwrap();
             assert!(!job.job_controlled);
             assert!(job.status_changed);
-            assert_eq!(job.status, WaitStatus::StillAlive);
+            assert_eq!(job.state, ProcessState::Running);
             assert_eq!(job.pid, env.jobs.last_async_pid());
             assert_eq!(job.name, "return -n 42");
         })

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -209,7 +209,7 @@ mod tests {
 
             let job = env.jobs.get(0).unwrap();
             assert!(!job.job_controlled);
-            assert!(job.status_changed);
+            assert!(job.state_changed);
             assert_eq!(job.state, ProcessState::Running);
             assert_eq!(job.pid, env.jobs.last_async_pid());
             assert_eq!(job.name, "return -n 42");

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -335,12 +335,12 @@ mod tests {
     use std::rc::Rc;
     use yash_env::builtin::Builtin;
     use yash_env::builtin::Type::Special;
+    use yash_env::job::ProcessState;
     use yash_env::job::WaitStatus;
     use yash_env::option::Option::Monitor;
     use yash_env::option::State::On;
     use yash_env::semantics::Field;
     use yash_env::system::r#virtual::FileBody;
-    use yash_env::system::r#virtual::ProcessState;
     use yash_env::trap::Signal;
     use yash_env::VirtualSystem;
 

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -612,7 +612,7 @@ mod tests {
             let job = env.jobs.iter().next().unwrap().1;
             assert!(job.job_controlled);
             assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
-            assert!(job.status_changed);
+            assert!(job.state_changed);
             assert_eq!(job.name, "return -n 0 | suspend x");
         })
     }

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -27,7 +27,6 @@ use std::rc::Rc;
 use yash_env::io::print_error;
 use yash_env::job::Job;
 use yash_env::job::ProcessState;
-use yash_env::job::WaitStatus::Stopped;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
@@ -70,11 +69,11 @@ pub async fn execute_absent_target(
         .job_control(JobControl::Foreground);
 
         match subshell.start_and_wait(env).await {
-            Ok(wait_status) => {
-                if let Stopped(pid, signal) = wait_status {
+            Ok((pid, state)) => {
+                if let ProcessState::Stopped(_) = state {
                     let mut job = Job::new(pid);
                     job.job_controlled = true;
-                    job.state = ProcessState::Stopped(signal);
+                    job.state = state;
                     job.name = redirs
                         .iter()
                         .format_with(" ", |redir, f| f(&format_args!("{redir}")))
@@ -82,7 +81,7 @@ pub async fn execute_absent_target(
                     env.jobs.add(job);
                 }
 
-                wait_status.try_into().unwrap()
+                state.try_into().unwrap()
             }
             Err(errno) => {
                 print_error(

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -26,6 +26,7 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::io::print_error;
 use yash_env::job::Job;
+use yash_env::job::ProcessState;
 use yash_env::job::WaitStatus::Stopped;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
@@ -70,10 +71,10 @@ pub async fn execute_absent_target(
 
         match subshell.start_and_wait(env).await {
             Ok(wait_status) => {
-                if let Stopped(pid, _signal) = wait_status {
+                if let Stopped(pid, signal) = wait_status {
                     let mut job = Job::new(pid);
                     job.job_controlled = true;
-                    job.status = wait_status;
+                    job.state = ProcessState::Stopped(signal);
                     job.name = redirs
                         .iter()
                         .format_with(" ", |redir, f| f(&format_args!("{redir}")))

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -28,6 +28,7 @@ use std::ffi::CString;
 use std::ops::ControlFlow::Continue;
 use yash_env::io::print_error;
 use yash_env::job::Job;
+use yash_env::job::ProcessState;
 use yash_env::job::WaitStatus::Stopped;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
@@ -93,10 +94,10 @@ pub async fn execute_external_utility(
 
     match subshell.start_and_wait(&mut env).await {
         Ok(wait_status) => {
-            if let Stopped(pid, _signal) = wait_status {
+            if let Stopped(pid, signal) = wait_status {
                 let mut job = Job::new(pid);
                 job.job_controlled = true;
-                job.status = wait_status;
+                job.state = ProcessState::Stopped(signal);
                 job.name = job_name;
                 env.jobs.add(job);
             }


### PR DESCRIPTION
This pull request replaces use of `WaitStatus` with `ProcessState` in our public API. Since `WaitStatus` is a type re-exported from the external `nix` crate, there is risk of incompatible changes to the type possibly introduced in the future. For reliable semantic versioning of our crates, we should expose the type defined in our own crate.

- [x] Move ProcessState to yash_env::job
- [x] Define `ProcessState::is_alive`
- [x] Use ProcessState in System::wait
- [x] Use ProcessState for Job::status, rename to Job::state
- [x] Use ProcessState for Job::expected_status, rename to Job::expected_state
- [x] Rename Job::status_changed to Job::state_changed
- [x] Rename JobRefMut::status_reported to JobRefMut::state_reported
- [x] Use ProcessState in JobSet::update_status
- [x] Use ProcessState in Env::wait_for_subshell
- [x] Use ProcessState in Subshell::start_and_wait
- [x] Use ProcessState instead of WaitStatus outside `yash-env`
- [x] Consider removing WaitStatusEx (or making it private)
- [x] Make WaitStatus private in yash_env::job
- [x] Indicate whether the core dump was generated in ProcessState::Signal
- [x] Consider removing `impl TryFrom<WaitStatus> for ExitStatus`
- [x] Remove FormatStatus in favor of directly implementing Display for ProcessState ~~Use ProcessState in FormatStatus~~
- [x] Re-enable test `job::fmt::tests::report_standard`
- [x] Review documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced job control with more accurate process state reporting.
  - Improved subshell handling with detailed process state and exit status information.
  
- **Bug Fixes**
  - Fixed inconsistencies in job state reporting across various built-in commands.
  
- **Refactor**
  - Replaced `WaitStatus` with `ProcessState` to unify process state management.
  
- **Style**
  - Updated terminology from "status" to "state" for clarity in job reporting.
  
- **Tests**
  - Adjusted tests to align with the new process state handling and reporting mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->