### PR TITLE
Migrate to our own Signal type

### DIFF
--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -92,7 +92,6 @@ use yash_env::job::id::parse;
 use yash_env::job::JobList;
 use yash_env::job::Pid;
 use yash_env::job::ProcessState;
-use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::system::Errno;
 use yash_env::system::System as _;
@@ -189,7 +188,11 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
     };
 
     match result {
-        Ok(state) => ExitStatus::try_from(state).unwrap().into(),
+        Ok(state) => env
+            .system
+            .exit_status_for_process_state(state)
+            .unwrap()
+            .into(),
         Err(error) => report_simple_failure(env, &error.to_string()).await,
     }
 }
@@ -208,6 +211,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::option::Option::Monitor;
     use yash_env::option::State::On;
+    use yash_env::semantics::ExitStatus;
     use yash_env::subshell::JobControl;
     use yash_env::subshell::Subshell;
     use yash_env::system::r#virtual::Process;

--- a/yash-builtin/src/kill/syntax.rs
+++ b/yash-builtin/src/kill/syntax.rs
@@ -374,6 +374,9 @@ pub fn parse(_env: &Env, args: Vec<Field>) -> Result<Command, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use yash_env::trap::Signal2;
+    use yash_env::System as _;
+    use yash_env::SystemEx as _;
 
     #[test]
     fn parse_signal_names() {
@@ -612,10 +615,17 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Need to merge the two Signal definitions"] // TODO
     fn option_l_with_operands() {
         let env = Env::new_virtual();
-        let exit_status = &ExitStatus::from(Signal::SIGQUIT).to_string();
-        let result = parse(&env, Field::dummies(["-l", "TERM", "1", exit_status]));
+        let number = &env
+            .system
+            .signal_to_raw_number(Signal2::Hup)
+            .unwrap()
+            .to_string();
+        let exit_status = &env.system.exit_status_for_signal(Signal2::Quit).to_string();
+
+        let result = parse(&env, Field::dummies(["-l", "TERM", number, exit_status]));
         assert_eq!(
             result,
             Ok(Command::Print {

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -141,28 +141,6 @@ impl ProcessState {
     }
 }
 
-/// Error value indicating that the process is running.
-///
-/// This error value may be returned by [`TryFrom<ProcessState>::try_from`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct RunningProcess;
-
-/// Converts `ProcessState` to `ExitStatus`.
-///
-/// For the `Running` state, the conversion fails with [`RunningProcess`].
-impl TryFrom<ProcessState> for ExitStatus {
-    type Error = RunningProcess;
-    fn try_from(state: ProcessState) -> Result<Self, RunningProcess> {
-        match state {
-            ProcessState::Exited(exit_status) => Ok(exit_status),
-            ProcessState::Signaled { signal, .. } | ProcessState::Stopped(signal) => {
-                Ok(ExitStatus::from(signal))
-            }
-            ProcessState::Running => Err(RunningProcess),
-        }
-    }
-}
-
 /// Set of one or more processes executing a pipeline
 ///
 /// In the current implementation, a job contains the process ID of one child

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -511,7 +511,7 @@ mod tests {
             {
                 let mut state = state.borrow_mut();
                 let process = state.processes.get_mut(&env.main_pid).unwrap();
-                assert!(process.blocked_signals().contains(Signal::SIGCHLD));
+                assert!(process.blocked_signals().contains(&Signal::SIGCHLD));
                 let _ = process.raise_signal(Signal::SIGCHLD);
             }
             env.wait_for_signal(Signal::SIGCHLD).await;
@@ -550,7 +550,7 @@ mod tests {
         {
             let mut state = system.state.borrow_mut();
             let process = state.processes.get_mut(&system.process_id).unwrap();
-            assert!(process.blocked_signals().contains(Signal::SIGCHLD));
+            assert!(process.blocked_signals().contains(&Signal::SIGCHLD));
             let _ = process.raise_signal(Signal::SIGCHLD);
         }
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -361,7 +361,8 @@ impl Env {
         loop {
             let (pid, state) = self.wait_for_subshell(target).await?;
             if !state.is_alive() {
-                return Ok((pid, state.try_into().unwrap()));
+                let exit_status = self.system.exit_status_for_process_state(state).unwrap();
+                return Ok((pid, exit_status));
             }
         }
     }

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -51,7 +51,7 @@ use self::system::Errno;
 pub use self::system::SharedSystem;
 use self::system::SignalHandling;
 pub use self::system::System;
-use self::system::SystemEx;
+pub use self::system::SystemEx;
 use self::trap::Signal;
 use self::trap::TrapSet;
 use self::variable::Scope;

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -16,8 +16,6 @@
 
 //! Type definitions for command execution.
 
-use crate::system::Errno;
-use nix::sys::signal::Signal;
 use std::ffi::c_int;
 use std::ops::ControlFlow;
 use std::process::ExitCode;
@@ -106,24 +104,6 @@ impl From<ExitStatus> for c_int {
 impl Termination for ExitStatus {
     fn report(self) -> ExitCode {
         (self.0 as u8).into()
-    }
-}
-
-/// Converts an exit status to the corresponding signal.
-///
-/// If there is a signal such that
-/// `exit_status == ExitStatus::from(signal)`,
-/// the signal is returned.
-/// The same if the exit status is the lowest 8 bits of such an exit status.
-/// The signal is also returned if the exit status is a signal number itself.
-/// Otherwise, an error is returned.
-impl TryFrom<ExitStatus> for Signal {
-    type Error = Errno;
-    fn try_from(exit_status: ExitStatus) -> std::result::Result<Signal, Errno> {
-        Signal::try_from(exit_status.0 - 0x180)
-            .or_else(|_| Signal::try_from(exit_status.0 - 0x80))
-            .or_else(|_| Signal::try_from(exit_status.0))
-            .map_err(Errno::from)
     }
 }
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -643,8 +643,7 @@ pub trait SystemEx: System {
         match state {
             ProcessState::Exited(exit_status) => Some(exit_status),
             ProcessState::Signaled { signal, .. } | ProcessState::Stopped(signal) => {
-                // TODO Some(self.exit_status_for_signal(signal))
-                Some(ExitStatus::from(signal))
+                Some(self.exit_status_for_signal(self.raw_number_to_signal(signal as _).unwrap()))
             }
             ProcessState::Running => None,
         }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -621,20 +621,6 @@ pub trait SystemEx: System {
         ExitStatus(raw_exit_status)
     }
 
-    /// Infers the signal that caused the process to exit or stop from the exit
-    /// status.
-    #[must_use]
-    fn signal_for_exit_status(&self, status: ExitStatus) -> Option<Signal2> {
-        for offset in [0x180, 0x80, 0] {
-            if status.0 > offset {
-                if let Ok(signal) = self.raw_number_to_signal(status.0 - offset) {
-                    return Some(signal);
-                }
-            }
-        }
-        None
-    }
-
     /// Returns the exit status for a process that has the specified state.
     ///
     /// This function returns `None` if the state is `Running`.

--- a/yash-env/src/system/errno.rs
+++ b/yash-env/src/system/errno.rs
@@ -278,6 +278,13 @@ impl From<nix::Error> for Errno {
     }
 }
 
+impl From<crate::system::UnknownSignalError> for Errno {
+    #[inline]
+    fn from(_: crate::system::UnknownSignalError) -> Self {
+        Self::EINVAL
+    }
+}
+
 impl From<Errno> for std::io::Error {
     #[inline]
     fn from(errno: Errno) -> Self {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -34,9 +34,11 @@ use super::Result;
 use super::SigSet;
 use super::SigmaskHow;
 use super::Signal;
+use super::Signal2;
 use super::System;
 use super::TimeSpec;
 use super::Times;
+use super::UnknownSignalError;
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::job::ProcessState;
@@ -343,6 +345,22 @@ impl System for RealSystem {
             children_user: tms.tms_cutime as f64 / ticks_per_second as f64,
             children_system: tms.tms_cstime as f64 / ticks_per_second as f64,
         })
+    }
+
+    #[inline]
+    fn signal_to_raw_number(
+        &self,
+        signal: Signal2,
+    ) -> std::result::Result<c_int, UnknownSignalError> {
+        signal.to_raw()
+    }
+
+    #[inline]
+    fn raw_number_to_signal(
+        &self,
+        number: c_int,
+    ) -> std::result::Result<Signal2, UnknownSignalError> {
+        Signal2::try_from_raw(number)
     }
 
     fn sigmask(

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -620,6 +620,8 @@ impl Dir for RealDir {
     }
 }
 
+mod signal;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -1,0 +1,385 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Signal definitions for the real system
+
+use crate::trap::Signal2;
+use crate::trap::UnknownSignalError;
+use std::ffi::c_int;
+use std::ops::RangeInclusive;
+
+/// Returns the range of real-time signals supported by the real system.
+///
+/// If the real system does not support real-time signals, `None` is returned.
+#[must_use]
+fn rt_range() -> Option<RangeInclusive<c_int>> {
+    #[cfg(target_os = "aix")]
+    return Some(nix::libc::SIGRTMIN..=nix::libc::SIGRTMAX);
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "l4re",
+        target_os = "linux",
+    ))]
+    return Some(nix::libc::SIGRTMIN()..=nix::libc::SIGRTMAX());
+
+    #[allow(unreachable_code)]
+    None
+}
+
+impl Signal2 {
+    /// Returns the raw signal number for the real system.
+    pub(super) fn to_raw(self) -> Result<c_int, UnknownSignalError> {
+        match self {
+            Signal2::Abrt => Ok(nix::libc::SIGABRT),
+            Signal2::Alrm => Ok(nix::libc::SIGALRM),
+            Signal2::Bus => Ok(nix::libc::SIGBUS),
+            Signal2::Chld => Ok(nix::libc::SIGCHLD),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "solaris",
+            ))]
+            Signal2::Cld => Ok(nix::libc::SIGCLD),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "solaris",
+            )))]
+            Signal2::Cld => Err(UnknownSignalError),
+            Signal2::Cont => Ok(nix::libc::SIGCONT),
+            #[cfg(not(any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            Signal2::Emt => Ok(nix::libc::SIGEMT),
+            #[cfg(any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            ))]
+            Signal2::Emt => Err(UnknownSignalError),
+            Signal2::Fpe => Ok(nix::libc::SIGFPE),
+            Signal2::Hup => Ok(nix::libc::SIGHUP),
+            Signal2::Ill => Ok(nix::libc::SIGILL),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            Signal2::Info => Ok(nix::libc::SIGINFO),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            ))]
+            Signal2::Info => Err(UnknownSignalError),
+            Signal2::Int => Ok(nix::libc::SIGINT),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            Signal2::Io => Ok(nix::libc::SIGIO),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            )))]
+            Signal2::Io => Err(UnknownSignalError),
+            Signal2::Iot => Ok(nix::libc::SIGIOT),
+            Signal2::Kill => Ok(nix::libc::SIGKILL),
+            #[cfg(target_os = "horizon")]
+            Signal2::Lost => Ok(nix::libc::SIGLOST),
+            #[cfg(not(target_os = "horizon"))]
+            Signal2::Lost => Err(UnknownSignalError),
+            Signal2::Pipe => Ok(nix::libc::SIGPIPE),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            Signal2::Poll => Ok(nix::libc::SIGPOLL),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            )))]
+            Signal2::Poll => Err(UnknownSignalError),
+            Signal2::Prof => Ok(nix::libc::SIGPROF),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "redox",
+                target_os = "solaris",
+            ))]
+            Signal2::Pwr => Ok(nix::libc::SIGPWR),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "redox",
+                target_os = "solaris",
+            )))]
+            Signal2::Pwr => Err(UnknownSignalError),
+            Signal2::Quit => Ok(nix::libc::SIGQUIT),
+            Signal2::Segv => Ok(nix::libc::SIGSEGV),
+            #[cfg(all(
+                any(
+                    target_os = "android",
+                    target_os = "emscripten",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                ),
+                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+            ))]
+            Signal2::Stkflt => Ok(nix::libc::SIGSTKFLT),
+            #[cfg(not(all(
+                any(
+                    target_os = "android",
+                    target_os = "emscripten",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                ),
+                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+            )))]
+            Signal2::Stkflt => Err(UnknownSignalError),
+            Signal2::Stop => Ok(nix::libc::SIGSTOP),
+            Signal2::Sys => Ok(nix::libc::SIGSYS),
+            Signal2::Term => Ok(nix::libc::SIGTERM),
+            #[cfg(target_os = "freebsd")]
+            Signal2::Thr => Ok(nix::libc::SIGTHR),
+            #[cfg(not(target_os = "freebsd"))]
+            Signal2::Thr => Err(UnknownSignalError),
+            Signal2::Trap => Ok(nix::libc::SIGTRAP),
+            Signal2::Tstp => Ok(nix::libc::SIGTSTP),
+            Signal2::Ttin => Ok(nix::libc::SIGTTIN),
+            Signal2::Ttou => Ok(nix::libc::SIGTTOU),
+            Signal2::Urg => Ok(nix::libc::SIGURG),
+            Signal2::Usr1 => Ok(nix::libc::SIGUSR1),
+            Signal2::Usr2 => Ok(nix::libc::SIGUSR2),
+            Signal2::Vtalrm => Ok(nix::libc::SIGVTALRM),
+            Signal2::Winch => Ok(nix::libc::SIGWINCH),
+            Signal2::Xcpu => Ok(nix::libc::SIGXCPU),
+            Signal2::Xfsz => Ok(nix::libc::SIGXFSZ),
+
+            Signal2::Rtmin(n) => {
+                if let Some(range) = rt_range() {
+                    if let Some(number) = range.start().checked_add(n) {
+                        if range.contains(&number) {
+                            return Ok(number);
+                        }
+                    }
+                }
+                Err(UnknownSignalError)
+            }
+            Signal2::Rtmax(n) => {
+                if let Some(range) = rt_range() {
+                    if let Some(number) = range.end().checked_add(n) {
+                        if range.contains(&number) {
+                            return Ok(number);
+                        }
+                    }
+                }
+                Err(UnknownSignalError)
+            }
+        }
+    }
+
+    /// Returns the signal for the raw signal number for the real system.
+    pub(super) fn try_from_raw(number: c_int) -> Result<Self, UnknownSignalError> {
+        // Some signals share the same number on some systems. This function
+        // returns the signal that is considered the most common or standard one.
+        #[allow(unreachable_patterns)]
+        match number {
+            // Standard signals
+            nix::libc::SIGABRT => Ok(Signal2::Abrt),
+            nix::libc::SIGALRM => Ok(Signal2::Alrm),
+            nix::libc::SIGBUS => Ok(Signal2::Bus),
+            nix::libc::SIGCHLD => Ok(Signal2::Chld),
+            nix::libc::SIGCONT => Ok(Signal2::Cont),
+            nix::libc::SIGFPE => Ok(Signal2::Fpe),
+            nix::libc::SIGHUP => Ok(Signal2::Hup),
+            nix::libc::SIGILL => Ok(Signal2::Ill),
+            nix::libc::SIGINT => Ok(Signal2::Int),
+            nix::libc::SIGKILL => Ok(Signal2::Kill),
+            nix::libc::SIGPIPE => Ok(Signal2::Pipe),
+            nix::libc::SIGQUIT => Ok(Signal2::Quit),
+            nix::libc::SIGSEGV => Ok(Signal2::Segv),
+            nix::libc::SIGSTOP => Ok(Signal2::Stop),
+            nix::libc::SIGTERM => Ok(Signal2::Term),
+            nix::libc::SIGTSTP => Ok(Signal2::Tstp),
+            nix::libc::SIGTTIN => Ok(Signal2::Ttin),
+            nix::libc::SIGTTOU => Ok(Signal2::Ttou),
+            nix::libc::SIGUSR1 => Ok(Signal2::Usr1),
+            nix::libc::SIGUSR2 => Ok(Signal2::Usr2),
+
+            // Non-standard but common signals
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            nix::libc::SIGPOLL => Ok(Signal2::Poll),
+            nix::libc::SIGPROF => Ok(Signal2::Prof),
+            nix::libc::SIGSYS => Ok(Signal2::Sys),
+            nix::libc::SIGTRAP => Ok(Signal2::Trap),
+            nix::libc::SIGURG => Ok(Signal2::Urg),
+            nix::libc::SIGVTALRM => Ok(Signal2::Vtalrm),
+            nix::libc::SIGWINCH => Ok(Signal2::Winch),
+            nix::libc::SIGXCPU => Ok(Signal2::Xcpu),
+            nix::libc::SIGXFSZ => Ok(Signal2::Xfsz),
+
+            // other signals
+            #[cfg(not(any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            nix::libc::SIGEMT => Ok(Signal2::Emt),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            nix::libc::SIGINFO => Ok(Signal2::Info),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            nix::libc::SIGIO => Ok(Signal2::Io),
+            #[cfg(target_os = "horizon")]
+            nix::libc::SIGLOST => Ok(Signal2::Lost),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "redox",
+                target_os = "solaris",
+            ))]
+            nix::libc::SIGPWR => Ok(Signal2::Pwr),
+            #[cfg(all(
+                any(
+                    target_os = "android",
+                    target_os = "emscripten",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                ),
+                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+            ))]
+            nix::libc::SIGSTKFLT => Ok(Signal2::Stkflt),
+            #[cfg(target_os = "freebsd")]
+            nix::libc::SIGTHR => Ok(Signal2::Thr),
+
+            _ => {
+                // Real-time signals
+                if let Some(range) = rt_range() {
+                    if range.contains(&number) {
+                        let incr = number - range.start();
+                        debug_assert!(incr >= 0);
+                        let decr = number - range.end();
+                        debug_assert!(decr <= 0);
+                        return if incr <= -decr {
+                            Ok(Signal2::Rtmin(incr))
+                        } else {
+                            Ok(Signal2::Rtmax(decr))
+                        };
+                    }
+                }
+
+                Err(UnknownSignalError)
+            }
+        }
+    }
+}

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -249,10 +249,22 @@ impl Signal2 {
                 }
                 Err(UnknownSignalError)
             }
