### PR TITLE
Kill built-in

### DIFF
--- a/yash-builtin/src/kill.rs
+++ b/yash-builtin/src/kill.rs
@@ -144,12 +144,39 @@
 //! Some implementations print `0` or `EXIT` for `kill -l 0` or `kill -l EXIT`
 //! while this implementation regards them as invalid operands.
 
+use crate::common::report_error;
 use yash_env::semantics::Field;
+use yash_env::trap::Signal;
 use yash_env::Env;
+
+/// Parsed command line arguments
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Command {
+    /// Sends a signal to processes
+    Send {
+        /// Signal to send
+        signal: Option<Signal>,
+        /// Target processes
+        targets: Vec<Field>,
+    },
+    /// Lists signal names or descriptions
+    Print {
+        /// Signal names or descriptions to list
+        ///
+        /// If empty, all signals are listed.
+        signals: Vec<Signal>,
+        /// Whether to print descriptions
+        verbose: bool,
+    },
+}
+
+pub mod syntax;
 
 /// Entry point of the kill built-in
 pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result {
-    _ = env;
-    _ = args;
-    todo!()
+    match syntax::parse(env, args) {
+        Ok(command) => todo!("{command:?}"),
+        Err(error) => report_error(env, error.to_message()).await,
+    }
 }

--- a/yash-builtin/src/kill.rs
+++ b/yash-builtin/src/kill.rs
@@ -172,13 +172,14 @@ pub enum Command {
 }
 
 pub mod print;
+pub mod send;
 pub mod syntax;
 
 impl Command {
     /// Executes the built-in.
     pub async fn execute(&self, env: &mut Env) -> crate::Result {
         match self {
-            Self::Send { signal, targets } => todo!("{signal:?} {targets:?}"),
+            Self::Send { signal, targets } => send::execute(env, *signal, targets).await,
             Self::Print { signals, verbose } => print::execute(env, signals, *verbose).await,
         }
     }

--- a/yash-builtin/src/kill.rs
+++ b/yash-builtin/src/kill.rs
@@ -55,7 +55,7 @@
 //! The **`-v`** option lists signal descriptions. This works like the `-l`
 //! option, but prints the signal number, name, and description instead of
 //! just the name. The `-v` option may be used with the `-l` option, in which
-//! case the `-l` option is ignored.
+//! case the `-l` option is ignored. (TODO: The description is not yet printed)
 //!
 //! # Operands
 //!
@@ -171,12 +171,23 @@ pub enum Command {
     },
 }
 
+pub mod print;
 pub mod syntax;
 
+impl Command {
+    /// Executes the built-in.
+    pub async fn execute(&self, env: &mut Env) -> crate::Result {
+        match self {
+            Self::Send { signal, targets } => todo!("{signal:?} {targets:?}"),
+            Self::Print { signals, verbose } => print::execute(env, signals, *verbose).await,
+        }
+    }
+}
+
 /// Entry point of the kill built-in
-pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result {
+pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
     match syntax::parse(env, args) {
-        Ok(command) => todo!("{command:?}"),
+        Ok(command) => command.execute(env).await,
         Err(error) => report_error(env, error.to_message()).await,
     }
 }

--- a/yash-builtin/src/kill.rs
+++ b/yash-builtin/src/kill.rs
@@ -1,0 +1,155 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Kill built-in
+//!
+//! The **`kill`** built-in sends a signal to processes.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! kill [-s SIGNAL|-n SIGNAL|-SIGNAL] target…
+//! ```
+//!
+//! ```sh
+//! kill -l|-v [SIGNAL|exit_status]…
+//! ```
+//!
+//! # Description
+//!
+//! Without the `-l` or `-v` option, the built-in sends a signal to processes.
+//!
+//! With the `-l` or `-v` option, the built-in lists signal names or
+//! descriptions.
+//!
+//! # Options
+//!
+//! The **`-s`** or **`-n`** option specifies the signal to send. The signal
+//! name is case-insensitive, but must be specified without the `SIG` prefix.
+//! The default signal is `SIGTERM`. (TODO: Allow the `SIG` prefix)
+//!
+//! The signal may be specified as a number instead of a name. If the number
+//! is zero, the built-in does not send a signal, but instead checks whether
+//! the shell can send the signal to the target processes.
+//!
+//! The obsolete syntax allows the signal name or number to be specified
+//! directly after the hyphen like `-TERM` and `-15` instead of `-s TERM` and
+//! `-n 15`.
+//!
+//! The **`-l`** option lists signal names. The names are printed one per line,
+//! without the `SIG` prefix.
+//!
+//! The **`-v`** option lists signal descriptions. This works like the `-l`
+//! option, but prints the signal number, name, and description instead of
+//! just the name. The `-v` option may be used with the `-l` option, in which
+//! case the `-l` option is ignored.
+//!
+//! # Operands
+//!
+//! Without the `-l` or `-v` option, the built-in takes one or more operands
+//! that specify the target processes. Each operand is one of the following:
+//!
+//! - A positive decimal integer, which should be a process ID
+//! - A negative decimal integer, which should be a negated process group ID
+//! - `0`, which means the current process group
+//! - `-1`, which means all processes
+//! - A [job ID](yash_env::job::id) with a leading `%`
+//!
+//! With the `-l` or `-v` option, the built-in may take operands that limit the
+//! output to the specified signals. Each operand is one of the following:
+//!
+//! - The exit status of a process that was terminated by a signal
+//! - A signal number
+//! - A signal name without the `SIG` prefix
+//!
+//! Without operands, the `-l` and `-v` options list all signals.
+//!
+//! # Errors
+//!
+//! It is an error if:
+//!
+//! - The `-l` or `-v` option is not specified and no target processes are
+//!   specified.
+//! - A specified signal is not supported by the shell.
+//! - A specified target process does not exist.
+//! - The target job specified by a job ID operand is not [job-controlled] by
+//!   the shell.
+//! - The signal cannot be sent to any of the target processes specified by an
+//!   operand.
+//! - An operand specified with the `-l` or `-v` option does not identify a
+//!   supported signal.
+//!
+//! [job-controlled]: yash_env::job::Job::job_controlled
+//!
+//! # Exit status
+//!
+//! The exit status is zero unless an error occurs. The exit status is zero if
+//! the signal is sent to at least one process for each operand, even if the
+//! signal cannot be sent to some of the processes.
+//!
+//! # Usage notes
+//!
+//! When a target is specified as a job ID, the built-in cannot tell whether
+//! the job process group still exists. If the job process group has been
+//! terminated and another process group has been created with the same
+//! process group ID, the built-in will send the signal to the new process
+//! group.
+//!
+//! # Portability
+//!
+//! Specifying a signal number other than `0` to the `-s` option is a
+//! non-standard extension.
+//!
+//! Specifying a signal number to the `-n` option is a ksh extension. This
+//! implementation also supports the `-n` option with a signal name.
+//!
+//! The `kill -SIGNAL target…` form may not be parsed as expected by other
+//! implementations when the signal name starts with an `s`. For example, `kill
+//! -stop 123` may try to send the `SIGTOP` signal instead of the `SIGSTOP`
+//! signal.
+//!
+//! POSIX defines the following signal numbers:
+//!
+//! - `0` (a dummy signal that can be used to check whether the shell can send
+//!   a signal to a process)
+//! - `1` (`SIGHUP`)
+//! - `2` (`SIGINT`)
+//! - `3` (`SIGQUIT`)
+//! - `6` (`SIGABRT`)
+//! - `9` (`SIGKILL`)
+//! - `14` (`SIGALRM`)
+//! - `15` (`SIGTERM`)
+//!
+//! Other signal numbers are implementation-defined.
+//!
+//! Using the `-l` option with more than one operand is a non-standard
+//! extension. Specifying a signal name operand to the `-l` option is a
+//! non-standard extension.
+//!
+//! The `-v` option is a non-standard extension.
+//!
+//! Some implementations print `0` or `EXIT` for `kill -l 0` or `kill -l EXIT`
+//! while this implementation regards them as invalid operands.
+
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Entry point of the kill built-in
+pub async fn main(env: &mut Env, args: Vec<Field>) -> yash_env::builtin::Result {
+    _ = env;
+    _ = args;
+    todo!()
+}

