### PR TITLE
Command built-in (POSIX portability)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "either",
+ "enumset",
  "futures-executor",
  "futures-util",
  "itertools",

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -17,9 +17,11 @@ publish = false
 
 [features]
 default = ["yash-semantics"]
+yash-semantics = ["dep:yash-semantics", "dep:enumset"]
 
 [dependencies]
 either = "1.9.0"
+enumset = { version = "1.1.2", optional = true }
 itertools = "0.11.0"
 thiserror = "1.0.47"
 yash-env = { path = "../yash-env", version = "0.1.0" }

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -78,6 +78,8 @@
 //!
 //! It is an error if the specified utility is not found or cannot be executed.
 //!
+//! With the `-v` option, no error message is printed for the utility not found.
+//!
 //! # Exit status
 //!
 //! Without the `-v` or `-V` option, the exit status is that of the utility

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -100,6 +100,7 @@
 //! print an error message to the standard output while others to the standard
 //! error.
 
+use crate::common::report_error;
 use enumset::EnumSet;
 use enumset::EnumSetType;
 use yash_env::semantics::Field;
@@ -217,9 +218,14 @@ impl From<Identify> for Command {
     }
 }
 
+pub mod syntax;
+
 /// Entry point of the `command` built-in
 ///
 /// This function parses the arguments into [`Command`] and executes it.
-pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
-    todo!()
+pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
+    match syntax::parse(env, args) {
+        Ok(command) => todo!("execute {command:?}"),
+        Err(error) => report_error(env, &error).await,
+    }
 }

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -64,8 +64,8 @@
 //! When the `-v` option is given, the built-in prints the following:
 //!
 //! - The absolute pathname of the utility, if found in the search path.
-//! - The utility name itself, if it is a special built-in, function, or shell
-//!   reserved word, hence not subject to search.
+//! - The utility name itself, if it is a non-substitutive built-in, function,
+//!   or shell reserved word, hence not subject to search.
 //! - A command line that would redefine the alias, if the name is an alias.
 //!
 //! When the `-V` option is given, the built-in describes the utility in a more
@@ -218,6 +218,16 @@ impl From<Identify> for Command {
     }
 }
 
+impl Command {
+    pub async fn execute(&self, env: &mut Env) -> crate::Result {
+        match self {
+            Self::Invoke(invoke) => todo!("{invoke:?}"), // invoke.execute(env).await,
+            Self::Identify(identify) => identify.execute(env).await,
+        }
+    }
+}
+
+pub mod identify;
 pub mod search;
 pub mod syntax;
 
@@ -226,7 +236,7 @@ pub mod syntax;
 /// This function parses the arguments into [`Command`] and executes it.
 pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
     match syntax::parse(env, args) {
-        Ok(command) => todo!("execute {command:?}"),
+        Ok(command) => command.execute(env).await,
         Err(error) => report_error(env, &error).await,
     }
 }

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -99,11 +99,18 @@
 //! When the utility is not found with the `-V` option, some implementations
 //! print an error message to the standard output while others to the standard
 //! error.
+//!
+//! # Implementation notes
+//!
+//! The `-p` option depends on [`System::confstr_path`] to obtain the standard
+//! search path. See [`RealSystem::confstr_path`] for the supported platforms.
 
 use crate::common::report_error;
 use enumset::EnumSet;
 use enumset::EnumSetType;
 use yash_env::semantics::Field;