+
+            Signal2::Number(n) => {
+                // Check if the number is valid
+                if Self::try_from_raw(n).is_ok() {
+                    Ok(n)
+                } else {
+                    Err(UnknownSignalError)
+                }
+            }
         }
     }
 
     /// Returns the signal for the raw signal number for the real system.
+    ///
+    /// This function returns `UnknownSignalError` if the given number is not a
+    /// valid signal.
     pub(super) fn try_from_raw(number: c_int) -> Result<Self, UnknownSignalError> {
         // Some signals share the same number on some systems. This function
         // returns the signal that is considered the most common or standard one.

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -678,6 +678,7 @@ impl System for VirtualSystem {
             Signal2::Xfsz => Ok(38),
             Signal2::Rtmin(0) | Signal2::Rtmax(-1) => Ok(39),
             Signal2::Rtmin(1) | Signal2::Rtmax(0) => Ok(40),
+            Signal2::Number(n) if self.raw_number_to_signal(n).is_ok() => Ok(n),
             _ => Err(UnknownSignalError),
         }
     }

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -68,8 +68,10 @@ use super::Result;
 use super::SigSet;
 use super::SigmaskHow;
 use super::Signal;
+use super::Signal2;
 use super::TimeSpec;
 use super::Times;
+use super::UnknownSignalError;
 use super::AT_FDCWD;
 use crate::io::Fd;
 use crate::job::Pid;