--- a/yash-builtin/src/kill/print.rs
+++ b/yash-builtin/src/kill/print.rs
@@ -1,0 +1,98 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Implementation of `Command::Print`
+//!
+//! The [`print`] function prepares the output of the `Print` command.
+//! The [`execute`] function calls [`print`] and actually prints the output.
+//!
+//! [`print`]: print()
+
+use std::ffi::c_int;
+use std::fmt::Write;
+use yash_env::trap::Signal;
+use yash_env::Env;
+
+/// Lists the specified signals into a string.
+///
+/// If `signals` is empty, all signals are listed.
+#[must_use]
+pub fn print(signals: &[Signal], verbose: bool) -> String {
+    let mut specified = signals.iter().copied();
+    let mut all = Signal::iterator();
+    let iter: &mut dyn Iterator<Item = Signal> = if signals.is_empty() {
+        &mut all
+    } else {
+        &mut specified
+    };
+
+    let mut result = String::new();
+    for signal in iter {
+        let name = signal.as_str();
+        let name = name.strip_prefix("SIG").unwrap_or(name);
+        if verbose {
+            let number = signal as c_int;
+            // TODO Include the description of the signal
+            writeln!(result, "{number}\t{name}").unwrap();
+        } else {
+            writeln!(result, "{name}").unwrap();
+        }
+    }
+    result
+}
+
+/// Executes the `Print` command.
+pub async fn execute(env: &mut Env, signals: &[Signal], verbose: bool) -> crate::Result {
+    let result = print(signals, verbose);
+    crate::common::output(env, &result).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn print_non_empty_non_verbose() {
+        let result = print(&[Signal::SIGTERM, Signal::SIGINT], false);
+        assert_eq!(result, "TERM\nINT\n");
+
+        let result = print(&[Signal::SIGKILL, Signal::SIGTSTP, Signal::SIGQUIT], false);
+        assert_eq!(result, "KILL\nTSTP\nQUIT\n");
+    }
+
+    #[test]
+    fn print_non_empty_verbose() {
+        let result = print(&[Signal::SIGTERM, Signal::SIGINT], true);
+        assert_eq!(result, "15\tTERM\n2\tINT\n");
+
+        let result = print(&[Signal::SIGKILL, Signal::SIGALRM, Signal::SIGQUIT], true);
+        assert_eq!(result, "9\tKILL\n14\tALRM\n3\tQUIT\n");
+    }
+
+    #[test]
+    fn print_all_non_verbose() {
+        let result = print(&[], false);
+        assert!(result.contains("HUP\n"), "result: {result:?}");
+        assert!(result.contains("INT\n"), "result: {result:?}");
+        assert!(result.contains("KILL\n"), "result: {result:?}");
+        assert!(result.contains("QUIT\n"), "result: {result:?}");
+        assert!(result.contains("STOP\n"), "result: {result:?}");
+        assert!(result.contains("TERM\n"), "result: {result:?}");
+        assert!(result.contains("TSTP\n"), "result: {result:?}");
+        assert!(result.contains("TTIN\n"), "result: {result:?}");
+        assert!(result.contains("TTOU\n"), "result: {result:?}");
+    }
+}

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -1,0 +1,170 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Implementation of `Command::Send`
+//!
+//! [`execute`] calls [`send`] for each target and reports all errors.
+//! [`send`] uses [`resolve_target`] to determine the argument to the
+//! [`kill`](yash_env::System::kill) system call.
+use crate::common::{report_failure, to_single_message};
+use std::borrow::Cow;
+use std::num::ParseIntError;
+use thiserror::Error;
+use yash_env::job::id::parse_tail;
+use yash_env::job::Pid;
+use yash_env::job::{id::FindError, JobSet};
+use yash_env::semantics::Field;
+use yash_env::system::Errno;
+use yash_env::trap::Signal;
+use yash_env::Env;
+use yash_env::System as _;
+use yash_syntax::source::pretty::{Annotation, AnnotationType, MessageBase};
+
+/// Error that may occur while [sending](send) a signal.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum Error {
+    /// The specified process (group) ID was not a valid integer.
+    #[error(transparent)]
+    ProcessId(#[from] ParseIntError),
+    /// The specified job ID did not uniquely identify a job.
+    #[error(transparent)]
+    JobId(#[from] FindError),
+    /// The job ID specifies a job that is not job-controlled.
+    #[error("target job is not job-controlled")]
+    Unmonitored,
+    /// An error occurred in the underlying system call.
+    #[error(transparent)]
+    System(#[from] Errno),
+}
+
+/// Resolves the specified target into a process (group) ID.
+///
+/// The target may be specified as a job ID, a process ID, or a process group
+/// ID. In case of a process group ID, the value should be negative.
+pub fn resolve_target(jobs: &JobSet, target: &str) -> Result<Pid, Error> {
+    if let Some(tail) = target.strip_prefix('%') {
+        let job_id = parse_tail(tail);
+        let index = job_id.find(jobs)?;
+        let job = &jobs[index];
+        if job.job_controlled {
+            Ok(-job.pid)
+        } else {
+            Err(Error::Unmonitored)
+        }
+    } else {
+        Ok(Pid(target.parse()?))
+    }
+}
+
+/// Sends the specified signal to the specified target.
+pub async fn send(env: &mut Env, signal: Option<Signal>, target: &Field) -> Result<(), Error> {
+    let pid = resolve_target(&env.jobs, &target.value)?;
+    env.system.kill(pid, signal).await?;
+    Ok(())
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[error("{target}: {error}")]
+struct TargetError<'a> {
+    target: &'a Field,
+    error: Error,
+}
+
+impl MessageBase for TargetError<'_> {
+    fn message_title(&self) -> Cow<str> {
+        "cannot send signal".into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        Annotation::new(
+            AnnotationType::Error,
+            self.to_string().into(),
+            &self.target.origin,
+        )
+    }
+}
+
+/// Executes the `Send` command.
+pub async fn execute(env: &mut Env, signal: Option<Signal>, targets: &[Field]) -> crate::Result {
+    let mut errors = Vec::new();
+    for target in targets {
+        if let Err(error) = send(env, signal, target).await {
+            errors.push(TargetError { target, error });
+        }
+    }
+
+    if let Some(message) = to_single_message(&{ errors }) {
+        report_failure(env, message).await
+    } else {
+        crate::Result::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use yash_env::job::Job;
+
+    #[test]
+    fn resolve_target_process_ids() {
+        let jobs = JobSet::new();
+
+        let result = resolve_target(&jobs, "123");
+        assert_eq!(result, Ok(Pid(123)));
+
+        let result = resolve_target(&jobs, "-456");
+        assert_eq!(result, Ok(Pid(-456)));
+    }
+
+    #[test]
+    fn resolve_target_job_id() {
+        let mut jobs = JobSet::new();
+        let mut job = Job::new(Pid(123));
+        job.job_controlled = true;
+        job.name = "my job".into();
+        jobs.add(job);
+
+        let result = resolve_target(&jobs, "%my");
+        assert_eq!(result, Ok(Pid(-123)));
+    }
+
+    #[test]
+    fn resolve_target_job_find_error() {
+        let jobs = JobSet::new();
+        let result = resolve_target(&jobs, "%my");
+        assert_eq!(result, Err(Error::JobId(FindError::NotFound)));
+    }
+
+    #[test]
+    fn resolve_target_unmonitored() {
+        let mut jobs = JobSet::new();
+        let mut job = Job::new(Pid(123));
+        job.job_controlled = false;
+        job.name = "my job".into();
+        jobs.add(job);
+
+        let result = resolve_target(&jobs, "%my");
+        assert_eq!(result, Err(Error::Unmonitored));
+    }
+
+    #[test]
+    fn resolve_target_invalid_string() {
+        let jobs = JobSet::new();
+        let result = resolve_target(&jobs, "abc");
+        assert_matches!(result, Err(Error::ProcessId(_)));
+    }
+}

--- a/yash-builtin/src/kill/syntax.rs
+++ b/yash-builtin/src/kill/syntax.rs
@@ -1,0 +1,215 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command line parsing
+//!
+//! This module parses command line arguments to the kill built-in.
+//! The parser is implemented without using the utilities in the
+//! [`crate::common::syntax`] crate because of the special syntax of the
+//! signal-specifying option.
+
+use super::Command;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_syntax::source::pretty::{Annotation, AnnotationType, Message};
+use yash_syntax::source::Location;
+
+/// Error that may occur during parsing
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// An argument starts with a hyphen (`-`) but is not a valid option.
+    #[error("unknown option")]
+    UnknownOption(Field),
+
+    /// The signal to send is specified and the `-l` or `-v` options is also
+    /// specified.
+    #[error("invalid option combination")]
+    ConflictingOptions {
+        /// Command line argument that specifies the signal to send
+        signal_arg: Field,
+        /// Name of the option that requests a list (`l` or `v`)
+        list_option_name: char,
+        /// Location of the `-l` or `-v` option
+        list_option_location: Location,
+    },
+
+    /// The `-s` or `-n` option is not followed by a signal name or number.
+    #[error("missing signal name or number")]
+    MissingSignal {
+        /// Name of the option for specifying a signal (`s` or `n`)
+        signal_option_name: char,
+        /// Location of the `-s` or `-n` option
+        signal_option_location: Location,
+    },
+
+    /// More than one signal to send is specified.
+    #[error("multiple signals specified")]
+    MultipleSignals(Field, Field),
+
+    /// A specified signal is not a valid signal name or number.
+    ///
+    /// This error is returned when the argument to the `-s` or `-n` option is
+    /// not a valid signal name or number. This error also occurs when an
+    /// operand given with the `-l` or `-v` option is not a valid signal name,
+    /// signal number, or exit status.
+    #[error("invalid signal")]
+    InvalidSignal(Field),
+
+    /// No target is specified and the `-l` or `-v` option is not specified.
+    #[error("no target process specified")]
+    MissingTarget,
+}
+
+impl Error {
+    /// Converts this error to a printable message
+    pub fn to_message(&self) -> Message {
+        let title = self.to_string().into();
+        let annotations = match self {
+            Error::UnknownOption(field) => vec![Annotation::new(
+                AnnotationType::Error,
+                format!("{:?} is not a valid option", field.value).into(),
+                &field.origin,
+            )],
+
+            Error::ConflictingOptions {
+                signal_arg,
+                list_option_name,
+                list_option_location,
+            } => vec![
+                Annotation::new(
+                    AnnotationType::Error,
+                    "signal to send is specified here".into(),
+                    &signal_arg.origin,
+                ),
+                Annotation::new(
+                    AnnotationType::Error,
+                    format!("option `{list_option_name}` is incompatible").into(),
+                    list_option_location,
+                ),
+            ],
+
+            Error::MissingSignal {
+                signal_option_name,
+                signal_option_location,
+            } => {
+                vec![Annotation::new(
+                    AnnotationType::Error,
+                    format!("option `{signal_option_name}` requires a signal name or number")
+                        .into(),
+                    signal_option_location,
+                )]
+            }
+
+            Error::MultipleSignals(field_1, field_2) => vec![
+                Annotation::new(
+                    AnnotationType::Error,
+                    format!("first signal {:?}", field_1.value).into(),
+                    &field_1.origin,
+                ),
+                Annotation::new(
+                    AnnotationType::Error,
+                    format!("second signal {:?}", field_2.value).into(),
+                    &field_2.origin,
+                ),
+            ],
+
+            Error::InvalidSignal(field) => vec![Annotation::new(
+                AnnotationType::Error,
+                format!("{:?} is not a valid signal name or number", field.value).into(),
+                &field.origin,
+            )],
+
+            Error::MissingTarget => vec![],
+        };
+
+        Message {
+            r#type: AnnotationType::Error,
+            title,
+            annotations,
+            footers: vec![],
+        }
+    }
+}
+
+/// Parse command line arguments
+pub fn parse(env: &Env, args: Vec<Field>) -> Result<Command, Error> {
+    _ = env;
+    _ = args;
+    // TODO
+    Err(Error::MissingTarget)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "TODO"]
+    fn unknown_option() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_s_conflicts_with_option_l() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_n_conflicts_with_option_l() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_s_conflicts_with_option_v() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_n_conflicts_with_option_v() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_s_without_signal() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn option_n_without_signal() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn multiple_signals_error() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn invalid_signal_argument_to_option_s() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn invalid_signal_argument_to_option_n() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn invalid_signal_operand_with_option_l() {}
+
+    #[test]
+    #[ignore = "TODO"]
+    fn invalid_signal_operand_with_option_v() {}
+
+    #[test]
+    fn missing_target() {
+        let env = Env::new_virtual();
+        let result = parse(&env, vec![]);
+        assert_eq!(result, Err(Error::MissingTarget));
+    }
+}

