### PR TITLE
Add ProcessResult

### DIFF
--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -259,10 +259,9 @@ mod tests {
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut child = Process::fork_from(pgid, &leader);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        // TODO
-        // _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
-        // _ = child.set_state(ProcessState::Stopped(Signal::SIGTSTP));
-        // _ = orphan.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        _ = leader.set_state(ProcessState::stopped(Signal::SIGTTIN));
+        _ = child.set_state(ProcessState::stopped(Signal::SIGTSTP));
+        _ = orphan.set_state(ProcessState::stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -281,11 +280,10 @@ mod tests {
         // The child should also be resumed as it belongs to the same process group.
         assert_eq!(state.processes[&child_id].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        // TODO
-        // assert_eq!(
-        //     state.processes[&orphan_id].state(),
-        //     ProcessState::Stopped(Signal::SIGSTOP),
-        // );
+        assert_eq!(
+            state.processes[&orphan_id].state(),
+            ProcessState::stopped(Signal::SIGSTOP),
+        );
     }
 
     #[test]
@@ -314,7 +312,7 @@ mod tests {
         job.job_controlled = true;
         let index = env.jobs.add(job);
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        // TODO _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        _ = process.set_state(ProcessState::stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -340,7 +338,7 @@ mod tests {
         env.jobs.set_current_job(orphan_index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
+        _ = leader.set_state(ProcessState::stopped(Signal::SIGTTIN));
         _ = orphan.set_state(ProcessState::Running);
         {
             let mut state = system.state.borrow_mut();
@@ -363,11 +361,11 @@ mod tests {
         let pid = Pid(123);
         let mut job = Job::new(pid);
         job.job_controlled = true;
-        // TODO job.state = ProcessState::Exited(ExitStatus::SUCCESS);
+        job.state = ProcessState::exited(ExitStatus::SUCCESS);
         let index = env.jobs.add(job);
         // This process (irrelevant to the job) happens to have the same PID as the job.
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        // TODO _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        _ = process.set_state(ProcessState::stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -380,11 +378,10 @@ mod tests {
 
         let state = system.state.borrow();
         // The process should not be resumed.
-        // TODO
-        // assert_eq!(
-        //     state.processes[&pid].state(),
-        //     ProcessState::Stopped(Signal::SIGSTOP),
-        // );
+        assert_eq!(
+            state.processes[&pid].state(),
+            ProcessState::stopped(Signal::SIGSTOP),
+        );
     }
 
     #[test]
@@ -423,8 +420,8 @@ mod tests {
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        // TODO _ = orphan.set_state(ProcessState::Stopped(Signal::SIGTTIN));
+        _ = leader.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = orphan.set_state(ProcessState::stopped(Signal::SIGTTIN));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -438,11 +435,10 @@ mod tests {
         // The current job's process group leader should be resumed.
         assert_eq!(state.processes[&pgid].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        // TODO
-        // assert_eq!(
-        //     state.processes[&orphan_id].state(),
-        //     ProcessState::Stopped(Signal::SIGTTIN),
-        // );
+        assert_eq!(
+            state.processes[&orphan_id].state(),
+            ProcessState::stopped(Signal::SIGTTIN),
+        );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
     }
@@ -479,10 +475,9 @@ mod tests {
         let mut process1 = Process::with_parent_and_group(system.process_id, pgid1);
         let mut process2 = Process::with_parent_and_group(system.process_id, pgid2);
         let mut process3 = Process::with_parent_and_group(system.process_id, pgid3);
-        // TODO
-        // _ = process1.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        // _ = process2.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        // _ = process3.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        _ = process1.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process2.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process3.set_state(ProcessState::stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid1, process1);
@@ -500,11 +495,10 @@ mod tests {
         assert_eq!(state.processes[&pgid1].state(), ProcessState::Running);
         assert_eq!(state.processes[&pgid3].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        // TODO
-        // assert_eq!(
-        //     state.processes[&pgid2].state(),
-        //     ProcessState::Stopped(Signal::SIGSTOP),
-        // );
+        assert_eq!(
+            state.processes[&pgid2].state(),
+            ProcessState::stopped(Signal::SIGSTOP),
+        );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
     }
@@ -522,7 +516,7 @@ mod tests {
         let index = env.jobs.add(job);
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
-        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        _ = leader.set_state(ProcessState::stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -259,9 +259,10 @@ mod tests {
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut child = Process::fork_from(pgid, &leader);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
-        _ = child.set_state(ProcessState::Stopped(Signal::SIGTSTP));
-        _ = orphan.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO
+        // _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
+        // _ = child.set_state(ProcessState::Stopped(Signal::SIGTSTP));
+        // _ = orphan.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -280,10 +281,11 @@ mod tests {
         // The child should also be resumed as it belongs to the same process group.
         assert_eq!(state.processes[&child_id].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        assert_eq!(
-            state.processes[&orphan_id].state(),
-            ProcessState::Stopped(Signal::SIGSTOP),
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&orphan_id].state(),
+        //     ProcessState::Stopped(Signal::SIGSTOP),
+        // );
     }
 
     #[test]
@@ -312,7 +314,7 @@ mod tests {
         job.job_controlled = true;
         let index = env.jobs.add(job);
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -338,7 +340,7 @@ mod tests {
         env.jobs.set_current_job(orphan_index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
+        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGTTIN));
         _ = orphan.set_state(ProcessState::Running);
         {
             let mut state = system.state.borrow_mut();
@@ -361,11 +363,11 @@ mod tests {
         let pid = Pid(123);
         let mut job = Job::new(pid);
         job.job_controlled = true;
-        job.state = ProcessState::Exited(ExitStatus::SUCCESS);
+        // TODO job.state = ProcessState::Exited(ExitStatus::SUCCESS);
         let index = env.jobs.add(job);
         // This process (irrelevant to the job) happens to have the same PID as the job.
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -378,10 +380,11 @@ mod tests {
 
         let state = system.state.borrow();
         // The process should not be resumed.
-        assert_eq!(
-            state.processes[&pid].state(),
-            ProcessState::Stopped(Signal::SIGSTOP),
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&pid].state(),
+        //     ProcessState::Stopped(Signal::SIGSTOP),
+        // );
     }
 
     #[test]
@@ -420,8 +423,8 @@ mod tests {
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        _ = orphan.set_state(ProcessState::Stopped(Signal::SIGTTIN));
+        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO _ = orphan.set_state(ProcessState::Stopped(Signal::SIGTTIN));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -435,10 +438,11 @@ mod tests {
         // The current job's process group leader should be resumed.
         assert_eq!(state.processes[&pgid].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        assert_eq!(
-            state.processes[&orphan_id].state(),
-            ProcessState::Stopped(Signal::SIGTTIN),
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&orphan_id].state(),
+        //     ProcessState::Stopped(Signal::SIGTTIN),
+        // );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
     }
@@ -475,9 +479,10 @@ mod tests {
         let mut process1 = Process::with_parent_and_group(system.process_id, pgid1);
         let mut process2 = Process::with_parent_and_group(system.process_id, pgid2);
         let mut process3 = Process::with_parent_and_group(system.process_id, pgid3);
-        _ = process1.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        _ = process2.set_state(ProcessState::Stopped(Signal::SIGSTOP));
-        _ = process3.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO
+        // _ = process1.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // _ = process2.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // _ = process3.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid1, process1);
@@ -495,10 +500,11 @@ mod tests {
         assert_eq!(state.processes[&pgid1].state(), ProcessState::Running);
         assert_eq!(state.processes[&pgid3].state(), ProcessState::Running);
         // Unrelated processes should not be resumed.
-        assert_eq!(
-            state.processes[&pgid2].state(),
-            ProcessState::Stopped(Signal::SIGSTOP),
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&pgid2].state(),
+        //     ProcessState::Stopped(Signal::SIGSTOP),
+        // );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
     }
@@ -516,7 +522,7 @@ mod tests {
         let index = env.jobs.add(job);
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
-        _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO _ = leader.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -203,6 +203,7 @@ mod tests {
     use std::cell::Cell;
     use std::rc::Rc;
     use yash_env::job::Job;
+    use yash_env::job::ProcessResult;
     use yash_env::option::Option::Monitor;
     use yash_env::option::State::On;
     use yash_env::subshell::JobControl;
@@ -235,11 +236,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = subshell_state;
+            job.state = subshell_result.into();
             let index = env.jobs.add(job);
 
             resume_job_by_index(&mut env, index).await.unwrap();
@@ -255,11 +256,11 @@ mod tests {
             env.options.set(Monitor, On);
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = subshell_state;
+            job.state = subshell_result.into();
             "my job name".clone_into(&mut job.name);
             let index = env.jobs.add(job);
 
@@ -281,11 +282,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = subshell_state;
+            job.state = subshell_result.into();
             let index = env.jobs.add(job);
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
@@ -311,11 +312,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = subshell_state;
+            job.state = subshell_result.into();
             let index = env.jobs.add(job);
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
@@ -335,11 +336,11 @@ mod tests {
             env.options.set(Monitor, On);
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
-            job.state = subshell_state;
+            job.state = subshell_result.into();
             let index = env.jobs.add(job);
 
             _ = resume_job_by_index(&mut env, index).await.unwrap();
@@ -419,20 +420,20 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state1, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result_1, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
-            job.state = subshell_state1;
+            job.state = subshell_result_1.into();
             env.jobs.add(job);
             // current job
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state2, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result_2, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
-            job.state = subshell_state2;
+            job.state = subshell_result_2.into();
             let index2 = env.jobs.add(job);
             env.jobs.set_current_job(index2).unwrap();
 
@@ -468,11 +469,11 @@ mod tests {
             // previous job
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state1, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result_1, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
-            job.state = subshell_state1;
+            job.state = subshell_result_1.into();
             job.name = "previous job".to_string();
             let index1 = env.jobs.add(job);
             // current job
@@ -483,11 +484,11 @@ mod tests {
                 })
             })
             .job_control(JobControl::Foreground);
-            let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state2, ProcessState::stopped(Signal::SIGSTOP));
+            let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
+            assert_eq!(subshell_result_2, ProcessResult::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
-            job.state = subshell_state2;
+            job.state = subshell_result_2.into();
             let index2 = env.jobs.add(job);
             env.jobs.set_current_job(index2).unwrap();
 

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -106,9 +106,10 @@ async fn wait_while_running(env: &mut Env, pid: Pid) -> Result<ProcessState, Err
         let (_pid, state) = env.wait_for_subshell(pid).await?;
         match state {
             ProcessState::Running => (),
-            ProcessState::Stopped(_) | ProcessState::Exited(_) | ProcessState::Signaled { .. } => {
-                return Ok(state)
-            }
+            _ => todo!(),
+            // ProcessState::Stopped(_) | ProcessState::Exited(_) | ProcessState::Signaled { .. } => {
+            //     return Ok(state)
+            // }
         }
     }
 }
@@ -239,7 +240,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_state;
@@ -259,7 +260,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_state;
@@ -285,7 +286,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_state;
@@ -293,9 +294,9 @@ mod tests {
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
 
-            assert_eq!(result, ProcessState::Exited(ExitStatus(42)));
+            // TODO assert_eq!(result, ProcessState::Exited(ExitStatus(42)));
             let state = state.borrow().processes[&pid].state();
-            assert_eq!(state, ProcessState::Exited(ExitStatus(42)));
+            // TODO assert_eq!(state, ProcessState::Exited(ExitStatus(42)));
             // The finished job should be removed from the job list.
             assert_eq!(env.jobs.get(index), None);
         })
@@ -315,7 +316,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_state;
@@ -323,11 +324,11 @@ mod tests {
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
 
-            assert_eq!(result, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(result, ProcessState::Stopped(Signal::SIGSTOP));
             let job_state = env.jobs[index].state;
-            assert_eq!(job_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(job_state, ProcessState::Stopped(Signal::SIGSTOP));
             let state = state.borrow().processes[&pid].state();
-            assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
         })
     }
 
@@ -339,7 +340,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid, subshell_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_state;
@@ -360,11 +361,11 @@ mod tests {
         let pid = Pid(123);
         let mut job = Job::new(pid);
         job.job_controlled = true;
-        job.state = ProcessState::Exited(ExitStatus(12));
+        // TODO job.state = ProcessState::Exited(ExitStatus(12));
         let index = env.jobs.add(job);
         // This process (irrelevant to the job) happens to have the same PID as the job.
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
+        // TODO _ = process.set_state(ProcessState::Stopped(Signal::SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -372,16 +373,17 @@ mod tests {
 
         let result = resume_job_by_index(&mut env, index).now_or_never().unwrap();
 
-        assert_eq!(result, Ok(ProcessState::Exited(ExitStatus(12))));
+        // TODO assert_eq!(result, Ok(ProcessState::Exited(ExitStatus(12))));
         // The finished job should be removed from the job list.
         assert_eq!(env.jobs.get(index), None);
 
         let state = system.state.borrow();
         // The process should not be resumed.
-        assert_eq!(
-            state.processes[&pid].state(),
-            ProcessState::Stopped(Signal::SIGSTOP),
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&pid].state(),
+        //     ProcessState::Stopped(Signal::SIGSTOP),
+        // );
     }
 
     #[test]
@@ -423,7 +425,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
             job.state = subshell_state1;
@@ -432,7 +434,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
             job.state = subshell_state2;
@@ -446,7 +448,7 @@ mod tests {
             assert_eq!(env.jobs.get(index2), None);
             // The previous job should still be there.
             let state = state.borrow().processes[&pid1].state();
-            assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
         })
     }
 
@@ -472,7 +474,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid1, subshell_state1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state1, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
             job.state = subshell_state1;
@@ -487,7 +489,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid2, subshell_state2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(subshell_state2, ProcessState::Stopped(Signal::SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
             job.state = subshell_state2;
@@ -501,7 +503,7 @@ mod tests {
             assert_eq!(env.jobs.get(index1), None);
             // The previous job should still be there.
             let state = state.borrow().processes[&pid2].state();
-            assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(state, ProcessState::Stopped(Signal::SIGSTOP));
         })
     }
 

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -233,6 +233,7 @@ mod tests {
     use yash_env::io::Fd;
     use yash_env::job::Job;
     use yash_env::job::Pid;
+    use yash_env::job::ProcessResult;
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::stack::Builtin;
@@ -259,7 +260,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -282,7 +283,7 @@ mod tests {
         let i11 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(12));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGTSTP);
+        job.state = ProcessState::stopped(Signal::SIGTSTP);
         job.name = "echo stopped".to_string();
         let i12 = env.jobs.add(job);
 
@@ -292,25 +293,23 @@ mod tests {
         let i13 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(14));
-        // TODO job.state = ProcessState::Exited(ExitStatus(42));
+        job.state = ProcessState::exited(42);
         job.name = "echo exited".to_string();
         let i14 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(15));
-        // TODO
-        // job.state = ProcessState::Signaled {
-        //     signal: Signal::SIGINT,
-        //     core_dump: false,
-        // };
+        job.state = ProcessState::Halted(ProcessResult::Signaled {
+            signal: Signal::SIGINT,
+            core_dump: false,
+        });
         job.name = "echo signaled".to_string();
         let i15 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(16));
-        // TODO
-        // job.state = ProcessState::Signaled {
-        //     signal: Signal::SIGQUIT,
-        //     core_dump: true,
-        // };
+        job.state = ProcessState::Halted(ProcessResult::Signaled {
+            signal: Signal::SIGQUIT,
+            core_dump: true,
+        });
         job.name = "echo core dumped".to_string();
         let i16 = env.jobs.add(job);
 
@@ -334,7 +333,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -361,13 +360,13 @@ mod tests {
 
         // job that will be removed because it's finished
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Exited(ExitStatus(0));
+        job.state = ProcessState::exited(0);
         job.name = "echo second".to_string();
         let i72 = env.jobs.add(job);
 
         // This one is also finished, but not removed because it's not reported.
         let mut job = Job::new(Pid(102));
-        // TODO job.state = ProcessState::Exited(ExitStatus(0));
+        job.state = ProcessState::exited(0);
         job.name = "echo third".to_string();
         let i102 = env.jobs.add(job);
 
@@ -389,7 +388,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -434,7 +433,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -459,7 +458,7 @@ mod tests {
         let mut env = Env::with_system(system);
 
         let mut job = Job::new(Pid(10));
-        // TODO job.state = ProcessState::Exited(ExitStatus(0));
+        job.state = ProcessState::exited(0);
         job.name = "exit 0".to_string();
         let i10 = env.jobs.add(job);
 
@@ -470,7 +469,7 @@ mod tests {
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert_matches!(env.jobs.get(i10), Some(&Job { state, .. }) => {
-            // TODO assert_eq!(state, ProcessState::Exited(ExitStatus(0)));
+            assert_eq!(state, ProcessState::exited(0));
         });
     }
 
@@ -481,7 +480,7 @@ mod tests {
         job.name = "echo first".to_string();
         let i42 = env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         let i72 = env.jobs.add(job);
 
@@ -518,7 +517,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -545,7 +544,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -566,7 +565,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -585,7 +584,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -605,7 +604,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -259,7 +259,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -282,7 +282,7 @@ mod tests {
         let i11 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(12));
-        job.state = ProcessState::Stopped(Signal::SIGTSTP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGTSTP);
         job.name = "echo stopped".to_string();
         let i12 = env.jobs.add(job);
 
@@ -292,23 +292,25 @@ mod tests {
         let i13 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(14));
-        job.state = ProcessState::Exited(ExitStatus(42));
+        // TODO job.state = ProcessState::Exited(ExitStatus(42));
         job.name = "echo exited".to_string();
         let i14 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(15));
-        job.state = ProcessState::Signaled {
-            signal: Signal::SIGINT,
-            core_dump: false,
-        };
+        // TODO
+        // job.state = ProcessState::Signaled {
+        //     signal: Signal::SIGINT,
+        //     core_dump: false,
+        // };
         job.name = "echo signaled".to_string();
         let i15 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(16));
-        job.state = ProcessState::Signaled {
-            signal: Signal::SIGQUIT,
-            core_dump: true,
-        };
+        // TODO
+        // job.state = ProcessState::Signaled {
+        //     signal: Signal::SIGQUIT,
+        //     core_dump: true,
+        // };
         job.name = "echo core dumped".to_string();
         let i16 = env.jobs.add(job);
 
@@ -332,7 +334,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -359,13 +361,13 @@ mod tests {
 
         // job that will be removed because it's finished
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         job.name = "echo second".to_string();
         let i72 = env.jobs.add(job);
 
         // This one is also finished, but not removed because it's not reported.
         let mut job = Job::new(Pid(102));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         job.name = "echo third".to_string();
         let i102 = env.jobs.add(job);
 
@@ -387,7 +389,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -432,7 +434,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -457,7 +459,7 @@ mod tests {
         let mut env = Env::with_system(system);
 
         let mut job = Job::new(Pid(10));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         job.name = "exit 0".to_string();
         let i10 = env.jobs.add(job);
 
@@ -468,7 +470,7 @@ mod tests {
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert_matches!(env.jobs.get(i10), Some(&Job { state, .. }) => {
-            assert_eq!(state, ProcessState::Exited(ExitStatus(0)));
+            // TODO assert_eq!(state, ProcessState::Exited(ExitStatus(0)));
         });
     }
 
@@ -479,7 +481,7 @@ mod tests {
         job.name = "echo first".to_string();
         let i42 = env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         let i72 = env.jobs.add(job);
 
@@ -516,7 +518,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -543,7 +545,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -564,7 +566,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -583,7 +585,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -603,7 +605,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -197,7 +197,7 @@ mod tests {
         let mut job = Job::new(Pid(123));
         job.job_controlled = true;
         job.is_owned = true;
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         job.name = "my job".into();
         jobs.add(job);
 

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -129,7 +129,6 @@ mod tests {
     use assert_matches::assert_matches;
     use yash_env::job::Job;
     use yash_env::job::ProcessState;
-    use yash_semantics::ExitStatus;
 
     #[test]
     fn resolve_target_process_ids() {
@@ -197,7 +196,7 @@ mod tests {
         let mut job = Job::new(Pid(123));
         job.job_controlled = true;
         job.is_owned = true;
-        // TODO job.state = ProcessState::Exited(ExitStatus(0));
+        job.state = ProcessState::exited(0);
         job.name = "my job".into();
         jobs.add(job);
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -136,10 +136,11 @@ mod tests {
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            assert_eq!(
-                env.jobs[index].state,
-                ProcessState::Exited(ExitStatus::default()),
-            );
+            // TODO
+            // assert_eq!(
+            //     env.jobs[index].state,
+            //     ProcessState::Exited(ExitStatus::default()),
+            // );
         });
     }
 
@@ -157,10 +158,11 @@ mod tests {
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            assert_eq!(
-                env.jobs[index].state,
-                ProcessState::Stopped(Signal::SIGSTOP),
-            );
+            // TODO
+            // assert_eq!(
+            //     env.jobs[index].state,
+            //     ProcessState::Stopped(Signal::SIGSTOP),
+            // );
         });
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -136,11 +136,10 @@ mod tests {
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            // TODO
-            // assert_eq!(
-            //     env.jobs[index].state,
-            //     ProcessState::Exited(ExitStatus::default()),
-            // );
+            assert_eq!(
+                env.jobs[index].state,
+                ProcessState::exited(ExitStatus::default()),
+            );
         });
     }
 
@@ -158,11 +157,10 @@ mod tests {
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            // TODO
-            // assert_eq!(
-            //     env.jobs[index].state,
-            //     ProcessState::Stopped(Signal::SIGSTOP),
-            // );
+            assert_eq!(
+                env.jobs[index].state,
+                ProcessState::stopped(Signal::SIGSTOP),
+            );
         });
     }
 

--- a/yash-builtin/src/wait/status.rs
+++ b/yash-builtin/src/wait/status.rs
@@ -78,17 +78,18 @@ pub fn job_status(
         }
 
         match job.state {
-            ProcessState::Exited(exit_status) => {
-                jobs.remove(index);
-                ControlFlow::Break(exit_status)
-            }
-            ProcessState::Signaled { signal, .. } => {
-                jobs.remove(index);
-                ControlFlow::Break(ExitStatus::from(signal))
-            }
-            ProcessState::Stopped(signal) if job_control.into() => {
-                ControlFlow::Break(ExitStatus::from(signal))
-            }
+            // TODO
+            // ProcessState::Exited(exit_status) => {
+            //     jobs.remove(index);
+            //     ControlFlow::Break(exit_status)
+            // }
+            // ProcessState::Signaled { signal, .. } => {
+            //     jobs.remove(index);
+            //     ControlFlow::Break(ExitStatus::from(signal))
+            // }
+            // ProcessState::Stopped(signal) if job_control.into() => {
+            //     ControlFlow::Break(ExitStatus::from(signal))
+            // }
             _ => ControlFlow::Continue(()),
         }
     }
@@ -144,7 +145,7 @@ mod tests {
     fn status_of_exited_job() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         let index = jobs.add(job);
 
         assert_eq!(
@@ -154,7 +155,7 @@ mod tests {
         assert_eq!(jobs.get(index), None);
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::Exited(ExitStatus(42));
+        // TODO job.state = ProcessState::Exited(ExitStatus(42));
         let index = jobs.add(job);
 
         assert_eq!(
@@ -168,10 +169,11 @@ mod tests {
     fn status_of_signaled_job() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::Signaled {
-            signal: Signal::SIGHUP,
-            core_dump: false,
-        };
+        // TODO
+        // job.state = ProcessState::Signaled {
+        //     signal: Signal::SIGHUP,
+        //     core_dump: false,
+        // };
         let index = jobs.add(job);
 
         assert_eq!(
@@ -181,10 +183,11 @@ mod tests {
         assert_eq!(jobs.get(index), None);
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::Signaled {
-            signal: Signal::SIGABRT,
-            core_dump: true,
-        };
+        // TODO
+        // job.state = ProcessState::Signaled {
+        //     signal: Signal::SIGABRT,
+        //     core_dump: true,
+        // };
         let index = jobs.add(job);
 
         assert_eq!(
@@ -198,14 +201,14 @@ mod tests {
     fn status_of_stopped_job_without_job_control() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::Stopped(Signal::SIGTSTP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGTSTP);
         let index = jobs.add(job);
 
         assert_eq!(job_status(index, Off)(&mut jobs), ControlFlow::Continue(()),);
         assert_eq!(jobs[index].pid, Pid(123));
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         let index = jobs.add(job);
 
         assert_eq!(job_status(index, Off)(&mut jobs), ControlFlow::Continue(()),);
@@ -216,7 +219,7 @@ mod tests {
     fn status_of_stopped_job_with_job_control() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::Stopped(Signal::SIGTSTP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGTSTP);
         let index = jobs.add(job);
 
         assert_eq!(
@@ -226,7 +229,7 @@ mod tests {
         assert_eq!(jobs[index].pid, Pid(123));
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         let index = jobs.add(job);
 
         assert_eq!(
@@ -285,7 +288,7 @@ mod tests {
     fn any_job_is_running_with_exited_jobs() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         jobs.add(job);
 
         assert_eq!(
@@ -294,7 +297,7 @@ mod tests {
         );
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::Exited(ExitStatus(42));
+        // TODO job.state = ProcessState::Exited(ExitStatus(42));
         jobs.add(job);
 
         assert_eq!(
@@ -319,7 +322,7 @@ mod tests {
 
         // Exited jobs are ignored
         let mut job = Job::new(Pid(789));
-        job.state = ProcessState::Exited(ExitStatus(0));
+        // TODO job.state = ProcessState::Exited(ExitStatus(0));
         jobs.add(job);
 
         assert_eq!(any_job_is_running(On)(&mut jobs), ControlFlow::Continue(()),);

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `job::ProcessState::{Exited, Signaled, Stopped}` in favor of `job::ProcessResult`
+- `job::ProcessState::to_wait_status`
 - `semantics::apply_errexit`
 
 ### Fixed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SystemEx::fd_is_pipe`
 - `SystemEx::set_blocking`
 - `job::ProcessResult`
-- `job::ProcessResult::is_alive`
+- `job::ProcessResult::{exited, is_stopped}`
 - `job::ProcessState::Halted`
+- `job::ProcessState::{stopped, exited, is_stopped}`
 - `impl From<trap::Condition> for stack::Frame`
 
 ### Changed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SystemEx::set_blocking`
 - `job::ProcessResult`
 - `job::ProcessResult::{exited, is_stopped}`
+- `impl From<job::ProcessResult> for ExitStatus`
 - `job::ProcessState::Halted`
 - `job::ProcessState::{stopped, exited, is_stopped}`
 - `impl From<trap::Condition> for stack::Frame`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SystemEx::set_blocking`
 - `job::ProcessResult`
 - `job::ProcessResult::is_alive`
+- `job::ProcessState::Halted`
 - `impl From<trap::Condition> for stack::Frame`
 
 ### Changed
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `job::ProcessState::{Exited, Signaled, Stopped}` in favor of `job::ProcessResult`
 - `semantics::apply_errexit`
 
 ### Fixed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `System::shell_path`
 - `SystemEx::fd_is_pipe`
 - `SystemEx::set_blocking`
+- `job::ProcessResult`
+- `job::ProcessResult::is_alive`
 - `impl From<trap::Condition> for stack::Frame`
 
 ### Changed

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -1057,7 +1057,7 @@ mod tests {
     #[allow(clippy::bool_assert_comparison)]
     fn updating_job_status_without_expected_state() {
         let mut list = JobList::default();
-        let state = todo!(); //ProcessState::Exited(ExitStatus(15));
+        let state = ProcessState::exited(15);
         assert_eq!(list.update_status(Pid(20), state), None);
 
         let i10 = list.add(Job::new(Pid(10)));
@@ -1069,7 +1069,7 @@ mod tests {
         assert_eq!(list[i20].state_changed, false);
 
         assert_eq!(list.update_status(Pid(20), state), Some(i20));
-        // TODO assert_eq!(list[i20].state, ProcessState::Exited(ExitStatus(15)));
+        assert_eq!(list[i20].state, ProcessState::exited(15));
         assert_eq!(list[i20].state_changed, true);
 
         assert_eq!(list[i10].state, ProcessState::Running);
@@ -1104,11 +1104,11 @@ mod tests {
         job.state_changed = false;
         let i20 = list.add(job);
 
-        let result = todo!(); // list.update_status(pid, ProcessState::Exited(ExitStatus(0)));
-        // TODO assert_eq!(result, Some(i20));
+        let result = list.update_status(pid, ProcessState::exited(0));
+        assert_eq!(result, Some(i20));
 
         let job = &list[i20];
-        // TODO assert_eq!(job.state, ProcessState::Exited(ExitStatus(0)));
+        assert_eq!(job.state, ProcessState::exited(0));
         assert_eq!(job.expected_state, None);
         assert_eq!(job.state_changed, true);
     }
@@ -1149,7 +1149,7 @@ mod tests {
         // suspended one.
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended.state = ProcessState::stopped(Signal::SIGSTOP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended.clone());
         let i20 = list.add(running.clone());
@@ -1176,7 +1176,7 @@ mod tests {
         assert_ne!(ex_current_job_index, ex_previous_job_index);
 
         let mut suspended = Job::new(Pid(20));
-        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended.state = ProcessState::stopped(Signal::SIGSTOP);
         let i20 = list.add(suspended);
         let now_current_job_index = list.current_job().unwrap();
         let now_previous_job_index = list.previous_job().unwrap();
@@ -1192,7 +1192,7 @@ mod tests {
         let i18 = list.add(running);
 
         let mut suspended_1 = Job::new(Pid(19));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGSTOP);
         let i19 = list.add(suspended_1);
 
         let ex_current_job_index = list.current_job().unwrap();
@@ -1201,7 +1201,7 @@ mod tests {
         assert_eq!(ex_previous_job_index, i18);
 
         let mut suspended_2 = Job::new(Pid(20));
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGSTOP);
         let i20 = list.add(suspended_2);
 
         let now_current_job_index = list.current_job().unwrap();
@@ -1220,9 +1220,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
         let mut suspended_3 = Job::new(Pid(13));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_3.state = ProcessState::stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1268,9 +1268,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
         let mut suspended_3 = Job::new(Pid(13));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_3.state = ProcessState::stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1302,8 +1302,8 @@ mod tests {
 
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
 
@@ -1341,8 +1341,8 @@ mod tests {
 
         let mut suspended_1 = Job::new(Pid(21));
         let mut suspended_2 = Job::new(Pid(22));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGSTOP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGSTOP);
         let i21 = list.add(suspended_1);
         let i22 = list.add(suspended_2);
 
@@ -1365,7 +1365,7 @@ mod tests {
     fn set_current_job_not_suspended() {
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended.state = ProcessState::stopped(Signal::SIGTSTP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended);
         let i20 = list.add(running);
@@ -1394,7 +1394,7 @@ mod tests {
     fn resuming_current_job_without_other_suspended_jobs() {
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended.state = ProcessState::stopped(Signal::SIGTSTP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended);
         let i20 = list.add(running);
@@ -1408,8 +1408,8 @@ mod tests {
         let mut list = JobList::default();
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGTSTP);
         let i10 = list.add(suspended_1);
         let i20 = list.add(suspended_2);
         list.set_current_job(i10).unwrap();
@@ -1425,9 +1425,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_3.state = ProcessState::stopped(Signal::SIGTSTP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1453,9 +1453,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_3.state = ProcessState::stopped(Signal::SIGTSTP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1481,9 +1481,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_2.state = ProcessState::stopped(Signal::SIGTSTP);
+        suspended_3.state = ProcessState::stopped(Signal::SIGTSTP);
         let i10 = list.add(suspended_1);
         let i20 = list.add(suspended_2);
         let _i30 = list.add(suspended_3);
@@ -1500,7 +1500,7 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i11).unwrap();
-        // TODO list.update_status(Pid(11), ProcessState::Stopped(Signal::SIGTTOU));
+        list.update_status(Pid(11), ProcessState::stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i11));
         assert_eq!(list.previous_job(), Some(i12));
     }
@@ -1511,7 +1511,7 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i11).unwrap();
-        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
+        list.update_status(Pid(12), ProcessState::stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i11));
     }
@@ -1523,7 +1523,7 @@ mod tests {
         let _i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i10).unwrap();
-        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTIN));
+        list.update_status(Pid(12), ProcessState::stopped(Signal::SIGTTIN));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i10));
     }
@@ -1534,12 +1534,12 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         let mut suspended = Job::new(Pid(10));
-        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTTIN);
+        suspended.state = ProcessState::stopped(Signal::SIGTTIN);
         let i10 = list.add(suspended);
         assert_eq!(list.current_job(), Some(i10));
         assert_eq!(list.previous_job(), Some(i11));
 
-        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
+        list.update_status(Pid(12), ProcessState::stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i10));
     }

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -118,11 +118,42 @@ impl Pid {
     pub const ALL: Self = Pid(-1);
 }
 
+/// Execution state of a process from which the exit status can be computed
+///
+/// This type is used to represent the result of a process execution. It is
+/// similar to the `WaitStatus` type defined in the `nix` crate, but it is
+/// simplified to represent only the states that are relevant to the shell.
+///
+/// This type only contains the states the process's exit status can be computed
+/// from. See also [`ProcessState`], which is a more general type that includes
+/// the states that are not directly related to the exit status.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessResult {
+    /// The process has been stopped by a signal.
+    Stopped(Signal),
+    /// The process has exited.
+    Exited(ExitStatus),
+    /// The process has been terminated by a signal.
+    Signaled { signal: Signal, core_dump: bool },
+}
+
+impl ProcessResult {
+    /// Whether the process is not yet terminated
+    #[must_use]
+    pub fn is_alive(&self) -> bool {
+        match self {
+            ProcessResult::Stopped(_) => true,
+            ProcessResult::Exited(_) | ProcessResult::Signaled { .. } => false,
+        }
+    }
+}
+
 /// Execution state of a process
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessState {
     /// The process is running.
     Running,
+    // TODO Redefine in terms of ProcessResult
     /// The process is stopped by a signal.
     Stopped(Signal),
     /// The process has exited.

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -148,18 +148,21 @@ impl ProcessResult {
     }
 }
 
-/// Execution state of a process
+/// Execution state of a process, either running or halted
+///
+/// This type is used to represent the current state of a process. It is similar
+/// to the `WaitStatus` type defined in the `nix` crate, but it is simplified to
+/// represent only the states that are relevant to the shell.
+///
+/// This type can represent all possible states of a process, including running,
+/// stopped, exited, and signaled states. When the process is not running, the
+/// state is represented by a [`ProcessResult`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessState {
     /// The process is running.
     Running,
-    // TODO Redefine in terms of ProcessResult
-    /// The process is stopped by a signal.
-    Stopped(Signal),
-    /// The process has exited.
-    Exited(ExitStatus),
-    /// The process has been terminated by a signal.
-    Signaled { signal: Signal, core_dump: bool },
+    /// The process has exited, stopped, or been terminated by a signal.
+    Halted(ProcessResult),
 }
 
 impl ProcessState {
@@ -167,8 +170,9 @@ impl ProcessState {
     #[must_use]
     pub fn is_alive(&self) -> bool {
         match self {
-            ProcessState::Running | ProcessState::Stopped(_) => true,
-            ProcessState::Exited(_) | ProcessState::Signaled { .. } => false,
+            _ => todo!(),
+            // ProcessState::Running | ProcessState::Stopped(_) => true,
+            // ProcessState::Exited(_) | ProcessState::Signaled { .. } => false,
         }
     }
 
@@ -179,12 +183,13 @@ impl ProcessState {
     #[must_use]
     pub fn to_wait_status(self, pid: Pid) -> WaitStatus {
         match self {
-            ProcessState::Running => WaitStatus::Continued(pid.into()),
-            ProcessState::Exited(exit_status) => WaitStatus::Exited(pid.into(), exit_status.0),
-            ProcessState::Stopped(signal) => WaitStatus::Stopped(pid.into(), signal),
-            ProcessState::Signaled { signal, core_dump } => {
-                WaitStatus::Signaled(pid.into(), signal, core_dump)
-            }
+            _ => todo!(),
+            // ProcessState::Running => WaitStatus::Continued(pid.into()),
+            // ProcessState::Exited(exit_status) => WaitStatus::Exited(pid.into(), exit_status.0),
+            // ProcessState::Stopped(signal) => WaitStatus::Stopped(pid.into(), signal),
+            // ProcessState::Signaled { signal, core_dump } => {
+            //     WaitStatus::Signaled(pid.into(), signal, core_dump)
+            // }
         }
     }
 
@@ -200,15 +205,23 @@ impl ProcessState {
     pub fn from_wait_status(status: WaitStatus) -> Option<(Pid, Self)> {
         match status {
             WaitStatus::Continued(pid) => Some((pid.into(), ProcessState::Running)),
-            WaitStatus::Exited(pid, exit_status) => {
-                Some((pid.into(), ProcessState::Exited(ExitStatus(exit_status))))
-            }
-            WaitStatus::Stopped(pid, signal) => Some((pid.into(), ProcessState::Stopped(signal))),
-            WaitStatus::Signaled(pid, signal, core_dump) => {
-                Some((pid.into(), ProcessState::Signaled { signal, core_dump }))
-            }
+            // TODO
+            // WaitStatus::Exited(pid, exit_status) => {
+            //     Some((pid.into(), ProcessState::Exited(ExitStatus(exit_status))))
+            // }
+            // WaitStatus::Stopped(pid, signal) => Some((pid.into(), ProcessState::Stopped(signal))),
+            // WaitStatus::Signaled(pid, signal, core_dump) => {
+            //     Some((pid.into(), ProcessState::Signaled { signal, core_dump }))
+            // }
             _ => None,
         }
+    }
+}
+
+impl From<ProcessResult> for ProcessState {
+    #[inline]
+    fn from(result: ProcessResult) -> Self {
+        Self::Halted(result)
     }
 }
 
@@ -225,11 +238,12 @@ impl TryFrom<ProcessState> for ExitStatus {
     type Error = RunningProcess;
     fn try_from(state: ProcessState) -> Result<Self, RunningProcess> {
         match state {
-            ProcessState::Exited(exit_status) => Ok(exit_status),
-            ProcessState::Signaled { signal, .. } | ProcessState::Stopped(signal) => {
-                Ok(ExitStatus::from(signal))
-            }
+            // ProcessState::Exited(exit_status) => Ok(exit_status),
+            // ProcessState::Signaled { signal, .. } | ProcessState::Stopped(signal) => {
+            //     Ok(ExitStatus::from(signal))
+            // }
             ProcessState::Running => Err(RunningProcess),
+            _ => todo!(),
         }
     }
 }
@@ -297,7 +311,7 @@ impl Job {
     }
 
     fn is_suspended(&self) -> bool {
-        matches!(self.state, ProcessState::Stopped(_))
+        todo!() // matches!(self.state, ProcessState::Stopped(_))
     }
 }
 
@@ -1023,7 +1037,7 @@ mod tests {
     #[allow(clippy::bool_assert_comparison)]
     fn updating_job_status_without_expected_state() {
         let mut list = JobList::default();
-        let state = ProcessState::Exited(ExitStatus(15));
+        let state = todo!(); //ProcessState::Exited(ExitStatus(15));
         assert_eq!(list.update_status(Pid(20), state), None);
 
         let i10 = list.add(Job::new(Pid(10)));
@@ -1035,7 +1049,7 @@ mod tests {
         assert_eq!(list[i20].state_changed, false);
 
         assert_eq!(list.update_status(Pid(20), state), Some(i20));
-        assert_eq!(list[i20].state, ProcessState::Exited(ExitStatus(15)));
+        // TODO assert_eq!(list[i20].state, ProcessState::Exited(ExitStatus(15)));
         assert_eq!(list[i20].state_changed, true);
 
         assert_eq!(list[i10].state, ProcessState::Running);
@@ -1070,11 +1084,11 @@ mod tests {
         job.state_changed = false;
         let i20 = list.add(job);
 
-        let result = list.update_status(pid, ProcessState::Exited(ExitStatus(0)));
-        assert_eq!(result, Some(i20));
+        let result = todo!(); // list.update_status(pid, ProcessState::Exited(ExitStatus(0)));
+        // TODO assert_eq!(result, Some(i20));
 
         let job = &list[i20];
-        assert_eq!(job.state, ProcessState::Exited(ExitStatus(0)));
+        // TODO assert_eq!(job.state, ProcessState::Exited(ExitStatus(0)));
         assert_eq!(job.expected_state, None);
         assert_eq!(job.state_changed, true);
     }
@@ -1115,7 +1129,7 @@ mod tests {
         // suspended one.
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended.clone());
         let i20 = list.add(running.clone());
@@ -1142,7 +1156,7 @@ mod tests {
         assert_ne!(ex_current_job_index, ex_previous_job_index);
 
         let mut suspended = Job::new(Pid(20));
-        suspended.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         let i20 = list.add(suspended);
         let now_current_job_index = list.current_job().unwrap();
         let now_previous_job_index = list.previous_job().unwrap();
@@ -1158,7 +1172,7 @@ mod tests {
         let i18 = list.add(running);
 
         let mut suspended_1 = Job::new(Pid(19));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         let i19 = list.add(suspended_1);
 
         let ex_current_job_index = list.current_job().unwrap();
@@ -1167,7 +1181,7 @@ mod tests {
         assert_eq!(ex_previous_job_index, i18);
 
         let mut suspended_2 = Job::new(Pid(20));
-        suspended_2.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         let i20 = list.add(suspended_2);
 
         let now_current_job_index = list.current_job().unwrap();
@@ -1186,9 +1200,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
         let mut suspended_3 = Job::new(Pid(13));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_3.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1234,9 +1248,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
         let mut suspended_3 = Job::new(Pid(13));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_3.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1268,8 +1282,8 @@ mod tests {
 
         let mut suspended_1 = Job::new(Pid(11));
         let mut suspended_2 = Job::new(Pid(12));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         list.add(suspended_1);
         list.add(suspended_2);
 
@@ -1307,8 +1321,8 @@ mod tests {
 
         let mut suspended_1 = Job::new(Pid(21));
         let mut suspended_2 = Job::new(Pid(22));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGSTOP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGSTOP);
         let i21 = list.add(suspended_1);
         let i22 = list.add(suspended_2);
 
@@ -1331,7 +1345,7 @@ mod tests {
     fn set_current_job_not_suspended() {
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended);
         let i20 = list.add(running);
@@ -1360,7 +1374,7 @@ mod tests {
     fn resuming_current_job_without_other_suspended_jobs() {
         let mut list = JobList::default();
         let mut suspended = Job::new(Pid(10));
-        suspended.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         let running = Job::new(Pid(20));
         let i10 = list.add(suspended);
         let i20 = list.add(running);
@@ -1374,8 +1388,8 @@ mod tests {
         let mut list = JobList::default();
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         let i10 = list.add(suspended_1);
         let i20 = list.add(suspended_2);
         list.set_current_job(i10).unwrap();
@@ -1391,9 +1405,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1419,9 +1433,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         list.add(suspended_1);
         list.add(suspended_2);
         list.add(suspended_3);
@@ -1447,9 +1461,9 @@ mod tests {
         let mut suspended_1 = Job::new(Pid(10));
         let mut suspended_2 = Job::new(Pid(20));
         let mut suspended_3 = Job::new(Pid(30));
-        suspended_1.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_2.state = ProcessState::Stopped(Signal::SIGTSTP);
-        suspended_3.state = ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_1.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_2.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
+        suspended_3.state = todo!(); // ProcessState::Stopped(Signal::SIGTSTP);
         let i10 = list.add(suspended_1);
         let i20 = list.add(suspended_2);
         let _i30 = list.add(suspended_3);
@@ -1466,7 +1480,7 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i11).unwrap();
-        list.update_status(Pid(11), ProcessState::Stopped(Signal::SIGTTOU));
+        // TODO list.update_status(Pid(11), ProcessState::Stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i11));
         assert_eq!(list.previous_job(), Some(i12));
     }
@@ -1477,7 +1491,7 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i11).unwrap();
-        list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
+        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i11));
     }
@@ -1489,7 +1503,7 @@ mod tests {
         let _i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         list.set_current_job(i10).unwrap();
-        list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTIN));
+        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTIN));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i10));
     }
@@ -1500,12 +1514,12 @@ mod tests {
         let i11 = list.add(Job::new(Pid(11)));
         let i12 = list.add(Job::new(Pid(12)));
         let mut suspended = Job::new(Pid(10));
-        suspended.state = ProcessState::Stopped(Signal::SIGTTIN);
+        suspended.state = todo!(); // ProcessState::Stopped(Signal::SIGTTIN);
         let i10 = list.add(suspended);
         assert_eq!(list.current_job(), Some(i10));
         assert_eq!(list.previous_job(), Some(i11));
 
-        list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
+        // TODO list.update_status(Pid(12), ProcessState::Stopped(Signal::SIGTTOU));
         assert_eq!(list.current_job(), Some(i12));
         assert_eq!(list.previous_job(), Some(i10));
     }

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -81,17 +81,18 @@ impl Display for ProcessState {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let s = match self {
             ProcessState::Running => return f.pad("Running"),
-            ProcessState::Stopped(signal) => format!("Stopped({signal})"),
-            ProcessState::Exited(ExitStatus(0)) => return f.pad("Done"),
-            ProcessState::Exited(exit_status) => format!("Done({exit_status})"),
-            ProcessState::Signaled {
-                signal,
-                core_dump: false,
-            } => format!("Killed({signal})"),
-            ProcessState::Signaled {
-                signal,
-                core_dump: true,
-            } => format!("Killed({signal}: core dumped)"),
+            _ => "TODO".to_string(),
+            // ProcessState::Stopped(signal) => format!("Stopped({signal})"),
+            // ProcessState::Exited(ExitStatus(0)) => return f.pad("Done"),
+            // ProcessState::Exited(exit_status) => format!("Done({exit_status})"),
+            // ProcessState::Signaled {
+            //     signal,
+            //     core_dump: false,
+            // } => format!("Killed({signal})"),
+            // ProcessState::Signaled {
+            //     signal,
+            //     core_dump: true,
+            // } => format!("Killed({signal}: core dumped)"),
         };
         f.pad(&s)
     }
@@ -192,53 +193,56 @@ mod tests {
 
     #[test]
     fn process_state_display_stopped() {
-        let state = ProcessState::Stopped(Signal::SIGSTOP);
-        assert_eq!(state.to_string(), "Stopped(SIGSTOP)");
-        let state = ProcessState::Stopped(Signal::SIGTSTP);
-        assert_eq!(state.to_string(), "Stopped(SIGTSTP)");
-        let state = ProcessState::Stopped(Signal::SIGTTIN);
-        assert_eq!(state.to_string(), "Stopped(SIGTTIN)");
-        let state = ProcessState::Stopped(Signal::SIGTTOU);
-        assert_eq!(state.to_string(), "Stopped(SIGTTOU)");
+        todo!()
+        // let state = ProcessState::Stopped(Signal::SIGSTOP);
+        // assert_eq!(state.to_string(), "Stopped(SIGSTOP)");
+        // let state = ProcessState::Stopped(Signal::SIGTSTP);
+        // assert_eq!(state.to_string(), "Stopped(SIGTSTP)");
+        // let state = ProcessState::Stopped(Signal::SIGTTIN);
+        // assert_eq!(state.to_string(), "Stopped(SIGTTIN)");
+        // let state = ProcessState::Stopped(Signal::SIGTTOU);
+        // assert_eq!(state.to_string(), "Stopped(SIGTTOU)");
     }
 
     #[test]
     fn process_state_display_exited() {
-        let state = ProcessState::Exited(ExitStatus(0));
-        assert_eq!(state.to_string(), "Done");
-        let state = ProcessState::Exited(ExitStatus(1));
-        assert_eq!(state.to_string(), "Done(1)");
-        let state = ProcessState::Exited(ExitStatus(2));
-        assert_eq!(state.to_string(), "Done(2)");
-        let state = ProcessState::Exited(ExitStatus(253));
-        assert_eq!(state.to_string(), "Done(253)");
+        todo!()
+        // let state = ProcessState::Exited(ExitStatus(0));
+        // assert_eq!(state.to_string(), "Done");
+        // let state = ProcessState::Exited(ExitStatus(1));
+        // assert_eq!(state.to_string(), "Done(1)");
+        // let state = ProcessState::Exited(ExitStatus(2));
+        // assert_eq!(state.to_string(), "Done(2)");
+        // let state = ProcessState::Exited(ExitStatus(253));
+        // assert_eq!(state.to_string(), "Done(253)");
     }
 
     #[test]
     fn process_state_display_signaled() {
-        let state = ProcessState::Signaled {
-            signal: Signal::SIGKILL,
-            core_dump: false,
-        };
-        assert_eq!(state.to_string(), "Killed(SIGKILL)");
+        todo!()
+        // let state = ProcessState::Signaled {
+        //     signal: Signal::SIGKILL,
+        //     core_dump: false,
+        // };
+        // assert_eq!(state.to_string(), "Killed(SIGKILL)");
 
-        let state = ProcessState::Signaled {
-            signal: Signal::SIGKILL,
-            core_dump: true,
-        };
-        assert_eq!(state.to_string(), "Killed(SIGKILL: core dumped)");
+        // let state = ProcessState::Signaled {
+        //     signal: Signal::SIGKILL,
+        //     core_dump: true,
+        // };
+        // assert_eq!(state.to_string(), "Killed(SIGKILL: core dumped)");
 
-        let state = ProcessState::Signaled {
-            signal: Signal::SIGTERM,
-            core_dump: false,
-        };
-        assert_eq!(state.to_string(), "Killed(SIGTERM)");
+        // let state = ProcessState::Signaled {
+        //     signal: Signal::SIGTERM,
+        //     core_dump: false,
+        // };
+        // assert_eq!(state.to_string(), "Killed(SIGTERM)");
 
-        let state = ProcessState::Signaled {
-            signal: Signal::SIGQUIT,
-            core_dump: true,
-        };
-        assert_eq!(state.to_string(), "Killed(SIGQUIT: core dumped)");
+        // let state = ProcessState::Signaled {
+        //     signal: Signal::SIGQUIT,
+        //     core_dump: true,
+        // };
+        // assert_eq!(state.to_string(), "Killed(SIGQUIT: core dumped)");
     }
 
     #[test]
@@ -250,7 +254,7 @@ mod tests {
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Running              echo ok");
 
-        job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Stopped(SIGSTOP)     echo ok");
 
@@ -266,10 +270,11 @@ mod tests {
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[6]   Stopped(SIGSTOP)     echo ok");
 
-        job.state = ProcessState::Signaled {
-            signal: Signal::SIGQUIT,
-            core_dump: true,
-        };
+        // TODO
+        // job.state = ProcessState::Signaled {
+        //     signal: Signal::SIGQUIT,
+        //     core_dump: true,
+        // };
         job.name = "exit 0".to_string();
         let report = Report { index, marker, job };
         assert_eq!(

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -57,17 +57,17 @@
 use super::Job;
 #[cfg(doc)]
 use super::JobList;
+use super::ProcessResult;
 use super::ProcessState;
 use crate::semantics::ExitStatus;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result;
 
-/// Formats a process state into a string.
+/// Formats a process result into a string.
 ///
-/// Process states are formatted as follows:
+/// Process results are formatted as follows:
 ///
-/// - `Running` for a running process
 /// - `Stopped(SIG…)` for a stopped process that has been stopped by the signal
 ///   `SIG…`
 /// - `Done` for a process that exited with exit status 0
@@ -77,24 +77,38 @@ use std::fmt::Result;
 ///   without a core dump
 /// - `Killed(SIG…: core dumped)` for a process that was terminated by the
 ///   signal `SIG…` with a core dump
+impl Display for ProcessResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Exited(ExitStatus::SUCCESS) => "Done".fmt(f),
+
+            Self::Exited(exit_status) => format!("Done({exit_status})").fmt(f),
+
+            Self::Stopped(signal) => format!("Stopped({signal})").fmt(f),
+
+            Self::Signaled {
+                signal,
+                core_dump: false,
+            } => format!("Killed({signal})").fmt(f),
+
+            Self::Signaled {
+                signal,
+                core_dump: true,
+            } => format!("Killed({signal}: core dumped)").fmt(f),
+        }
+    }
+}
+
+/// Formats a process state into a string.
+///
+/// The `Running` state is formatted as `"Running"`. The `Halted` state
+/// delegates to the formatting of the [`ProcessResult`] that it contains.
 impl Display for ProcessState {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let s = match self {
-            ProcessState::Running => return f.pad("Running"),
-            _ => "TODO".to_string(),
-            // ProcessState::Stopped(signal) => format!("Stopped({signal})"),
-            // ProcessState::Exited(ExitStatus(0)) => return f.pad("Done"),
-            // ProcessState::Exited(exit_status) => format!("Done({exit_status})"),
-            // ProcessState::Signaled {
-            //     signal,
-            //     core_dump: false,
-            // } => format!("Killed({signal})"),
-            // ProcessState::Signaled {
-            //     signal,
-            //     core_dump: true,
-            // } => format!("Killed({signal}: core dumped)"),
-        };
-        f.pad(&s)
+        match self {
+            ProcessState::Running => "Running".fmt(f),
+            ProcessState::Halted(result) => result.fmt(f),
+        }
     }
 }
 
@@ -186,63 +200,73 @@ mod tests {
     use crate::trap::Signal;
 
     #[test]
+    fn process_result_display_stopped() {
+        let result = ProcessResult::Stopped(Signal::SIGSTOP);
+        assert_eq!(result.to_string(), "Stopped(SIGSTOP)");
+        let result = ProcessResult::Stopped(Signal::SIGTSTP);
+        assert_eq!(result.to_string(), "Stopped(SIGTSTP)");
+        let result = ProcessResult::Stopped(Signal::SIGTTIN);
+        assert_eq!(result.to_string(), "Stopped(SIGTTIN)");
+        let result = ProcessResult::Stopped(Signal::SIGTTOU);
+        assert_eq!(result.to_string(), "Stopped(SIGTTOU)");
+    }
+
+    #[test]
+    fn process_result_display_exited() {
+        let result = ProcessResult::exited(0);
+        assert_eq!(result.to_string(), "Done");
+        let result = ProcessResult::exited(1);
+        assert_eq!(result.to_string(), "Done(1)");
+        let result = ProcessResult::exited(2);
+        assert_eq!(result.to_string(), "Done(2)");
+        let result = ProcessResult::exited(253);
+        assert_eq!(result.to_string(), "Done(253)");
+    }
+
+    #[test]
+    fn process_result_display_signaled() {
+        let result = ProcessResult::Signaled {
+            signal: Signal::SIGKILL,
+            core_dump: false,
+        };
+        assert_eq!(result.to_string(), "Killed(SIGKILL)");
+
+        let result = ProcessResult::Signaled {
+            signal: Signal::SIGKILL,
+            core_dump: true,
+        };
+        assert_eq!(result.to_string(), "Killed(SIGKILL: core dumped)");
+
+        let result = ProcessResult::Signaled {
+            signal: Signal::SIGTERM,
+            core_dump: false,
+        };
+        assert_eq!(result.to_string(), "Killed(SIGTERM)");
+
+        let result = ProcessResult::Signaled {
+            signal: Signal::SIGQUIT,
+            core_dump: true,
+        };
+        assert_eq!(result.to_string(), "Killed(SIGQUIT: core dumped)");
+    }
+
+    #[test]
     fn process_state_display_running() {
         let state = ProcessState::Running;
         assert_eq!(state.to_string(), "Running");
     }
 
     #[test]
-    fn process_state_display_stopped() {
-        todo!()
-        // let state = ProcessState::Stopped(Signal::SIGSTOP);
-        // assert_eq!(state.to_string(), "Stopped(SIGSTOP)");
-        // let state = ProcessState::Stopped(Signal::SIGTSTP);
-        // assert_eq!(state.to_string(), "Stopped(SIGTSTP)");
-        // let state = ProcessState::Stopped(Signal::SIGTTIN);
-        // assert_eq!(state.to_string(), "Stopped(SIGTTIN)");
-        // let state = ProcessState::Stopped(Signal::SIGTTOU);
-        // assert_eq!(state.to_string(), "Stopped(SIGTTOU)");
-    }
-
-    #[test]
-    fn process_state_display_exited() {
-        todo!()
-        // let state = ProcessState::Exited(ExitStatus(0));
-        // assert_eq!(state.to_string(), "Done");
-        // let state = ProcessState::Exited(ExitStatus(1));
-        // assert_eq!(state.to_string(), "Done(1)");
-        // let state = ProcessState::Exited(ExitStatus(2));
-        // assert_eq!(state.to_string(), "Done(2)");
-        // let state = ProcessState::Exited(ExitStatus(253));
-        // assert_eq!(state.to_string(), "Done(253)");
-    }
-
-    #[test]
-    fn process_state_display_signaled() {
-        todo!()
-        // let state = ProcessState::Signaled {
-        //     signal: Signal::SIGKILL,
-        //     core_dump: false,
-        // };
-        // assert_eq!(state.to_string(), "Killed(SIGKILL)");
-
-        // let state = ProcessState::Signaled {
-        //     signal: Signal::SIGKILL,
-        //     core_dump: true,
-        // };
-        // assert_eq!(state.to_string(), "Killed(SIGKILL: core dumped)");
-
-        // let state = ProcessState::Signaled {
-        //     signal: Signal::SIGTERM,
-        //     core_dump: false,
-        // };
-        // assert_eq!(state.to_string(), "Killed(SIGTERM)");
-
-        // let state = ProcessState::Signaled {
-        //     signal: Signal::SIGQUIT,
-        //     core_dump: true,
-        // };
-        // assert_eq!(state.to_string(), "Killed(SIGQUIT: core dumped)");
+    fn process_state_display_halted() {
+        let state = ProcessState::stopped(Signal::SIGSTOP);
+        assert_eq!(state.to_string(), "Stopped(SIGSTOP)");
+        let state = ProcessState::exited(0);
+        assert_eq!(state.to_string(), "Done");
+        let state = ProcessState::Halted(ProcessResult::Signaled {
+            signal: Signal::SIGKILL,
+            core_dump: false,
+        });
+        assert_eq!(state.to_string(), "Killed(SIGKILL)");
     }
 
     #[test]
@@ -254,7 +278,7 @@ mod tests {
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Running              echo ok");
 
-        // TODO job.state = ProcessState::Stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(Signal::SIGSTOP);
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Stopped(SIGSTOP)     echo ok");
 
@@ -270,11 +294,10 @@ mod tests {
         let report = Report { index, marker, job };
         assert_eq!(report.to_string(), "[6]   Stopped(SIGSTOP)     echo ok");
 
-        // TODO
-        // job.state = ProcessState::Signaled {
-        //     signal: Signal::SIGQUIT,
-        //     core_dump: true,
-        // };
+        job.state = ProcessState::Halted(ProcessResult::Signaled {
+            signal: Signal::SIGQUIT,
+            core_dump: true,
+        });
         job.name = "exit 0".to_string();
         let report = Report { index, marker, job };
         assert_eq!(

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -360,8 +360,10 @@ impl Env {
     ) -> Result<(Pid, ExitStatus), Errno> {
         loop {
             let (pid, state) = self.wait_for_subshell(target).await?;
-            if !state.is_alive() {
-                return Ok((pid, state.try_into().unwrap()));
+            if let Ok(exit_status) = state.try_into() {
+                if !state.is_alive() {
+                    return Ok((pid, exit_status));
+                }
             }
         }
     }

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -602,7 +602,7 @@ mod tests {
             });
             let (pid, _) = subshell.start(&mut env).await.unwrap();
             let result = env.wait_for_subshell(pid).await;
-            // TODO assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
+            assert_eq!(result, Ok((pid, ProcessState::exited(42))));
         });
     }
 
@@ -617,8 +617,8 @@ mod tests {
             job.name = "my job".to_string();
             let job_index = env.jobs.add(job.clone());
             let result = env.wait_for_subshell(pid).await;
-            // TODO assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
-            // TODO job.state = ProcessState::Exited(ExitStatus(42));
+            assert_eq!(result, Ok((pid, ProcessState::exited(42))));
+            job.state = ProcessState::exited(42);
             assert_eq!(env.jobs[job_index], job);
         });
     }

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -602,7 +602,7 @@ mod tests {
             });
             let (pid, _) = subshell.start(&mut env).await.unwrap();
             let result = env.wait_for_subshell(pid).await;
-            assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
+            // TODO assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
         });
     }
 
@@ -617,8 +617,8 @@ mod tests {
             job.name = "my job".to_string();
             let job_index = env.jobs.add(job.clone());
             let result = env.wait_for_subshell(pid).await;
-            assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
-            job.state = ProcessState::Exited(ExitStatus(42));
+            // TODO assert_eq!(result, Ok((pid, ProcessState::Exited(ExitStatus(42)))));
+            // TODO job.state = ProcessState::Exited(ExitStatus(42));
             assert_eq!(env.jobs[job_index], job);
         });
     }
@@ -691,8 +691,8 @@ mod tests {
         env.update_all_subshell_statuses();
 
         // Now we have the results.
-        assert_eq!(env.jobs[job_1].state, ProcessState::Exited(ExitStatus(12)));
-        assert_eq!(env.jobs[job_2].state, ProcessState::Exited(ExitStatus(35)));
+        // TODO assert_eq!(env.jobs[job_1].state, ProcessState::Exited(ExitStatus(12)));
+        // TODO assert_eq!(env.jobs[job_2].state, ProcessState::Exited(ExitStatus(35)));
         assert_eq!(env.jobs[job_3].state, ProcessState::Running);
     }
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -241,9 +241,7 @@ where
             let (pid, state) = env.wait_for_subshell(pid).await?;
             let is_done = match state {
                 ProcessState::Running => false,
-                _ => todo!(),
-                // ProcessState::Stopped(_) => job_control.is_some(),
-                // ProcessState::Exited(_) | ProcessState::Signaled { .. } => true,
+                ProcessState::Halted(result) => !result.is_stopped() || job_control.is_some(),
             };
             if is_done {
                 break Ok((pid, state));
@@ -588,7 +586,7 @@ mod tests {
                 Box::pin(async { env.exit_status = ExitStatus(42) })
             });
             let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            // TODO assert_eq!(process_state, ProcessState::Exited(ExitStatus(42)));
+            assert_eq!(process_state, ProcessState::exited(42));
         });
     }
 
@@ -603,7 +601,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            // TODO assert_eq!(process_state, ProcessState::Exited(ExitStatus(123)));
+            assert_eq!(process_state, ProcessState::exited(123));
             assert_eq!(state.borrow().foreground, Some(env.main_pgid));
         });
     }
@@ -654,11 +652,7 @@ mod tests {
                 .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            // TODO
-            // assert_eq!(
-            //     child_result,
-            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
-            // );
+            assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
 
             let state = state.borrow();
             let parent_process = &state.processes[&parent_env.main_pid];
@@ -718,11 +712,7 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            // TODO
-            // assert_eq!(
-            //     child_result,
-            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
-            // );
+            assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -761,11 +751,7 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            // TODO
-            // assert_eq!(
-            //     child_result,
-            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
-            // );
+            assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -798,11 +784,7 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            // TODO
-            // assert_eq!(
-            //     child_result,
-            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
-            // );
+            assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -835,11 +817,7 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            // TODO
-            // assert_eq!(
-            //     child_result,
-            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
-            // );
+            assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -241,8 +241,9 @@ where
             let (pid, state) = env.wait_for_subshell(pid).await?;
             let is_done = match state {
                 ProcessState::Running => false,
-                ProcessState::Stopped(_) => job_control.is_some(),
-                ProcessState::Exited(_) | ProcessState::Signaled { .. } => true,
+                _ => todo!(),
+                // ProcessState::Stopped(_) => job_control.is_some(),
+                // ProcessState::Exited(_) | ProcessState::Signaled { .. } => true,
             };
             if is_done {
                 break Ok((pid, state));
@@ -587,7 +588,7 @@ mod tests {
                 Box::pin(async { env.exit_status = ExitStatus(42) })
             });
             let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(process_state, ProcessState::Exited(ExitStatus(42)));
+            // TODO assert_eq!(process_state, ProcessState::Exited(ExitStatus(42)));
         });
     }
 
@@ -602,7 +603,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (_pid, process_state) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(process_state, ProcessState::Exited(ExitStatus(123)));
+            // TODO assert_eq!(process_state, ProcessState::Exited(ExitStatus(123)));
             assert_eq!(state.borrow().foreground, Some(env.main_pgid));
         });
     }
@@ -653,10 +654,11 @@ mod tests {
                 .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            assert_eq!(
-                child_result,
-                (child_pid, ProcessState::Exited(ExitStatus(123)))
-            );
+            // TODO
+            // assert_eq!(
+            //     child_result,
+            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
+            // );
 
             let state = state.borrow();
             let parent_process = &state.processes[&parent_env.main_pid];
@@ -716,10 +718,11 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            assert_eq!(
-                child_result,
-                (child_pid, ProcessState::Exited(ExitStatus(123)))
-            );
+            // TODO
+            // assert_eq!(
+            //     child_result,
+            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
+            // );
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -758,10 +761,11 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            assert_eq!(
-                child_result,
-                (child_pid, ProcessState::Exited(ExitStatus(123)))
-            );
+            // TODO
+            // assert_eq!(
+            //     child_result,
+            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
+            // );
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -794,10 +798,11 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            assert_eq!(
-                child_result,
-                (child_pid, ProcessState::Exited(ExitStatus(123)))
-            );
+            // TODO
+            // assert_eq!(
+            //     child_result,
+            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
+            // );
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
@@ -830,10 +835,11 @@ mod tests {
             .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
-            assert_eq!(
-                child_result,
-                (child_pid, ProcessState::Exited(ExitStatus(123)))
-            );
+            // TODO
+            // assert_eq!(
+            //     child_result,
+            //     (child_pid, ProcessState::Exited(ExitStatus(123)))
+            // );
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -292,8 +292,9 @@ impl VirtualSystem {
 
             match process.state {
                 ProcessState::Running => Poll::Ready(()),
-                ProcessState::Exited(_) | ProcessState::Signaled { .. } => Poll::Pending,
-                ProcessState::Stopped(_) => {
+                _ => todo!(),
+                // ProcessState::Exited(_) | ProcessState::Signaled { .. } => Poll::Pending,
+                _ /* TODO ProcessState::Stopped(_) */ => {
                     waker.set(Some(cx.waker().clone()));
                     process.wake_on_resumption(Rc::downgrade(&waker));
                     Poll::Pending
@@ -907,12 +908,13 @@ impl System for VirtualSystem {
                         .processes
                         .get_mut(&process_id)
                         .expect("missing child process");
-                    if process.state == ProcessState::Running
-                        && process.set_state(ProcessState::Exited(child_env.exit_status))
-                    {
-                        let ppid = process.ppid;
-                        raise_sigchld(&mut state, ppid);
-                    }
+                    // TODO
+                    // if process.state == ProcessState::Running
+                    //     && process.set_state(ProcessState::Exited(child_env.exit_status))
+                    // {
+                    //     let ppid = process.ppid;
+                    //     raise_sigchld(&mut state, ppid);
+                    // }
                 });
 
                 executor
@@ -1234,12 +1236,13 @@ impl Future for ProcessRunner<'_> {
         let mut process = this.system.current_process_mut();
         match process.state {
             ProcessState::Running => Poll::Pending,
-            ProcessState::Exited(_) | ProcessState::Signaled { .. } => Poll::Ready(()),
-            ProcessState::Stopped(_) => {
-                this.waker.set(Some(cx.waker().clone()));
-                process.wake_on_resumption(Rc::downgrade(&this.waker));
-                Poll::Pending
-            }
+            _ => todo!(),
+            // ProcessState::Exited(_) | ProcessState::Signaled { .. } => Poll::Ready(()),
+            // ProcessState::Stopped(_) => {
+            //     this.waker.set(Some(cx.waker().clone()));
+            //     process.wake_on_resumption(Rc::downgrade(&this.waker));
+            //     Poll::Pending
+            // }
         }
     }
 }
@@ -1821,13 +1824,14 @@ mod tests {
             .now_or_never();
         // The future should be pending because the current process has been killed
         assert_eq!(result, None);
-        assert_eq!(
-            system.current_process().state(),
-            ProcessState::Signaled {
-                signal: Signal::SIGINT,
-                core_dump: false
-            }
-        );
+        // TODO
+        // assert_eq!(
+        //     system.current_process().state(),
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGINT,
+        //         core_dump: false
+        //     }
+        // );
 
         let mut system = VirtualSystem::new();
         let state = system.state.borrow();
@@ -1864,13 +1868,14 @@ mod tests {
         assert_eq!(result, None);
         let state = system.state.borrow();
         for process in state.processes.values() {
-            assert_eq!(
-                process.state,
-                ProcessState::Signaled {
-                    signal: Signal::SIGTERM,
-                    core_dump: false
-                }
-            );
+            // TODO
+            // assert_eq!(
+            //     process.state,
+            //     ProcessState::Signaled {
+            //         signal: Signal::SIGTERM,
+            //         core_dump: false
+            //     }
+            // );
         }
     }
 
@@ -1898,27 +1903,28 @@ mod tests {
         // The future should be pending because the current process has been killed
         assert_eq!(result, None);
         let state = system.state.borrow();
-        assert_eq!(
-            state.processes[&system.process_id].state,
-            ProcessState::Signaled {
-                signal: Signal::SIGQUIT,
-                core_dump: true
-            }
-        );
-        assert_eq!(
-            state.processes[&Pid(10)].state,
-            ProcessState::Signaled {
-                signal: Signal::SIGQUIT,
-                core_dump: true
-            }
-        );
-        assert_eq!(
-            state.processes[&Pid(11)].state,
-            ProcessState::Signaled {
-                signal: Signal::SIGQUIT,
-                core_dump: true
-            }
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&system.process_id].state,
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGQUIT,
+        //         core_dump: true
+        //     }
+        // );
+        // assert_eq!(
+        //     state.processes[&Pid(10)].state,
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGQUIT,
+        //         core_dump: true
+        //     }
+        // );
+        // assert_eq!(
+        //     state.processes[&Pid(11)].state,
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGQUIT,
+        //         core_dump: true
+        //     }
+        // );
         assert_eq!(state.processes[&Pid(21)].state, ProcessState::Running);
     }
 
@@ -1951,20 +1957,21 @@ mod tests {
             ProcessState::Running
         );
         assert_eq!(state.processes[&Pid(10)].state, ProcessState::Running);
-        assert_eq!(
-            state.processes[&Pid(11)].state,
-            ProcessState::Signaled {
-                signal: Signal::SIGHUP,
-                core_dump: false
-            }
-        );
-        assert_eq!(
-            state.processes[&Pid(21)].state,
-            ProcessState::Signaled {
-                signal: Signal::SIGHUP,
-                core_dump: false
-            }
-        );
+        // TODO
+        // assert_eq!(
+        //     state.processes[&Pid(11)].state,
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGHUP,
+        //         core_dump: false
+        //     }
+        // );
+        // assert_eq!(
+        //     state.processes[&Pid(21)].state,
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGHUP,
+        //         core_dump: false
+        //     }
+        // );
     }
 
     #[test]
@@ -2419,7 +2426,7 @@ mod tests {
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
-        assert_eq!(result, Ok(Some((pid, ProcessState::Exited(ExitStatus(5))))));
+        // TODO assert_eq!(result, Ok(Some((pid, ProcessState::Exited(ExitStatus(5))))));
     }
 
     #[test]
@@ -2444,16 +2451,17 @@ mod tests {
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
-        assert_eq!(
-            result,
-            Ok(Some((
-                pid,
-                ProcessState::Signaled {
-                    signal: Signal::SIGKILL,
-                    core_dump: false
-                }
-            )))
-        );
+        // TODO
+        // assert_eq!(
+        //     result,
+        //     Ok(Some((
+        //         pid,
+        //         ProcessState::Signaled {
+        //             signal: Signal::SIGKILL,
+        //             core_dump: false
+        //         }
+        //     )))
+        // );
     }
 
     #[test]
@@ -2478,10 +2486,11 @@ mod tests {
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
-        assert_eq!(
-            result,
-            Ok(Some((pid, ProcessState::Stopped(Signal::SIGSTOP))))
-        );
+        // TODO
+        // assert_eq!(
+        //     result,
+        //     Ok(Some((pid, ProcessState::Stopped(Signal::SIGSTOP))))
+        // );
     }
 
     #[test]
@@ -2518,10 +2527,11 @@ mod tests {
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
-        assert_eq!(
-            result,
-            Ok(Some((pid, ProcessState::Exited(ExitStatus(123)))))
-        );
+        // TODO
+        // assert_eq!(
+        //     result,
+        //     Ok(Some((pid, ProcessState::Exited(ExitStatus(123)))))
+        // );
     }
 
     #[test]

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -267,9 +267,10 @@ impl Process {
     ///
     /// This function does nothing if the process is not stopped.
     pub fn wake_on_resumption(&mut self, waker: Weak<Cell<Option<Waker>>>) {
-        if matches!(self.state, ProcessState::Stopped(_)) {
-            self.resumption_awaiters.push(waker);
-        }
+        // TODO
+        // if matches!(self.state, ProcessState::Stopped(_)) {
+        //     self.resumption_awaiters.push(waker);
+        // }
     }
 
     /// Returns the process state.
@@ -305,8 +306,9 @@ impl Process {
                         }
                     }
                 }
-                ProcessState::Exited(_) | ProcessState::Signaled { .. } => self.close_fds(),
-                ProcessState::Stopped(_) => (),
+                // ProcessState::Exited(_) | ProcessState::Signaled { .. } => self.close_fds(),
+                // ProcessState::Stopped(_) => (),
+                _ => todo!(),
             }
             self.state_has_changed = true;
             true
@@ -416,9 +418,9 @@ impl Process {
                 let process_state_changed = match SignalEffect::of(signal) {
                     SignalEffect::None | SignalEffect::Resume => false,
                     SignalEffect::Terminate { core_dump } => {
-                        self.set_state(ProcessState::Signaled { signal, core_dump })
+                        todo!() // self.set_state(ProcessState::Signaled { signal, core_dump })
                     }
-                    SignalEffect::Suspend => self.set_state(ProcessState::Stopped(signal)),
+                    SignalEffect::Suspend => todo!(), // self.set_state(ProcessState::Stopped(signal)),
                 };
                 SignalResult {
                     delivered: true,
@@ -592,7 +594,7 @@ mod tests {
     #[test]
     fn process_set_state_wakes_on_resumed() {
         let mut process = Process::with_parent_and_group(Pid(1), Pid(2));
-        process.state = ProcessState::Stopped(Signal::SIGTSTP);
+        // TODO process.state = ProcessState::Stopped(Signal::SIGTSTP);
         let process = Rc::new(RefCell::new(process));
         let process2 = Rc::clone(&process);
         let waker = Rc::new(Cell::new(None));
@@ -619,17 +621,18 @@ mod tests {
     #[test]
     fn process_set_state_closes_all_fds_on_exit() {
         let (mut process, _reader, _writer) = process_with_pipe();
-        assert!(process.set_state(ProcessState::Exited(ExitStatus(3))));
+        // TODO assert!(process.set_state(ProcessState::Exited(ExitStatus(3))));
         assert!(process.fds().is_empty(), "{:?}", process.fds());
     }
 
     #[test]
     fn process_set_state_closes_all_fds_on_signaled() {
         let (mut process, _reader, _writer) = process_with_pipe();
-        assert!(process.set_state(ProcessState::Signaled {
-            signal: Signal::SIGINT,
-            core_dump: false
-        }));
+        // TODO
+        // assert!(process.set_state(ProcessState::Signaled {
+        //     signal: Signal::SIGINT,
+        //     core_dump: false
+        // }));
         assert!(process.fds().is_empty(), "{:?}", process.fds());
     }
 
@@ -763,13 +766,14 @@ mod tests {
                 process_state_changed: true,
             }
         );
-        assert_eq!(
-            process.state(),
-            ProcessState::Signaled {
-                signal: Signal::SIGTERM,
-                core_dump: false
-            }
-        );
+        // TODO
+        // assert_eq!(
+        //     process.state(),
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGTERM,
+        //         core_dump: false
+        //     }
+        // );
         assert_eq!(process.caught_signals, []);
     }
 
@@ -785,13 +789,14 @@ mod tests {
                 process_state_changed: true,
             }
         );
-        assert_eq!(
-            process.state(),
-            ProcessState::Signaled {
-                signal: Signal::SIGABRT,
-                core_dump: true
-            }
-        );
+        // TODO
+        // assert_eq!(
+        //     process.state(),
+        //     ProcessState::Signaled {
+        //         signal: Signal::SIGABRT,
+        //         core_dump: true
+        //     }
+        // );
         assert_eq!(process.caught_signals, []);
         // TODO Check if core dump file has been created
     }
@@ -808,14 +813,14 @@ mod tests {
                 process_state_changed: true,
             }
         );
-        assert_eq!(process.state(), ProcessState::Stopped(Signal::SIGTSTP));
+        // TODO assert_eq!(process.state(), ProcessState::Stopped(Signal::SIGTSTP));
         assert_eq!(process.caught_signals, []);
     }
 
     #[test]
     fn process_raise_signal_default_continuing() {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
-        let _ = process.set_state(ProcessState::Stopped(Signal::SIGTTOU));
+        // TODO let _ = process.set_state(ProcessState::Stopped(Signal::SIGTTOU));
         let result = process.raise_signal(Signal::SIGCONT);
         assert_eq!(
             result,
@@ -849,7 +854,7 @@ mod tests {
     #[test]
     fn process_raise_signal_ignored_and_blocked_sigcont() {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
-        let _ = process.set_state(ProcessState::Stopped(Signal::SIGTTOU));
+        // TODO let _ = process.set_state(ProcessState::Stopped(Signal::SIGTTOU));
         let _ = process.set_signal_handling(Signal::SIGCONT, SignalHandling::Ignore);
         let _ = process.block_signals(SigmaskHow::SIG_BLOCK, &to_set([Signal::SIGCONT]));
         let result = process.raise_signal(Signal::SIGCONT);

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -39,13 +39,14 @@ pub async fn execute(env: &mut Env, body: Rc<List>, location: &Location) -> Resu
     let subshell = subshell.job_control(JobControl::Foreground);
     match subshell.start_and_wait(env).await {
         Ok((pid, state)) => {
-            if let ProcessState::Stopped(_) = state {
-                let mut job = Job::new(pid);
-                job.job_controlled = true;
-                job.state = state;
-                job.name = body.to_string();
-                env.jobs.add(job);
-            }
+            // TODO
+            // if let ProcessState::Stopped(_) = state {
+            //     let mut job = Job::new(pid);
+            //     job.job_controlled = true;
+            //     job.state = state;
+            //     job.name = body.to_string();
+            //     env.jobs.add(job);
+            // }
 
             env.exit_status = state.try_into().unwrap();
             env.apply_errexit()
@@ -178,7 +179,7 @@ mod tests {
             let (&pid, process) = state.processes.last_key_value().unwrap();
             assert_ne!(pid, env.main_pid);
             assert_ne!(process.pgid(), env.main_pgid);
-            assert_eq!(process.state(), ProcessState::Exited(ExitStatus(12)));
+            // TODO assert_eq!(process.state(), ProcessState::Exited(ExitStatus(12)));
 
             assert_eq!(env.jobs.len(), 0);
         })
@@ -200,13 +201,13 @@ mod tests {
             let (&pid, process) = state.processes.last_key_value().unwrap();
             assert_ne!(pid, env.main_pid);
             assert_ne!(process.pgid(), env.main_pgid);
-            assert_eq!(process.state(), ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(process.state(), ProcessState::Stopped(Signal::SIGSTOP));
 
             assert_eq!(env.jobs.len(), 1);
             let job = env.jobs.iter().next().unwrap().1;
             assert_eq!(job.pid, pid);
             assert!(job.job_controlled);
-            assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
             assert!(job.state_changed);
             assert_eq!(job.name, "suspend foo");
         })

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -37,16 +37,16 @@ pub async fn execute(env: &mut Env, body: Rc<List>, location: &Location) -> Resu
     let subshell = Subshell::new(|sub_env, _job_control| Box::pin(subshell_main(sub_env, body_2)));
     let subshell = subshell.job_control(JobControl::Foreground);
     match subshell.start_and_wait(env).await {
-        Ok((pid, state)) => {
-            if state.is_stopped() {
+        Ok((pid, result)) => {
+            if result.is_stopped() {
                 let mut job = Job::new(pid);
                 job.job_controlled = true;
-                job.state = state;
+                job.state = result.into();
                 job.name = body.to_string();
                 env.jobs.add(job);
             }
 
-            env.exit_status = state.try_into().unwrap();
+            env.exit_status = result.into();
             env.apply_errexit()
         }
         Err(errno) => {

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -144,13 +144,14 @@ async fn execute_job_controlled_pipeline(
 
     match subshell.start_and_wait(env).await {
         Ok((pid, state)) => {
-            if let ProcessState::Stopped(_) = state {
-                let mut job = Job::new(pid);
-                job.job_controlled = true;
-                job.state = state;
-                job.name = to_job_name(commands);
-                env.jobs.add(job);
-            }
+            // TODO
+            // if let ProcessState::Stopped(_) = state {
+            //     let mut job = Job::new(pid);
+            //     job.job_controlled = true;
+            //     job.state = state;
+            //     job.name = to_job_name(commands);
+            //     env.jobs.add(job);
+            // }
 
             env.exit_status = state.try_into().unwrap();
             Continue(())
@@ -405,7 +406,7 @@ mod tests {
                 if *pid == env.main_pid {
                     assert_eq!(process.state(), ProcessState::Running);
                 } else {
-                    assert_matches!(process.state(), ProcessState::Exited(_));
+                    // TODO assert_matches!(process.state(), ProcessState::Exited(_));
                 }
             }
         });
@@ -433,7 +434,7 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&async_pid];
-            assert_eq!(process.state(), ProcessState::Exited(ExitStatus(7)));
+            // TODO assert_eq!(process.state(), ProcessState::Exited(ExitStatus(7)));
             assert!(process.state_has_changed());
         });
     }
@@ -629,7 +630,7 @@ mod tests {
             assert_eq!(env.jobs.len(), 1);
             let job = env.jobs.iter().next().unwrap().1;
             assert!(job.job_controlled);
-            assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
+            // TODO assert_eq!(job.state, ProcessState::Stopped(Signal::SIGSTOP));
             assert!(job.state_changed);
             assert_eq!(job.name, "return -n 0 | suspend x");
         })

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -142,16 +142,16 @@ async fn execute_job_controlled_pipeline(
     .job_control(JobControl::Foreground);
 
     match subshell.start_and_wait(env).await {
-        Ok((pid, state)) => {
-            if state.is_stopped() {
+        Ok((pid, result)) => {
+            if result.is_stopped() {
                 let mut job = Job::new(pid);
                 job.job_controlled = true;
-                job.state = state;
+                job.state = result.into();
                 job.name = to_job_name(commands);
                 env.jobs.add(job);
             }
 
-            env.exit_status = state.try_into().unwrap();
+            env.exit_status = result.into();
             Continue(())
         }
         Err(errno) => {

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -70,16 +70,17 @@ pub async fn execute_absent_target(
 
         match subshell.start_and_wait(env).await {
             Ok((pid, state)) => {
-                if let ProcessState::Stopped(_) = state {
-                    let mut job = Job::new(pid);
-                    job.job_controlled = true;
-                    job.state = state;
-                    job.name = redirs
-                        .iter()
-                        .format_with(" ", |redir, f| f(&format_args!("{redir}")))
-                        .to_string();
-                    env.jobs.add(job);
-                }
+                // TODO
+                // if let ProcessState::Stopped(_) = state {
+                //     let mut job = Job::new(pid);
+                //     job.job_controlled = true;
+                //     job.state = state;
+                //     job.name = redirs
+                //         .iter()
+                //         .format_with(" ", |redir, f| f(&format_args!("{redir}")))
+                //         .to_string();
+                //     env.jobs.add(job);
+                // }
 
                 state.try_into().unwrap()
             }

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -68,11 +68,11 @@ pub async fn execute_absent_target(
         .job_control(JobControl::Foreground);
 
         match subshell.start_and_wait(env).await {
-            Ok((pid, state)) => {
-                if state.is_stopped() {
+            Ok((pid, result)) => {
+                if result.is_stopped() {
                     let mut job = Job::new(pid);
                     job.job_controlled = true;
-                    job.state = state;
+                    job.state = result.into();
                     job.name = redirs
                         .iter()
                         .format_with(" ", |redir, f| f(&format_args!("{redir}")))
@@ -80,7 +80,7 @@ pub async fn execute_absent_target(
                     env.jobs.add(job);
                 }
 
-                state.try_into().unwrap()
+                result.into()
             }
             Err(errno) => {
                 print_error(

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -26,7 +26,6 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::io::print_error;
 use yash_env::job::Job;
-use yash_env::job::ProcessState;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
@@ -70,17 +69,16 @@ pub async fn execute_absent_target(
 
         match subshell.start_and_wait(env).await {
             Ok((pid, state)) => {
-                // TODO
-                // if let ProcessState::Stopped(_) = state {
-                //     let mut job = Job::new(pid);
-                //     job.job_controlled = true;
-                //     job.state = state;
-                //     job.name = redirs
-                //         .iter()
-                //         .format_with(" ", |redir, f| f(&format_args!("{redir}")))
-                //         .to_string();
-                //     env.jobs.add(job);
-                // }
+                if state.is_stopped() {
+                    let mut job = Job::new(pid);
+                    job.job_controlled = true;
+                    job.state = state;
+                    job.name = redirs
+                        .iter()
+                        .format_with(" ", |redir, f| f(&format_args!("{redir}")))
+                        .to_string();
+                    env.jobs.add(job);
+                }
 
                 state.try_into().unwrap()
             }

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -110,16 +110,16 @@ pub async fn start_external_utility_in_subshell_and_wait(
     .job_control(JobControl::Foreground);
 
     match subshell.start_and_wait(env).await {
-        Ok((pid, state)) => {
-            if state.is_stopped() {
+        Ok((pid, result)) => {
+            if result.is_stopped() {
                 let mut job = Job::new(pid);
                 job.job_controlled = true;
-                job.state = state;
+                job.state = result.into();
                 job.name = job_name;
                 env.jobs.add(job);
             }
 
-            state.try_into().unwrap()
+            result.into()
         }
         Err(errno) => {
             print_error(

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -112,13 +112,14 @@ pub async fn start_external_utility_in_subshell_and_wait(
 
     match subshell.start_and_wait(env).await {
         Ok((pid, state)) => {
-            if let ProcessState::Stopped(_) = state {
-                let mut job = Job::new(pid);
-                job.job_controlled = true;
-                job.state = state;
-                job.name = job_name;
-                env.jobs.add(job);
-            }
+            // TODO
+            // if let ProcessState::Stopped(_) = state {
+            //     let mut job = Job::new(pid);
+            //     job.job_controlled = true;
+            //     job.state = state;
+            //     job.name = job_name;
+            //     env.jobs.add(job);
+            // }
 
             state.try_into().unwrap()
         }

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -27,7 +27,6 @@ use std::ffi::CString;
 use std::ops::ControlFlow::Continue;
 use yash_env::io::print_error;
 use yash_env::job::Job;
-use yash_env::job::ProcessState;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::semantics::Result;
@@ -112,14 +111,13 @@ pub async fn start_external_utility_in_subshell_and_wait(
 
     match subshell.start_and_wait(env).await {
         Ok((pid, state)) => {
-            // TODO
-            // if let ProcessState::Stopped(_) = state {
-            //     let mut job = Job::new(pid);
-            //     job.job_controlled = true;
-            //     job.state = state;
-            //     job.name = job_name;
-            //     env.jobs.add(job);
-            // }
+            if state.is_stopped() {
+                let mut job = Job::new(pid);
+                job.job_controlled = true;
+                job.state = state;
+                job.name = job_name;
+                env.jobs.add(job);
+            }
 
             state.try_into().unwrap()
         }


### PR DESCRIPTION
This refactoring project introduces the `ProcessResult` enum, which is represents the state of a process but the `Running` state. The `ProcessState` enum is redefined in terms of `ProcessResult`. This allows more fine-grained type checking on conversion from those enum to `ExitStatus`.

- [x] Add `ProcessResult`
- [x] Redefine `ProcessState` in terms of `ProcessResult`
- [x] Return `ProcessResult` from `Subshell::start_and_wait`