@@ -629,6 +631,104 @@ impl System for VirtualSystem {
     /// Returns `times` in [`SystemState`].
     fn times(&self) -> Result<Times> {
         Ok(self.state.borrow().times)
+    }
+
+    fn signal_to_raw_number(
+        &self,
+        signal: Signal2,
+    ) -> std::result::Result<c_int, UnknownSignalError> {
+        match signal {
+            Signal2::Abrt => Ok(1),
+            Signal2::Alrm => Ok(2),
+            Signal2::Bus => Ok(3),
+            Signal2::Chld => Ok(4),
+            Signal2::Cld => Ok(5),
+            Signal2::Cont => Ok(6),
+            Signal2::Emt => Ok(7),
+            Signal2::Fpe => Ok(8),
+            Signal2::Hup => Ok(9),
+            Signal2::Ill => Ok(10),
+            Signal2::Info => Ok(11),
+            Signal2::Int => Ok(12),
+            Signal2::Io => Ok(13),
+            Signal2::Iot => Ok(14),
+            Signal2::Kill => Ok(15),
+            Signal2::Lost => Ok(16),
+            Signal2::Pipe => Ok(17),
+            Signal2::Poll => Ok(18),
+            Signal2::Prof => Ok(19),
+            Signal2::Pwr => Ok(20),
+            Signal2::Quit => Ok(21),
+            Signal2::Segv => Ok(22),
+            Signal2::Stkflt => Ok(23),
+            Signal2::Stop => Ok(24),
+            Signal2::Sys => Ok(25),
+            Signal2::Term => Ok(26),
+            Signal2::Thr => Ok(27),
+            Signal2::Trap => Ok(28),
+            Signal2::Tstp => Ok(29),
+            Signal2::Ttin => Ok(30),
+            Signal2::Ttou => Ok(31),
+            Signal2::Urg => Ok(32),
+            Signal2::Usr1 => Ok(33),
+            Signal2::Usr2 => Ok(34),
+            Signal2::Vtalrm => Ok(35),
+            Signal2::Winch => Ok(36),
+            Signal2::Xcpu => Ok(37),
+            Signal2::Xfsz => Ok(38),
+            Signal2::Rtmin(0) | Signal2::Rtmax(-1) => Ok(39),
+            Signal2::Rtmin(1) | Signal2::Rtmax(0) => Ok(40),
+            _ => Err(UnknownSignalError),
+        }
+    }
+
+    fn raw_number_to_signal(
+        &self,
+        number: c_int,
+    ) -> std::result::Result<Signal2, UnknownSignalError> {
+        match number {
+            1 => Ok(Signal2::Abrt),
+            2 => Ok(Signal2::Alrm),
+            3 => Ok(Signal2::Bus),
+            4 => Ok(Signal2::Chld),
+            5 => Ok(Signal2::Cld),
+            6 => Ok(Signal2::Cont),
+            7 => Ok(Signal2::Emt),
+            8 => Ok(Signal2::Fpe),
+            9 => Ok(Signal2::Hup),
+            10 => Ok(Signal2::Ill),
+            11 => Ok(Signal2::Info),
+            12 => Ok(Signal2::Int),
+            13 => Ok(Signal2::Io),
+            14 => Ok(Signal2::Iot),
+            15 => Ok(Signal2::Kill),
+            16 => Ok(Signal2::Lost),
+            17 => Ok(Signal2::Pipe),
+            18 => Ok(Signal2::Poll),
+            19 => Ok(Signal2::Prof),
+            20 => Ok(Signal2::Pwr),
+            21 => Ok(Signal2::Quit),
+            22 => Ok(Signal2::Segv),
+            23 => Ok(Signal2::Stkflt),
+            24 => Ok(Signal2::Stop),
+            25 => Ok(Signal2::Sys),
+            26 => Ok(Signal2::Term),
+            27 => Ok(Signal2::Thr),
+            28 => Ok(Signal2::Trap),
+            29 => Ok(Signal2::Tstp),
+            30 => Ok(Signal2::Ttin),
+            31 => Ok(Signal2::Ttou),
+            32 => Ok(Signal2::Urg),
+            33 => Ok(Signal2::Usr1),
+            34 => Ok(Signal2::Usr2),
+            35 => Ok(Signal2::Vtalrm),
+            36 => Ok(Signal2::Winch),
+            37 => Ok(Signal2::Xcpu),
+            38 => Ok(Signal2::Xfsz),
+            39 => Ok(Signal2::Rtmin(0)),
+            40 => Ok(Signal2::Rtmax(0)),
+            _ => Err(UnknownSignalError),
+        }
     }
 
     fn sigmask(

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -27,12 +27,12 @@ use crate::system::resource::Resource;
 use crate::system::resource::RLIM_INFINITY;
 use crate::system::SelectSystem;
 use crate::SignalHandling;
-use nix::sys::signal::SigSet;
 use nix::sys::signal::SigmaskHow;
 use nix::sys::signal::Signal;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::fmt::Debug;
@@ -81,10 +81,10 @@ pub struct Process {
     signal_handlings: HashMap<Signal, SignalHandling>,
 
     /// Set of blocked signals
-    blocked_signals: SigSet,
+    blocked_signals: BTreeSet<Signal>,
 
     /// Set of pending signals
-    pending_signals: SigSet,
+    pending_signals: BTreeSet<Signal>,
 
     /// List of signals that have been delivered and caught
     pub(crate) caught_signals: Vec<Signal>,
@@ -135,8 +135,8 @@ impl Process {
             state_has_changed: false,
             resumption_awaiters: Vec::new(),
             signal_handlings: HashMap::new(),
-            blocked_signals: SigSet::empty(),
-            pending_signals: SigSet::empty(),
+            blocked_signals: BTreeSet::new(),
+            pending_signals: BTreeSet::new(),
             caught_signals: Vec::new(),
             resource_limits: HashMap::new(),
             selector: Weak::new(),
@@ -151,8 +151,8 @@ impl Process {
         let mut child = Self::with_parent_and_group(ppid, parent.pgid);
         child.fds = parent.fds.clone();
         child.signal_handlings.clone_from(&parent.signal_handlings);
-        child.blocked_signals = parent.blocked_signals;
-        child.pending_signals = SigSet::empty();
+        child.blocked_signals.clone_from(&parent.blocked_signals);
+        child.pending_signals = BTreeSet::new();
         child
     }
 
@@ -328,7 +328,7 @@ impl Process {
     }
 
     /// Returns the currently blocked signals.
-    pub fn blocked_signals(&self) -> &SigSet {
+    pub fn blocked_signals(&self) -> &BTreeSet<Signal> {
         &self.blocked_signals
     }
 
@@ -336,7 +336,7 @@ impl Process {
     ///
     /// A signal is pending when it has been raised but not yet delivered
     /// because it is being blocked.
-    pub fn pending_signals(&self) -> &SigSet {
+    pub fn pending_signals(&self) -> &BTreeSet<Signal> {
         &self.pending_signals
     }
 
@@ -349,26 +349,24 @@ impl Process {
     /// that case, the caller must send a SIGCHLD to the parent process of this
     /// process.
     #[must_use = "send SIGCHLD if process state has changed"]
-    pub fn block_signals(&mut self, how: SigmaskHow, signals: &SigSet) -> SignalResult {
+    pub fn block_signals(&mut self, how: SigmaskHow, signals: &[Signal]) -> SignalResult {
         match how {
-            SigmaskHow::SIG_SETMASK => self.blocked_signals = *signals,
+            SigmaskHow::SIG_SETMASK => self.blocked_signals = signals.iter().copied().collect(),
             SigmaskHow::SIG_BLOCK => self.blocked_signals.extend(signals),
             SigmaskHow::SIG_UNBLOCK => {
-                for signal in Signal::iterator() {
-                    if signals.contains(signal) {
-                        self.blocked_signals.remove(signal);
-                    }
+                for signal in signals {
+                    self.blocked_signals.remove(signal);
                 }
             }
             _ => unreachable!(),
         }
 
+        let signals_to_deliver = self.pending_signals.difference(&self.blocked_signals);
+        let signals_to_deliver = signals_to_deliver.copied().collect::<Vec<Signal>>();
         let mut result = SignalResult::default();
-        for signal in Signal::iterator() {
-            if self.pending_signals.contains(signal) && !self.blocked_signals.contains(signal) {
-                self.pending_signals.remove(signal);
-                result |= self.deliver_signal(signal);
-            }
+        for signal in signals_to_deliver {
+            self.pending_signals.remove(&signal);
+            result |= self.deliver_signal(signal);
         }
         result
     }
@@ -458,9 +456,9 @@ impl Process {
 
         let mut result = if signal != Signal::SIGKILL
             && signal != Signal::SIGSTOP
-            && self.blocked_signals().contains(signal)
+            && self.blocked_signals().contains(&signal)
         {
-            self.pending_signals.add(signal);
+            self.pending_signals.insert(signal);
             SignalResult::default()
         } else {
             self.deliver_signal(signal)
@@ -638,81 +636,69 @@ mod tests {
         let process = Process::with_parent_and_group(Pid(10), Pid(11));
         let initial_set = process.blocked_signals();
         for signal in Signal::iterator() {
-            assert!(!initial_set.contains(signal), "contained signal {signal}");
+            assert!(!initial_set.contains(&signal), "contained signal {signal}");
         }
     }
 
     #[test]
     fn process_sigmask_setmask() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let mut some_set = SigSet::empty();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGCHLD);
-        let result = process.block_signals(SigmaskHow::SIG_SETMASK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_SETMASK, &[Signal::SIGINT, Signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        // TODO assert_eq!(result_set, some_set);
-        assert!(result_set.contains(Signal::SIGINT));
-        assert!(result_set.contains(Signal::SIGCHLD));
+        assert!(result_set.contains(&Signal::SIGINT));
+        assert!(result_set.contains(&Signal::SIGCHLD));
+        assert_eq!(result_set.len(), 2);
 
-        some_set.clear();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGQUIT);
-        let result = process.block_signals(SigmaskHow::SIG_SETMASK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_SETMASK, &[Signal::SIGINT, Signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(Signal::SIGINT));
-        assert!(result_set.contains(Signal::SIGQUIT));
-        assert!(!result_set.contains(Signal::SIGCHLD));
+        assert!(result_set.contains(&Signal::SIGINT));
+        assert!(result_set.contains(&Signal::SIGQUIT));
+        assert_eq!(result_set.len(), 2);
     }
 
     #[test]
     fn process_sigmask_block() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let mut some_set = SigSet::empty();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGCHLD);
-        let result = process.block_signals(SigmaskHow::SIG_BLOCK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_BLOCK, &[Signal::SIGINT, Signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        // TODO assert_eq!(result_set, some_set);
-        assert!(result_set.contains(Signal::SIGINT));
-        assert!(result_set.contains(Signal::SIGCHLD));
+        assert!(result_set.contains(&Signal::SIGINT));
+        assert!(result_set.contains(&Signal::SIGCHLD));
+        assert_eq!(result_set.len(), 2);
 
-        some_set.clear();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGQUIT);
-        let result = process.block_signals(SigmaskHow::SIG_BLOCK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_BLOCK, &[Signal::SIGINT, Signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(Signal::SIGINT));
-        assert!(result_set.contains(Signal::SIGQUIT));
-        assert!(result_set.contains(Signal::SIGCHLD));
+        assert!(result_set.contains(&Signal::SIGINT));
+        assert!(result_set.contains(&Signal::SIGQUIT));
+        assert!(result_set.contains(&Signal::SIGCHLD));
+        assert_eq!(result_set.len(), 3);
     }
 
     #[test]
     fn process_sigmask_unblock() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let mut some_set = SigSet::empty();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGCHLD);
-        let result = process.block_signals(SigmaskHow::SIG_BLOCK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_BLOCK, &[Signal::SIGINT, Signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
-        some_set.clear();
-        some_set.add(Signal::SIGINT);
-        some_set.add(Signal::SIGQUIT);
-        let result = process.block_signals(SigmaskHow::SIG_UNBLOCK, &some_set);
+        let result =
+            process.block_signals(SigmaskHow::SIG_UNBLOCK, &[Signal::SIGINT, Signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(!result_set.contains(Signal::SIGINT));
-        assert!(!result_set.contains(Signal::SIGQUIT));
-        assert!(result_set.contains(Signal::SIGCHLD));
+        assert!(result_set.contains(&Signal::SIGCHLD));
+        assert_eq!(result_set.len(), 1);
     }
 
     #[test]
@@ -851,7 +837,7 @@ mod tests {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
         let _ = process.set_state(ProcessState::Stopped(Signal::SIGTTOU));
         let _ = process.set_signal_handling(Signal::SIGCONT, SignalHandling::Ignore);
-        let _ = process.block_signals(SigmaskHow::SIG_BLOCK, &to_set([Signal::SIGCONT]));
+        let _ = process.block_signals(SigmaskHow::SIG_BLOCK, &[Signal::SIGCONT]);
         let result = process.raise_signal(Signal::SIGCONT);
         assert_eq!(
             result,
@@ -863,7 +849,7 @@ mod tests {
         );
         assert_eq!(process.state(), ProcessState::Running);
         assert_eq!(process.caught_signals, []);
-        assert!(process.pending_signals.contains(Signal::SIGCONT));
+        assert!(process.pending_signals.contains(&Signal::SIGCONT));
     }
 
     #[test]
@@ -883,20 +869,11 @@ mod tests {
         assert_eq!(process.caught_signals, [Signal::SIGCHLD]);
     }
 
-    fn to_set<I: IntoIterator<Item = Signal>>(signals: I) -> SigSet {
-        let mut set = SigSet::empty();
-        // TODO set.extend(signals)
-        for signal in signals {
-            set.add(signal);
-        }
-        set
-    }
-
     #[test]
     fn process_raise_signal_blocked() {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
         process.set_signal_handling(Signal::SIGCHLD, SignalHandling::Catch);
-        let result = process.block_signals(SigmaskHow::SIG_BLOCK, &to_set([Signal::SIGCHLD]));
+        let result = process.block_signals(SigmaskHow::SIG_BLOCK, &[Signal::SIGCHLD]);
         assert_eq!(
             result,
             SignalResult {
@@ -918,7 +895,7 @@ mod tests {
         assert_eq!(process.state(), ProcessState::Running);
         assert_eq!(process.caught_signals, []);
 
-        let result = process.block_signals(SigmaskHow::SIG_SETMASK, &SigSet::empty());
+        let result = process.block_signals(SigmaskHow::SIG_SETMASK, &[]);
         assert_eq!(
             result,
             SignalResult {

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -36,6 +36,7 @@
 mod cond;
 mod state;
 
+pub use self::cond::signal::{Signal as Signal2, UnknownSignalError, SIGNALS};
 pub use self::cond::{Condition, ParseConditionError, Signal};
 pub use self::state::{Action, SetActionError, TrapState};
 use self::state::{EnterSubshellOption, GrandState};

--- a/yash-env/src/trap/cond.rs
+++ b/yash-env/src/trap/cond.rs
@@ -16,12 +16,13 @@
 
 //! Items that define trap conditions
 
+pub mod signal;
+
 #[cfg(doc)]
 use super::state::Action;
-use std::ffi::c_int;
-// TODO Support real-time signals
 #[doc(no_inline)]
 pub use nix::sys::signal::Signal;
+use std::ffi::c_int;
 
 /// Condition under which an [`Action`] is executed
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/yash-env/src/trap/cond/signal.rs
+++ b/yash-env/src/trap/cond/signal.rs
@@ -1,0 +1,368 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines signals.
+//!
+//! Signals are a method of inter-process communication used to notify a process
+//! that a specific event has occurred. This module provides a list of signals
+//! defined by POSIX with additional support for some non-standard signals.
+//!
+//! Signals are represented by the [`Signal`] enum, which defines a set of
+//! signal names that may (or may not) be used on the system. It also allows
+//! representing real-time signals relatively to the minimum or maximum
+//! real-time signal number. The type also provides methods for converting
+//! signals to and from names.
+//!
+//! This module is defined independently of the system, so it does not operate
+//! on signal numbers that are actually sent to processes. Non-standard signals
+//! and real-time signals represented by `Signal` may not be available on the
+//! real system.
+//!
+//! Proper signal names are all uppercase and starts with `"SIG"`. However, the
+//! names defined, parsed, and displayed in this module do not include the
+//! `"SIG"` prefix.
+
+use std::borrow::Cow;
+use std::ffi::c_int;
+
+/// Signal
+///
+/// See the [module-level documentation](self) for details.
+///
+/// This type implements `PartialOrd` and `Ord` to allow sorting signals
+/// alphabetically. Real-time signals are ordered after other signals. Note that
+/// the ordering is not based on the actual signal numbers.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Signal {
+    /// `SIGABRT` (process abort signal)
+    Abrt,
+    /// `SIGALRM` (alarm clock)
+    Alrm,
+    /// `SIGBUS` (access to an undefined portion of a memory object)
+    Bus,
+    /// `SIGCHLD` (child process terminated, stopped, or continued)
+    Chld,
+    /// `SIGCLD` (child process terminated, stopped, or continued)
+    Cld,
+    /// `SIGCONT` (continue executing, if stopped)
+    Cont,
+    /// `SIGEMT` (emulation trap)
+    Emt,
+    /// `SIGFPE` (erroneous arithmetic operation)
+    Fpe,
+    /// `SIGHUP` (hangup)
+    Hup,
+    /// `SIGILL` (illegal instruction)
+    Ill,
+    /// `SIGINFO` (status request from keyboard)
+    Info,
+    /// `SIGINT` (interrupt)
+    Int,
+    /// `SIGIO` (I/O is possible on a file descriptor)
+    Io,
+    /// `SIGIOT` (I/O trap)
+    Iot,
+    /// `SIGKILL` (kill)
+    Kill,
+    /// `SIGLOST` (resource lost)
+    Lost,
+    /// `SIGPIPE` (write on a pipe with no one to read it)
+    Pipe,
+    /// `SIGPOLL` (pollable event)
+    Poll,
+    /// `SIGPROF` (profiling timer expired)
+    Prof,
+    /// `SIGPWR` (power failure)
+    Pwr,
+    /// `SIGQUIT` (quit)
+    Quit,
+    /// `SIGSEGV` (invalid memory reference)
+    Segv,
+    /// `SIGSTKFLT` (stack fault)
+    Stkflt,
+    /// `SIGSTOP` (stop executing)
+    Stop,
+    /// `SIGSYS` (bad system call)
+    Sys,
+    /// `SIGTERM` (termination)
+    Term,
+    /// `SIGTHR` (thread interrupt)
+    Thr,
+    /// `SIGTRAP` (trace trap)
+    Trap,
+    /// `SIGTSTP` (stop executing)
+    Tstp,
+    /// `SIGTTIN` (background process attempting read)
+    Ttin,
+    /// `SIGTTOU` (background process attempting write)
+    Ttou,
+    /// `SIGURG` (high bandwidth data is available at a socket)
+    Urg,
+    /// `SIGUSR1` (user-defined signal 1)
+    Usr1,
+    /// `SIGUSR2` (user-defined signal 2)
+    Usr2,
+    /// `SIGVTALRM` (virtual timer expired)
+    Vtalrm,
+    /// `SIGWINCH` (window size change)
+    Winch,
+    /// `SIGXCPU` (CPU time limit exceeded)
+    Xcpu,
+    /// `SIGXFSZ` (file size limit exceeded)
+    Xfsz,
+
+    /// Real-time signal with a number relative to the minimum real-time signal
+    ///
+    /// `RTMIN(n)` represents the real-time signal `SIGRTMIN + n`, where `n` is
+    /// expected to be a non-negative integer between `0` and
+    /// `SIGRTMAX - SIGRTMIN`.
+    Rtmin(c_int),
+
+    /// Real-time signal with a number relative to the maximum real-time signal
+    ///
+    /// `RTMAX(n)` represents the real-time signal `SIGRTMAX + n`, where `n` is
+    /// expected to be a non-positive integer between `SIGRTMIN - SIGRTMAX` and
+    /// `0`.
+    Rtmax(c_int),
+}
+
+/// List of all signals except real-time signals
+pub const SIGNALS: &[Signal] = &[
+    Signal::Abrt,
+    Signal::Alrm,
+    Signal::Bus,
+    Signal::Chld,
+    Signal::Cld,
+    Signal::Cont,
+    Signal::Emt,
+    Signal::Fpe,
+    Signal::Hup,
+    Signal::Ill,
+    Signal::Info,
+    Signal::Int,
+    Signal::Io,
+    Signal::Iot,
+    Signal::Kill,
+    Signal::Lost,
+    Signal::Pipe,
+    Signal::Poll,
+    Signal::Prof,
+    Signal::Pwr,
+    Signal::Quit,
+    Signal::Segv,
+    Signal::Stkflt,
+    Signal::Stop,
+    Signal::Sys,
+    Signal::Term,
+    Signal::Thr,
+    Signal::Trap,
+    Signal::Tstp,
+    Signal::Ttin,
+    Signal::Ttou,
+    Signal::Urg,
+    Signal::Usr1,
+    Signal::Usr2,
+    Signal::Vtalrm,
+    Signal::Winch,
+    Signal::Xcpu,
+    Signal::Xfsz,
+];
+
+impl Signal {
+    /// Returns the name of the signal.
+    ///
+    /// For most signals, this function returns a static string that is the
+    /// signal name in uppercase without the `"SIG"` prefix. For real-time
+    /// signals `RTMIN(n)` and `RTMAX(n)` where `n` is non-zero, this function
+    /// returns a dynamically allocated string that is `RTMIN` or `RTMAX`
+    /// followed by the relative number `n`. Examples of the returned strings
+    /// are `"TERM"`, `"RTMIN"` and `"RTMAX-5"`.
+    ///
+    /// The returned name can be converted back to the signal using the
+    /// `FromStr` implementation for `Signal`.
+    #[must_use]
+    pub fn name(&self) -> Cow<'static, str> {
+        match *self {
+            Signal::Abrt => Cow::Borrowed("ABRT"),
+            Signal::Alrm => Cow::Borrowed("ALRM"),
+            Signal::Bus => Cow::Borrowed("BUS"),
+            Signal::Chld => Cow::Borrowed("CHLD"),
+            Signal::Cld => Cow::Borrowed("CLD"),
+            Signal::Cont => Cow::Borrowed("CONT"),
+            Signal::Emt => Cow::Borrowed("EMT"),
+            Signal::Fpe => Cow::Borrowed("FPE"),
+            Signal::Hup => Cow::Borrowed("HUP"),
+            Signal::Ill => Cow::Borrowed("ILL"),
+            Signal::Info => Cow::Borrowed("INFO"),
+            Signal::Int => Cow::Borrowed("INT"),
+            Signal::Io => Cow::Borrowed("IO"),
+            Signal::Iot => Cow::Borrowed("IOT"),
+            Signal::Kill => Cow::Borrowed("KILL"),
+            Signal::Lost => Cow::Borrowed("LOST"),
+            Signal::Pipe => Cow::Borrowed("PIPE"),
+            Signal::Poll => Cow::Borrowed("POLL"),
+            Signal::Prof => Cow::Borrowed("PROF"),
+            Signal::Pwr => Cow::Borrowed("PWR"),
+            Signal::Quit => Cow::Borrowed("QUIT"),
+            Signal::Segv => Cow::Borrowed("SEGV"),
+            Signal::Stkflt => Cow::Borrowed("STKFLT"),
+            Signal::Stop => Cow::Borrowed("STOP"),
+            Signal::Sys => Cow::Borrowed("SYS"),
+            Signal::Term => Cow::Borrowed("TERM"),
+            Signal::Thr => Cow::Borrowed("THR"),
+            Signal::Trap => Cow::Borrowed("TRAP"),
+            Signal::Tstp => Cow::Borrowed("TSTP"),
+            Signal::Ttin => Cow::Borrowed("TTIN"),
+            Signal::Ttou => Cow::Borrowed("TTOU"),
+            Signal::Urg => Cow::Borrowed("URG"),
+            Signal::Usr1 => Cow::Borrowed("USR1"),
+            Signal::Usr2 => Cow::Borrowed("USR2"),
+            Signal::Vtalrm => Cow::Borrowed("VTALRM"),
+            Signal::Winch => Cow::Borrowed("WINCH"),
+            Signal::Xcpu => Cow::Borrowed("XCPU"),
+            Signal::Xfsz => Cow::Borrowed("XFSZ"),
+            Signal::Rtmin(0) => Cow::Borrowed("RTMIN"),
+            Signal::Rtmax(0) => Cow::Borrowed("RTMAX"),
+            Signal::Rtmin(n) => Cow::Owned(format!("RTMIN{n:+}")),
+            Signal::Rtmax(n) => Cow::Owned(format!("RTMAX{n:+}")),
+        }
+    }
+}
+
+#[test]
+fn test_name() {
+    assert_eq!(Signal::Term.name(), "TERM");
+    assert_eq!(Signal::Int.name(), "INT");
+    assert_eq!(Signal::Rtmin(0).name(), "RTMIN");
+    assert_eq!(Signal::Rtmax(0).name(), "RTMAX");
+    assert_eq!(Signal::Rtmin(1).name(), "RTMIN+1");
+    assert_eq!(Signal::Rtmin(20).name(), "RTMIN+20");
+    assert_eq!(Signal::Rtmax(-1).name(), "RTMAX-1");
+    assert_eq!(Signal::Rtmax(-20).name(), "RTMAX-20");
+}
+
+/// Prints the signal name.
+///
+/// See [`Signal::name`] for the format of the printed signal names.
+impl std::fmt::Display for Signal {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.name().fmt(f)
+    }
+}
+
+/// Error returned when an invalid signal is specified.
+///
+/// This error is returned when a signal name is not recognized or a signal
+/// is not supported on the system.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UnknownSignalError;
+
+/// Parses a signal name.
+///
+/// This implementation supports parsing signal names in uppercase without the
+/// `"SIG"` prefix. It also supports parsing real-time signals with relative
+/// numbers. See [`Signal::name`] for the format of the signal names that can be
+/// parsed.
+impl std::str::FromStr for Signal {
+    type Err = UnknownSignalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ABRT" => Ok(Signal::Abrt),
+            "ALRM" => Ok(Signal::Alrm),
+            "BUS" => Ok(Signal::Bus),
+            "CHLD" => Ok(Signal::Chld),
+            "CLD" => Ok(Signal::Cld),
+            "CONT" => Ok(Signal::Cont),
+            "EMT" => Ok(Signal::Emt),
+            "FPE" => Ok(Signal::Fpe),
+            "HUP" => Ok(Signal::Hup),
+            "ILL" => Ok(Signal::Ill),
+            "INFO" => Ok(Signal::Info),
+            "INT" => Ok(Signal::Int),
+            "IO" => Ok(Signal::Io),
+            "IOT" => Ok(Signal::Iot),
+            "KILL" => Ok(Signal::Kill),
+            "LOST" => Ok(Signal::Lost),
+            "PIPE" => Ok(Signal::Pipe),
+            "POLL" => Ok(Signal::Poll),
+            "PROF" => Ok(Signal::Prof),
+            "PWR" => Ok(Signal::Pwr),
+            "QUIT" => Ok(Signal::Quit),
+            "SEGV" => Ok(Signal::Segv),
+            "STKFLT" => Ok(Signal::Stkflt),
+            "STOP" => Ok(Signal::Stop),
+            "SYS" => Ok(Signal::Sys),
+            "TERM" => Ok(Signal::Term),
+            "THR" => Ok(Signal::Thr),
+            "TRAP" => Ok(Signal::Trap),
+            "TSTP" => Ok(Signal::Tstp),
+            "TTIN" => Ok(Signal::Ttin),
+            "TTOU" => Ok(Signal::Ttou),
+            "URG" => Ok(Signal::Urg),
+            "USR1" => Ok(Signal::Usr1),
+            "USR2" => Ok(Signal::Usr2),
+            "VTALRM" => Ok(Signal::Vtalrm),
+            "WINCH" => Ok(Signal::Winch),
+            "XCPU" => Ok(Signal::Xcpu),
+            "XFSZ" => Ok(Signal::Xfsz),
+
+            "RTMIN" => Ok(Signal::Rtmin(0)),
+            "RTMAX" => Ok(Signal::Rtmax(0)),
+            _ => {
+                if let Some(tail) = s.strip_prefix("RTMIN") {
+                    if tail.starts_with(['+', '-']) {
+                        if let Ok(n) = tail.parse() {
+                            return Ok(Signal::Rtmin(n));
+                        }
+                    }
+                }
+                if let Some(tail) = s.strip_prefix("RTMAX") {
+                    if tail.starts_with(['+', '-']) {
+                        if let Ok(n) = tail.parse() {
+                            return Ok(Signal::Rtmax(n));
+                        }
+                    }
+                }
+                Err(UnknownSignalError)
+            }
+        }
+    }
+}
+
+#[test]
+fn test_from_str() {
+    assert_eq!("ABRT".parse(), Ok(Signal::Abrt));
+    assert_eq!("INT".parse(), Ok(Signal::Int));
+    assert_eq!("QUIT".parse(), Ok(Signal::Quit));
+
+    assert_eq!("RTMIN".parse(), Ok(Signal::Rtmin(0)));
+    assert_eq!("RTMIN+0".parse(), Ok(Signal::Rtmin(0)));
+    assert_eq!("RTMIN+1".parse(), Ok(Signal::Rtmin(1)));
+
+    assert_eq!("RTMAX".parse(), Ok(Signal::Rtmax(0)));
+    assert_eq!("RTMAX-0".parse(), Ok(Signal::Rtmax(0)));
+    assert_eq!("RTMAX-1".parse(), Ok(Signal::Rtmax(-1)));
+
+    assert_eq!("".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("FOO".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("int".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("RTMIN0".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("RTMIN+".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("RTMAX0".parse::<Signal>(), Err(UnknownSignalError));
+    assert_eq!("RTMAX-".parse::<Signal>(), Err(UnknownSignalError));
+}

--- a/yash-env/src/trap/cond/signal.rs
+++ b/yash-env/src/trap/cond/signal.rs
@@ -145,6 +145,48 @@ pub enum Signal {
     Number(c_int),
 }
 
+// TODO Remove these aliases
+impl Signal {
+    pub const SIGABRT: Self = Self::Abrt;
+    pub const SIGALRM: Self = Self::Alrm;
+    pub const SIGBUS: Self = Self::Bus;
+    pub const SIGCHLD: Self = Self::Chld;
+    pub const SIGCLD: Self = Self::Cld;
+    pub const SIGCONT: Self = Self::Cont;
+    pub const SIGEMT: Self = Self::Emt;
+    pub const SIGFPE: Self = Self::Fpe;
+    pub const SIGHUP: Self = Self::Hup;
+    pub const SIGILL: Self = Self::Ill;
+    pub const SIGINFO: Self = Self::Info;
+    pub const SIGINT: Self = Self::Int;
+    pub const SIGIO: Self = Self::Io;
+    pub const SIGIOT: Self = Self::Iot;
+    pub const SIGKILL: Self = Self::Kill;
+    pub const SIGLOST: Self = Self::Lost;
+    pub const SIGPIPE: Self = Self::Pipe;
+    pub const SIGPOLL: Self = Self::Poll;
+    pub const SIGPROF: Self = Self::Prof;
+    pub const SIGPWR: Self = Self::Pwr;
+    pub const SIGQUIT: Self = Self::Quit;
+    pub const SIGSEGV: Self = Self::Segv;
+    pub const SIGSTKFLT: Self = Self::Stkflt;
+    pub const SIGSTOP: Self = Self::Stop;
+    pub const SIGSYS: Self = Self::Sys;
+    pub const SIGTERM: Self = Self::Term;
+    pub const SIGTHR: Self = Self::Thr;
+    pub const SIGTRAP: Self = Self::Trap;
+    pub const SIGTSTP: Self = Self::Tstp;
+    pub const SIGTTIN: Self = Self::Ttin;
+    pub const SIGTTOU: Self = Self::Ttou;
+    pub const SIGURG: Self = Self::Urg;
+    pub const SIGUSR1: Self = Self::Usr1;
+    pub const SIGUSR2: Self = Self::Usr2;
+    pub const SIGVTALRM: Self = Self::Vtalrm;
+    pub const SIGWINCH: Self = Self::Winch;
+    pub const SIGXCPU: Self = Self::Xcpu;
+    pub const SIGXFSZ: Self = Self::Xfsz;
+}
+
 /// List of all named signals
 ///
 /// This list does not include the `Rtmin`, `Rtmax`, and `Number` variants.

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -91,6 +91,7 @@ mod tests {
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::option::State::On;
     use yash_env::trap::Signal;
+    use yash_env::trap::Signal2;
     use yash_env::VirtualSystem;
     use yash_syntax::syntax::CompoundCommand;
 
@@ -186,6 +187,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Need to merge the two Signal definitions"] // TODO
     fn job_controlled_suspended_subshell_in_job_list() {
         in_virtual_system(|mut env, state| async move {
             env.builtins.insert("suspend", suspend_builtin());
@@ -195,7 +197,10 @@ mod tests {
             let command: CompoundCommand = "(suspend foo)".parse().unwrap();
             let result = command.execute(&mut env).await;
             assert_eq!(result, Continue(()));
-            assert_eq!(env.exit_status, ExitStatus::from(Signal::SIGSTOP));
+            assert_eq!(
+                env.exit_status,
+                env.system.exit_status_for_signal(Signal2::Stop)
+            );
 
             let state = state.borrow();
             let (&pid, process) = state.processes.last_key_value().unwrap();

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -28,6 +28,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
+use yash_env::system::SystemEx as _;
 use yash_env::Env;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::List;
@@ -47,7 +48,7 @@ pub async fn execute(env: &mut Env, body: Rc<List>, location: &Location) -> Resu
                 env.jobs.add(job);
             }
 
-            env.exit_status = state.try_into().unwrap();
+            env.exit_status = env.system.exit_status_for_process_state(state).unwrap();
             env.apply_errexit()
         }
         Err(errno) => {

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -346,6 +346,7 @@ mod tests {
     use yash_env::semantics::Field;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::trap::Signal;
+    use yash_env::trap::Signal2;
     use yash_env::VirtualSystem;
 
     #[test]
@@ -614,6 +615,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Need to merge the two Signal definitions"] // TODO
     fn job_controlled_suspended_pipeline_in_job_list() {
         in_virtual_system(|mut env, state| async move {
             env.builtins.insert("return", return_builtin());
@@ -624,7 +626,10 @@ mod tests {
             let pipeline: syntax::Pipeline = "return -n 0 | suspend x".parse().unwrap();
             let result = pipeline.execute(&mut env).await;
             assert_eq!(result, Continue(()));
-            assert_eq!(env.exit_status, ExitStatus::from(Signal::SIGSTOP));
+            assert_eq!(
+                env.exit_status,
+                env.system.exit_status_for_signal(Signal2::Stop)
+            );
 
             assert_eq!(env.jobs.len(), 1);
             let job = env.jobs.iter().next().unwrap().1;

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -36,7 +36,7 @@ use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
 use yash_env::system::Errno;
 use yash_env::system::FdFlag;
-use yash_env::system::SystemEx;
+use yash_env::system::SystemEx as _;
 use yash_env::Env;
 use yash_env::System;
 use yash_syntax::syntax;
@@ -152,7 +152,7 @@ async fn execute_job_controlled_pipeline(
                 env.jobs.add(job);
             }
 
-            env.exit_status = state.try_into().unwrap();
+            env.exit_status = env.system.exit_status_for_process_state(state).unwrap();
             Continue(())
         }
         Err(errno) => {

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -32,6 +32,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
+use yash_env::system::SystemEx as _;
 use yash_env::Env;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
@@ -81,7 +82,7 @@ pub async fn execute_absent_target(
                     env.jobs.add(job);
                 }
 
-                state.try_into().unwrap()
+                env.system.exit_status_for_process_state(state).unwrap()
             }
             Err(errno) => {
                 print_error(

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -34,6 +34,7 @@ use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
 use yash_env::system::Errno;
+use yash_env::system::SystemEx as _;
 use yash_env::variable::Context;
 use yash_env::Env;
 use yash_env::System;
@@ -120,7 +121,7 @@ pub async fn start_external_utility_in_subshell_and_wait(
                 env.jobs.add(job);
             }
 
-            state.try_into().unwrap()
+            env.system.exit_status_for_process_state(state).unwrap()
         }
         Err(errno) => {
             print_error(


### PR DESCRIPTION
This is part of #353.

This PR also adds support for real-time signals on some platforms.

- [x] Add the new `Signal` definition
- [x] Expose conversion of `Signal` from and to raw numbers in `System`
- [x] Remove use of `SigSet` from `System`
- [x] Add iterator for all supported signals in real system
- ~~Move conversion from signal number to `Condition` out of `impl std::str::FromStr for Condition`~~
- [x] Rewrite conversion between `ProcessState` and nix's `WaitStatus`
- [x] Replace `impl TryFrom<ProcessState> for ExitStatus` with `SystemEx::exit_status_for_process_state`
- [x] Replace `impl From<Signal> for ExitStatus` with `SystemEx::exit_status_for_signal`
- [x] Remove `impl TryFrom<ExitStatus> for Signal`
- [ ] Migrate to the new `Signal`
- [ ] Address remaining TODO comments
- [ ] Update documentation
- [ ] Update CHANGELOG

----

Additional todo:

- Refactor `ProcessState` so we don't have to unwrap the result of `SystemEx::exit_status_for_process_state`
    - Maybe we should add `ProcessResult::{Exited,Signaled,Stopped}` which is guaranteed to have a corresponding exit status. `Subshell::start_and_wait` (and maybe some other functions) should return the new enum. → #366