+#[cfg(doc)]
+use yash_env::system::{real::RealSystem, System};
 use yash_env::Env;
 
 /// Category of command name resolution

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -1,0 +1,109 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command built-in
+//!
+//! The **`command`** built-in executes a utility bypassing shell functions.
+//! This is useful when you want to execute a utility that has the same name as
+//! a shell function. The built-in also has options to search for the location
+//! of the utility.
+//!
+//! # Synopsis
+//!
+//! ```sh
+//! command [-p] name [arguments…]
+//! ```
+//!
+//! ```sh
+//! command -v|-V [-p] name
+//! ```
+//!
+//! # Description
+//!
+//! Without the `-v` or `-V` option, the `command` built-in executes the utility
+//! specified by the *name* with the given *arguments*. This is similar to the
+//! execution of a simple command, but the shell functions are not searched for
+//! the *name*.
+//!
+//! With the `-v` or `-V` option, the built-in identifies the type of the *name*
+//! and, optionally, the location of the utility. The `-v` option prints the
+//! pathname of the utility, if found, and the `-V` option prints a more
+//! detailed description of the utility.
+//!
+//! # Options
+//!
+//! The **`-p`** option causes the built-in to search for the utility in the
+//! standard search path instead of the current `$PATH`.
+//!
+//! The **`-v`** option identifies the type of the command name and prints the
+//! pathname of the utility, if found.
+//!
+//! The **`-V`** option identifies the type of the command name and prints a
+//! more detailed description of the utility.
+//!
+//! # Operands
+//!
+//! The ***name*** operand specifies the name of the utility to execute or
+//! identify. The ***arguments*** are passed to the utility when executing it.
+//!
+//! # Standard output
+//!
+//! When the `-v` option is given, the built-in prints the following:
+//!
+//! - The absolute pathname of the utility, if found in the search path.
+//! - The utility name itself, if it is a special built-in, function, or shell
+//!   reserved word, hence not subject to search.
+//! - A command line that would redefine the alias, if the name is an alias.
+//!
+//! When the `-V` option is given, the built-in describes the utility in a more
+//! descriptive, human-readable format. The exact format is not specified here
+//! as it is subject to change.
+//!
+//! Nothing is printed if the utility is not found.
+//!
+//! # Errors
+//!
+//! It is an error if the specified utility is not found or cannot be executed.
+//!
+//! # Exit status
+//!
+//! Without the `-v` or `-V` option, the exit status is that of the utility
+//! executed. If the utility is not found, the exit status is 127. If the
+//! utility is found but cannot be executed, the exit status is 126.
+//!
+//! With the `-v` or `-V` option, the exit status is 0 if the utility is found
+//! and 1 if not found.
+//!
+//! # Portability
+//!
+//! POSIX requires that the `name` operand be specified, but many
+//! implementations allow it to be omitted, in which case the built-in does
+//! nothing.
+//!
+//! When the utility is not found with the `-v` or `-V` option, some
+//! implementations return a non-zero exit status other than 1, especially 127.
+//!
+//! When the utility is not found with the `-V` option, some implementations
+//! print an error message to the standard output while others to the standard
+//! error.
+
+use yash_env::semantics::Field;
+use yash_env::Env;
+
+/// Entry point of the `command` built-in
+pub async fn main(_env: &mut Env, _args: Vec<Field>) -> crate::Result {
+    todo!()
+}

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -226,7 +226,7 @@ impl From<Identify> for Command {
 }
 
 impl Command {
-    pub async fn execute(&self, env: &mut Env) -> crate::Result {
+    pub async fn execute(self, env: &mut Env) -> crate::Result {
         match self {
             Self::Invoke(invoke) => invoke.execute(env).await,
             Self::Identify(identify) => identify.execute(env).await,

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -228,13 +228,14 @@ impl From<Identify> for Command {
 impl Command {
     pub async fn execute(&self, env: &mut Env) -> crate::Result {
         match self {
-            Self::Invoke(invoke) => todo!("{invoke:?}"), // invoke.execute(env).await,
+            Self::Invoke(invoke) => invoke.execute(env).await,
             Self::Identify(identify) => identify.execute(env).await,
         }
     }
 }
 
 pub mod identify;
+mod invoke;
 pub mod search;
 pub mod syntax;
 

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -218,6 +218,7 @@ impl From<Identify> for Command {
     }
 }
 
+pub mod search;
 pub mod syntax;
 
 /// Entry point of the `command` built-in

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -28,6 +28,7 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::ffi::OsStringExt as _;
 use std::path::PathBuf;
 use yash_env::builtin::Type;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::Env;
 use yash_env::System;
@@ -248,7 +249,11 @@ impl Identify {
         let output_result = output(env, &result).await;
 
         let error_result = if let Some(message) = to_single_message(&errors) {
-            report_failure(env, message).await
+            if self.verbose {
+                report_failure(env, message).await
+            } else {
+                crate::Result::from(ExitStatus::FAILURE)
+            }
         } else {
             crate::Result::default()
         };

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -109,12 +109,12 @@ fn normalize_target<E: NormalizeEnv>(env: &E, target: &mut Target) -> Result<(),
 ///
 /// This function is a helper for [`identify`]. It produces the description of
 /// the command search result that is to be printed to the standard output.
-fn describe_target<'f, W>(
+fn describe_target<W>(
     target: &Target,
-    name: &'f Field,
+    name: &Field,
     verbose: bool,
     result: &mut W,
-) -> Result<(), NotFound<'f>>
+) -> std::fmt::Result
 where
     W: std::fmt::Write,
 {
@@ -129,23 +129,23 @@ where
                     Type::Extension => "extension built-in",
                     Type::Substitutive => "substitutive built-in",
                 };
-                write!(result, "{}: {}", name.value, desc).unwrap();
+                write!(result, "{}: {}", name.value, desc)?;
                 if let Some(path) = path {
-                    write!(result, " at {}", quoted(&path)).unwrap();
+                    write!(result, " at {}", quoted(&path))?;
                 }
-                writeln!(result).unwrap();
+                writeln!(result)?;
             } else {
                 let output = path.as_deref().unwrap_or(&name.value);
-                writeln!(result, "{}", output).unwrap();
+                writeln!(result, "{}", output)?;
             }
             Ok(())
         }
 
         Target::Function(_) => {
             if verbose {
-                writeln!(result, "{}: function", name.value).unwrap();
+                writeln!(result, "{}: function", name.value)?;
             } else {
-                writeln!(result, "{}", name.value).unwrap();
+                writeln!(result, "{}", name.value)?;
             }
             Ok(())
         }
@@ -158,10 +158,9 @@ where
                     "{}: external utility at {}",
                     name.value,
                     quoted(&path)
-                )
-                .unwrap();
+                )?;
             } else {
-                writeln!(result, "{}", path).unwrap();
+                writeln!(result, "{}", path)?;
             }
             Ok(())
         }
@@ -220,7 +219,8 @@ where
 
     let mut target = search(env, &name.value).ok_or(NotFound { name })?;
     normalize_target(env.env, &mut target).map_err(|()| NotFound { name })?;