--- a/yash-builtin/src/kill/syntax.rs
+++ b/yash-builtin/src/kill/syntax.rs
@@ -22,8 +22,11 @@
 //! signal-specifying option.
 
 use super::Command;
+use std::ffi::c_int;
 use thiserror::Error;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::trap::Signal;
 use yash_env::Env;
 use yash_syntax::source::pretty::{Annotation, AnnotationType, Message};
 use yash_syntax::source::Location;
@@ -146,12 +149,226 @@ impl Error {
     }
 }
 
-/// Parse command line arguments
-pub fn parse(env: &Env, args: Vec<Field>) -> Result<Command, Error> {
-    _ = env;
-    _ = args;
-    // TODO
-    Err(Error::MissingTarget)
+/// Converts a string to a signal.
+///
+/// The string should be a signal name.
+///
+/// If the string is a valid signal name, this function returns `Some(signal)`.
+/// Otherwise, this function returns `None`.
+///
+/// The signal name is parsed case-insensitively.
+///
+/// If `allow_sig_prefix` is `true`, the `SIG` prefix is optional for signal
+/// names. Otherwise, the `SIG` prefix must **not** be present.
+#[must_use]
+pub fn parse_signal_name(s: &str, allow_sig_prefix: bool) -> Option<Signal> {
+    let mut name = String::with_capacity(s.len() + 3);
+    name.push_str(s);
+    name.make_ascii_uppercase();
+    if !allow_sig_prefix || !name.starts_with("SIG") {
+        name.insert_str(0, "SIG");
+    }
+    name.parse().ok()
+}
+
+/// Converts a string to a signal.
+///
+/// The string may be a signal name or a signal number.
+///
+/// If the string is a valid signal name or number, this function returns
+/// `Some(Some(signal))`. If the string represents the dummy signal number `0`,
+/// this function returns `Some(None)`. Otherwise, this function returns `None`.
+///
+/// The signal name is parsed case-insensitively.
+///
+/// If `allow_sig_prefix` is `true`, the `SIG` prefix is optional for signal
+/// names. Otherwise, the `SIG` prefix must **not** be present.
+#[must_use]
+pub fn parse_signal_name_or_number(s: &str, allow_sig_prefix: bool) -> Option<Option<Signal>> {
+    if let Ok(number) = s.parse::<c_int>() {
+        if number == 0 {
+            Some(None)
+        } else {
+            number.try_into().ok().map(Some)
+        }
+    } else {
+        parse_signal_name(s, allow_sig_prefix).map(Some)
+    }
+}
+
+/// Updates a signal and its origin.
+///
+/// `new_signal` is the new value of `signal`. It should be the result of
+/// [`parse_signal`]. If it is `None`, this function returns
+/// `Error::InvalidSignal(new_signal_origin)`.
+///
+/// `new_signal_origin` should be the field containing the string that was
+/// parsed to obtain `new_signal`. It is used to update `signal_origin`.
+/// However, if `signal_origin` already contains a field, this function returns
+/// `Error::MultipleSignals(signal_origin.take().unwrap(), new_signal_origin)`.
+fn set_signal(
+    signal: &mut Option<Signal>,
+    signal_origin: &mut Option<Field>,
+    new_signal: Option<Option<Signal>>,
+    new_signal_origin: Field,
+) -> Result<(), Error> {
+    let Some(new_signal) = new_signal else {
+        return Err(Error::InvalidSignal(new_signal_origin));
+    };
+    if let Some(prev) = signal_origin.take() {
+        return Err(Error::MultipleSignals(prev, new_signal_origin));
+    }
+    *signal = new_signal;
+    *signal_origin = Some(new_signal_origin);
+    Ok(())
+}
+
+/// Converts an invalid signal error to an unknown option error.
+#[must_use]
+fn invalid_signal_to_unknown_option(error: Error) -> Error {
+    match error {
+        Error::InvalidSignal(field) => Error::UnknownOption(field),
+        error => error,
+    }
+}
+
+/// Parses operands to the `-l` or `-v` option.
+fn parse_signals<I: Iterator<Item = Field>>(
+    operands: I,
+    allow_sig_prefix: bool,
+) -> Result<Vec<Signal>, Error> {
+    let parse_one = move |operand: Field| {
+        if let Some(exit_status) = operand.value.parse().ok().map(ExitStatus) {
+            exit_status.try_into().ok()
+        } else {
+            parse_signal_name(&operand.value, allow_sig_prefix)
+        }
+        .ok_or(Error::InvalidSignal(operand))
+    };
+
+    operands.map(parse_one).collect()
+}
+
+/// Parse the case where the `-l` or `-v` option is specified.
+fn parse_list_case<I: Iterator<Item = Field>>(
+    operands: I,
+    allow_sig_prefix: bool,
+    signal_origin: Option<Field>,
+    list_option_name: char,
+    list_option_location: Location,
+    verbose: bool,
+) -> Result<Command, Error> {
+    if let Some(signal_arg) = signal_origin {
+        Err(Error::ConflictingOptions {
+            signal_arg,
+            list_option_name,
+            list_option_location,
+        })
+    } else {
+        let signals = parse_signals(operands, allow_sig_prefix)?;
+        Ok(Command::Print { signals, verbose })
+    }
+}
+
+/// Parses command line arguments.
+pub fn parse(_env: &Env, args: Vec<Field>) -> Result<Command, Error> {
+    let allow_sig_prefix = false; // TODO true depending on the shell option
+    let mut args = args.into_iter().peekable();
+    let mut signal = Some(Signal::SIGTERM);
+    let mut signal_origin = None;
+    let mut list = None;
+    let mut verbose = None;
+
+    // Parse options
+    while let Some(arg) =
+        args.next_if(|arg| arg.value.strip_prefix('-').is_some_and(|s| !s.is_empty()))
+    {
+        let options = &arg.value[1..];
+        if options == "-" {
+            debug_assert_eq!(arg.value, "--");
+            break;
+        }
+
+        let mut chars = options.chars();
+        while let Some(option) = chars.next() {
+            match option {
+                's' | 'n' => {
+                    let remainder = chars.as_str();
+                    if remainder.is_empty() {
+                        let Some(current_signal_arg) = args.next() else {
+                            return Err(Error::MissingSignal {
+                                signal_option_name: option,
+                                signal_option_location: arg.origin,
+                            });
+                        };
+                        set_signal(
+                            &mut signal,
+                            &mut signal_origin,
+                            parse_signal_name_or_number(
+                                &current_signal_arg.value,
+                                allow_sig_prefix,
+                            ),
+                            current_signal_arg,
+                        )?;
+                    } else {
+                        set_signal(
+                            &mut signal,
+                            &mut signal_origin,
+                            parse_signal_name_or_number(remainder, allow_sig_prefix)
+                                .or_else(|| parse_signal_name_or_number(options, allow_sig_prefix)),
+                            arg,
+                        )?;
+                    }
+                    break;
+                }
+                'l' => {
+                    list = Some(arg.origin.clone());
+                }
+                'v' => {
+                    verbose = Some(arg.origin.clone());
+                }
+                _ => {
+                    set_signal(
+                        &mut signal,
+                        &mut signal_origin,
+                        parse_signal_name_or_number(options, allow_sig_prefix),
+                        arg,
+                    )
+                    .map_err(invalid_signal_to_unknown_option)?;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Parse operands and compute the result
+    if let Some(option_location) = verbose {
+        parse_list_case(
+            args,
+            allow_sig_prefix,
+            signal_origin,
+            'v',
+            option_location,
+            true,
+        )
+    } else if let Some(option_location) = list {
+        parse_list_case(
+            args,
+            allow_sig_prefix,
+            signal_origin,
+            'l',
+            option_location,
+            false,
+        )
+    } else {
+        // Command::Send case
+        if args.peek().is_none() {
+            Err(Error::MissingTarget)
+        } else {
+            let targets = args.collect();
+            Ok(Command::Send { signal, targets })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -159,52 +376,469 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore = "TODO"]
-    fn unknown_option() {}
+    fn parse_signal_names() {
+        assert_eq!(parse_signal_name("TERM", false), Some(Signal::SIGTERM));
+        assert_eq!(parse_signal_name("TeRm", false), Some(Signal::SIGTERM));
+        assert_eq!(parse_signal_name("INT", false), Some(Signal::SIGINT));
+        assert_eq!(parse_signal_name("uSr2", false), Some(Signal::SIGUSR2));
+
+        // When `allow_sig_prefix` is `true`, the `SIG` prefix is optional.
+        assert_eq!(parse_signal_name("tErM", true), Some(Signal::SIGTERM));
+        assert_eq!(parse_signal_name("sIgtErM", true), Some(Signal::SIGTERM));
+
+        // When `allow_sig_prefix` is `false`, the `SIG` prefix must not be present.
+        assert_eq!(parse_signal_name("sIgtErM", false), None);
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_s_conflicts_with_option_l() {}
+    fn parse_signal_numbers() {
+        assert_eq!(parse_signal_name_or_number("0", false), Some(None));
+        assert_eq!(
+            parse_signal_name_or_number("1", false),
+            Some(Some(Signal::SIGHUP))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("2", false),
+            Some(Some(Signal::SIGINT))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("3", false),
+            Some(Some(Signal::SIGQUIT))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("6", false),
+            Some(Some(Signal::SIGABRT))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("9", false),
+            Some(Some(Signal::SIGKILL))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("14", false),
+            Some(Some(Signal::SIGALRM))
+        );
+        assert_eq!(
+            parse_signal_name_or_number("15", false),
+            Some(Some(Signal::SIGTERM))
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_n_conflicts_with_option_l() {}
+    fn parse_signal_name_or_number_errors() {
+        assert_eq!(parse_signal_name_or_number("", false), None);
+        assert_eq!(parse_signal_name_or_number("TERM1", false), None);
+        assert_eq!(parse_signal_name_or_number("1TERM", false), None);
+        assert_eq!(parse_signal_name_or_number("-1", false), None);
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_s_conflicts_with_option_v() {}
+    fn empty_operand() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies([""]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGTERM),
+                targets: Field::dummies([""]),
+            })
+        )
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_n_conflicts_with_option_v() {}
+    fn single_hyphen_operand() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGTERM),
+                targets: Field::dummies(["-"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_s_without_signal() {}
+    fn double_hyphen_separator() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-s", "INT", "--", "0"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGINT),
+                targets: Field::dummies(["0"]),
+            })
+        );
+
+        let result = parse(&env, Field::dummies(["-l", "--", "9"]));
+        assert_eq!(
+            result,
+            Ok(Command::Print {
+                signals: vec![Signal::SIGKILL],
+                verbose: false,
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn option_n_without_signal() {}
+    fn option_s_with_separate_signal_name_argument() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-s", "QuIt", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGQUIT),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn multiple_signals_error() {}
+    fn option_s_with_adjacent_signal_name_argument() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-sQuIt", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGQUIT),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn invalid_signal_argument_to_option_s() {}
+    fn option_s_with_separate_signal_number_argument() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-s", "9", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGKILL),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn invalid_signal_argument_to_option_n() {}
+    fn option_n_with_separate_signal_name_argument() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-n", "QuIt", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGQUIT),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn invalid_signal_operand_with_option_l() {}
+    fn bare_signal_name_in_uppercase() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-KILL", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGKILL),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
 
     #[test]
-    #[ignore = "TODO"]
-    fn invalid_signal_operand_with_option_v() {}
+    fn bare_signal_name_starting_with_s() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-stop", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGSTOP),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
+
+    #[test]
+    fn base_signal_number() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-9", "1"]));
+        assert_eq!(
+            result,
+            Ok(Command::Send {
+                signal: Some(Signal::SIGKILL),
+                targets: Field::dummies(["1"]),
+            })
+        );
+    }
+
+    #[test]
+    fn option_l_without_operands() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-l"]));
+        assert_eq!(
+            result,
+            Ok(Command::Print {
+                signals: vec![],
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn option_v_without_operands() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-v"]));
+        assert_eq!(
+            result,
+            Ok(Command::Print {
+                signals: vec![],
+                verbose: true,
+            })
+        );
+    }
+
+    #[test]
+    fn option_l_and_v_combined() {
+        let env = Env::new_virtual();
+        let expected_result = Ok(Command::Print {
+            signals: vec![],
+            verbose: true,
+        });
+
+        assert_eq!(parse(&env, Field::dummies(["-lv"])), expected_result);
+        assert_eq!(parse(&env, Field::dummies(["-vl"])), expected_result);
+        assert_eq!(parse(&env, Field::dummies(["-l", "-v"])), expected_result);
+        assert_eq!(parse(&env, Field::dummies(["-v", "-l"])), expected_result);
+    }
+
+    #[test]
+    fn option_l_with_operands() {
+        let env = Env::new_virtual();
+        let exit_status = &ExitStatus::from(Signal::SIGQUIT).to_string();
+        let result = parse(&env, Field::dummies(["-l", "TERM", "1", exit_status]));
+        assert_eq!(
+            result,
+            Ok(Command::Print {
+                signals: vec![Signal::SIGTERM, Signal::SIGHUP, Signal::SIGQUIT],
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-x"]));
+        assert_eq!(result, Err(Error::UnknownOption(Field::dummy("-x"))));
+    }
+
+    #[test]
+    fn option_s_conflicts_with_option_l() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-s", "TERM", "-l"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("TERM"),
+                list_option_name: 'l',
+                list_option_location: Location::dummy("-l"),
+            })
+        );
+
+        let result = parse(&env, Field::dummies(["-ls", "TERM"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("TERM"),
+                list_option_name: 'l',
+                list_option_location: Location::dummy("-ls"),
+            })
+        );
+    }
+
+    #[test]
+    fn option_n_conflicts_with_option_l() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-n", "9", "-l"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("9"),
+                list_option_name: 'l',
+                list_option_location: Location::dummy("-l"),
+            })
+        );
+
+        let result = parse(&env, Field::dummies(["-ln", "9"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("9"),
+                list_option_name: 'l',
+                list_option_location: Location::dummy("-ln"),
+            })
+        );
+    }
+
+    #[test]
+    fn option_s_conflicts_with_option_v() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-s", "TERM", "-v"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("TERM"),
+                list_option_name: 'v',
+                list_option_location: Location::dummy("-v"),
+            })
+        );
+
+        let result = parse(&env, Field::dummies(["-lvls", "TERM"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("TERM"),
+                list_option_name: 'v',
+                list_option_location: Location::dummy("-lvls"),
+            })
+        );
+    }
+
+    #[test]
+    fn option_n_conflicts_with_option_v() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-n", "9", "-v"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("9"),
+                list_option_name: 'v',
+                list_option_location: Location::dummy("-v"),
+            })
+        );
+
+        let result = parse(&env, Field::dummies(["-lvln", "9"]));
+        assert_eq!(
+            result,
+            Err(Error::ConflictingOptions {
+                signal_arg: Field::dummy("9"),
+                list_option_name: 'v',
+                list_option_location: Location::dummy("-lvln"),
+            })
+        );
+    }
+
+    #[test]
+    fn option_s_without_signal() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-s"]));
+        assert_eq!(
+            result,
+            Err(Error::MissingSignal {
+                signal_option_name: 's',
+                signal_option_location: Location::dummy("-s"),
+            })
+        );
+    }
+
+    #[test]
+    fn option_n_without_signal() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-n"]));
+        assert_eq!(
+            result,
+            Err(Error::MissingSignal {
+                signal_option_name: 'n',
+                signal_option_location: Location::dummy("-n"),
+            })
+        );
+    }
+
+    #[test]
+    fn multiple_signals_error_on_option_s() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-INT", "-s", "TERM"]));
+        assert_eq!(
+            result,
+            Err(Error::MultipleSignals(
+                Field::dummy("-INT"),
+                Field::dummy("TERM")
+            ))
+        );
+    }
+
+    #[test]
+    fn multiple_signals_error_on_option_n() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-s", "TERM", "-nINT"]));
+        assert_eq!(
+            result,
+            Err(Error::MultipleSignals(
+                Field::dummy("TERM"),
+                Field::dummy("-nINT")
+            ))
+        );
+    }
+
+    #[test]
+    fn multiple_signals_error_on_bare_signal_name() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-n", "TERM", "-QUIT"]));
+        assert_eq!(
+            result,
+            Err(Error::MultipleSignals(
+                Field::dummy("TERM"),
+                Field::dummy("-QUIT")
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_separate_signal_argument_to_option_s() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-s", "TERM1", "123"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("TERM1"))));
+    }
+
+    #[test]
+    fn invalid_separate_signal_argument_to_option_n() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-n", "-1", "123"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("-1"))));
+    }
+
+    #[test]
+    fn invalid_adjoined_signal_argument_to_option_s() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-sTERM1", "123"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("-sTERM1"))));
+    }
+
+    #[test]
+    fn invalid_signal_operand_with_option_l() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-l", "TERM1"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("TERM1"))));
+
+        let result = parse(&env, Field::dummies(["-l", "TERM", "0", "1"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("0"))));
+    }
+
+    #[test]
+    fn invalid_signal_operand_with_option_v() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-v", "TERM1"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("TERM1"))));
+
+        let result = parse(&env, Field::dummies(["-v", "TERM", "0", "1"]));
+        assert_eq!(result, Err(Error::InvalidSignal(Field::dummy("0"))));
+    }
 
     #[test]
     fn missing_target() {

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -62,6 +62,7 @@ pub mod export;
 pub mod fg;
 pub mod getopts;
 pub mod jobs;
+pub mod kill;
 pub mod pwd;
 #[cfg(feature = "yash-semantics")]
 pub mod read;
@@ -191,6 +192,13 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Mandatory,
             execute: |env, args| Box::pin(jobs::main(env, args)),
+        },
+    ),
+    (
+        "kill",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(kill::main(env, args)),
         },
     ),
     (

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -184,6 +184,26 @@ fn if_command() {
 }
 
 #[test]
+fn kill_builtin_1() {
+    run("kill1-p.sh")
+}
+
+#[test]
+fn kill_builtin_2() {
+    run("kill2-p.sh")
+}
+
+#[test]
+fn kill_builtin_3() {
+    run("kill3-p.sh")
+}
+
+#[test]
+fn kill_builtin_4() {
+    run_with_pty("kill4-p.sh")
+}
+
+#[test]
 fn nop_builtins() {
     run("nop-p.sh")
 }

--- a/yash/tests/scripted_test/bg-p.sh
+++ b/yash/tests/scripted_test/bg-p.sh
@@ -29,7 +29,6 @@ __IN__
 1
 __OUT__
 
-: TODO Needs the kill built-in <<\__IN__
 test_OE 'already running job is ignored' -m
 while kill -s CONT $$; do sleep 1; done &
 bg >/dev/null

--- a/yash/tests/scripted_test/exit-p.sh
+++ b/yash/tests/scripted_test/exit-p.sh
@@ -78,6 +78,18 @@ trap exit EXIT
 exit 1
 __IN__
 
+if [ "$(uname)" = Darwin ]; then
+    # On macOS, kill(2) does not appear to run any signal handlers
+    # synchronously, making it impossible for the shell to respond to self-sent
+    # signals at a predictable time. To work around this issue, the kill
+    # built-in is called in a subshell on macOS, using the SIGCHLD signal as a
+    # synchronization trigger. 
+    setup <<\__EOF__
+killx() (command kill "$@")
+alias kill=killx
+__EOF__
+fi
+
 test_OE -e 3 'exit from signal trap with 3'
 trap '(exit 2); exit 3' INT
 (exit 1)

--- a/yash/tests/scripted_test/fg-p.sh
+++ b/yash/tests/scripted_test/fg-p.sh
@@ -34,7 +34,6 @@ sh -c 'kill -s STOP $$; ...'
 fg >/dev/null
 __IN__
 
-: TODO Needs the kill built-in <<\__IN__
 test_x -e 127 'resumed job is disowned unless suspended again' -m
 cat fifo >/dev/null &
 exec 3>fifo

--- a/yash/tests/scripted_test/kill1-p.sh
+++ b/yash/tests/scripted_test/kill1-p.sh
@@ -1,0 +1,55 @@
+# kill1-p.sh: test of the kill built-in for any POSIX-compliant shell, part 1
+
+posix="true"
+
+test_E -e 0 'printing all signal names'
+kill -l
+__IN__
+
+# $1 = LINENO, $2 = signal number, $3 = signal name w/o SIG
+test_printing_signal_name_from_number() {
+    testcase "$1" -e 0 "printing signal name $3 from number" \
+        3<<__IN__ 4<<__OUT__ 5</dev/null
+kill -l $2
+__IN__
+$3
+__OUT__
+}
+
+test_printing_signal_name_from_number "$LINENO" 1 HUP
+test_printing_signal_name_from_number "$LINENO" 2 INT
+test_printing_signal_name_from_number "$LINENO" 3 QUIT
+test_printing_signal_name_from_number "$LINENO" 6 ABRT
+test_printing_signal_name_from_number "$LINENO" 9 KILL
+test_printing_signal_name_from_number "$LINENO" 14 ALRM
+test_printing_signal_name_from_number "$LINENO" 15 TERM
+
+# $1 = LINENO, $2 = signal name w/o SIG
+test_printing_signal_name_from_exit_status() (
+    if sh -c "kill -s $2 \$\$"; then
+        skip="true"
+    fi
+    testcase "$1" -e 0 "printing signal name $2 from exit status" \
+        3<<__IN__ 4<<__OUT__ 5</dev/null
+sh -c 'kill -s $2 \$\$'
+kill -l \$?
+__IN__
+$2
+__OUT__
+)
+
+test_printing_signal_name_from_exit_status "$LINENO" HUP
+test_printing_signal_name_from_exit_status "$LINENO" INT
+test_printing_signal_name_from_exit_status "$LINENO" QUIT
+test_printing_signal_name_from_exit_status "$LINENO" ABRT
+test_printing_signal_name_from_exit_status "$LINENO" KILL
+test_printing_signal_name_from_exit_status "$LINENO" ALRM
+test_printing_signal_name_from_exit_status "$LINENO" TERM
+
+test_OE -e TERM 'sending default signal TERM'
+kill $$
+__IN__
+
+test_OE -e 0 'sending null signal: -s 0'
+kill -s 0 $$
+__IN__

--- a/yash/tests/scripted_test/kill2-p.sh
+++ b/yash/tests/scripted_test/kill2-p.sh
@@ -1,0 +1,43 @@
+# kill2-p.sh: test of the kill built-in for any POSIX-compliant shell, part 2
+
+posix="true"
+
+# $1 = LINENO, $2 = signal name w/o SIG, $3 = prefix for $2
+test_sending_signal_kill() {
+    testcase "$1" -e "$2" "sending signal: $3$2" \
+        3<<__IN__ 4</dev/null 5</dev/null
+kill $3$2 \$\$
+__IN__
+}
+
+# Rust catches SIGBUS and SIGSEGV by default, so we skip these signals.
+
+test_sending_signal_kill "$LINENO" ABRT '-s '
+test_sending_signal_kill "$LINENO" ALRM '-s '
+#test_sending_signal_kill "$LINENO" BUS  '-s '
+test_sending_signal_kill "$LINENO" FPE  '-s '
+test_sending_signal_kill "$LINENO" HUP  '-s '
+test_sending_signal_kill "$LINENO" ILL  '-s '
+test_sending_signal_kill "$LINENO" INT  '-s '
+test_sending_signal_kill "$LINENO" KILL '-s '
+test_sending_signal_kill "$LINENO" PIPE '-s '
+test_sending_signal_kill "$LINENO" QUIT '-s '
+#test_sending_signal_kill "$LINENO" SEGV '-s '
+test_sending_signal_kill "$LINENO" TERM '-s '
+test_sending_signal_kill "$LINENO" USR1 '-s '
+test_sending_signal_kill "$LINENO" USR2 '-s '
+
+test_sending_signal_kill "$LINENO" ABRT -
+test_sending_signal_kill "$LINENO" ALRM -
+#test_sending_signal_kill "$LINENO" BUS  -
+test_sending_signal_kill "$LINENO" FPE  -
+test_sending_signal_kill "$LINENO" HUP  -
+test_sending_signal_kill "$LINENO" ILL  -
+test_sending_signal_kill "$LINENO" INT  -
+test_sending_signal_kill "$LINENO" KILL -
+test_sending_signal_kill "$LINENO" PIPE -
+test_sending_signal_kill "$LINENO" QUIT -
+#test_sending_signal_kill "$LINENO" SEGV -
+test_sending_signal_kill "$LINENO" TERM -
+test_sending_signal_kill "$LINENO" USR1 -
+test_sending_signal_kill "$LINENO" USR2 -

--- a/yash/tests/scripted_test/kill3-p.sh
+++ b/yash/tests/scripted_test/kill3-p.sh
@@ -1,0 +1,53 @@
+# kill3-p.sh: test of the kill built-in for any POSIX-compliant shell, part 3
+
+posix="true"
+
+# $1 = LINENO, $2 = signal name w/o SIG, $3 = prefix for $2
+test_sending_signal_ignore() {
+    testcase "$1" -e 0 "sending signal: $3$2" \
+        3<<__IN__ 4</dev/null 5</dev/null
+kill $3$2 \$\$
+__IN__
+}
+
+test_sending_signal_ignore "$LINENO" CHLD '-s '
+test_sending_signal_ignore "$LINENO" CONT '-s '
+test_sending_signal_ignore "$LINENO" URG  '-s '
+
+test_sending_signal_ignore "$LINENO" CHLD -
+test_sending_signal_ignore "$LINENO" CONT -
+test_sending_signal_ignore "$LINENO" URG  -
+
+# $1 = LINENO, $2 = signal name w/o SIG, $3 = prefix for $2
+test_sending_signal_stop() {
+    testcase "$1" -e 0 "sending signal: $3$2" \
+        3<<__IN__ 4</dev/null 5</dev/null
+(kill $3$2 \$\$; status=\$?; kill -s CONT \$\$; exit \$status)
+__IN__
+}
+
+test_sending_signal_stop "$LINENO" STOP '-s '
+test_sending_signal_stop "$LINENO" TSTP '-s '
+test_sending_signal_stop "$LINENO" TTIN '-s '
+test_sending_signal_stop "$LINENO" TTOU '-s '
+
+test_sending_signal_stop "$LINENO" STOP -
+test_sending_signal_stop "$LINENO" TSTP -
+test_sending_signal_stop "$LINENO" TTIN -
+test_sending_signal_stop "$LINENO" TTOU -
+
+# $1 = LINENO, $2 = signal name w/o SIG, $3 = signal number
+test_sending_signal_num_kill_self() {
+    testcase "$1" -e "$2" "sending signal: -$3" \
+        3<<__IN__ 4</dev/null 5</dev/null
+kill -$3 \$\$
+__IN__
+}
+
+test_sending_signal_num_kill_self "$LINENO" HUP  1
+test_sending_signal_num_kill_self "$LINENO" INT  2
+test_sending_signal_num_kill_self "$LINENO" QUIT 3
+test_sending_signal_num_kill_self "$LINENO" ABRT 6
+test_sending_signal_num_kill_self "$LINENO" KILL 9
+test_sending_signal_num_kill_self "$LINENO" ALRM 14
+test_sending_signal_num_kill_self "$LINENO" TERM 15

--- a/yash/tests/scripted_test/kill4-p.sh
+++ b/yash/tests/scripted_test/kill4-p.sh
@@ -1,0 +1,74 @@
+# kill4-p.sh: test of the kill built-in for any POSIX-compliant shell, part 4
+
+posix="true"
+
+# This FIFO is for synchronization between processes. First, it ensures the
+# receiver has started before the sender sends a signal. Next, the receiver
+# tries to reopen the FIFO so that the receiver does not exit before it
+# receives the signal.
+mkfifo fifo
+
+# all processes in the same process group
+test_oE 'sending signal to process 0' -m
+kill -s HUP 0 >fifo | cat fifo fifo
+kill -l $?
+__IN__
+HUP
+__OUT__
+
+test_oE 'sending signal with negative process number: -s HUP' -m
+(
+pgid="$(exec sh -c 'echo $PPID')"
+kill -s HUP -- -$pgid >fifo | cat fifo fifo
+)
+kill -l $?
+__IN__
+HUP
+__OUT__
+
+test_oE 'sending signal with negative process number: -1' -m
+(
+pgid="$(exec sh -c 'echo $PPID')"
+kill -1 -- -$pgid >fifo | cat fifo fifo
+)
+kill -l $?
+__IN__
+HUP
+__OUT__
+
+(
+setup 'halt() while kill -s CONT $$; do sleep 1; done'
+mkfifo fifo1 fifo2 fifo3
+
+test_oE 'sending signal to background job' -m
+# The subshells stop at the redirections, waiting for the unopened FIFOs.
+(>fifo1; echo not reached 1 >&2) |
+(>fifo2; echo not reached 2 >&2) |
+(>fifo3; echo not reached 3 >&2) &
+halt &
+kill -s USR1 '%?echo'
+wait '%?echo'
+kill -l $?
+kill -s USR2 %halt
+wait %halt
+kill -l $?
+__IN__
+USR1
+USR2
+__OUT__
+
+test_oE 'sending to multiple processes' -m
+# The subshells stop at the redirections, waiting for the unopened FIFOs.
+(>fifo1; echo not reached 1 >&2) &
+(>fifo2; echo not reached 2 >&2) &
+kill '%?fifo1' '%?fifo2'
+wait '%?fifo1'
+kill -l $?
+wait '%?fifo2'
+kill -l $?
+__IN__
+TERM
+TERM
+__OUT__
+
+)

--- a/yash/tests/scripted_test/trap-p.sh
+++ b/yash/tests/scripted_test/trap-p.sh
@@ -2,6 +2,18 @@
 
 posix="true"
 
+if [ "$(uname)" = Darwin ]; then
+    # On macOS, kill(2) does not appear to run any signal handlers
+    # synchronously, making it impossible for the shell to respond to self-sent
+    # signals at a predictable time. To work around this issue, the kill
+    # built-in is called in a subshell on macOS, using the SIGCHLD signal as a
+    # synchronization trigger. 
+    setup <<\__EOF__
+killx() (command kill "$@")
+alias kill=killx
+__EOF__
+fi
+
 test_OE -e USR1 'setting default trap'
 trap - USR1
 kill -s USR1 $$

--- a/yash/tests/scripted_test/wait-p.sh
+++ b/yash/tests/scripted_test/wait-p.sh
@@ -97,26 +97,22 @@ exit 1&
 wait $!
 __IN__
 
-: TODO Needs the kill built-in <<\__OUT__
 test_oE 'trap interrupts wait' -m
 interrupted=false
 trap 'interrupted=true' USR1
-(
-    set +m
-    trap 'echo received USR2; exit' USR2
-    while kill -s USR1 $$; do sleep 1; done # loop until signaled
-)&
-wait $!
+while kill -s 0 $$; do kill -s USR1 $$; done&
+# The asynchronous job should eventually interrupt the wait.
+wait
 status=$?
 echo interrupted=$interrupted $((status > 128))
 kill -l $status
-# Now, the background job should be still running.
+trap '' USR1
+# Now the job should be still running. Kill it.
 kill -s USR2 %
-wait $!
+wait
 echo waited $?
 __IN__
 interrupted=true 1
 USR1
-received USR2
 waited 0
 __OUT__


### PR DESCRIPTION
- [x] Syntax
- [x] Sending
- [x] Printing
- [x] Scripted test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `kill` built-in command in the yash shell for sending signals to processes, listing signal names or descriptions, and handling various signaling options.
- **Refactor**
	- Improved command line parsing for the `kill` command to handle various options and signal types more accurately.
- **Tests**
	- Added comprehensive test scripts for the `kill` built-in command, covering scenarios like printing signal names, sending different signals, and handling special cases on macOS.
- **Bug Fixes**
	- Implemented adjustments for signal handling on macOS to ensure proper synchronization with the SIGCHLD signal and improved handling of asynchronous job interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->