### PR TITLE
Make yash-syntax compile on windows/wasm/embedded

### DIFF
--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -80,8 +80,12 @@ use itertools::Itertools;
 use std::cell::OnceCell;
 use std::fmt;
 use std::fmt::Write;
+#[cfg(unix)]
 use std::os::unix::io::RawFd;
 use std::rc::Rc;
+
+#[cfg(not(unix))]
+type RawFd = i32;
 
 /// Result of [`Unquote::write_unquoted`].
 ///


### PR DESCRIPTION
hi!

I'm using yash-syntax in multiple projects, and for my latest trick I'm trying to compile it on windows too. There's no execution happening in what I'm doing, instead I'm using yash-syntax to parse shell into an AST. This should be operating system agnostic since it's only datastructures and string processing.

The crate currently does not compile on anything that isn't unix due to this line:

```rust
use std::os::unix::io::RawFd;
```

According to the docs of [`RawFd`](https://doc.rust-lang.org/std/os/fd/type.RawFd.html) this is an alias for [`c_int`](https://doc.rust-lang.org/std/os/raw/type.c_int.html), which in turn is documented as:

> This type will almost always be [i32](https://doc.rust-lang.org/std/primitive.i32.html), but may differ on some esoteric systems.

I think it's fair to just alias RawFd to i32 on anything that isn't unix. From what I can tell (at least inside of the yash-syntax crate) this is only used to parse `2>&1` into `2` and `1`.