-    describe_target(&target, name, verbose, result)
+    describe_target(&target, name, verbose, result).unwrap();
+    Ok(())
 }
 
 impl Identify {

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -115,6 +115,10 @@ impl NormalizeEnv for Env {
 /// This function makes sure any path contained in the target is absolute and
 /// names an executable file. If the path cannot be normalized, this function
 /// returns an error.
+///
+/// The error returned from this function does not contain any message because
+/// this function is used only by [`categorize`], which only need to report
+/// that the target is not found.
 fn normalize_target<E: NormalizeEnv>(env: &E, target: &mut Target) -> Result<(), ()> {
     match target {
         Target::Function(_) | Target::Builtin { path: None, .. } => Ok(()),

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -1,0 +1,410 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command identifying semantics
+
+use super::search::SearchEnv;
+use super::Identify;
+use crate::command::Category;
+use crate::common::{output, report_failure, to_single_message};
+use std::borrow::Cow;
+use yash_env::builtin::Type;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_quote::quoted;
+use yash_semantics::command_search::search;
+use yash_semantics::command_search::Target;
+use yash_syntax::parser::lex::Keyword;
+use yash_syntax::source::pretty::Annotation;
+use yash_syntax::source::pretty::AnnotationType;
+use yash_syntax::source::pretty::MessageBase;
+
+/// Error object for the command not found
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NotFound<'a> {
+    /// Command name that was not found
+    pub name: &'a Field,
+}
+
+impl MessageBase for NotFound<'_> {
+    fn message_title(&self) -> Cow<str> {
+        "command not found".into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        let label = format!("{}: not found", self.name.value).into();
+        let location = &self.name.origin;
+        Annotation::new(AnnotationType::Error, label, location)
+    }
+}
+
+/// Identifies the command and appends the description to the result.
+///
+/// This function is a helper for [`identify`]. It produces the description of
+/// the command search result that is to be printed to the standard output.
+fn identify_target<'f, W>(
+    target: &Target,
+    name: &'f Field,
+    verbose: bool,
+    result: &mut W,
+) -> Result<(), NotFound<'f>>
+where
+    W: std::fmt::Write,
+{
+    match target {
+        // TODO Needs the path to the built-in
+        Target::Builtin(builtin) => {
+            if verbose {
+                let desc = match builtin.r#type {
+                    Type::Special => "special built-in",
+                    Type::Mandatory => "mandatory built-in",
+                    Type::Elective => "elective built-in",
+                    Type::Extension => "extension built-in",
+                    Type::Substitutive => "substitutive built-in",
+                };
+                writeln!(result, "{}: {}", name.value, desc).unwrap();
+            } else {
+                writeln!(result, "{}", name.value).unwrap();
+            }
+            Ok(())
+        }
+
+        Target::Function(_) => {
+            if verbose {
+                writeln!(result, "{}: function", name.value).unwrap();
+            } else {
+                writeln!(result, "{}", name.value).unwrap();
+            }
+            Ok(())
+        }
+
+        Target::External { path } => {
+            let path = path.to_string_lossy();
+            if verbose {
+                writeln!(
+                    result,
+                    "{}: external utility at {}",
+                    name.value,
+                    quoted(&path)
+                )
+                .unwrap();
+            } else {
+                writeln!(result, "{}", path).unwrap();
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Identifies the command and appends the description to the result.
+///
+/// This function produces the description of the command search result that is
+/// to be printed to the standard output.
+pub fn identify<'f, W>(
+    name: &'f Field,
+    env: &mut SearchEnv,
+    verbose: bool,
+    result: &mut W,
+) -> Result<(), NotFound<'f>>
+where
+    W: std::fmt::Write,
+{
+    if env.params.categories.contains(Category::Keyword)
+        && Keyword::try_from(name.value.as_str()).is_ok()
+    {
+        if verbose {
+            writeln!(result, "{}: keyword", name.value).unwrap();
+        } else {
+            writeln!(result, "{}", name.value).unwrap();
+        }
+        return Ok(());
+    }
+
+    if env.params.categories.contains(Category::Alias) {
+        if let Some(alias) = env.env.aliases.get(name.value.as_str()) {
+            if verbose {
+                writeln!(
+                    result,
+                    "{}: alias for `{}`",
+                    alias.0.name, alias.0.replacement
+                )
+                .unwrap();
+            } else {
+                write!(result, "alias ").unwrap();
+                if alias.0.name.starts_with('-') {
+                    write!(result, "-- ").unwrap();
+                }
+                writeln!(
+                    result,
+                    "{}={}",
+                    quoted(&alias.0.name),
+                    quoted(&alias.0.replacement)
+                )
+                .unwrap();
+            }
+            return Ok(());
+        }
+    }
+
+    let target = search(env, &name.value).ok_or(NotFound { name })?;
+    identify_target(&target, name, verbose, result)
+}
+
+impl Identify {
+    /// Identifies the commands and returns the result.
+    ///
+    /// This function returns a string that should be printed to the standard
+    /// output, as well as a list of errors that should be printed to the
+    /// standard error.
+    pub fn result(&self, env: &mut Env) -> (String, Vec<NotFound>) {
+        let params = &self.search;
+        let env = &mut SearchEnv { env, params };
+        let mut result = String::new();
+        let mut errors = Vec::new();
+        for name in &self.names {
+            if let Err(error) = identify(name, env, self.verbose, &mut result) {
+                errors.push(error);
+            }
+        }
+        (result, errors)
+    }
+
+    /// Performs the identifying semantics.
+    pub async fn execute(&self, env: &mut Env) -> crate::Result {
+        let (result, errors) = self.result(env);
+
+        let output_result = output(env, &result).await;
+
+        let error_result = if let Some(message) = to_single_message(&errors) {
+            report_failure(env, message).await
+        } else {
+            crate::Result::default()
+        };
+
+        output_result.max(error_result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::Search;
+    use std::ffi::CString;
+    use yash_env::builtin::Builtin;
+    use yash_env::function::Function;
+    use yash_syntax::alias::HashEntry;
+    use yash_syntax::source::Location;
+    use yash_syntax::syntax::FullCompoundCommand;
+
+    #[test]
+    fn identify_keyword() {
+        let name = &Field::dummy("if");
+        let env = &mut Env::new_virtual();
+        let params = &Search::default_for_identify();
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        identify(name, env, false, &mut output).unwrap();
+        assert_eq!(output, "if\n");
+
+        let mut output = String::new();
+        identify(name, env, true, &mut output).unwrap();
+        assert_eq!(output, "if: keyword\n");
+    }
+
+    #[test]
+    fn identify_non_keyword() {
+        let name = &Field::dummy("foo");
+        let env = &mut Env::new_virtual();
+        let params = &Search::default_for_identify();
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        let result = identify(name, env, false, &mut output);
+        assert_eq!(output, "");
+        assert_eq!(result, Err(NotFound { name }));
+    }
+
+    #[test]
+    fn excluding_keyword() {
+        let name = &Field::dummy("if");
+        let env = &mut Env::new_virtual();
+        let params = &mut Search::default_for_identify();
+        params.categories.remove(Category::Keyword);
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        let result = identify(name, env, false, &mut output);
+        assert_eq!(output, "");
+        assert_eq!(result, Err(NotFound { name }));
+    }
+
+    #[test]
+    fn identify_alias() {
+        let name = &Field::dummy("a");
+        let env = &mut Env::new_virtual();
+        env.aliases.insert(HashEntry::new(
+            "a".to_string(),
+            "A".to_string(),
+            false,
+            Location::dummy("a"),
+        ));
+        let params = &Search::default_for_identify();
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        identify(name, env, false, &mut output).unwrap();
+        assert_eq!(output, "alias a=A\n");
+
+        let mut output = String::new();
+        identify(name, env, true, &mut output).unwrap();
+        assert_eq!(output, "a: alias for `A`\n");
+    }
+
+    #[test]
+    fn identify_non_alias() {
+        let name = &Field::dummy("a");
+        let env = &mut Env::new_virtual();
+        let params = &Search::default_for_identify();
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        let result = identify(name, env, false, &mut output);
+        assert_eq!(output, "");
+        assert_eq!(result, Err(NotFound { name }));
+    }
+
+    #[test]
+    fn excluding_alias() {
+        let name = &Field::dummy("a");
+        let env = &mut Env::new_virtual();
+        env.aliases.insert(HashEntry::new(
+            "a".to_string(),
+            "A".to_string(),
+            false,
+            Location::dummy("a"),
+        ));
+        let params = &mut Search::default_for_identify();
+        params.categories.remove(Category::Alias);
+        let env = &mut SearchEnv { env, params };
+
+        let mut output = String::new();
+        let result = identify(name, env, false, &mut output);
+        assert_eq!(output, "");
+        assert_eq!(result, Err(NotFound { name }));
+    }
+
+    #[test]
+    fn identify_builtin_without_path() {
+        let name = &Field::dummy(":");
+        let target = &Target::Builtin(Builtin {
+            r#type: Type::Special,
+            execute: |_, _| unreachable!(),
+        });
+
+        let mut output = String::new();
+        identify_target(target, name, false, &mut output).unwrap();
+        assert_eq!(output, ":\n");
+
+        let mut output = String::new();
+        identify_target(target, name, true, &mut output).unwrap();
+        assert_eq!(output, ":: special built-in\n");
+    }
+
+    // TODO identify_builtin_with_path
+
+    #[test]
+    fn identify_function() {
+        let name = &Field::dummy("f");
+        let command: FullCompoundCommand = "{ :; }".parse().unwrap();
+        let location = Location::dummy("f");
+        let function = Function::new("f", command, location);
+        let target = &Target::Function(function.into());
+
+        let mut output = String::new();
+        identify_target(target, name, false, &mut output).unwrap();
+        assert_eq!(output, "f\n");
+
+        let mut output = String::new();
+        identify_target(target, name, true, &mut output).unwrap();
+        assert_eq!(output, "f: function\n");
+    }
+
+    #[test]
+    fn identify_external() {
+        let name = &Field::dummy("ls");
+        let target = &Target::External {
+            path: CString::new("/bin/ls").unwrap(),
+        };
+
+        let mut output = String::new();
+        identify_target(target, name, false, &mut output).unwrap();
+        assert_eq!(output, "/bin/ls\n");
+
+        let mut output = String::new();
+        identify_target(target, name, true, &mut output).unwrap();
+        assert_eq!(output, "ls: external utility at /bin/ls\n");
+    }
+
+    #[test]
+    fn identify_result_without_error() {
+        let env = &mut Env::new_virtual();
+
+        let mut identify = Identify::default();
+        let (result, errors) = identify.result(env);
+        assert_eq!(result, "");
+        assert_eq!(errors, []);
+
+        identify.names.push(Field::dummy("if"));
+        let (result, errors) = identify.result(env);
+        assert_eq!(result, "if\n");
+        assert_eq!(errors, []);
+
+        identify.verbose = true;
+        let (result, errors) = identify.result(env);
+        assert_eq!(result, "if: keyword\n");
+        assert_eq!(errors, []);
+
+        identify.names.push(Field::dummy("fi"));
+        let (result, errors) = identify.result(env);
+        assert_eq!(result, "if: keyword\nfi: keyword\n");
+        assert_eq!(errors, []);
+    }
+
+    #[test]
+    fn identify_result_with_error() {
+        let env = &mut Env::new_virtual();
+        let identify = Identify {
+            names: Field::dummies(["if", "oops", "fi", "bar"]),
+            ..Identify::default()
+        };
+
+        let (result, errors) = identify.result(env);
+
+        assert_eq!(result, "if\nfi\n");
+        assert_eq!(
+            errors,
+            [
+                NotFound {
+                    name: &Field::dummy("oops")
+                },
+                NotFound {
+                    name: &Field::dummy("bar")
+                }
+            ]
+        );
+    }
+}

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -24,6 +24,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::Env;
 use yash_semantics::command::simple_command::execute_function_body;
+use yash_semantics::command::simple_command::start_external_utility_in_subshell_and_wait;
 use yash_semantics::command_search::search;
 use yash_semantics::command_search::Target;
 
@@ -68,7 +69,10 @@ async fn invoke_target(env: &mut Env, target: Target, mut fields: Vec<Field>) ->
             crate::Result::with_exit_status_and_divert(env.exit_status, divert)
         }
 
-        Target::External { .. } => todo!(),
+        Target::External { path } => {
+            let exit_status = start_external_utility_in_subshell_and_wait(env, path, fields).await;
+            crate::Result::from(exit_status)
+        }
     }
 }
 

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -1,0 +1,96 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command invoking semantics
+
+use crate::common::report_failure;
+
+use super::identify::NotFound;
+use super::search::SearchEnv;
+use super::Invoke;
+use yash_env::semantics::ExitStatus;
+use yash_env::Env;
+use yash_semantics::command_search::search;
+
+impl Invoke {
+    /// Execute the command
+    pub async fn execute(&self, env: &mut Env) -> crate::Result {
+        let Some(name) = self.fields.first() else {
+            return crate::Result::default();
+        };
+
+        let params = &self.search;
+        let search_env = &mut SearchEnv { env, params };
+        let Some(target) = search(search_env, &name.value) else {
+            let mut result = report_failure(env, &NotFound { name }).await;
+            result.set_exit_status(ExitStatus::NOT_FOUND);
+            return result;
+        };
+
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Search;
+    use super::*;
+    use crate::tests::assert_stderr;
+    use crate::tests::assert_stdout;
+    use enumset::EnumSet;
+    use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::builtin::Builtin;
+    use yash_env::builtin::Type::Special;
+    use yash_env::semantics::Field;
+    use yash_env::VirtualSystem;
+
+    #[test]
+    fn empty_command_invocation() {
+        let mut env = Env::new_virtual();
+        let invoke = Invoke::default();
+        let result = invoke.execute(&mut env).now_or_never().unwrap();
+        assert_eq!(result, crate::Result::default());
+    }
+
+    #[test]
+    fn command_not_found() {
+        let system = Box::new(VirtualSystem::new());
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(system);
+        env.builtins.insert(
+            "foo",
+            Builtin {
+                r#type: Special,
+                execute: |_, _| unreachable!(),
+            },
+        );
+        let invoke = Invoke {
+            fields: Field::dummies(["foo"]),
+            search: Search {
+                standard_path: false,
+                categories: EnumSet::empty(),
+            },
+        };
+
+        let result = invoke.execute(&mut env).now_or_never().unwrap();
+        assert_eq!(result.exit_status(), ExitStatus::NOT_FOUND);
+        assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("not found"), "stderr: {stderr:?}");
+        });
+    }
+}

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -1,0 +1,67 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command search
+//!
+//! This module provides the search functionality of the `command` built-in.
+//! It is based on the [`yash_semantics::command_search`] module, but it adds
+//! the ability to select the category of the command to search for.
+
+use super::Search;
+use std::collections::HashMap;
+use std::ffi::CStr;
+use yash_env::builtin::Builtin;
+use yash_env::function::FunctionSet;
+use yash_env::variable::Variable;
+use yash_env::Env;
+
+/// Environment adapter for applying the search parameters
+///
+/// This type implements the [`yash_semantics::command_search::SearchEnv`] trait
+/// by extracting results from the environment filtered by the search
+/// parameters.
+#[derive(Clone, Copy, Debug)]
+pub struct SearchEnv<'a> {
+    pub env: &'a Env,
+    pub params: &'a Search,
+}
+
+impl yash_semantics::command_search::PathEnv for SearchEnv<'_> {
+    fn path(&self) -> Option<&Variable> {
+        // TODO Seems like this trait function needs to be changed to return
+        // something more abstract so that we can return the result of confstr.
+        todo!()
+    }
+
+    #[inline]
+    fn is_executable_file(&self, path: &CStr) -> bool {
+        self.env.is_executable_file(path)
+    }
+}
+
+impl yash_semantics::command_search::SearchEnv for SearchEnv<'_> {
+    fn builtins(&self) -> &HashMap<&'static str, Builtin> {
+        // TODO Can we change this trait function to take a built-in name and
+        // return a reference to the built-in?
+        todo!()
+    }
+
+    fn functions(&self) -> &FunctionSet {
+        // TODO Can we change this trait function to take a function name and
+        // return a reference to the function?
+        todo!()
+    }
+}

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -22,8 +22,9 @@
 
 use super::Search;
 use std::ffi::CStr;
+use std::rc::Rc;
 use yash_env::builtin::Builtin;
-use yash_env::function::FunctionSet;
+use yash_env::function::Function;
 use yash_env::variable::Variable;
 use yash_env::Env;
 
@@ -56,9 +57,7 @@ impl yash_semantics::command_search::SearchEnv for SearchEnv<'_> {
         todo!("return built-in {name}")
     }
 
-    fn functions(&self) -> &FunctionSet {
-        // TODO Can we change this trait function to take a function name and
-        // return a reference to the function?
-        todo!()
+    fn function(&self, name: &str) -> Option<&Rc<Function>> {
+        todo!("return function {name}")
     }
 }

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -21,7 +21,6 @@
 //! the ability to select the category of the command to search for.
 
 use super::Search;
-use std::collections::HashMap;
 use std::ffi::CStr;
 use yash_env::builtin::Builtin;
 use yash_env::function::FunctionSet;
@@ -53,10 +52,8 @@ impl yash_semantics::command_search::PathEnv for SearchEnv<'_> {
 }
 
 impl yash_semantics::command_search::SearchEnv for SearchEnv<'_> {
-    fn builtins(&self) -> &HashMap<&'static str, Builtin> {
-        // TODO Can we change this trait function to take a built-in name and
-        // return a reference to the built-in?
-        todo!()
+    fn builtin(&self, name: &str) -> Option<Builtin> {
+        todo!("return built-in {name}")
     }
 
     fn functions(&self) -> &FunctionSet {

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -25,7 +25,7 @@ use std::ffi::CStr;
 use std::rc::Rc;
 use yash_env::builtin::Builtin;
 use yash_env::function::Function;
-use yash_env::variable::Variable;
+use yash_env::variable::Expansion;
 use yash_env::Env;
 
 /// Environment adapter for applying the search parameters
@@ -40,9 +40,7 @@ pub struct SearchEnv<'a> {
 }
 
 impl yash_semantics::command_search::PathEnv for SearchEnv<'_> {
-    fn path(&self) -> Option<&Variable> {
-        // TODO Seems like this trait function needs to be changed to return
-        // something more abstract so that we can return the result of confstr.
+    fn path(&self) -> Expansion<'_> {
         todo!()
     }
 

--- a/yash-builtin/src/command/syntax.rs
+++ b/yash-builtin/src/command/syntax.rs
@@ -1,0 +1,204 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Command line argument parser for the command built-in
+
+use super::Command;
+use super::Identify;
+use super::Invoke;
+use super::Search;
+use crate::common::syntax::parse_arguments;
+use crate::common::syntax::Mode;
+use crate::common::syntax::OptionSpec;
+use crate::common::syntax::ParseError;
+use thiserror::Error;
+use yash_env::semantics::Field;
+use yash_env::Env;
+use yash_syntax::source::pretty::Message;
+
+/// Error in parsing command line arguments
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// An error occurred in the common parser.
+    #[error(transparent)]
+    CommonError(#[from] ParseError<'static>),
+    // TODO MissingCommandName
+    // TODO TooManyCommandNames
+    // TODO UninvokableCategory
+}
+
+impl<'a> From<&'a Error> for Message<'a> {
+    fn from(error: &'a Error) -> Self {
+        match error {
+            Error::CommonError(error) => error.into(),
+        }
+    }
+}
+
+const OPTION_SPECS: &[OptionSpec] = &[
+    OptionSpec::new().short('p').long("path"),
+    OptionSpec::new().short('v').long("identify"),
+    OptionSpec::new().short('V').long("verbose-identify"),
+];
+
+pub fn parse(env: &Env, args: Vec<Field>) -> Result<Command, Error> {
+    let (options, operands) = parse_arguments(OPTION_SPECS, Mode::with_env(env), args)?;
+
+    // Interpret options
+    let mut standard_path = false;
+    let mut verbose_identify = None;
+    for option in options {
+        match option.spec.get_short() {
+            Some('p') => standard_path = true,
+            Some('v') => verbose_identify = Some(false),
+            Some('V') => verbose_identify = Some(true),
+            _ => unreachable!("unhandled option: {:?}", option),
+        }
+    }
+
+    // Produce the result
+    if let Some(verbose) = verbose_identify {
+        let mut search = Search::default_for_identify();
+        search.standard_path = standard_path;
+        let identify = Identify {
+            names: operands,
+            search,
+            verbose,
+        };
+        Ok(identify.into())
+    } else {
+        let mut search = Search::default_for_invoke();
+        search.standard_path = standard_path;
+        let fields = operands;
+        let invoke = Invoke { fields, search };
+        Ok(invoke.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::Category;
+    use assert_matches::assert_matches;
+    use enumset::EnumSet;
+
+    #[test]
+    fn invoke_without_options() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["foo", "bar", "baz"]));
+
+        assert_matches!(result, Ok(Command::Invoke(invoke)) => {
+            assert_eq!(invoke.fields, Field::dummies(["foo", "bar", "baz"]));
+            assert_eq!(
+                invoke.search,
+                Search {
+                    standard_path: false,
+                    categories: Category::Builtin | Category::ExternalUtility
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn invoke_with_p_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-p", "foo"]));
+
+        assert_matches!(result, Ok(Command::Invoke(invoke)) => {
+            assert_eq!(invoke.fields, Field::dummies(["foo"]));
+            assert_eq!(
+                invoke.search,
+                Search {
+                    standard_path: true,
+                    categories: Category::Builtin | Category::ExternalUtility
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn identify_without_options() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-v", "foo"]));
+
+        assert_matches!(result, Ok(Command::Identify(identify)) => {
+            assert_eq!(identify.names, Field::dummies(["foo"]));
+            assert_eq!(
+                identify.search,
+                Search {
+                    standard_path: false,
+                    categories: EnumSet::all()
+                }
+            );
+            assert!(!identify.verbose);
+        });
+    }
+
+    #[test]
+    fn identify_with_p_option() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-v", "-p", "foo"]));
+
+        assert_matches!(result, Ok(Command::Identify(identify)) => {
+            assert_eq!(identify.names, Field::dummies(["foo"]));
+            assert_eq!(
+                identify.search,
+                Search {
+                    standard_path: true,
+                    categories: EnumSet::all()
+                }
+            );
+            assert!(!identify.verbose);
+        });
+    }
+
+    #[test]
+    fn verbosely_identify_without_options() {
+        let env = Env::new_virtual();
+        let result = parse(&env, Field::dummies(["-V", "bar"]));
+
+        assert_matches!(result, Ok(Command::Identify(identify)) => {
+            assert_eq!(identify.names, Field::dummies(["bar"]));
+            assert_eq!(
+                identify.search,
+                Search {
+                    standard_path: false,
+                    categories: EnumSet::all()
+                }
+            );
+            assert!(identify.verbose);
+        });
+    }
+
+    // This ordering is not specified by POSIX, but it is consistent with the
+    // older versions of yash.
+    #[test]
+    #[allow(non_snake_case)]
+    fn last_specified_option_wins_between_v_and_V() {
+        let env = Env::new_virtual();
+
+        let result = parse(&env, Field::dummies(["-V", "-v", "baz"]));
+        assert_matches!(result, Ok(Command::Identify(identify)) => {
+            assert!(!identify.verbose);
+        });
+
+        let result = parse(&env, Field::dummies(["-v", "-V", "baz"]));
+        assert_matches!(result, Ok(Command::Identify(identify)) => {
+            assert!(identify.verbose);
+        });
+    }
+}

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -40,6 +40,7 @@
 //! crate, which is enabled by default. If you disable the `yash-semantics`
 //! feature, the following built-ins will be unavailable:
 //!
+//! - `command`
 //! - `eval`
 //! - `exec`
 //! - `read`
@@ -51,6 +52,8 @@ pub mod bg;
 pub mod r#break;
 pub mod cd;
 pub mod colon;
+#[cfg(feature = "yash-semantics")]
+pub mod command;
 pub mod common;
 pub mod r#continue;
 #[cfg(feature = "yash-semantics")]
@@ -134,6 +137,14 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         Builtin {
             r#type: Mandatory,
             execute: |env, args| Box::pin(cd::main(env, args)),
+        },
+    ),
+    #[cfg(feature = "yash-semantics")]
+    (
+        "command",
+        Builtin {
+            r#type: Mandatory,
+            execute: |env, args| Box::pin(command::main(env, args)),
         },
     ),
     (

--- a/yash-env/src/builtin.rs
+++ b/yash-env/src/builtin.rs
@@ -34,7 +34,7 @@ use std::pin::Pin;
 pub mod getopts;
 
 /// Types of built-in utilities.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Type {
     /// Special built-in
     ///
@@ -243,7 +243,7 @@ impl From<ExitStatus> for Result {
 pub type Main = fn(&mut Env, Vec<Field>) -> Pin<Box<dyn Future<Output = Result> + '_>>;
 
 /// Built-in utility definition.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Builtin {
     /// Type of the built-in.
     pub r#type: Type,

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -62,6 +62,7 @@ use std::ffi::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fmt::Debug;
 use std::future::Future;
 use std::io::SeekFrom;
@@ -382,6 +383,12 @@ pub trait System: Debug {
     ///
     /// Returns `Ok(None)` if the user is not found.
     fn getpwnam_dir(&self, name: &str) -> nix::Result<Option<PathBuf>>;
+
+    /// Returns the standard `$PATH` value where all standard utilities are
+    /// expected to be found.
+    ///
+    /// This is a thin wrapper around the `confstr(_CS_PATH, …)`.
+    fn confstr_path(&self) -> nix::Result<OsString>;
 }
 
 /// Sentinel for the current working directory
@@ -946,6 +953,9 @@ impl System for SharedSystem {
     }
     fn getpwnam_dir(&self, name: &str) -> nix::Result<Option<PathBuf>> {
         self.0.borrow().getpwnam_dir(name)
+    }
+    fn confstr_path(&self) -> nix::Result<OsString> {
+        self.0.borrow().confstr_path()
     }
 }
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -437,8 +437,9 @@ impl System for RealSystem {
             if size == 0 {
                 return Err(Errno::last());
             }
-            let mut buffer = Vec::with_capacity(size);
-            let final_size = nix::libc::confstr(nix::libc::_CS_PATH, buffer.as_mut_ptr(), size);
+            let mut buffer = Vec::<u8>::with_capacity(size);
+            let final_size =
+                nix::libc::confstr(nix::libc::_CS_PATH, buffer.as_mut_ptr() as *mut _, size);
             if final_size == 0 {
                 return Err(Errno::last());
             }
@@ -446,7 +447,7 @@ impl System for RealSystem {
                 return Err(Errno::ERANGE);
             }
             buffer.set_len(final_size - 1); // The last byte is a null terminator.
-            Ok(OsString::from_vec(buffer))
+            return Ok(OsString::from_vec(buffer));
         }
 
         #[allow(unreachable_code)]

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -51,6 +51,7 @@ use std::ffi::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::future::Future;
 use std::io::SeekFrom;
 use std::os::unix::ffi::OsStrExt;
@@ -420,6 +421,36 @@ impl System for RealSystem {
 
     fn getpwnam_dir(&self, name: &str) -> nix::Result<Option<std::path::PathBuf>> {
         nix::unistd::User::from_name(name).map(|o| o.map(|passwd| passwd.dir))
+    }
+
+    fn confstr_path(&self) -> nix::Result<OsString> {
+        // TODO Support other platforms
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos"
+        ))]
+        unsafe {
+            use std::os::unix::ffi::OsStringExt as _;
+            let size = nix::libc::confstr(nix::libc::_CS_PATH, std::ptr::null_mut(), 0);
+            if size == 0 {
+                return Err(Errno::last());
+            }
+            let mut buffer = Vec::with_capacity(size);
+            let final_size = nix::libc::confstr(nix::libc::_CS_PATH, buffer.as_mut_ptr(), size);
+            if final_size == 0 {
+                return Err(Errno::last());
+            }
+            if final_size > size {
+                return Err(Errno::ERANGE);
+            }
+            buffer.set_len(final_size - 1); // The last byte is a null terminator.
+            Ok(OsString::from_vec(buffer))
+        }
+
+        #[allow(unreachable_code)]
+        Err(Errno::ENOSYS)
     }
 }
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -87,6 +87,7 @@ use std::ffi::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fmt::Debug;
 use std::future::poll_fn;
 use std::future::Future;
@@ -988,6 +989,19 @@ impl System for VirtualSystem {
         let state = self.state.borrow();
         Ok(state.home_dirs.get(name).cloned())
     }
+
+    /// Returns the standard path for the system.
+    ///
+    /// This function returns the value of [`SystemState::path`]. If it is empty,
+    /// it returns the `ENOSYS` error.
+    fn confstr_path(&self) -> nix::Result<OsString> {
+        let path = self.state.borrow().path.clone();
+        if path.is_empty() {
+            Err(Errno::ENOSYS)
+        } else {
+            Ok(path)
+        }
+    }
 }
 
 fn send_signal_to_processes(
@@ -1055,6 +1069,9 @@ pub struct SystemState {
     /// [`VirtualSystem::getpwnam_dir`] looks up its argument in this
     /// dictionary.
     pub home_dirs: HashMap<String, PathBuf>,
+
+    /// Standard path returned by [`VirtualSystem::confstr_path`]
+    pub path: OsString,
 }
 
 impl SystemState {

--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -46,6 +46,7 @@
 //! [`Env::push_context`] returns a [`EnvContextGuard`] that implements
 //! `DerefMut<Target = Env>`.
 
+use crate::semantics::Field;
 #[cfg(doc)]
 use crate::Env;
 use itertools::Itertools;
@@ -88,6 +89,27 @@ pub struct PositionalParams {
     pub values: Vec<String>,
     /// Location of the last modification of positional parameters
     pub last_modified_location: Option<Location>,
+}
+
+impl PositionalParams {
+    /// Creates a `PositionalParams` instance from fields.
+    ///
+    /// The given iterator should be a non-empty sequence of fields. The first
+    /// field is the name of the command whose origin is used as the
+    /// `last_modified_location`. The rest of the fields are the values of
+    /// positional parameters.
+    pub fn from_fields<I>(fields: I) -> Self
+    where
+        I: IntoIterator<Item = Field>,
+    {
+        let mut fields = fields.into_iter();
+        let last_modified_location = fields.next().map(|field| field.origin);
+        let values = fields.map(|field| field.value).collect();
+        Self {
+            values,
+            last_modified_location,
+        }
+    }
 }
 
 /// Variable context

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -221,6 +221,7 @@ use builtin::execute_builtin;
 
 mod function;
 use function::execute_function;
+pub use function::execute_function_body;
 
 mod external;
 use external::execute_external_utility;

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -170,7 +170,7 @@ impl Command for syntax::SimpleCommand {
         use crate::command_search::Target::{Builtin, External, Function};
         if let Some(name) = fields.first() {
             match search(env, &name.value) {
-                Some(Builtin(builtin)) => {
+                Some(Builtin { builtin, .. }) => {
                     execute_builtin(env, builtin, &self.assigns, fields, &self.redirs).await
                 }
                 Some(Function(function)) => {

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -226,6 +226,7 @@ pub use function::execute_function_body;
 mod external;
 use external::execute_external_utility;
 pub use external::replace_current_process;
+pub use external::start_external_utility_in_subshell_and_wait;
 pub use external::to_c_strings;
 
 #[cfg(test)]

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -50,7 +50,7 @@ use yash_env::System;
 /// Target of a simple command execution
 ///
 /// This is the result of the [command search](search).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Target {
     /// Built-in utility
     Builtin {
@@ -168,6 +168,10 @@ impl SearchEnv for Env {
 /// need to update a cache of the results of external utility search (TODO:
 /// which is not yet implemented). The function does not otherwise modify the
 /// environment.
+///
+/// If the given name contains a slash, the function immediately returns an
+/// external utility target, regardless of whether the named external utility
+/// actually exists.
 pub fn search<E: SearchEnv>(env: &mut E, name: &str) -> Option<Target> {
     if name.contains('/') {
         return if let Ok(path) = CString::new(name) {

--- a/yash/tests/scripted_test.rs
+++ b/yash/tests/scripted_test.rs
@@ -114,6 +114,11 @@ fn cd_builtin() {
 }
 
 #[test]
+fn command_builtin() {
+    run("command-p.sh")
+}
+
+#[test]
 fn command_substitution() {
     run("cmdsub-p.sh")
 }

--- a/yash/tests/scripted_test/command-p.sh
+++ b/yash/tests/scripted_test/command-p.sh
@@ -1,0 +1,311 @@
+# command-p.sh: test of the command built-in for any POSIX-compliant shell
+
+posix="true"
+
+test_o 'redirection error on special built-in does not kill shell'
+command : <_no_such_file_
+echo reached
+__IN__
+reached
+__OUT__
+
+test_o 'dot script not found does not kill shell'
+command . ./_no_such_file_
+echo reached
+__IN__
+reached
+__OUT__
+
+test_o 'assignment on special built-in is temporary'
+a=a
+a=b command :
+echo $a
+__IN__
+a
+__OUT__
+
+test_OE -e n 'command ignores function (mandatory built-in)'
+false () { true; }
+command false
+__IN__
+
+test_E -e 0 'command ignores function (substitutive built-in)'
+echo () { false; }
+command echo
+__IN__
+
+test_OE -e 0 'command ignores function (external command)'
+cat () { false; }
+command cat </dev/null
+__IN__
+
+: TODO yash is broken <<\__OUT__
+test_oE -e 0 'command exec retains redirection'
+command exec 3<<\__END__
+here
+__END__
+cat <&3
+__IN__
+here
+__OUT__
+
+test_oE 'effect on environment'
+command read a <<\__END__
+foo
+__END__
+echo $a
+__IN__
+foo
+__OUT__
+
+(
+# TODO The -p option is not supported on some systems.
+case "$(uname)" in
+    (Darwin)
+        ;;
+    (*)
+        skip='true'
+        ;;
+esac
+
+test_o -e 0 'executing with standard path'
+PATH=
+command -p echo foo bar | command -p cat
+__IN__
+foo bar
+__OUT__
+
+)
+
+(
+setup 'set -e'
+
+test_oE -e 0 'describing reserved word ! (-v)'
+command -v !
+__IN__
+!
+__OUT__
+
+test_oE -e 0 'describing reserved word { (-v)'
+command -v {
+__IN__
+{
+__OUT__
+
+test_oE -e 0 'describing reserved word } (-v)'
+command -v }
+__IN__
+}
+__OUT__
+
+test_oE -e 0 'describing reserved word case (-v)'
+command -v case
+__IN__
+case
+__OUT__
+
+test_oE -e 0 'describing reserved word do (-v)'
+command -v do
+__IN__
+do
+__OUT__
+
+test_oE -e 0 'describing reserved word done (-v)'
+command -v done
+__IN__
+done
+__OUT__
+
+test_oE -e 0 'describing reserved word elif (-v)'
+command -v elif
+__IN__
+elif
+__OUT__
+
+test_oE -e 0 'describing reserved word else (-v)'
+command -v else
+__IN__
+else
+__OUT__
+
+test_oE -e 0 'describing reserved word esac (-v)'
+command -v esac
+__IN__
+esac
+__OUT__
+
+test_oE -e 0 'describing reserved word fi (-v)'
+command -v fi
+__IN__
+fi
+__OUT__
+
+test_oE -e 0 'describing reserved word for (-v)'
+command -v for
+__IN__
+for
+__OUT__
+
+test_oE -e 0 'describing reserved word if (-v)'
+command -v if
+__IN__
+if
+__OUT__
+
+test_oE -e 0 'describing reserved word in (-v)'
+command -v in
+__IN__
+in
+__OUT__
+
+test_oE -e 0 'describing reserved word then (-v)'
+command -v then
+__IN__
+then
+__OUT__
+
+test_oE -e 0 'describing reserved word until (-v)'
+command -v until
+__IN__
+until
+__OUT__
+
+test_oE -e 0 'describing reserved word while (-v)'
+command -v while
+__IN__
+while
+__OUT__
+
+test_E -e 0 'describing reserved word (-V)'
+command -V !
+__IN__
+
+test_oE -e 0 'describing special built-in (-v)'
+command -v :
+__IN__
+:
+__OUT__
+
+test_E -e 0 'describing special built-in (-V)'
+command -V :
+__IN__
+
+test_x -e 0 'exit status of describing non-special built-in (-v)'
+command -v echo
+__IN__
+
+test_x -e 0 'exit status of describing non-special built-in (-V)'
+command -V echo
+__IN__
+
+test_E -e 0 'output of describing non-special built-in (-v)'
+command -v echo | grep '^/'
+__IN__
+
+test_x -e 0 'output of describing non-special built-in (-V)'
+command -V echo | grep -F "$(command -v echo)"
+__IN__
+
+test_x -e 0 'exit status of describing external command (-v, no slash)'
+command -v cat
+__IN__
+
+test_x -e 0 'exit status of describing external command (-V, no slash)'
+command -V cat
+__IN__
+
+test_E -e 0 'output of describing external command (-v, no slash)'
+command -v cat | grep '^/'
+__IN__
+
+test_E -e 0 'output of describing external command (-V, no slash)'
+command -V cat | grep -F "$(command -v cat)"
+__IN__
+
+>foo
+chmod a+x foo
+
+test_x -e 0 'exit status of describing external command (-v, with slash)'
+command -v ./foo
+__IN__
+
+test_x -e 0 'exit status of describing external command (-V, with slash)'
+command -V ./foo
+__IN__
+
+test_E -e 0 'output of describing external command (-v, with slash)'
+command -v ./foo | grep '^/' | grep '/foo$'
+__IN__
+
+test_E -e 0 'output of describing external command (-V, with slash)'
+command -V ./foo | grep -F "$(command -v ./foo)"
+__IN__
+
+test_oE -e 0 'describing function (-v)'
+cat() { :; }
+command -v cat
+__IN__
+cat
+__OUT__
+
+test_E -e 0 'describing function (-V)'
+cat() { :; }
+command -V cat
+__IN__
+
+test_oE -e 0 'describing alias (-v)'
+alias abc='echo ABC'
+command="$(command -v abc)"
+unalias abc
+eval "$command"
+abc
+__IN__
+ABC
+__OUT__
+
+test_OE -e 0 'describing alias (-V)'
+alias abc=xyz
+d="$(command -V abc)"
+case "$d" in
+    (*abc*xyz*|*xyz*abc*) # expected output contains alias name and value
+        ;;
+    (*)
+        printf '%s\n' "$d" # print non-conforming result
+        ;;
+esac
+__IN__
+
+test_OE -e n 'describing non-existent command (-v)'
+PATH=
+command -v _no_such_command_
+__IN__
+
+test_x -e n 'describing non-existent command (-V)'
+PATH=
+command -V _no_such_command_
+__IN__
+
+# TODO The -p option is not supported on some systems.
+case "$(uname)" in
+    (Darwin)
+        ;;
+    (*)
+        skip='true'
+        ;;
+esac
+
+test_x -e 0 'describing external command with standard path (-v)'
+PATH=
+command -pv cat
+__IN__
+
+test_x -e 0 'describing external command with standard path (-V)'
+PATH=
+command -pV cat
+__IN__
+
+)
+
+test_O -d -e 127 'executing non-existent command'
+command ./_no_such_command_
+__IN__

--- a/yash/tests/scripted_test/typeset-y.sh
+++ b/yash/tests/scripted_test/typeset-y.sh
@@ -1,10 +1,9 @@
 # typeset-y.tst: yash-specific test of the typeset built-in
 
-: TODO Needs the command built-in <<\__OUT__
 test_oE -e 0 'typeset is an elective built-in'
 command -V typeset
 __IN__
-typeset: an elective built-in
+typeset: elective built-in
 __OUT__
 
 test_oE -e 0 'defining variable in global namespace' -e


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `command` built-in functionality in the yash shell, allowing users to execute utilities, search for commands, and identify command types and locations.
  - Added a method to retrieve the standard `$PATH` value across different system implementations.
- **Enhancements**
  - Improved handling and execution of external utilities and shell functions, including better error handling and job control.
  - Enhanced command search functionality with more detailed categorization and precise searching capabilities.
- **Bug Fixes**
  - Adjusted pattern matching for command execution to ensure accurate processing.
- **Tests**
  - Added new test functions and scripts to validate the `command` built-in's functionality and compliance with POSIX standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->