### PR TITLE
Migrate to our own Signal type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c9e4e654bdc69159e3552035e0d6d702e2326e0cd4e05c6bd100027214c6b6"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +332,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -510,6 +544,7 @@ dependencies = [
  "itertools",
  "nix",
  "slab",
+ "strum",
  "tempfile",
  "thiserror",
  "yash-quote",

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `impl Default for common::syntax::OptionSpec`
 - `trap::CondSpec`
+- `trap::Error`
 - `trap::ErrorCause`
+
+### Changed
+
+- `trap::Command::execute` now returns `Result<String, Vec<Error>>`
+  (previously `Result<String, Vec<(SetActionError, Condition, Field)>>`).
 
 ## [0.1.0] - 2024-04-13
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - Unreleased
+## [0.2.0] - Unreleased
 
 ### Added
 
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `trap::display_traps` is now marked `#[must_use]`.
 - `trap::display_traps` is now additionally takes a
   `yash_env::trap::SignalSystem` argument.
+- `wait::core::Error::Trapped` now contains a `yash_env::signal::Number`
+  instead of a `yash_env::trap::Signal`.
 
 ## [0.1.0] - 2024-04-13
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `trap::Command::SetAction::conditions` is now a `Vec<(CondSpec, Field)>`
+  (previously `Vec<(Condition, Field)>`).
 - `trap::Command::execute` now returns `Result<String, Vec<Error>>`
   (previously `Result<String, Vec<(SetActionError, Condition, Field)>>`).
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -10,12 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `impl Default for common::syntax::OptionSpec`
+- `kill::Signal`
+- `kill::syntax::parse_signal`
+- `kill::print::InvalidSignal`
+- Support for real-time signals in the kill built-in
 - `trap::CondSpec`
 - `trap::Error`
 - `trap::ErrorCause`
 
 ### Changed
 
+- `kill::syntax::parse_signal` now returns an `Option<kill::Signal>` instead of
+  `Option<Option<yash_env::trap::Signal>>`
+- `kill::send::execute` now additionally takes the
+  `signal_origin: Option<&Field>` argument.
+- `kill::print::print` now additionally takes the `system: &SystemEx` argument
+  and returns `Result<String, Vec<InvalidSignal>>` (previously `String`).
+- `kill::Command::Send::signal` is now a `kill::Signal`
+  (previously `Option<yash_env::trap::Signal>`).
+- `kill::Command::Send` now has a `signal_origin: Option<Field>` field.
+- `kill::Command::Print::signals` is now a `Vec<kill::Signal>`
+  (previously `Vec<yash_env::trap::Signal>`).
 - `trap::Command::SetAction::conditions` is now a `Vec<(CondSpec, Field)>`
   (previously `Vec<(Condition, Field)>`).
 - `trap::Command::execute` now returns `Result<String, Vec<Error>>`
@@ -25,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `yash_env::trap::SignalSystem` argument.
 - `wait::core::Error::Trapped` now contains a `yash_env::signal::Number`
   instead of a `yash_env::trap::Signal`.
+
+### Removed
+
+- `kill::syntax::parse_signal_name`
+- `kill::syntax::parse_signal_name_or_number`
 
 ## [0.1.0] - 2024-04-13
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (previously `Vec<(Condition, Field)>`).
 - `trap::Command::execute` now returns `Result<String, Vec<Error>>`
   (previously `Result<String, Vec<(SetActionError, Condition, Field)>>`).
+- `trap::display_traps` is now marked `#[must_use]`.
+- `trap::display_traps` is now additionally takes a
+  `yash_env::trap::SignalSystem` argument.
 
 ## [0.1.0] - 2024-04-13
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `impl Default for common::syntax::OptionSpec`
+- `trap::CondSpec`
+- `trap::ErrorCause`
 
 ## [0.1.0] - 2024-04-13
 

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -87,8 +87,6 @@ use std::borrow::Cow;
 use std::fmt::Display;
 use thiserror::Error;
 use yash_env::io::Fd;
-use yash_env::job::fmt::Marker;
-use yash_env::job::fmt::OldReport;
 use yash_env::job::id::parse;
 use yash_env::job::id::FindError;
 use yash_env::job::id::ParseError;
@@ -164,12 +162,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeEr
         return Err(ResumeError::Unmonitored);
     }
 
-    let report = OldReport {
-        index,
-        marker: Marker::None,
-        job: &job,
-    };
-    let line = format!("[{}] {}\n", report.number(), job.name);
+    let line = format!("[{}] {}\n", index + 1, job.name);
     env.system.write_all(Fd::STDOUT, line.as_bytes()).await?;
     drop(line);
 

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -88,7 +88,7 @@ use std::fmt::Display;
 use thiserror::Error;
 use yash_env::io::Fd;
 use yash_env::job::fmt::Marker;
-use yash_env::job::fmt::Report;
+use yash_env::job::fmt::OldReport;
 use yash_env::job::id::parse;
 use yash_env::job::id::FindError;
 use yash_env::job::id::ParseError;
@@ -164,7 +164,7 @@ async fn resume_job_by_index(env: &mut Env, index: usize) -> Result<(), ResumeEr
         return Err(ResumeError::Unmonitored);
     }
 
-    let report = Report {
+    let report = OldReport {
         index,
         marker: Marker::None,
         job: &job,

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -234,6 +234,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::system::r#virtual::Process;
+    use yash_env::system::r#virtual::{SIGSTOP, SIGTSTP, SIGTTIN};
     use yash_env::VirtualSystem;
 
     #[test]
@@ -252,9 +253,9 @@ mod tests {
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut child = Process::fork_from(pgid, &leader);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::stopped(Signal::SIGTTIN));
-        _ = child.set_state(ProcessState::stopped(Signal::SIGTSTP));
-        _ = orphan.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = leader.set_state(ProcessState::stopped(SIGTTIN));
+        _ = child.set_state(ProcessState::stopped(SIGTSTP));
+        _ = orphan.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -275,7 +276,7 @@ mod tests {
         // Unrelated processes should not be resumed.
         assert_eq!(
             state.processes[&orphan_id].state(),
-            ProcessState::stopped(Signal::SIGSTOP),
+            ProcessState::stopped(SIGSTOP),
         );
     }
 
@@ -305,7 +306,7 @@ mod tests {
         job.job_controlled = true;
         let index = env.jobs.add(job);
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -331,7 +332,7 @@ mod tests {
         env.jobs.set_current_job(orphan_index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::stopped(Signal::SIGTTIN));
+        _ = leader.set_state(ProcessState::stopped(SIGTTIN));
         _ = orphan.set_state(ProcessState::Running);
         {
             let mut state = system.state.borrow_mut();
@@ -358,7 +359,7 @@ mod tests {
         let index = env.jobs.add(job);
         // This process (irrelevant to the job) happens to have the same PID as the job.
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -373,7 +374,7 @@ mod tests {
         // The process should not be resumed.
         assert_eq!(
             state.processes[&pid].state(),
-            ProcessState::stopped(Signal::SIGSTOP),
+            ProcessState::stopped(SIGSTOP),
         );
     }
 
@@ -413,8 +414,8 @@ mod tests {
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
         let mut orphan = Process::with_parent_and_group(system.process_id, orphan_id);
-        _ = leader.set_state(ProcessState::stopped(Signal::SIGSTOP));
-        _ = orphan.set_state(ProcessState::stopped(Signal::SIGTTIN));
+        _ = leader.set_state(ProcessState::stopped(SIGSTOP));
+        _ = orphan.set_state(ProcessState::stopped(SIGTTIN));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);
@@ -430,7 +431,7 @@ mod tests {
         // Unrelated processes should not be resumed.
         assert_eq!(
             state.processes[&orphan_id].state(),
-            ProcessState::stopped(Signal::SIGTTIN),
+            ProcessState::stopped(SIGTTIN),
         );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
@@ -468,9 +469,9 @@ mod tests {
         let mut process1 = Process::with_parent_and_group(system.process_id, pgid1);
         let mut process2 = Process::with_parent_and_group(system.process_id, pgid2);
         let mut process3 = Process::with_parent_and_group(system.process_id, pgid3);
-        _ = process1.set_state(ProcessState::stopped(Signal::SIGSTOP));
-        _ = process2.set_state(ProcessState::stopped(Signal::SIGSTOP));
-        _ = process3.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process1.set_state(ProcessState::stopped(SIGSTOP));
+        _ = process2.set_state(ProcessState::stopped(SIGSTOP));
+        _ = process3.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid1, process1);
@@ -490,7 +491,7 @@ mod tests {
         // Unrelated processes should not be resumed.
         assert_eq!(
             state.processes[&pgid2].state(),
-            ProcessState::stopped(Signal::SIGSTOP),
+            ProcessState::stopped(SIGSTOP),
         );
         // No error message should be printed on success.
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
@@ -509,7 +510,7 @@ mod tests {
         let index = env.jobs.add(job);
         env.jobs.set_current_job(index).unwrap();
         let mut leader = Process::with_parent_and_group(system.process_id, pgid);
-        _ = leader.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = leader.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pgid, leader);

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -209,6 +209,7 @@ mod tests {
     use yash_env::subshell::JobControl;
     use yash_env::subshell::Subshell;
     use yash_env::system::r#virtual::Process;
+    use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::VirtualSystem;
 
     async fn suspend(env: &mut Env) {
@@ -237,7 +238,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_result.into();
@@ -257,7 +258,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_result.into();
@@ -283,7 +284,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_result.into();
@@ -313,7 +314,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_result.into();
@@ -321,11 +322,11 @@ mod tests {
 
             let result = resume_job_by_index(&mut env, index).await.unwrap();
 
-            assert_eq!(result, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(result, ProcessState::stopped(SIGSTOP));
             let job_state = env.jobs[index].state;
-            assert_eq!(job_state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(job_state, ProcessState::stopped(SIGSTOP));
             let state = state.borrow().processes[&pid].state();
-            assert_eq!(state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(state, ProcessState::stopped(SIGSTOP));
         })
     }
 
@@ -337,7 +338,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
             job.state = subshell_result.into();
@@ -362,7 +363,7 @@ mod tests {
         let index = env.jobs.add(job);
         // This process (irrelevant to the job) happens to have the same PID as the job.
         let mut process = Process::with_parent_and_group(system.process_id, pid);
-        _ = process.set_state(ProcessState::stopped(Signal::SIGSTOP));
+        _ = process.set_state(ProcessState::stopped(SIGSTOP));
         {
             let mut state = system.state.borrow_mut();
             state.processes.insert(pid, process);
@@ -378,7 +379,7 @@ mod tests {
         // The process should not be resumed.
         assert_eq!(
             state.processes[&pid].state(),
-            ProcessState::stopped(Signal::SIGSTOP),
+            ProcessState::stopped(SIGSTOP),
         );
     }
 
@@ -421,7 +422,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result_1, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result_1, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
             job.state = subshell_result_1.into();
@@ -430,7 +431,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result_2, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result_2, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
             job.state = subshell_result_2.into();
@@ -444,7 +445,7 @@ mod tests {
             assert_eq!(env.jobs.get(index2), None);
             // The previous job should still be there.
             let state = state.borrow().processes[&pid1].state();
-            assert_eq!(state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(state, ProcessState::stopped(SIGSTOP));
         })
     }
 
@@ -470,7 +471,7 @@ mod tests {
             let subshell =
                 Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
             let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result_1, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result_1, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
             job.state = subshell_result_1.into();
@@ -485,7 +486,7 @@ mod tests {
             })
             .job_control(JobControl::Foreground);
             let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
-            assert_eq!(subshell_result_2, ProcessResult::Stopped(Signal::SIGSTOP));
+            assert_eq!(subshell_result_2, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
             job.state = subshell_result_2.into();
@@ -499,7 +500,7 @@ mod tests {
             assert_eq!(env.jobs.get(index1), None);
             // The previous job should still be there.
             let state = state.borrow().processes[&pid2].state();
-            assert_eq!(state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(state, ProcessState::stopped(SIGSTOP));
         })
     }
 

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -96,6 +96,7 @@ use yash_env::job::id::parse_tail;
 use yash_env::job::id::FindError;
 use yash_env::job::Job;
 use yash_env::semantics::Field;
+use yash_env::system::SharedSystem;
 use yash_env::Env;
 use yash_syntax::source::pretty::Annotation;
 use yash_syntax::source::pretty::AnnotationType;
@@ -111,7 +112,7 @@ const OPTIONS: &[OptionSpec] = &[
 struct Accumulator {
     current_job_index: Option<usize>,
     previous_job_index: Option<usize>,
-    alternate_format: bool,
+    show_pid: bool,
     pgid_only: bool,
     print: String,
     indices_reported: Vec<usize>,
@@ -123,10 +124,10 @@ impl Accumulator {
     /// 1. Formats a job report in `self.print` so it can be printed later.
     /// 1. Remembers the job index in `self.indices_reported` so the job can be
     ///    removed later.
-    fn report(&mut self, index: usize, job: &Job) {
-        use yash_env::job::fmt::{Marker, OldReport};
-        let report = OldReport {
-            index,
+    fn report(&mut self, index: usize, job: &Job, system: &SharedSystem) {
+        use yash_env::job::fmt::{Marker, Report, State};
+        let report = Report {
+            number: index + 1,
             marker: if self.current_job_index == Some(index) {
                 Marker::CurrentJob
             } else if self.previous_job_index == Some(index) {
@@ -134,13 +135,13 @@ impl Accumulator {
             } else {
                 Marker::None
             },
-            job,
+            pid: self.show_pid.then_some(job.pid),
+            state: State::from_process_state(job.state, system),
+            name: &job.name,
         };
 
         if self.pgid_only {
             writeln!(self.print, "{}", job.pid)
-        } else if self.alternate_format {
-            writeln!(self.print, "{report:#}")
         } else {
             writeln!(self.print, "{report}")
         }
@@ -173,7 +174,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let mut accumulator = Accumulator {
         current_job_index: env.jobs.current_job(),
         previous_job_index: env.jobs.previous_job(),
-        alternate_format: false,
+        show_pid: false,
         pgid_only: false,
         print: String::new(),
         indices_reported: Vec::new(),
@@ -182,7 +183,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     // Apply options
     for option in options {
         match option.spec.get_short() {
-            Some('l') => accumulator.alternate_format = true,
+            Some('l') => accumulator.show_pid = true,
             Some('p') => accumulator.pgid_only = true,
             _ => unreachable!("unhandled option: {:?}", option),
         }
@@ -191,14 +192,14 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     if operands.is_empty() {
         // Report all jobs
         for (index, job) in &env.jobs {
-            accumulator.report(index, job)
+            accumulator.report(index, job, &env.system)
         }
     } else {
         // Report jobs specified by the operands
         for operand in operands {
             let job_id = parse(&operand.value).unwrap_or_else(|_| parse_tail(&operand.value));
             match job_id.find(&env.jobs) {
-                Ok(index) => accumulator.report(index, &env.jobs[index]),
+                Ok(index) => accumulator.report(index, &env.jobs[index], &env.system),
                 Err(error) => {
                     return report_failure(env, find_error_message(error, &operand)).await
                 }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -124,8 +124,8 @@ impl Accumulator {
     /// 1. Remembers the job index in `self.indices_reported` so the job can be
     ///    removed later.
     fn report(&mut self, index: usize, job: &Job) {
-        use yash_env::job::fmt::{Marker, Report};
-        let report = Report {
+        use yash_env::job::fmt::{Marker, OldReport};
+        let report = OldReport {
             index,
             marker: if self.current_job_index == Some(index) {
                 Marker::CurrentJob

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -240,7 +240,7 @@ mod tests {
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::system::r#virtual::VirtualSystem;
-    use yash_env::trap::Signal;
+    use yash_env::system::r#virtual::{SIGINT, SIGQUIT, SIGSTOP, SIGTSTP};
 
     #[test]
     fn no_operands_no_jobs() {
@@ -261,7 +261,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -284,7 +284,7 @@ mod tests {
         let i11 = env.jobs.add(job);
 
         let mut job = Job::new(Pid(12));
-        job.state = ProcessState::stopped(Signal::SIGTSTP);
+        job.state = ProcessState::stopped(SIGTSTP);
         job.name = "echo stopped".to_string();
         let i12 = env.jobs.add(job);
 
@@ -300,7 +300,7 @@ mod tests {
 
         let mut job = Job::new(Pid(15));
         job.state = ProcessState::Halted(ProcessResult::Signaled {
-            signal: Signal::SIGINT,
+            signal: SIGINT,
             core_dump: false,
         });
         job.name = "echo signaled".to_string();
@@ -308,7 +308,7 @@ mod tests {
 
         let mut job = Job::new(Pid(16));
         job.state = ProcessState::Halted(ProcessResult::Signaled {
-            signal: Signal::SIGQUIT,
+            signal: SIGQUIT,
             core_dump: true,
         });
         job.name = "echo core dumped".to_string();
@@ -334,7 +334,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -389,7 +389,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -434,7 +434,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
         env.jobs.add(Job::new(Pid(100)));
@@ -481,7 +481,7 @@ mod tests {
         job.name = "echo first".to_string();
         let i42 = env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         let i72 = env.jobs.add(job);
 
@@ -518,7 +518,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -545,7 +545,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -566,7 +566,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -585,7 +585,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 
@@ -605,7 +605,7 @@ mod tests {
         job.name = "echo first".to_string();
         env.jobs.add(job);
         let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         job.name = "echo second".to_string();
         env.jobs.add(job);
 

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -19,6 +19,8 @@
 //! [`execute`] calls [`send`] for each target and reports all errors.
 //! [`send`] uses [`resolve_target`] to determine the argument to the
 //! [`kill`](yash_env::System::kill) system call.
+
+use super::Signal;
 use crate::common::{report_failure, to_single_message};
 use std::borrow::Cow;
 use std::num::ParseIntError;
@@ -28,10 +30,8 @@ use yash_env::job::Pid;
 use yash_env::job::{id::FindError, JobList};
 use yash_env::semantics::Field;
 use yash_env::signal;
-use yash_env::system::real::RealSystem;
 use yash_env::system::Errno;
 use yash_env::system::System as _;
-use yash_env::trap::Signal;
 use yash_env::Env;
 use yash_syntax::source::pretty::{Annotation, AnnotationType, MessageBase};
 
@@ -93,6 +93,28 @@ pub async fn send(
 }
 
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[error("signal {signal} not supported on this system")]
+struct UnsupportedSignal<'a> {
+    signal: Signal,
+    // TODO Consider: origin: &'a Location,
+    origin: &'a Field,
+}
+
+impl MessageBase for UnsupportedSignal<'_> {
+    fn message_title(&self) -> Cow<str> {
+        "unsupported signal".into()
+    }
+
+    fn main_annotation(&self) -> Annotation<'_> {
+        Annotation::new(
+            AnnotationType::Error,
+            self.to_string().into(),
+            &self.origin.origin,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[error("{target}: {error}")]
 struct TargetError<'a> {
     target: &'a Field,
@@ -114,16 +136,28 @@ impl MessageBase for TargetError<'_> {
 }
 
 /// Executes the `Send` command.
-pub async fn execute(env: &mut Env, signal: Option<Signal>, targets: &[Field]) -> crate::Result {
+///
+/// This function sends the specified signal to the specified targets.
+/// If an error occurs, it reports the error to the standard error and returns a
+/// non-zero exit status.
+///
+/// `signal_origin` is the field that specified the signal. It is used to report
+/// the error location if the signal is not supported on the current system. If
+/// it is `None` and the `signal` is not supported, the function panics.
+pub async fn execute(
+    env: &mut Env,
+    signal: Signal,
+    signal_origin: Option<&Field>,
+    targets: &[Field],
+) -> crate::Result {
+    let Ok(signal) = signal.to_number(&env.system) else {
+        let origin = signal_origin.unwrap();
+        let message = UnsupportedSignal { signal, origin };
+        return report_failure(env, &message).await;
+    };
+
     let mut errors = Vec::new();
     for target in targets {
-        let signal = signal.map(|signal| {
-            let name = unsafe { RealSystem::new() }
-                .validate_signal(signal as _)
-                .unwrap()
-                .0;
-            env.system.signal_number_from_name(name).unwrap()
-        });
         if let Err(error) = send(env, signal, target).await {
             errors.push(TargetError { target, error });
         }
@@ -139,9 +173,14 @@ pub async fn execute(env: &mut Env, signal: Option<Signal>, targets: &[Field]) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::assert_stderr;
     use assert_matches::assert_matches;
+    use futures_util::FutureExt;
+    use std::rc::Rc;
     use yash_env::job::Job;
     use yash_env::job::ProcessState;
+    use yash_env::semantics::ExitStatus;
+    use yash_env::system::r#virtual::VirtualSystem;
 
     #[test]
     fn resolve_target_process_ids() {
@@ -222,5 +261,17 @@ mod tests {
         let jobs = JobList::new();
         let result = resolve_target(&jobs, "abc");
         assert_matches!(result, Err(Error::ProcessId(_)));
+    }
+
+    #[test]
+    fn execute_unsupported_signal() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Box::new(system));
+        let result = execute(&mut env, Signal::Number(-1), Some(&Field::dummy("-1")), &[])
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result, crate::Result::from(ExitStatus::FAILURE));
+        assert_stderr(&state, |stderr| assert_ne!(stderr, ""));
     }
 }

--- a/yash-builtin/src/kill/signal.rs
+++ b/yash-builtin/src/kill/signal.rs
@@ -1,0 +1,233 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Definition of signal arguments
+//!
+//! This module defines the [`Signal`] type representing a signal to be sent or
+//! printed by the kill built-in.
+
+use std::borrow::Cow;
+use std::fmt::Display;
+use std::str::FromStr;
+use yash_env::semantics::ExitStatus;
+use yash_env::signal::{Name, Number, RawNumber};
+use yash_env::system::{System, SystemEx};
+
+/// Specification of a signal to be sent by the kill built-in
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Signal {
+    /// A signal specified by name
+    Name(Name),
+    /// A signal specified by raw number
+    Number(RawNumber),
+}
+
+/// Parses a signal from a string
+///
+/// The string is parsed as a signal name or number. If the string is a number,
+/// it is parsed as a raw number. Otherwise, it is parsed as a signal name
+/// case-insensitively. The signal name must be specified without the `SIG`
+/// prefix.
+impl FromStr for Signal {
+    type Err = <Name as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(number) = s.parse() {
+            Ok(Self::Number(number))
+        } else {
+            let mut s = Cow::Borrowed(s);
+            if s.contains(|c: char| c.is_ascii_lowercase()) {
+                s.to_mut().make_ascii_uppercase();
+            }
+            Ok(Self::Name(s.parse()?))
+        }
+    }
+}
+
+impl Display for Signal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Name(name) => name.fmt(f),
+            Self::Number(number) => number.fmt(f),
+        }
+    }
+}
+
+/// Error indicating that a [`Signal`] is not supported
+///
+/// This error may be returned from [`Signal::to_number`] when the signal is not
+/// supported by the system.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UnsupportedSignal;
+
+impl Signal {
+    /// Returns the signal number to be sent.
+    ///
+    /// If the signal is specified by name, the signal number is resolved from
+    /// the name. If the signal is specified by number, the number is validated
+    /// and returned. The special signal number 0 represents a dummy signal that
+    /// is not actually sent. The function returns `Ok(None)` for this signal.
+    ///
+    /// If the signal is not supported by the system, the function returns an
+    /// error.
+    pub fn to_number<S: System>(self, system: &S) -> Result<Option<Number>, UnsupportedSignal> {
+        match self {
+            Signal::Name(name) => match system.signal_number_from_name(name) {
+                Some(number) => Ok(Some(number)),
+                None => Err(UnsupportedSignal),
+            },
+            Signal::Number(0) => Ok(None),
+            Signal::Number(number) => match system.validate_signal(number) {
+                Some((_name, number)) => Ok(Some(number)),
+                None => Err(UnsupportedSignal),
+            },
+        }
+    }
+
+    /// Returns the signal name and number to be printed.
+    ///
+    /// If the signal is specified by name, the signal number is resolved from
+    /// the name. If the signal is specified by number, the number is interpreted
+    /// as an exit status and converted to a signal number. The function returns
+    /// `None` if `self` does not represent a valid signal.
+    #[must_use]
+    pub fn to_name_and_number<S: SystemEx>(self, system: &S) -> Option<(Name, Number)> {
+        match self {
+            Signal::Name(name) => Some((name, system.signal_number_from_name(name)?)),
+            Signal::Number(number) => {
+                let exit_status = ExitStatus::from(number);
+                let number = exit_status.to_signal_number(system)?;
+                Some((system.signal_name_from_number(number), number))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroI32;
+    use yash_env::signal::UnknownNameError;
+    use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::r#virtual::{SIGHUP, SIGINT, SIGRTMAX, SIGRTMIN};
+
+    #[test]
+    fn signal_from_str_number() {
+        assert_eq!("0".parse(), Ok(Signal::Number(0)));
+        assert_eq!("1".parse(), Ok(Signal::Number(1)));
+        assert_eq!("999".parse(), Ok(Signal::Number(999)));
+    }
+
+    #[test]
+    fn signal_from_str_uppercase_name() {
+        assert_eq!("HUP".parse(), Ok(Signal::Name(Name::Hup)));
+        assert_eq!("INT".parse(), Ok(Signal::Name(Name::Int)));
+        assert_eq!("QUIT".parse(), Ok(Signal::Name(Name::Quit)));
+    }
+
+    #[test]
+    fn signal_from_str_lowercase_name() {
+        assert_eq!("hup".parse(), Ok(Signal::Name(Name::Hup)));
+        assert_eq!("int".parse(), Ok(Signal::Name(Name::Int)));
+        assert_eq!("quit".parse(), Ok(Signal::Name(Name::Quit)));
+    }
+
+    #[test]
+    fn signal_from_str_mixed_case_name() {
+        assert_eq!("Hup".parse(), Ok(Signal::Name(Name::Hup)));
+        assert_eq!("iNt".parse(), Ok(Signal::Name(Name::Int)));
+        assert_eq!("quIT".parse(), Ok(Signal::Name(Name::Quit)));
+    }
+
+    #[test]
+    fn signal_from_str_name_with_sig_prefix() {
+        assert_eq!("SIGHUP".parse::<Signal>(), Err(UnknownNameError));
+    }
+
+    #[test]
+    fn signal_name_to_number_supported() {
+        let system = VirtualSystem::new();
+        assert_eq!(Signal::Name(Name::Hup).to_number(&system), Ok(Some(SIGHUP)));
+        assert_eq!(Signal::Name(Name::Int).to_number(&system), Ok(Some(SIGINT)));
+
+        let next = Number::from_raw_unchecked(NonZeroI32::new(SIGRTMIN.as_raw() + 1).unwrap());
+        assert_eq!(
+            Signal::Name(Name::Rtmin(1)).to_number(&system),
+            Ok(Some(next))
+        );
+        let prev = Number::from_raw_unchecked(NonZeroI32::new(SIGRTMAX.as_raw() - 1).unwrap());
+        assert_eq!(
+            Signal::Name(Name::Rtmax(-1)).to_number(&system),
+            Ok(Some(prev))
+        );
+    }
+
+    #[test]
+    fn signal_name_to_number_unsupported() {
+        let system = VirtualSystem::new();
+        assert_eq!(
+            Signal::Name(Name::Rtmin(-1)).to_number(&system),
+            Err(UnsupportedSignal)
+        );
+        assert_eq!(
+            Signal::Name(Name::Rtmax(1)).to_number(&system),
+            Err(UnsupportedSignal)
+        );
+    }
+
+    #[test]
+    fn signal_0_to_number() {
+        let system = VirtualSystem::new();
+        assert_eq!(Signal::Number(0).to_number(&system), Ok(None));
+    }
+
+    #[test]
+    fn signal_number_to_number_supported() {
+        let system = VirtualSystem::new();
+        assert_eq!(
+            Signal::Number(SIGHUP.as_raw()).to_number(&system),
+            Ok(Some(SIGHUP))
+        );
+        assert_eq!(
+            Signal::Number(SIGINT.as_raw()).to_number(&system),
+            Ok(Some(SIGINT))
+        );
+
+        let next = Number::from_raw_unchecked(NonZeroI32::new(SIGRTMIN.as_raw() + 1).unwrap());
+        assert_eq!(
+            Signal::Number(next.as_raw()).to_number(&system),
+            Ok(Some(next))
+        );
+        let prev = Number::from_raw_unchecked(NonZeroI32::new(SIGRTMAX.as_raw() - 1).unwrap());
+        assert_eq!(
+            Signal::Number(prev.as_raw()).to_number(&system),
+            Ok(Some(prev))
+        );
+    }
+
+    #[test]
+    fn signal_number_to_number_unsupported() {
+        let system = VirtualSystem::new();
+        assert_eq!(
+            Signal::Number(-1).to_number(&system),
+            Err(UnsupportedSignal)
+        );
+        assert_eq!(
+            Signal::Number(RawNumber::MAX).to_number(&system),
+            Err(UnsupportedSignal)
+        );
+    }
+}

--- a/yash-builtin/src/kill/syntax.rs
+++ b/yash-builtin/src/kill/syntax.rs
@@ -163,7 +163,7 @@ impl Error {
 /// names. Otherwise, the `SIG` prefix must **not** be present.
 #[must_use]
 pub fn parse_signal(mut s: &str, allow_sig_prefix: bool) -> Option<Signal> {
-    fn starts_with_sig(s: &str) -> bool {
+    fn starts_with_sig_case_insensitive(s: &str) -> bool {
         let mut cs = s.chars();
         matches!(
             (cs.next(), cs.next(), cs.next()),
@@ -171,7 +171,7 @@ pub fn parse_signal(mut s: &str, allow_sig_prefix: bool) -> Option<Signal> {
         )
     }
 
-    if allow_sig_prefix && starts_with_sig(s) {
+    if allow_sig_prefix && starts_with_sig_case_insensitive(s) {
         // Skip the `SIG` prefix
         s = &s[3..];
     }

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -259,8 +259,8 @@ mod tests {
     use yash_env::option::Option::*;
     use yash_env::option::OptionSet;
     use yash_env::option::State::*;
+    use yash_env::system::r#virtual::SIGTSTP;
     use yash_env::system::SignalHandling;
-    use yash_env::trap::Signal::SIGTSTP;
     use yash_env::variable::Scope;
     use yash_env::variable::Value;
     use yash_env::VirtualSystem;

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -119,6 +119,9 @@
 //! are cleared when the built-in modifies any trap in the subshell. See
 //! [`TrapSet::enter_subshell`] and [`TrapSet::set_action`] for details.
 
+mod cond;
+
+pub use self::cond::CondSpec;
 use crate::common::report_error;
 use crate::common::report_failure;
 use crate::common::syntax::parse_arguments;
@@ -126,6 +129,7 @@ use crate::common::syntax::Mode;
 use crate::common::to_single_message;
 use std::borrow::Cow;
 use std::fmt::Write;
+use thiserror::Error;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::trap::Action;
@@ -175,6 +179,18 @@ pub fn display_traps(traps: &TrapSet) -> String {
         writeln!(output, "trap -- {} {}", quoted(command), cond).ok();
     }
     output
+}
+
+/// Cause of an error that may occur while executing the `trap` built-in
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorCause {
+    /// The specified condition is not supported.
+    #[error("signal not supported on this system")]
+    UnsupportedSignal,
+    /// An error occurred while [setting a trap](TrapSet::set_action).
+    #[error(transparent)]
+    SetAction(#[from] SetActionError),
 }
 
 impl Command {

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -284,8 +284,8 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::r#virtual::{SIGINT, SIGPIPE, SIGUSR1, SIGUSR2};
     use yash_env::system::SignalHandling;
-    use yash_env::trap::Signal;
     use yash_env::Env;
     use yash_env::VirtualSystem;
 
@@ -299,10 +299,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(
-            process.signal_handling(Signal::SIGUSR1),
-            SignalHandling::Ignore
-        );
+        assert_eq!(process.signal_handling(SIGUSR1), SignalHandling::Ignore);
     }
 
     #[test]
@@ -315,10 +312,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(
-            process.signal_handling(Signal::SIGUSR2),
-            SignalHandling::Catch
-        );
+        assert_eq!(process.signal_handling(SIGUSR2), SignalHandling::Catch);
     }
 
     #[test]
@@ -331,10 +325,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(
-            process.signal_handling(Signal::SIGPIPE),
-            SignalHandling::Default
-        );
+        assert_eq!(process.signal_handling(SIGPIPE), SignalHandling::Default);
     }
 
     #[test]
@@ -441,7 +432,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         system
             .current_process_mut()
-            .set_signal_handling(Signal::SIGINT, SignalHandling::Ignore);
+            .set_signal_handling(SIGINT, SignalHandling::Ignore);
         let mut env = Env::with_system(Box::new(system.clone()));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
@@ -453,7 +444,7 @@ mod tests {
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
         assert_eq!(
-            system.current_process().signal_handling(Signal::SIGINT),
+            system.current_process().signal_handling(SIGINT),
             SignalHandling::Ignore
         );
     }

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -129,7 +129,7 @@ use std::fmt::Write;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::trap::Action;
-use yash_env::trap::Condition;
+use yash_env::trap::OldCondition;
 use yash_env::trap::SetActionError;
 use yash_env::trap::TrapSet;
 use yash_env::Env;
@@ -149,7 +149,7 @@ pub enum Command {
     /// Set an action for one or more conditions
     SetAction {
         action: Action,
-        conditions: Vec<(Condition, Field)>,
+        conditions: Vec<(OldCondition, Field)>,
     },
 }
 
@@ -182,7 +182,10 @@ impl Command {
     ///
     /// If successful, returns a string that should be printed to the standard
     /// output. On failure, returns a non-empty list of errors.
-    pub fn execute(self, env: &mut Env) -> Result<String, Vec<(SetActionError, Condition, Field)>> {
+    pub fn execute(
+        self,
+        env: &mut Env,
+    ) -> Result<String, Vec<(SetActionError, OldCondition, Field)>> {
         match self {
             Self::PrintAll => Ok(display_traps(&env.traps)),
 
@@ -213,7 +216,7 @@ impl Command {
 
 /// Wrapper for creating an error message for a trap setting error
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct Error((SetActionError, Condition, Field));
+struct Error((SetActionError, OldCondition, Field));
 
 impl MessageBase for Error {
     fn message_title(&self) -> Cow<str> {

--- a/yash-builtin/src/trap/cond.rs
+++ b/yash-builtin/src/trap/cond.rs
@@ -45,6 +45,19 @@ impl From<signal::RawNumber> for CondSpec {
 }
 
 impl CondSpec {
+    /// Resolves the condition specification to a name and a signal number that can
+    /// be passed to [`TrapSet::set_action`](yash_env::trap::TrapSet::set_action).
+    #[must_use]
+    pub(super) fn resolve<S: System>(&self, system: &S) -> Option<Condition> {
+        match *self {
+            CondSpec::Exit | CondSpec::Number(0) => Some(Condition::Exit),
+            CondSpec::SignalName(name) => {
+                Some(Condition::Signal(system.signal_number_from_name(name)?))
+            }
+            CondSpec::Number(number) => Some(Condition::Signal(system.validate_signal(number)?.1)),
+        }
+    }
+
     /// Converts this `CondSpec` to a `Condition`.
     ///
     /// If this `CondSpec` contains a signal name or number that is not

--- a/yash-builtin/src/trap/cond.rs
+++ b/yash-builtin/src/trap/cond.rs
@@ -1,0 +1,103 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Definition of `CondSpec`
+
+use yash_env::signal;
+use yash_env::system::System;
+use yash_env::system::SystemEx as _;
+use yash_env::trap::Condition;
+
+/// Interpretation of a command line operand that specifies a trap condition
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum CondSpec {
+    /// The `EXIT` condition
+    Exit,
+    /// A symbolic name of a signal
+    SignalName(signal::Name),
+    /// A signal number (or 0 for `EXIT`)
+    Number(signal::RawNumber),
+}
+
+impl From<signal::Name> for CondSpec {
+    fn from(name: signal::Name) -> Self {
+        Self::SignalName(name)
+    }
+}
+
+impl From<signal::RawNumber> for CondSpec {
+    fn from(number: signal::RawNumber) -> Self {
+        Self::Number(number)
+    }
+}
+
+impl CondSpec {
+    /// Converts this `CondSpec` to a `Condition`.
+    ///
+    /// If this `CondSpec` contains a signal name or number that is not
+    /// supported by the system, this function returns `None`.
+    #[must_use]
+    pub fn to_condition<S: System>(&self, system: &S) -> Option<Condition> {
+        match self {
+            Self::Exit => Some(Condition::Exit),
+            Self::SignalName(name) => {
+                Some(Condition::Signal(system.signal_number_from_name(*name)?))
+            }
+            Self::Number(0) => Some(Condition::Exit),
+            Self::Number(number) => Some(Condition::Signal(system.validate_signal(*number)?.1)),
+        }
+    }
+
+    /// Converts a `Condition` to a `CondSpec`.
+    ///
+    /// If the `Condition` is of an unknown variant, this function returns `None`.
+    #[must_use]
+    pub fn from_condition<S: System>(cond: &Condition, system: &S) -> Option<Self> {
+        match cond {
+            Condition::Exit => Some(Self::Exit),
+            Condition::Signal(number) => {
+                Some(Self::SignalName(system.signal_name_from_number(*number)))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CondSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exit => "EXIT".fmt(f),
+            Self::SignalName(name) => name.fmt(f),
+            Self::Number(number) => number.fmt(f),
+        }
+    }
+}
+
+impl std::str::FromStr for CondSpec {
+    type Err = signal::UnknownNameError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(number) = s.parse() {
+            return Ok(Self::Number(number));
+        }
+
+        if s == "EXIT" {
+            Ok(Self::Exit)
+        } else {
+            Ok(Self::SignalName(s.parse()?))
+        }
+    }
+}

--- a/yash-builtin/src/trap/syntax.rs
+++ b/yash-builtin/src/trap/syntax.rs
@@ -129,7 +129,7 @@ fn is_non_negative_integer(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use yash_env::trap::{Condition, Signal};
+    use yash_env::trap::{OldCondition, Signal};
 
     #[test]
     fn print_all_for_no_operands() {
@@ -144,7 +144,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
             })
         );
     }
@@ -156,7 +156,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(Condition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
             })
         );
     }
@@ -168,7 +168,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Command("echo".into()),
-                conditions: vec![(Condition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
             })
         );
     }
@@ -181,9 +181,9 @@ mod tests {
             Ok(Command::SetAction {
                 action: Action::Default,
                 conditions: vec![
-                    (Condition::Signal(Signal::SIGHUP), Field::dummy("HUP")),
-                    (Condition::Signal(Signal::SIGINT), Field::dummy("2")),
-                    (Condition::Signal(Signal::SIGTERM), Field::dummy("TERM")),
+                    (OldCondition::Signal(Signal::SIGHUP), Field::dummy("HUP")),
+                    (OldCondition::Signal(Signal::SIGINT), Field::dummy("2")),
+                    (OldCondition::Signal(Signal::SIGTERM), Field::dummy("TERM")),
                 ]
             })
         );
@@ -196,7 +196,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(Condition::Signal(Signal::SIGHUP), Field::dummy("HUP"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("HUP"))]
             })
         );
 
@@ -205,7 +205,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(Condition::Signal(Signal::SIGQUIT), Field::dummy("QUIT"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGQUIT), Field::dummy("QUIT"))]
             })
         );
     }
@@ -217,7 +217,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Signal(Signal::SIGHUP), Field::dummy("1"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("1"))]
             })
         );
     }
@@ -229,7 +229,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Exit, Field::dummy("EXIT"))]
+                conditions: vec![(OldCondition::Exit, Field::dummy("EXIT"))]
             })
         );
     }
@@ -241,7 +241,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Exit, Field::dummy("0"))]
+                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
             })
         );
     }
@@ -265,7 +265,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Signal(Signal::SIGHUP), Field::dummy("1"))]
+                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("1"))]
             })
         );
     }
@@ -277,7 +277,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(Condition::Exit, Field::dummy("0"))]
+                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
             })
         );
     }
@@ -289,7 +289,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Command("-1".into()),
-                conditions: vec![(Condition::Exit, Field::dummy("0"))]
+                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
             })
         );
     }

--- a/yash-builtin/src/trap/syntax.rs
+++ b/yash-builtin/src/trap/syntax.rs
@@ -101,6 +101,8 @@ pub fn interpret(
         });
 
     // Parse the remaining operands as conditions
+    // TODO Case-insensitive parse
+    // TODO Allow SIG prefix
     let (conditions, errors): (Vec<_>, Vec<_>) = operands
         .map(|operand| match operand.value.parse() {
             Ok(condition) => Ok((condition, operand)),

--- a/yash-builtin/src/trap/syntax.rs
+++ b/yash-builtin/src/trap/syntax.rs
@@ -128,8 +128,9 @@ fn is_non_negative_integer(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::CondSpec;
     use super::*;
-    use yash_env::trap::{OldCondition, Signal};
+    use yash_env::signal::Name;
 
     #[test]
     fn print_all_for_no_operands() {
@@ -144,7 +145,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(CondSpec::SignalName(Name::Int), Field::dummy("INT"))]
             })
         );
     }
@@ -156,7 +157,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(CondSpec::SignalName(Name::Int), Field::dummy("INT"))]
             })
         );
     }
@@ -168,7 +169,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Command("echo".into()),
-                conditions: vec![(OldCondition::Signal(Signal::SIGINT), Field::dummy("INT"))]
+                conditions: vec![(CondSpec::SignalName(Name::Int), Field::dummy("INT"))]
             })
         );
     }
@@ -181,9 +182,9 @@ mod tests {
             Ok(Command::SetAction {
                 action: Action::Default,
                 conditions: vec![
-                    (OldCondition::Signal(Signal::SIGHUP), Field::dummy("HUP")),
-                    (OldCondition::Signal(Signal::SIGINT), Field::dummy("2")),
-                    (OldCondition::Signal(Signal::SIGTERM), Field::dummy("TERM")),
+                    (CondSpec::SignalName(Name::Hup), Field::dummy("HUP")),
+                    (CondSpec::Number(2), Field::dummy("2")),
+                    (CondSpec::SignalName(Name::Term), Field::dummy("TERM")),
                 ]
             })
         );
@@ -196,7 +197,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("HUP"))]
+                conditions: vec![(CondSpec::SignalName(Name::Hup), Field::dummy("HUP"))]
             })
         );
 
@@ -205,7 +206,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Ignore,
-                conditions: vec![(OldCondition::Signal(Signal::SIGQUIT), Field::dummy("QUIT"))]
+                conditions: vec![(CondSpec::SignalName(Name::Quit), Field::dummy("QUIT"))]
             })
         );
     }
@@ -217,7 +218,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("1"))]
+                conditions: vec![(CondSpec::Number(1), Field::dummy("1"))]
             })
         );
     }
@@ -229,7 +230,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Exit, Field::dummy("EXIT"))]
+                conditions: vec![(CondSpec::Exit, Field::dummy("EXIT"))]
             })
         );
     }
@@ -241,19 +242,19 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
+                conditions: vec![(CondSpec::Number(0), Field::dummy("0"))]
             })
         );
     }
 
     #[test]
     fn action_with_unknown_conditions() {
-        let result = interpret(vec![], Field::dummies(["-", "FOOBAR", "INT", "999999999"]));
+        let result = interpret(vec![], Field::dummies(["-", "FOOBAR", "INT", "9999999999"]));
         assert_eq!(
             result,
             Err(vec![
                 Error::UnknownCondition(Field::dummy("FOOBAR")),
-                Error::UnknownCondition(Field::dummy("999999999")),
+                Error::UnknownCondition(Field::dummy("9999999999")),
             ])
         );
     }
@@ -265,7 +266,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Signal(Signal::SIGHUP), Field::dummy("1"))]
+                conditions: vec![(CondSpec::Number(1), Field::dummy("1"))]
             })
         );
     }
@@ -277,7 +278,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Default,
-                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
+                conditions: vec![(CondSpec::Number(0), Field::dummy("0"))]
             })
         );
     }
@@ -289,7 +290,7 @@ mod tests {
             result,
             Ok(Command::SetAction {
                 action: Action::Command("-1".into()),
-                conditions: vec![(OldCondition::Exit, Field::dummy("0"))]
+                conditions: vec![(CondSpec::Number(0), Field::dummy("0"))]
             })
         );
     }

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -106,7 +106,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::subshell::Subshell;
-    use yash_env::system::r#virtual::SIGTERM;
+    use yash_env::system::r#virtual::{SIGSTOP, SIGTERM};
     use yash_env::trap::Action;
     use yash_env::variable::Value;
     use yash_env::VirtualSystem;
@@ -158,10 +158,7 @@ mod tests {
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            assert_eq!(
-                env.jobs[index].state,
-                ProcessState::stopped(Signal::SIGSTOP),
-            );
+            assert_eq!(env.jobs[index].state, ProcessState::stopped(SIGSTOP),);
         });
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -178,7 +178,7 @@ mod tests {
             env.traps
                 .set_action(
                     &mut env.system,
-                    Signal::SIGTERM,
+                    SIGTERM,
                     Action::Command("foo=bar".into()),
                     Location::dummy("somewhere"),
                     false,

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -152,13 +152,13 @@ mod tests {
             let pid = subshell.start(&mut env).await.unwrap().0;
             let index = env.jobs.add(Job::new(pid));
             // Suspend the child process.
-            env.system.kill(pid, Some(Signal::SIGSTOP)).await.unwrap();
+            env.system.kill(pid, Some(SIGSTOP)).await.unwrap();
 
             // The job is suspended, so the function returns immediately.
             let result = wait_for_any_job_or_trap(&mut env).await;
             assert_eq!(result, Ok(()));
             // The job state is updated.
-            assert_eq!(env.jobs[index].state, ProcessState::stopped(SIGSTOP),);
+            assert_eq!(env.jobs[index].state, ProcessState::stopped(SIGSTOP));
         });
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -22,8 +22,8 @@
 
 use thiserror::Error;
 use yash_env::job::Pid;
+use yash_env::signal;
 use yash_env::system::Errno;
-use yash_env::trap::Signal;
 use yash_env::Env;
 use yash_env::System as _;
 use yash_semantics::trap::run_trap_if_caught;
@@ -36,8 +36,8 @@ pub enum Error {
     NothingToWait,
     /// The built-in was interrupted by a signal and the trap action was
     /// executed.
-    #[error("trapped({0})")]
-    Trapped(Signal, yash_env::semantics::Result),
+    #[error("trapped signal {0}")]
+    Trapped(signal::Number, yash_env::semantics::Result),
     /// An unexpected error occurred in the underlying system.
     #[error("system error: {0}")]
     SystemError(#[from] Errno),
@@ -195,7 +195,7 @@ mod tests {
 
                 // Now the function should return.
                 let result = future.await;
-                assert_eq!(result, Err(Error::Trapped(Signal::SIGTERM, Continue(()))));
+                assert_eq!(result, Err(Error::Trapped(SIGTERM, Continue(()))));
             }
 
             // The trap action must have assigned the variable.

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -106,6 +106,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::subshell::Subshell;
+    use yash_env::system::r#virtual::SIGTERM;
     use yash_env::trap::Action;
     use yash_env::variable::Value;
     use yash_env::VirtualSystem;
@@ -193,7 +194,7 @@ mod tests {
                 assert_eq!(poll!(&mut future), Poll::Pending);
 
                 // Trigger the trap.
-                _ = system.current_process_mut().raise_signal(Signal::SIGTERM);
+                _ = system.current_process_mut().raise_signal(SIGTERM);
 
                 // Now the function should return.
                 let result = future.await;

--- a/yash-builtin/src/wait/status.rs
+++ b/yash-builtin/src/wait/status.rs
@@ -122,7 +122,7 @@ mod tests {
     use super::*;
     use yash_env::job::{Job, Pid};
     use yash_env::option::State::{Off, On};
-    use yash_env::trap::Signal;
+    use yash_env::system::r#virtual::{SIGABRT, SIGHUP, SIGSTOP, SIGTSTP};
 
     #[test]
     fn status_of_unknown_job() {
@@ -171,27 +171,27 @@ mod tests {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
         job.state = ProcessState::Halted(ProcessResult::Signaled {
-            signal: Signal::SIGHUP,
+            signal: SIGHUP,
             core_dump: false,
         });
         let index = jobs.add(job);
 
         assert_eq!(
             job_status(index, Off)(&mut jobs),
-            ControlFlow::Break(ExitStatus::from(Signal::SIGHUP)),
+            ControlFlow::Break(ExitStatus::from(SIGHUP)),
         );
         assert_eq!(jobs.get(index), None);
 
         let mut job = Job::new(Pid(456));
         job.state = ProcessState::Halted(ProcessResult::Signaled {
-            signal: Signal::SIGABRT,
+            signal: SIGABRT,
             core_dump: true,
         });
         let index = jobs.add(job);
 
         assert_eq!(
             job_status(index, On)(&mut jobs),
-            ControlFlow::Break(ExitStatus::from(Signal::SIGABRT)),
+            ControlFlow::Break(ExitStatus::from(SIGABRT)),
         );
         assert_eq!(jobs.get(index), None);
     }
@@ -200,14 +200,14 @@ mod tests {
     fn status_of_stopped_job_without_job_control() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::stopped(Signal::SIGTSTP);
+        job.state = ProcessState::stopped(SIGTSTP);
         let index = jobs.add(job);
 
         assert_eq!(job_status(index, Off)(&mut jobs), ControlFlow::Continue(()),);
         assert_eq!(jobs[index].pid, Pid(123));
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         let index = jobs.add(job);
 
         assert_eq!(job_status(index, Off)(&mut jobs), ControlFlow::Continue(()),);
@@ -218,22 +218,22 @@ mod tests {
     fn status_of_stopped_job_with_job_control() {
         let mut jobs = JobList::new();
         let mut job = Job::new(Pid(123));
-        job.state = ProcessState::stopped(Signal::SIGTSTP);
+        job.state = ProcessState::stopped(SIGTSTP);
         let index = jobs.add(job);
 
         assert_eq!(
             job_status(index, On)(&mut jobs),
-            ControlFlow::Break(ExitStatus::from(Signal::SIGTSTP)),
+            ControlFlow::Break(ExitStatus::from(SIGTSTP)),
         );
         assert_eq!(jobs[index].pid, Pid(123));
 
         let mut job = Job::new(Pid(456));
-        job.state = ProcessState::stopped(Signal::SIGSTOP);
+        job.state = ProcessState::stopped(SIGSTOP);
         let index = jobs.add(job);
 
         assert_eq!(
             job_status(index, On)(&mut jobs),
-            ControlFlow::Break(ExitStatus::from(Signal::SIGSTOP)),
+            ControlFlow::Break(ExitStatus::from(SIGSTOP)),
         );
         assert_eq!(jobs[index].pid, Pid(456));
     }

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -35,8 +35,8 @@ use std::ops::ControlFlow::{Break, Continue};
 use yash_builtin::BUILTINS;
 use yash_env::option::Option::{Interactive, Monitor, Stdin};
 use yash_env::option::State::On;
+use yash_env::signal;
 use yash_env::system::SignalHandling;
-use yash_env::trap::Signal::SIGPIPE;
 use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::System;
@@ -134,7 +134,11 @@ pub fn bin_main() -> i32 {
     // Rust by default sets SIGPIPE to SIG_IGN, which is not desired.
     // As an imperfect workaround, we set SIGPIPE to SIG_DFL here.
     // TODO Use unix_sigpipe: https://github.com/rust-lang/rust/issues/97889
-    _ = env.system.sigaction(SIGPIPE, SignalHandling::Default);
+    let sigpipe = env
+        .system
+        .signal_number_from_name(signal::Name::Pipe)
+        .unwrap();
+    _ = env.system.sigaction(sigpipe, SignalHandling::Default);
 
     let system = env.system.clone();
     let mut pool = futures_executor::LocalPool::new();

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -20,12 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl From<job::ProcessResult> for ExitStatus`
 - `job::ProcessState::Halted`
 - `job::ProcessState::{stopped, exited, is_stopped}`
+- `impl Hash for job::fmt::Marker`
+- `job::fmt::State`
 - `impl From<trap::Condition> for stack::Frame`
 - `signal::{Number, RawNumber, Name, NameIter, UnknownNameError}`
 
 ### Changed
 
 - `stack::Frame` is now `non_exhaustive`.
+- `job::fmt::Report` has been totally rewritten.
 - `system::virtual::FileSystem::get` now fails with `EACCES` when search
   permission is denied for any directory component of the path.
 - The following methods of `system::virtual::Process` now operate on

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `job::ProcessState::{Exited, Signaled, Stopped}` in favor of `job::ProcessResult`
 - `job::ProcessState::to_wait_status`
+- `impl std::fmt::Display for job::ProcessResult`
+- `impl std::fmt::Display for job::ProcessState`
 - `semantics::apply_errexit`
 
 ### Fixed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `signal::{Number, RawNumber, Name, NameIter, UnknownNameError}`
 - `trap::SignalSystem::signal_name_from_number`
 - `trap::SignalSystem::signal_number_from_name`
+- `ExitStatus::to_signal_number`
 
 ### Changed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl std::fmt::Display for job::ProcessState`
 - `impl From<Signal> for ExitStatus`
 - `semantics::apply_errexit`
+- `trap::Signal`
 - `trap::ParseConditionError`
 
 ### Fixed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `job::ProcessState::{from_wait_status, to_wait_status}`
 - `impl std::fmt::Display for job::ProcessResult`
 - `impl std::fmt::Display for job::ProcessState`
+- `impl From<Signal> for ExitStatus`
 - `semantics::apply_errexit`
 - `trap::ParseConditionError`
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -35,27 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permission is denied for any directory component of the path.
 - `job::ProcessResult::{Stopped, Signaled}` now have associated values of type
   `signal::Number` instead of `trap::Signal`.
-- `job::ProcessState::stopped` now takes a `signal::Number` parameter instead of
-  a `trap::Signal`.
-- The following methods of `system::System` now operate on `signal::Number`
-  instead of `trap::Signal`:
-    - `kill`
-    - `sigaction`
-- The following methods of `system::virtual::Process` now operate on
-  `signal::Number` instead of `trap::Signal`:
-    - `signal_handling`
-    - `set_signal_handling`
+- The following methods now operate on `signal::Number` instead of `trap::Signal`:
+    - `Env::wait_for_signal`
+    - `Env::wait_for_signals`
+    - `job::ProcessState::stopped`
+    - `system::System::caught_signals`
+    - `system::System::kill`
+    - `system::System::sigaction`
+    - `system::virtual::Process::signal_handling`
+    - `system::virtual::Process::set_signal_handling`
+    - `trap::TrapSet::catch_signal`
+    - `trap::TrapSet::take_caught_signal`
+    - `trap::TrapSet::take_signal_if_caught`
 - `system::virtual::SignalEffect::of` now takes a `signal::Number` parameter
   instead of a `trap::Signal`. This function is now `const`.
 - The type parameter constraint for `subshell::Subshell` is now
   `F: for<'a> FnOnce(&'a mut Env, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>> + 'static`.
   The `Output` type of the returned future has been changed from
   `semantics::Result` to `()`.
-- The following methods of `trap::TrapSet` now operate on `signal::Number`
-  instead of `trap::Signal`:
-    - `catch_signal`
-    - `take_caught_signal`
-    - `take_signal_if_caught`
 
 ### Removed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `job::fmt::State`
 - `impl From<trap::Condition> for stack::Frame`
 - `signal::{Number, RawNumber, Name, NameIter, UnknownNameError}`
+- `trap::SignalSystem::signal_name_from_number`
+- `trap::SignalSystem::signal_number_from_name`
 
 ### Changed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `signal::Number` instead of `trap::Signal`.
 - `job::ProcessState::stopped` now takes a `signal::Number` parameter instead of
   a `trap::Signal`.
+- The following methods of `system::System` now operate on `signal::Number`
+  instead of `trap::Signal`:
+    - `kill`
 - The following methods of `system::virtual::Process` now operate on
   `signal::Number` instead of `trap::Signal`:
     - `signal_handling`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `F: for<'a> FnOnce(&'a mut Env, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>> + 'static`.
   The `Output` type of the returned future has been changed from
   `semantics::Result` to `()`.
+- The following methods of `trap::TrapSet` now operate on `signal::Number`
+  instead of `trap::Signal`:
+    - `catch_signal`
+    - `take_caught_signal`
+    - `take_signal_if_caught`
 
 ### Removed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -31,10 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `job::fmt::Report` has been totally rewritten.
 - `system::virtual::FileSystem::get` now fails with `EACCES` when search
   permission is denied for any directory component of the path.
+- `job::ProcessResult::{Stopped, Signaled}` now have associated values of type
+  `signal::Number` instead of `trap::Signal`.
+- `job::ProcessState::stopped` now takes a `signal::Number` parameter instead of
+  a `trap::Signal`.
 - The following methods of `system::virtual::Process` now operate on
   `signal::Number` instead of `trap::Signal`:
     - `signal_handling`
     - `set_signal_handling`
+- `system::virtual::SignalEffect::of` now takes a `signal::Number` parameter
+  instead of a `trap::Signal`. This function is now `const`.
 - The type parameter constraint for `subshell::Subshell` is now
   `F: for<'a> FnOnce(&'a mut Env, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>> + 'static`.
   The `Output` type of the returned future has been changed from
@@ -43,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `job::ProcessState::{Exited, Signaled, Stopped}` in favor of `job::ProcessResult`
-- `job::ProcessState::to_wait_status`
+- `job::ProcessState::{from_wait_status, to_wait_status}`
 - `impl std::fmt::Display for job::ProcessResult`
 - `impl std::fmt::Display for job::ProcessState`
 - `semantics::apply_errexit`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following methods of `system::System` now operate on `signal::Number`
   instead of `trap::Signal`:
     - `kill`
+    - `sigaction`
 - The following methods of `system::virtual::Process` now operate on
   `signal::Number` instead of `trap::Signal`:
     - `signal_handling`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Env::errexit_is_applicable`
 - `System::shell_path`
+- `System::{validate_signal, signal_number_from_name}`
+- `SystemEx::signal_name_from_number`
 - `SystemEx::fd_is_pipe`
 - `SystemEx::set_blocking`
 - `job::ProcessResult`
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `job::ProcessState::Halted`
 - `job::ProcessState::{stopped, exited, is_stopped}`
 - `impl From<trap::Condition> for stack::Frame`
+- `signal::{Number, RawNumber, Name, NameIter, UnknownNameError}`
 
 ### Changed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl std::fmt::Display for job::ProcessResult`
 - `impl std::fmt::Display for job::ProcessState`
 - `semantics::apply_errexit`
+- `trap::ParseConditionError`
 
 ### Fixed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `stack::Frame` is now `non_exhaustive`.
 - `system::virtual::FileSystem::get` now fails with `EACCES` when search
   permission is denied for any directory component of the path.
+- The following methods of `system::virtual::Process` now operate on
+  `signal::Number` instead of `trap::Signal`:
+    - `signal_handling`
+    - `set_signal_handling`
 - The type parameter constraint for `subshell::Subshell` is now
   `F: for<'a> FnOnce(&'a mut Env, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>> + 'static`.
   The `Output` type of the returned future has been changed from

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -22,6 +22,7 @@ futures-util = "0.3.28"
 itertools = "0.11.0"
 nix = { version = "0.27.0", features = ["fs", "poll", "process", "signal", "term", "user"] }
 slab = "0.4.9"
+strum = { version = "0.26.2", features = ["derive"] }
 tempfile = "3.8.0"
 thiserror = "1.0.47"
 yash-quote = { path = "../yash-quote", version = "1.1.1" }

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -21,51 +21,43 @@
 //! job status report printed between commands in an interactive shell.
 //!
 //! The format includes the job number, an optional marker representing the
-//! current or previous job, the current state, and the job name, in this order.
-//! An example of a formatted job is:
-//!
-//! ```text
-//! [2] + Running              cat foo bar | grep baz
-//! ```
-//!
-//! The process ID is inserted before the current state when the alternate mode
-//! flag (`#`) is used:
+//! current or previous job, the optional process ID, the current state, and the
+//! job name, in this order. An example of a formatted job is:
 //!
 //! ```text
 //! [2] + 24437 Running              cat foo bar | grep baz
 //! ```
 //!
 //! To format a job, you create an instance of [`Report`] and use the `Display`
-//! trait's method (typically by using the `format!` macro).
+//! trait's method (typically by using the `format!` macro or calling the
+//! `to_string` method).
 //!
 //! ```
-//! /* FIXME
-//! use yash_env::job::{Job, Pid};
-//! use yash_env::job::fmt::{Marker, Report};
-//! let mut job = Job::new(Pid(123));
-//! job.name = "sleep 10".to_string();
+//! use yash_env::job::fmt::{Marker, Report, State};
 //! let report = Report {
-//!     index: 2,
+//!     number: 3,
 //!     marker: Marker::None,
-//!     job: &job,
+//!     pid: None,
+//!     state: State::Running,
+//!     name: "sleep 10",
 //! };
-//! let s = format!("{}", report);
-//! assert_eq!(s, "[3]   Running              sleep 10");
-//! let s = format!("{:#}", report);
-//! assert_eq!(s, "[3]     123 Running              sleep 10");
-//! */
+//! assert_eq!(report.to_string(), "[3]   Running              sleep 10");
 //! ```
 
 use super::Job;
 #[cfg(doc)]
 use super::JobList;
+use super::Pid;
 use super::ProcessResult;
 use super::ProcessState;
 use crate::semantics::ExitStatus;
+use crate::signal;
+use crate::system::System;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result;
 
+// TODO Remove these impls
 /// Formats a process result into a string.
 ///
 /// Process results are formatted as follows:
@@ -115,7 +107,7 @@ impl Display for ProcessState {
 }
 
 /// Type of a marker indicating the current and previous job
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Marker {
     None,
     CurrentJob,
@@ -139,6 +131,120 @@ impl Marker {
 impl Display for Marker {
     fn fmt(&self, f: &mut Formatter) -> Result {
         self.as_char().fmt(f)
+    }
+}
+
+/// State of a job
+///
+/// This enumeration represents the state of a job. The string representation of
+/// the state is used in the job status report.
+///
+/// This type is similar to the [`ProcessState`] type, but it uses
+/// [`signal::Name`] instead of [`signal::Number`] to represent signals so that
+/// the signal names are shown in the job status report.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum State {
+    /// The job is running.
+    Running,
+    /// The process has been stopped by a signal.
+    Stopped(signal::Name),
+    /// The process has exited.
+    Exited(ExitStatus),
+    /// The process has been terminated by a signal.
+    Signaled {
+        signal: signal::Name,
+        core_dump: bool,
+    },
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Running => "Running".fmt(f),
+
+            Self::Exited(ExitStatus::SUCCESS) => "Done".fmt(f),
+
+            Self::Exited(exit_status) => format!("Done({exit_status})").fmt(f),
+
+            Self::Stopped(signal) => format!("Stopped(SIG{signal})").fmt(f),
+
+            Self::Signaled {
+                signal,
+                core_dump: false,
+            } => format!("Killed(SIG{signal})").fmt(f),
+
+            Self::Signaled {
+                signal,
+                core_dump: true,
+            } => format!("Killed(SIG{signal}: core dumped)").fmt(f),
+        }
+    }
+}
+
+impl State {
+    /// Creates a `State` from a process state.
+    ///
+    /// This function converts a [`ProcessState`] into a `State` by converting
+    /// the contained signal number into a signal name using the given system.
+    /// If the signal number is not recognized, the signal name `Rtmin(-1)` is
+    /// used as a fallback replacement.
+    #[must_use]
+    pub fn from_process_state<S: System>(state: ProcessState, system: &S) -> Self {
+        fn convert<S: System>(number: signal::RawNumber, system: &S) -> signal::Name {
+            match system.validate_signal(number as _) {
+                Some((name, _number)) => name,
+                None => signal::Name::Rtmin(-1),
+            }
+        }
+
+        match state {
+            ProcessState::Running => Self::Running,
+            ProcessState::Halted(result) => match result {
+                ProcessResult::Exited(status) => Self::Exited(status),
+                ProcessResult::Stopped(signal) => Self::Stopped(convert(signal as _, system)),
+                ProcessResult::Signaled { signal, core_dump } => {
+                    let signal = convert(signal as _, system);
+                    Self::Signaled { signal, core_dump }
+                }
+            },
+        }
+    }
+}
+
+/// Set of data to produce a job status report
+///
+/// This structure contains the information necessary to format a job status
+/// report, which can be produced by the `Display` trait's method.
+/// See the [module documentation](self) for details.
+#[derive(Clone, Debug)]
+pub struct Report<'a> {
+    /// Job number
+    ///
+    /// Usually, this value is the index of the job in the job list plus one.
+    pub number: usize,
+
+    /// Type of the marker indicating the current and previous job
+    pub marker: Marker,
+
+    /// Process ID of the job
+    ///
+    /// This field is optional and is only included when it is not `None`.
+    pub pid: Option<Pid>,
+
+    /// Current state of the job
+    pub state: State,
+
+    /// Job name
+    pub name: &'a str,
+}
+
+impl std::fmt::Display for Report<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "[{}] {} ", self.number, self.marker)?;
+        if let Some(pid) = self.pid {
+            write!(f, "{:5} ", pid)?;
+        }
+        write!(f, "{:20} {}", self.state, self.name)
     }
 }
 
@@ -269,6 +375,59 @@ mod tests {
             core_dump: false,
         });
         assert_eq!(state.to_string(), "Killed(SIGKILL)");
+    }
+
+    #[test]
+    fn state_display() {
+        let state = State::Running;
+        assert_eq!(state.to_string(), "Running");
+        let state = State::Stopped(signal::Name::Stop);
+        assert_eq!(state.to_string(), "Stopped(SIGSTOP)");
+        let state = State::Exited(ExitStatus::SUCCESS);
+        assert_eq!(state.to_string(), "Done");
+        let state = State::Exited(ExitStatus::NOT_FOUND);
+        assert_eq!(state.to_string(), "Done(127)");
+        let state = State::Signaled {
+            signal: signal::Name::Kill,
+            core_dump: false,
+        };
+        assert_eq!(state.to_string(), "Killed(SIGKILL)");
+    }
+
+    #[test]
+    fn report_display() {
+        let mut report = Report {
+            number: 1,
+            marker: Marker::None,
+            pid: None,
+            state: State::Running,
+            name: "echo ok",
+        };
+        assert_eq!(report.to_string(), "[1]   Running              echo ok");
+
+        report.number = 2;
+        assert_eq!(report.to_string(), "[2]   Running              echo ok");
+
+        report.marker = Marker::CurrentJob;
+        assert_eq!(report.to_string(), "[2] + Running              echo ok");
+
+        report.pid = Some(Pid(42));
+        assert_eq!(
+            report.to_string(),
+            "[2] +    42 Running              echo ok"
+        );
+
+        report.pid = Some(Pid(123456));
+        assert_eq!(
+            report.to_string(),
+            "[2] + 123456 Running              echo ok"
+        );
+
+        report.name = "foo | bar";
+        assert_eq!(
+            report.to_string(),
+            "[2] + 123456 Running              foo | bar"
+        );
     }
 
     #[test]

--- a/yash-env/src/job/fmt.rs
+++ b/yash-env/src/job/fmt.rs
@@ -39,6 +39,7 @@
 //! trait's method (typically by using the `format!` macro).
 //!
 //! ```
+//! /* FIXME
 //! use yash_env::job::{Job, Pid};
 //! use yash_env::job::fmt::{Marker, Report};
 //! let mut job = Job::new(Pid(123));
@@ -52,6 +53,7 @@
 //! assert_eq!(s, "[3]   Running              sleep 10");
 //! let s = format!("{:#}", report);
 //! assert_eq!(s, "[3]     123 Running              sleep 10");
+//! */
 //! ```
 
 use super::Job;
@@ -146,7 +148,7 @@ impl Display for Marker {
 /// report, which can be produced by the `Display` trait's method.
 /// See the [module documentation](self) for details.
 #[derive(Clone, Copy, Debug)]
-pub struct Report<'a> {
+pub struct OldReport<'a> {
     /// Index of the job
     ///
     /// This value should be the index at which the job appears in its
@@ -162,7 +164,7 @@ pub struct Report<'a> {
     pub job: &'a Job,
 }
 
-impl Report<'_> {
+impl OldReport<'_> {
     /// Returns the job number of the job.
     ///
     /// The job number is a positive integer that is one greater than the index
@@ -176,7 +178,7 @@ impl Report<'_> {
 }
 
 /// Formats a job status report.
-impl Display for Report<'_> {
+impl Display for OldReport<'_> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let number = self.number();
         let marker = self.marker;
@@ -275,23 +277,23 @@ mod tests {
         let marker = Marker::CurrentJob;
         let job = &mut Job::new(Pid(42));
         job.name = "echo ok".to_string();
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Running              echo ok");
 
         job.state = ProcessState::stopped(Signal::SIGSTOP);
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(report.to_string(), "[1] + Stopped(SIGSTOP)     echo ok");
 
         let marker = Marker::PreviousJob;
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(report.to_string(), "[1] - Stopped(SIGSTOP)     echo ok");
 
         let marker = Marker::None;
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(report.to_string(), "[1]   Stopped(SIGSTOP)     echo ok");
 
         let index = 5;
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(report.to_string(), "[6]   Stopped(SIGSTOP)     echo ok");
 
         job.state = ProcessState::Halted(ProcessResult::Signaled {
@@ -299,7 +301,7 @@ mod tests {
             core_dump: true,
         });
         job.name = "exit 0".to_string();
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(
             report.to_string(),
             "[6]   Killed(SIGQUIT: core dumped) exit 0"
@@ -312,14 +314,14 @@ mod tests {
         let marker = Marker::CurrentJob;
         let job = &mut Job::new(Pid(42));
         job.name = "echo ok".to_string();
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(
             format!("{report:#}"),
             "[1] +    42 Running              echo ok"
         );
 
         job.pid = Pid(123456);
-        let report = Report { index, marker, job };
+        let report = OldReport { index, marker, job };
         assert_eq!(
             format!("{report:#}"),
             "[1] + 123456 Running              echo ok"

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -451,6 +451,7 @@ pub mod job;
 pub mod option;
 pub mod pwd;
 pub mod semantics;
+pub mod signal;
 pub mod stack;
 pub mod subshell;
 pub mod system;

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -471,10 +471,10 @@ mod tests {
     use crate::system::r#virtual::SystemState;
     use crate::system::r#virtual::SIGCHLD;
     use crate::trap::Action;
-    use crate::trap::Signal;
     use futures_executor::LocalPool;
     use futures_util::task::LocalSpawnExt as _;
     use futures_util::FutureExt as _;
+    use nix::sys::signal::Signal;
     use std::cell::RefCell;
     use yash_syntax::source::Location;
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -466,6 +466,7 @@ mod tests {
     use crate::subshell::Subshell;
     use crate::system::r#virtual::INode;
     use crate::system::r#virtual::SystemState;
+    use crate::system::r#virtual::SIGCHLD;
     use crate::trap::Action;
     use futures_executor::LocalPool;
     use futures_util::task::LocalSpawnExt as _;
@@ -515,7 +516,7 @@ mod tests {
                 let mut state = state.borrow_mut();
                 let process = state.processes.get_mut(&env.main_pid).unwrap();
                 assert!(process.blocked_signals().contains(Signal::SIGCHLD));
-                let _ = process.raise_signal(Signal::SIGCHLD);
+                let _ = process.raise_signal(SIGCHLD);
             }
             env.wait_for_signal(Signal::SIGCHLD).await;
 
@@ -554,7 +555,7 @@ mod tests {
             let mut state = system.state.borrow_mut();
             let process = state.processes.get_mut(&system.process_id).unwrap();
             assert!(process.blocked_signals().contains(Signal::SIGCHLD));
-            let _ = process.raise_signal(Signal::SIGCHLD);
+            let _ = process.raise_signal(SIGCHLD);
         }
 
         let result = env.poll_signals().unwrap();

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -131,16 +131,6 @@ impl ExitStatus {
     }
 }
 
-/// Converts a signal to the corresponding exit status.
-///
-/// POSIX requires the exit status to be greater than 128. The current
-/// implementation returns `signal_number + 384`.
-impl From<Signal> for ExitStatus {
-    fn from(signal: Signal) -> Self {
-        Self::from(signal as c_int + 0x180)
-    }
-}
-
 /// Converts the exit status to `ExitCode`.
 ///
 /// Note that `ExitCode` only supports exit statuses in the range of 0 to 255.
@@ -266,26 +256,6 @@ mod tests {
     use super::*;
     use crate::system::r#virtual::VirtualSystem;
     use crate::system::r#virtual::{SIGINT, SIGTERM};
-
-    #[test]
-    fn signal_try_from_exit_status() {
-        let result = Signal::try_from(ExitStatus(0));
-        assert!(result.is_err(), "result = {result:?}");
-
-        assert_eq!(
-            Signal::try_from(ExitStatus(Signal::SIGINT as c_int)),
-            Ok(Signal::SIGINT)
-        );
-
-        let mut exit_status = ExitStatus::from(Signal::SIGTERM);
-        exit_status.0 &= 0xFF;
-        assert_eq!(Signal::try_from(exit_status), Ok(Signal::SIGTERM));
-
-        assert_eq!(
-            Signal::try_from(ExitStatus::from(Signal::SIGHUP)),
-            Ok(Signal::SIGHUP)
-        );
-    }
 
     #[test]
     fn exit_status_to_signal_number() {

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -16,6 +16,7 @@
 
 //! Type definitions for command execution.
 
+use crate::signal;
 use crate::system::Errno;
 use nix::sys::signal::Signal;
 use std::ffi::c_int;
@@ -96,6 +97,16 @@ impl From<c_int> for ExitStatus {
 impl From<ExitStatus> for c_int {
     fn from(exit_status: ExitStatus) -> c_int {
         exit_status.0
+    }
+}
+
+/// Converts a signal number to the corresponding exit status.
+///
+/// POSIX requires the exit status to be greater than 128. The current
+/// implementation returns `signal_number + 384`.
+impl From<signal::Number> for ExitStatus {
+    fn from(number: signal::Number) -> Self {
+        Self::from(number.as_raw() + 0x180)
     }
 }
 

--- a/yash-env/src/signal.rs
+++ b/yash-env/src/signal.rs
@@ -1,0 +1,472 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Type definitions for signals
+//!
+//! Signals are a method of inter-process communication used to notify a process
+//! that a specific event has occurred. This module provides a list of signals
+//! defined by POSIX with additional support for some non-standard signals.
+//!
+//! This module defines two abstractions for signals: [`Name`] and [`Number`].
+//! The `Name` type identifies a signal by its name, while the `Number` type
+//! represents a signal by its number. This reflects the fact that different
+//! systems may use different signal numbers for the same signal name and that
+//! some exotic signals may not be available on all systems.
+//!
+//! A [`Name`] can represent a single signal name, such as `SIGINT`
+//! ([`Name::Int`]), regardless of whether the signal is available on the
+//! [`System`]. `Name`s are more useful for user-facing applications, as they
+//! are easier to read and understand.
+//!
+//! A [`Number`] represents a signal that is available on the [`System`] by its
+//! signal number. The number is guaranteed to be a positive integer, so it
+//! optimizes the size of `Option<Number>`, etc. `Number`s are used in most
+//! signal-related functions of the [`System`] to efficiently interact with the
+//! underlying system calls.
+//!
+//! All proper signal names start with `"SIG"`. However, the names defined,
+//! parsed, and displayed in this module do not include the `"SIG"` prefix.
+
+#[cfg(doc)]
+use crate::system::System;
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::ffi::c_int;
+use std::num::NonZeroI32;
+use std::str::FromStr;
+use strum::{EnumIter, IntoEnumIterator};
+use thiserror::Error;
+
+/// Raw signal number
+///
+/// This is a type alias for the raw signal number used by the underlying
+/// system. POSIX requires valid signal numbers to be positive `c_int` values.
+///
+/// The current implementation of conversion between `RawNumber` and `Number`
+/// assumes that `c_int` is a 32-bit signed integer type. This is a reasonable
+/// assumption, as POSIX requires `c_int` to be at least 32 bits wide, but it
+/// may break on systems where `c_int` is wider than 32 bits.
+pub type RawNumber = c_int;
+
+/// Signal name
+///
+/// This enum identifies a signal by its name. It can be used to represent
+/// signals regardless of whether they are available on the [`System`].
+///
+/// Use the [`System::validate_signal`] function to obtain a `Name` from a
+/// signal number. The [`System::signal_number_from_name`] function can be used
+/// to convert a `Name` to a `Number`.
+#[derive(Clone, Copy, Debug, EnumIter, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Name {
+    /// `SIGABRT` (process abort signal)
+    Abrt,
+    /// `SIGALRM` (alarm clock)
+    Alrm,
+    /// `SIGBUS` (access to an undefined portion of a memory object)
+    Bus,
+    /// `SIGCHLD` (child process terminated, stopped, or continued)
+    Chld,
+    /// `SIGCLD` (child process terminated, stopped, or continued)
+    Cld,
+    /// `SIGCONT` (continue executing, if stopped)
+    Cont,
+    /// `SIGEMT` (emulation trap)
+    Emt,
+    /// `SIGFPE` (erroneous arithmetic operation)
+    Fpe,
+    /// `SIGHUP` (hangup)
+    Hup,
+    /// `SIGILL` (illegal instruction)
+    Ill,
+    /// `SIGINFO` (status request from keyboard)
+    Info,
+    /// `SIGINT` (interrupt)
+    Int,
+    /// `SIGIO` (I/O is possible on a file descriptor)
+    Io,
+    /// `SIGIOT` (I/O trap)
+    Iot,
+    /// `SIGKILL` (kill)
+    Kill,
+    /// `SIGLOST` (resource lost)
+    Lost,
+    /// `SIGPIPE` (write on a pipe with no one to read it)
+    Pipe,
+    /// `SIGPOLL` (pollable event)
+    Poll,
+    /// `SIGPROF` (profiling timer expired)
+    Prof,
+    /// `SIGPWR` (power failure)
+    Pwr,
+    /// `SIGQUIT` (quit)
+    Quit,
+    /// `SIGSEGV` (invalid memory reference)
+    Segv,
+    /// `SIGSTKFLT` (stack fault)
+    Stkflt,
+    /// `SIGSTOP` (stop executing)
+    Stop,
+    /// `SIGSYS` (bad system call)
+    Sys,
+    /// `SIGTERM` (termination)
+    Term,
+    /// `SIGTHR` (thread interrupt)
+    Thr,
+    /// `SIGTRAP` (trace trap)
+    Trap,
+    /// `SIGTSTP` (stop executing)
+    Tstp,
+    /// `SIGTTIN` (background process attempting read)
+    Ttin,
+    /// `SIGTTOU` (background process attempting write)
+    Ttou,
+    /// `SIGURG` (high bandwidth data is available at a socket)
+    Urg,
+    /// `SIGUSR1` (user-defined signal 1)
+    Usr1,
+    /// `SIGUSR2` (user-defined signal 2)
+    Usr2,
+    /// `SIGVTALRM` (virtual timer expired)
+    Vtalrm,
+    /// `SIGWINCH` (window size change)
+    Winch,
+    /// `SIGXCPU` (CPU time limit exceeded)
+    Xcpu,
+    /// `SIGXFSZ` (file size limit exceeded)
+    Xfsz,
+
+    /// Real-time signal with a number relative to the minimum real-time signal
+    ///
+    /// `Rtmin(n)` represents the real-time signal `SIGRTMIN + n`, where `n` is
+    /// expected to be a non-negative integer between `0` and
+    /// `SIGRTMAX - SIGRTMIN`.
+    Rtmin(RawNumber),
+
+    /// Real-time signal with a number relative to the maximum real-time signal
+    ///
+    /// `Rtmax(n)` represents the real-time signal `SIGRTMAX + n`, where `n` is
+    /// expected to be a non-positive integer between `SIGRTMIN - SIGRTMAX` and
+    /// `0`.
+    Rtmax(RawNumber),
+}
+
+/// Compares two signal names.
+///
+/// The comparison is allowed only between two `Rtmin` values or two `Rtmax`
+/// values. The comparison is based on the numerical value of the signal number.
+impl PartialOrd for Name {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Self::Rtmin(a), Self::Rtmin(b)) | (Self::Rtmax(a), Self::Rtmax(b)) => a.partial_cmp(b),
+            _ => None,
+        }
+    }
+}
+
+impl Name {
+    /// Returns an iterator over all signal names.
+    ///
+    /// This is a convenience method that returns an iterator over all signal
+    /// names. The iterator yields all signal names other than `Rtmin` and
+    /// `Rtmax` in the alphabetical order, followed by `Rtmin(0)` and `Rtmax(0)`
+    /// as the last two items.
+    ///
+    /// Note that the iterator works independently of the underlying system and
+    /// does not check whether the signals are available on the system.
+    #[inline(always)]
+    pub fn iter() -> NameIter {
+        <Self as IntoEnumIterator>::iter()
+    }
+
+    /// Returns the name as a string.
+    ///
+    /// For most signals, this function returns a static string that is the
+    /// signal name in uppercase without the `"SIG"` prefix. For real-time
+    /// signals `Rtmin(n)` and `Rtmax(n)` where `n` is non-zero, this function
+    /// returns a dynamically allocated string that is `RTMIN` or `RTMAX`
+    /// followed by the relative number `n`. Examples of the returned strings
+    /// are `"TERM"`, `"RTMIN"`, and `"RTMAX-5"`.
+    ///
+    /// The returned name can be converted back to the signal using the
+    /// [`FromStr`] implementation for `Name`.
+    #[must_use]
+    pub fn as_string(&self) -> Cow<'static, str> {
+        match *self {
+            Self::Abrt => Cow::Borrowed("ABRT"),
+            Self::Alrm => Cow::Borrowed("ALRM"),
+            Self::Bus => Cow::Borrowed("BUS"),
+            Self::Chld => Cow::Borrowed("CHLD"),
+            Self::Cld => Cow::Borrowed("CLD"),
+            Self::Cont => Cow::Borrowed("CONT"),
+            Self::Emt => Cow::Borrowed("EMT"),
+            Self::Fpe => Cow::Borrowed("FPE"),
+            Self::Hup => Cow::Borrowed("HUP"),
+            Self::Ill => Cow::Borrowed("ILL"),
+            Self::Info => Cow::Borrowed("INFO"),
+            Self::Int => Cow::Borrowed("INT"),
+            Self::Io => Cow::Borrowed("IO"),
+            Self::Iot => Cow::Borrowed("IOT"),
+            Self::Kill => Cow::Borrowed("KILL"),
+            Self::Lost => Cow::Borrowed("LOST"),
+            Self::Pipe => Cow::Borrowed("PIPE"),
+            Self::Poll => Cow::Borrowed("POLL"),
+            Self::Prof => Cow::Borrowed("PROF"),
+            Self::Pwr => Cow::Borrowed("PWR"),
+            Self::Quit => Cow::Borrowed("QUIT"),
+            Self::Segv => Cow::Borrowed("SEGV"),
+            Self::Stkflt => Cow::Borrowed("STKFLT"),
+            Self::Stop => Cow::Borrowed("STOP"),
+            Self::Sys => Cow::Borrowed("SYS"),
+            Self::Term => Cow::Borrowed("TERM"),
+            Self::Thr => Cow::Borrowed("THR"),
+            Self::Trap => Cow::Borrowed("TRAP"),
+            Self::Tstp => Cow::Borrowed("TSTP"),
+            Self::Ttin => Cow::Borrowed("TTIN"),
+            Self::Ttou => Cow::Borrowed("TTOU"),
+            Self::Urg => Cow::Borrowed("URG"),
+            Self::Usr1 => Cow::Borrowed("USR1"),
+            Self::Usr2 => Cow::Borrowed("USR2"),
+            Self::Vtalrm => Cow::Borrowed("VTALRM"),
+            Self::Winch => Cow::Borrowed("WINCH"),
+            Self::Xcpu => Cow::Borrowed("XCPU"),
+            Self::Xfsz => Cow::Borrowed("XFSZ"),
+            Self::Rtmin(0) => Cow::Borrowed("RTMIN"),
+            Self::Rtmax(0) => Cow::Borrowed("RTMAX"),
+            Self::Rtmin(n) => Cow::Owned(format!("RTMIN{n:+}")),
+            Self::Rtmax(n) => Cow::Owned(format!("RTMAX{n:+}")),
+        }
+    }
+}
+
+impl std::fmt::Display for Name {
+    /// Writes the signal name to the formatter.
+    ///
+    /// See [`Name::as_string`] for the format of the produced string.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_string().fmt(f)
+    }
+}
+
+#[test]
+fn test_name_to_string() {
+    assert_eq!(Name::Term.to_string(), "TERM");
+    assert_eq!(Name::Int.to_string(), "INT");
+    assert_eq!(Name::Rtmin(0).to_string(), "RTMIN");
+    assert_eq!(Name::Rtmax(0).to_string(), "RTMAX");
+    assert_eq!(Name::Rtmin(1).to_string(), "RTMIN+1");
+    assert_eq!(Name::Rtmin(20).to_string(), "RTMIN+20");
+    assert_eq!(Name::Rtmax(-1).to_string(), "RTMAX-1");
+    assert_eq!(Name::Rtmax(-20).to_string(), "RTMAX-20");
+}
+
+/// Error value for an unknown signal name
+///
+/// This error is used by the [`FromStr`] implementation for [`Name`] to
+/// indicate that the input string does not match any known signal name.
+#[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+pub struct UnknownNameError;
+
+impl std::fmt::Display for UnknownNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unknown signal name")
+    }
+}
+
+/// Parses a signal name from a string.
+///
+/// This function parses a signal name from a string. The input string is
+/// expected to be an uppercase signal name without the `"SIG"` prefix. The
+/// function returns the corresponding signal name if the input string matches a
+/// known signal name. Otherwise, it returns an error.
+///
+/// See [`Name::as_string`] for the format of the input string.
+impl FromStr for Name {
+    type Err = UnknownNameError;
+
+    fn from_str(s: &str) -> Result<Self, UnknownNameError> {
+        match s {
+            "ABRT" => Ok(Self::Abrt),
+            "ALRM" => Ok(Self::Alrm),
+            "BUS" => Ok(Self::Bus),
+            "CHLD" => Ok(Self::Chld),
+            "CLD" => Ok(Self::Cld),
+            "CONT" => Ok(Self::Cont),
+            "EMT" => Ok(Self::Emt),
+            "FPE" => Ok(Self::Fpe),
+            "HUP" => Ok(Self::Hup),
+            "ILL" => Ok(Self::Ill),
+            "INFO" => Ok(Self::Info),
+            "INT" => Ok(Self::Int),
+            "IO" => Ok(Self::Io),
+            "IOT" => Ok(Self::Iot),
+            "KILL" => Ok(Self::Kill),
+            "LOST" => Ok(Self::Lost),
+            "PIPE" => Ok(Self::Pipe),
+            "POLL" => Ok(Self::Poll),
+            "PROF" => Ok(Self::Prof),
+            "PWR" => Ok(Self::Pwr),
+            "QUIT" => Ok(Self::Quit),
+            "SEGV" => Ok(Self::Segv),
+            "STKFLT" => Ok(Self::Stkflt),
+            "STOP" => Ok(Self::Stop),
+            "SYS" => Ok(Self::Sys),
+            "TERM" => Ok(Self::Term),
+            "THR" => Ok(Self::Thr),
+            "TRAP" => Ok(Self::Trap),
+            "TSTP" => Ok(Self::Tstp),
+            "TTIN" => Ok(Self::Ttin),
+            "TTOU" => Ok(Self::Ttou),
+            "URG" => Ok(Self::Urg),
+            "USR1" => Ok(Self::Usr1),
+            "USR2" => Ok(Self::Usr2),
+            "VTALRM" => Ok(Self::Vtalrm),
+            "WINCH" => Ok(Self::Winch),
+            "XCPU" => Ok(Self::Xcpu),
+            "XFSZ" => Ok(Self::Xfsz),
+
+            "RTMIN" => Ok(Self::Rtmin(0)),
+            "RTMAX" => Ok(Self::Rtmax(0)),
+            _ => {
+                if let Some(tail) = s.strip_prefix("RTMIN") {
+                    if tail.starts_with(['+', '-']) {
+                        if let Ok(n) = tail.parse() {
+                            return Ok(Self::Rtmin(n));
+                        }
+                    }
+                }
+                if let Some(tail) = s.strip_prefix("RTMAX") {
+                    if tail.starts_with(['+', '-']) {
+                        if let Ok(n) = tail.parse() {
+                            return Ok(Self::Rtmax(n));
+                        }
+                    }
+                }
+                Err(UnknownNameError)
+            }
+        }
+    }
+}
+
+#[test]
+fn test_name_from_str() {
+    assert_eq!("ABRT".parse(), Ok(Name::Abrt));
+    assert_eq!("INT".parse(), Ok(Name::Int));
+    assert_eq!("QUIT".parse(), Ok(Name::Quit));
+
+    assert_eq!("RTMIN".parse(), Ok(Name::Rtmin(0)));
+    assert_eq!("RTMIN+0".parse(), Ok(Name::Rtmin(0)));
+    assert_eq!("RTMIN+1".parse(), Ok(Name::Rtmin(1)));
+
+    assert_eq!("RTMAX".parse(), Ok(Name::Rtmax(0)));
+    assert_eq!("RTMAX-0".parse(), Ok(Name::Rtmax(0)));
+    assert_eq!("RTMAX-1".parse(), Ok(Name::Rtmax(-1)));
+
+    assert_eq!("".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("FOO".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("int".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("RTMIN0".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("RTMIN+".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("RTMAX0".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("RTMAX-".parse::<Name>(), Err(UnknownNameError));
+    assert_eq!("2".parse::<Name>(), Err(UnknownNameError));
+}
+
+/// Signal number
+///
+/// This is a wrapper type for signal numbers. It is guaranteed to be a positive
+/// integer, so it optimizes the size of `Option<Number>`, etc.
+///
+/// To make sure that all `Number`s are valid, you can only obtain a `Number`
+/// from an instance of [`System`]. Use the [`System::validate_signal`] and
+/// [`System::signal_number_from_name`] methods to create a `Number` from a raw
+/// signal number or a signal name, respectively.
+///
+/// Signal numbers are specific to the underlying system. Passing a signal
+/// number obtained from [`RealSystem`] to [`VirtualSystem`] (or vice versa) is
+/// not supported and may result in unexpected behavior, though it is not
+/// checked by the type system.
+///
+/// [`RealSystem`]: crate::system::real::RealSystem
+/// [`VirtualSystem`]: crate::system::virtual::VirtualSystem
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
+#[repr(transparent)]
+pub struct Number(NonZeroI32);
+
+impl Number {
+    /// Returns the raw signal number.
+    #[inline(always)]
+    #[must_use]
+    pub fn as_raw(self) -> RawNumber {
+        self.0.get()
+    }
+
+    /// Returns the raw signal number as a `NonZeroI32`.
+    #[inline(always)]
+    #[must_use]
+    pub fn as_raw_non_zero(self) -> NonZeroI32 {
+        self.0
+    }
+
+    /// Creates a new `Number` from a raw signal number.
+    ///
+    /// This is a backdoor method that allows creating a `Number` from an
+    /// arbitrary raw signal number. The caller must ensure that the raw signal
+    /// number is a valid signal number.
+    ///
+    /// This function is not marked `unsafe` because creating an invalid
+    /// `Number` does not lead to undefined behavior. However, it is not
+    /// recommended to use this function unless you are sure that the raw signal
+    /// number is valid. To make sure that all `Number`s are valid, use the
+    /// [`System::validate_signal`] and [`System::signal_number_from_name`]
+    /// methods instead.
+    #[inline(always)]
+    #[must_use]
+    pub fn from_raw_unchecked(raw: NonZeroI32) -> Self {
+        Self(raw)
+    }
+}
+
+impl std::fmt::Display for Number {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl std::fmt::Binary for Number {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl std::fmt::Octal for Number {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl std::fmt::LowerHex for Number {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl std::fmt::UpperHex for Number {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/yash-env/src/signal.rs
+++ b/yash-env/src/signal.rs
@@ -40,6 +40,7 @@
 //! All proper signal names start with `"SIG"`. However, the names defined,
 //! parsed, and displayed in this module do not include the `"SIG"` prefix.
 
+use crate::system::Errno;
 #[cfg(doc)]
 use crate::system::System;
 use std::borrow::Cow;
@@ -283,6 +284,14 @@ pub struct UnknownNameError;
 impl std::fmt::Display for UnknownNameError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("unknown signal name")
+    }
+}
+
+/// Converts an unknown signal name error to `Errno::EINVAL`.
+impl From<UnknownNameError> for Errno {
+    #[inline]
+    fn from(UnknownNameError: UnknownNameError) -> Self {
+        Errno::EINVAL
     }
 }
 

--- a/yash-env/src/signal.rs
+++ b/yash-env/src/signal.rs
@@ -410,14 +410,14 @@ impl Number {
     /// Returns the raw signal number.
     #[inline(always)]
     #[must_use]
-    pub fn as_raw(self) -> RawNumber {
+    pub const fn as_raw(self) -> RawNumber {
         self.0.get()
     }
 
     /// Returns the raw signal number as a `NonZeroI32`.
     #[inline(always)]
     #[must_use]
-    pub fn as_raw_non_zero(self) -> NonZeroI32 {
+    pub const fn as_raw_non_zero(self) -> NonZeroI32 {
         self.0
     }
 
@@ -435,7 +435,7 @@ impl Number {
     /// methods instead.
     #[inline(always)]
     #[must_use]
-    pub fn from_raw_unchecked(raw: NonZeroI32) -> Self {
+    pub const fn from_raw_unchecked(raw: NonZeroI32) -> Self {
         Self(raw)
     }
 }

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -75,7 +75,7 @@ pub enum Frame {
     DotScript,
 
     /// Trap
-    Trap(crate::trap::Condition),
+    Trap(crate::trap::OldCondition),
     // TODO function
 }
 
@@ -85,8 +85,8 @@ impl From<Builtin> for Frame {
     }
 }
 
-impl From<crate::trap::Condition> for Frame {
-    fn from(condition: crate::trap::Condition) -> Self {
+impl From<crate::trap::OldCondition> for Frame {
+    fn from(condition: crate::trap::OldCondition) -> Self {
         Frame::Trap(condition)
     }
 }

--- a/yash-env/src/stack.rs
+++ b/yash-env/src/stack.rs
@@ -75,7 +75,7 @@ pub enum Frame {
     DotScript,
 
     /// Trap
-    Trap(crate::trap::OldCondition),
+    Trap(crate::trap::Condition),
     // TODO function
 }
 
@@ -85,8 +85,8 @@ impl From<Builtin> for Frame {
     }
 }
 
-impl From<crate::trap::OldCondition> for Frame {
-    fn from(condition: crate::trap::OldCondition) -> Self {
+impl From<crate::trap::Condition> for Frame {
+    fn from(condition: crate::trap::Condition) -> Self {
         Frame::Trap(condition)
     }
 }

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -639,12 +639,12 @@ mod tests {
 
             parent_env
                 .system
-                .kill(child_pid, Some(Signal::SIGINT))
+                .kill(child_pid, Some(SIGINT))
                 .await
                 .unwrap();
             parent_env
                 .system
-                .kill(child_pid, Some(Signal::SIGQUIT))
+                .kill(child_pid, Some(SIGQUIT))
                 .await
                 .unwrap();
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -36,7 +36,7 @@ use crate::system::SigSet;
 use crate::system::SigmaskHow::{SIG_BLOCK, SIG_SETMASK};
 use crate::system::System;
 use crate::system::SystemEx;
-use crate::trap::Signal::{SIGINT, SIGQUIT};
+use crate::trap::Signal;
 use crate::Env;
 use std::future::Future;
 use std::pin::Pin;
@@ -277,8 +277,8 @@ impl<'a> MaskGuard<'a> {
 
         let mut sigint_sigquit = SigSet::empty();
         let mut old_mask = SigSet::empty();
-        sigint_sigquit.add(SIGINT);
-        sigint_sigquit.add(SIGQUIT);
+        sigint_sigquit.add(Signal::SIGINT);
+        sigint_sigquit.add(Signal::SIGQUIT);
 
         let success = self
             .env
@@ -312,6 +312,7 @@ mod tests {
     use crate::semantics::ExitStatus;
     use crate::system::r#virtual::INode;
     use crate::system::r#virtual::SystemState;
+    use crate::system::r#virtual::{SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
     use crate::system::Errno;
     use crate::system::SignalHandling;
     use crate::tests::in_virtual_system;
@@ -319,7 +320,6 @@ mod tests {
     use crate::trap::Signal::SIGCHLD;
     use assert_matches::assert_matches;
     use futures_executor::LocalPool;
-    use nix::sys::signal::Signal::{SIGTSTP, SIGTTIN, SIGTTOU};
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -640,12 +640,12 @@ mod tests {
 
             parent_env
                 .system
-                .kill(child_pid, Some(SIGINT))
+                .kill(child_pid, Some(Signal::SIGINT))
                 .await
                 .unwrap();
             parent_env
                 .system
-                .kill(child_pid, Some(SIGQUIT))
+                .kill(child_pid, Some(Signal::SIGQUIT))
                 .await
                 .unwrap();
 
@@ -654,8 +654,8 @@ mod tests {
 
             let state = state.borrow();
             let parent_process = &state.processes[&parent_env.main_pid];
-            assert!(!parent_process.blocked_signals().contains(SIGINT));
-            assert!(!parent_process.blocked_signals().contains(SIGQUIT));
+            assert!(!parent_process.blocked_signals().contains(Signal::SIGINT));
+            assert!(!parent_process.blocked_signals().contains(Signal::SIGQUIT));
             let child_process = &state.processes[&child_pid];
             assert_eq!(
                 child_process.signal_handling(SIGINT),

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -36,8 +36,8 @@ use crate::system::SigSet;
 use crate::system::SigmaskHow::{SIG_BLOCK, SIG_SETMASK};
 use crate::system::System;
 use crate::system::SystemEx;
-use crate::trap::Signal;
 use crate::Env;
+use nix::sys::signal::Signal;
 use std::future::Future;
 use std::pin::Pin;
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -312,12 +312,11 @@ mod tests {
     use crate::semantics::ExitStatus;
     use crate::system::r#virtual::INode;
     use crate::system::r#virtual::SystemState;
-    use crate::system::r#virtual::{SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
+    use crate::system::r#virtual::{SIGCHLD, SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
     use crate::system::Errno;
     use crate::system::SignalHandling;
     use crate::tests::in_virtual_system;
     use crate::trap::Action;
-    use crate::trap::Signal::SIGCHLD;
     use assert_matches::assert_matches;
     use futures_executor::LocalPool;
     use std::cell::Cell;

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -1093,6 +1093,17 @@ impl System for SharedSystem {
 }
 
 impl SignalSystem for SharedSystem {
+    #[inline]
+    fn signal_name_from_number(&self, number: signal::Number) -> signal::Name {
+        SystemEx::signal_name_from_number(self, number)
+    }
+
+    #[inline]
+    fn signal_number_from_name(&self, name: signal::Name) -> signal::Number {
+        System::signal_number_from_name(self, name)
+            .unwrap_or_else(|| panic!("unsupported signal name: {name:?}"))
+    }
+
     fn set_signal_handling(
         &mut self,
         signal: nix::sys::signal::Signal,

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -292,7 +292,8 @@ pub trait System: Debug {
 
     /// Sends a signal.
     ///
-    /// This is a thin wrapper around the `kill` system call.
+    /// This is a thin wrapper around the `kill` system call. If `signal` is
+    /// `None`, permission to send a signal is checked, but no signal is sent.
     ///
     /// The virtual system version of this function blocks the calling thread if
     /// the signal stops or terminates the current process, hence returning a
@@ -300,7 +301,7 @@ pub trait System: Debug {
     fn kill(
         &mut self,
         target: Pid,
-        signal: Option<Signal>,
+        signal: Option<signal::Number>,
     ) -> Pin<Box<dyn Future<Output = Result<()>>>>;
 
     /// Waits for a next event.
@@ -1029,7 +1030,7 @@ impl System for SharedSystem {
     fn kill(
         &mut self,
         target: Pid,
-        signal: Option<Signal>,
+        signal: Option<signal::Number>,
     ) -> Pin<Box<(dyn Future<Output = Result<()>>)>> {
         self.0.borrow_mut().kill(target, signal)
     }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -227,6 +227,9 @@ pub trait System: Debug {
     fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)>;
 
     /// Gets the signal number from the signal name.
+    ///
+    /// This function returns the signal number corresponding to the signal name
+    /// in the system. If the signal name is not supported, it returns `None`.
     #[must_use]
     fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number>;
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -40,7 +40,6 @@ use crate::semantics::ExitStatus;
 use crate::signal;
 #[cfg(doc)]
 use crate::subshell::Subshell;
-use crate::trap::Signal;
 use crate::trap::SignalSystem;
 use crate::Env;
 use futures_util::future::poll_fn;
@@ -55,6 +54,7 @@ pub use nix::fcntl::OFlag;
 pub use nix::sys::signal::SigSet;
 #[doc(no_inline)]
 pub use nix::sys::signal::SigmaskHow;
+use nix::sys::signal::Signal;
 #[doc(no_inline)]
 pub use nix::sys::stat::{FileStat, Mode, SFlag};
 #[doc(no_inline)]

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -1115,9 +1115,8 @@ impl SignalSystem for SharedSystem {
     }
 
     #[inline]
-    fn signal_number_from_name(&self, name: signal::Name) -> signal::Number {
+    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
         System::signal_number_from_name(self, name)
-            .unwrap_or_else(|| panic!("unsupported signal name: {name:?}"))
     }
 
     fn set_signal_handling(

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -1494,9 +1494,10 @@ impl AsyncSignal {
 
 #[cfg(test)]
 mod tests {
+    use super::r#virtual::VirtualSystem;
+    use super::r#virtual::PIPE_SIZE;
+    use super::r#virtual::{SIGCHLD, SIGINT, SIGTERM};
     use super::*;
-    use crate::system::r#virtual::VirtualSystem;
-    use crate::system::r#virtual::PIPE_SIZE;
     use assert_matches::assert_matches;
     use futures_util::task::noop_waker;
     use futures_util::task::noop_waker_ref;
@@ -1692,8 +1693,8 @@ mod tests {
             assert!(process.blocked_signals().contains(Signal::SIGCHLD));
             assert!(process.blocked_signals().contains(Signal::SIGINT));
             assert!(process.blocked_signals().contains(Signal::SIGUSR1));
-            let _ = process.raise_signal(Signal::SIGCHLD);
-            let _ = process.raise_signal(Signal::SIGINT);
+            let _ = process.raise_signal(SIGCHLD);
+            let _ = process.raise_signal(SIGINT);
         }
         let result = future.as_mut().poll(&mut context);
         assert_eq!(result, Poll::Pending);
@@ -1726,7 +1727,7 @@ mod tests {
             let mut state = state.borrow_mut();
             let process = state.processes.get_mut(&process_id).unwrap();
             assert!(process.blocked_signals().contains(Signal::SIGCHLD));
-            let _ = process.raise_signal(Signal::SIGCHLD);
+            let _ = process.raise_signal(SIGCHLD);
         }
         let result = future.as_mut().poll(&mut context);
         assert_eq!(result, Poll::Pending);
@@ -1757,8 +1758,8 @@ mod tests {
         {
             let mut state = state.borrow_mut();
             let process = state.processes.get_mut(&process_id).unwrap();
-            let _ = process.raise_signal(Signal::SIGCHLD);
-            let _ = process.raise_signal(Signal::SIGTERM);
+            let _ = process.raise_signal(SIGCHLD);
+            let _ = process.raise_signal(SIGTERM);
         }
         system.select(false).unwrap();
 
@@ -1782,8 +1783,8 @@ mod tests {
         {
             let mut state = state.borrow_mut();
             let process = state.processes.get_mut(&process_id).unwrap();
-            let _ = process.raise_signal(Signal::SIGINT);
-            let _ = process.raise_signal(Signal::SIGTERM);
+            let _ = process.raise_signal(SIGINT);
+            let _ = process.raise_signal(SIGTERM);
         }
         system.select(false).unwrap();
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -350,13 +350,13 @@ impl System for RealSystem {
 
     fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
         let non_zero = NonZeroI32::new(number)?;
-        let name = signal::Name::try_from_raw(number)?;
+        let name = signal::Name::try_from_raw_real(number)?;
         Some((name, signal::Number::from_raw_unchecked(non_zero)))
     }
 
     #[inline(always)]
     fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
-        name.to_raw()
+        name.to_raw_real()
     }
 
     fn sigmask(

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -16,9 +16,10 @@
 
 //! Implementation of `System` that actually interacts with the system.
 
+mod signal;
+
 use super::resource::LimitPair;
 use super::resource::Resource;
-use super::signal;
 use super::AtFlags;
 use super::ChildProcessStarter;
 use super::Dir;
@@ -351,8 +352,9 @@ impl System for RealSystem {
         todo!()
     }
 
-    fn signal_number_from_name(&self, _name: signal::Name) -> Option<signal::Number> {
-        todo!()
+    #[inline(always)]
+    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
+        name.to_raw()
     }
 
     fn sigmask(

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -413,10 +413,11 @@ impl System for RealSystem {
     fn kill(
         &mut self,
         target: Pid,
-        signal: Option<Signal>,
+        signal: Option<signal::Number>,
     ) -> Pin<Box<(dyn Future<Output = Result<()>>)>> {
         Box::pin(async move {
-            nix::sys::signal::kill(target.into(), signal)?;
+            let raw = signal.map_or(0, signal::Number::as_raw);
+            unsafe { nix::libc::kill(target.0, raw) }.errno_if_m1()?;
             Ok(())
         })
     }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -18,6 +18,7 @@
 
 use super::resource::LimitPair;
 use super::resource::Resource;
+use super::signal;
 use super::AtFlags;
 use super::ChildProcessStarter;
 use super::Dir;
@@ -343,6 +344,15 @@ impl System for RealSystem {
             children_user: tms.tms_cutime as f64 / ticks_per_second as f64,
             children_system: tms.tms_cstime as f64 / ticks_per_second as f64,
         })
+    }
+
+    fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
+        let _ = number;
+        todo!()
+    }
+
+    fn signal_number_from_name(&self, _name: signal::Name) -> Option<signal::Number> {
+        todo!()
     }
 
     fn sigmask(

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -61,6 +61,7 @@ use std::ffi::OsString;
 use std::future::Future;
 use std::io::SeekFrom;
 use std::mem::MaybeUninit;
+use std::num::NonZeroI32;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::ffi::OsStringExt as _;
 use std::os::unix::io::IntoRawFd;
@@ -348,8 +349,9 @@ impl System for RealSystem {
     }
 
     fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
-        let _ = number;
-        todo!()
+        let non_zero = NonZeroI32::new(number)?;
+        let name = signal::Name::try_from_raw(number)?;
+        Some((name, signal::Number::from_raw_unchecked(non_zero)))
     }
 
     #[inline(always)]

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -46,7 +46,7 @@ fn rt_range() -> RangeInclusive<RawNumber> {
 
 impl Name {
     /// Returns the raw signal number for the real system.
-    pub(super) fn to_raw(self) -> Option<Number> {
+    pub(super) fn to_raw_real(self) -> Option<Number> {
         #[inline]
         fn wrap(number: RawNumber) -> Option<Number> {
             NonZeroI32::new(number).map(Number::from_raw_unchecked)
@@ -261,7 +261,7 @@ impl Name {
     /// Returns the signal for the raw signal number for the real system.
     ///
     /// This function returns `None` if the given number is not a valid signal.
-    pub(super) fn try_from_raw(number: RawNumber) -> Option<Self> {
+    pub(super) fn try_from_raw_real(number: RawNumber) -> Option<Self> {
         // Some signals share the same number on some systems. This function
         // returns the signal that is considered the most common or standard one.
         #[allow(unreachable_patterns)]

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -1,0 +1,260 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Signal implementation for the real system
+
+pub use crate::signal::*;
+use std::num::NonZeroI32;
+use std::ops::RangeInclusive;
+
+/// Returns the range of real-time signals supported by the real system.
+///
+/// If the real system does not support real-time signals, this function returns
+/// an empty range.
+#[must_use]
+fn rt_range() -> RangeInclusive<RawNumber> {
+    #[cfg(target_os = "aix")]
+    return nix::libc::SIGRTMIN..=nix::libc::SIGRTMAX;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "l4re",
+        target_os = "linux",
+    ))]
+    return nix::libc::SIGRTMIN()..=nix::libc::SIGRTMAX();
+
+    #[allow(unreachable_code)]
+    {
+        #[allow(clippy::reversed_empty_ranges)]
+        return 0..=-1;
+    }
+}
+
+impl Name {
+    /// Returns the raw signal number for the real system.
+    pub(super) fn to_raw(self) -> Option<Number> {
+        #[inline]
+        fn wrap(number: RawNumber) -> Option<Number> {
+            NonZeroI32::new(number).map(Number::from_raw_unchecked)
+        }
+
+        match self {
+            Self::Abrt => wrap(nix::libc::SIGABRT),
+            Self::Alrm => wrap(nix::libc::SIGALRM),
+            Self::Bus => wrap(nix::libc::SIGBUS),
+            Self::Chld => wrap(nix::libc::SIGCHLD),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "solaris",
+            ))]
+            Self::Cld => wrap(nix::libc::SIGCLD),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "solaris",
+            )))]
+            Self::Cld => None,
+            Self::Cont => wrap(nix::libc::SIGCONT),
+            #[cfg(not(any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            Self::Emt => wrap(nix::libc::SIGEMT),
+            #[cfg(any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            ))]
+            Self::Emt => None,
+            Self::Fpe => wrap(nix::libc::SIGFPE),
+            Self::Hup => wrap(nix::libc::SIGHUP),
+            Self::Ill => wrap(nix::libc::SIGILL),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            )))]
+            Self::Info => wrap(nix::libc::SIGINFO),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "linux",
+                target_os = "redox",
+            ))]
+            Self::Info => None,
+            Self::Int => wrap(nix::libc::SIGINT),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            Self::Io => wrap(nix::libc::SIGIO),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            )))]
+            Self::Io => None,
+            Self::Iot => wrap(nix::libc::SIGIOT),
+            Self::Kill => wrap(nix::libc::SIGKILL),
+            #[cfg(target_os = "horizon")]
+            Self::Lost => wrap(nix::libc::SIGLOST),
+            #[cfg(not(target_os = "horizon"))]
+            Self::Lost => None,
+            Self::Pipe => wrap(nix::libc::SIGPIPE),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            ))]
+            Self::Poll => wrap(nix::libc::SIGPOLL),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "solaris",
+            )))]
+            Self::Poll => None,
+            Self::Prof => wrap(nix::libc::SIGPROF),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "redox",
+                target_os = "solaris",
+            ))]
+            Self::Pwr => wrap(nix::libc::SIGPWR),
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "nto",
+                target_os = "redox",
+                target_os = "solaris",
+            )))]
+            Self::Pwr => None,
+            Self::Quit => wrap(nix::libc::SIGQUIT),
+            Self::Segv => wrap(nix::libc::SIGSEGV),
+            #[cfg(all(
+                any(
+                    target_os = "android",
+                    target_os = "emscripten",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                ),
+                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+            ))]
+            Self::Stkflt => wrap(nix::libc::SIGSTKFLT),
+            #[cfg(not(all(
+                any(
+                    target_os = "android",
+                    target_os = "emscripten",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                ),
+                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+            )))]
+            Self::Stkflt => None,
+            Self::Stop => wrap(nix::libc::SIGSTOP),
+            Self::Sys => wrap(nix::libc::SIGSYS),
+            Self::Term => wrap(nix::libc::SIGTERM),
+            #[cfg(target_os = "freebsd")]
+            Self::Thr => wrap(nix::libc::SIGTHR),
+            #[cfg(not(target_os = "freebsd"))]
+            Self::Thr => None,
+            Self::Trap => wrap(nix::libc::SIGTRAP),
+            Self::Tstp => wrap(nix::libc::SIGTSTP),
+            Self::Ttin => wrap(nix::libc::SIGTTIN),
+            Self::Ttou => wrap(nix::libc::SIGTTOU),
+            Self::Urg => wrap(nix::libc::SIGURG),
+            Self::Usr1 => wrap(nix::libc::SIGUSR1),
+            Self::Usr2 => wrap(nix::libc::SIGUSR2),
+            Self::Vtalrm => wrap(nix::libc::SIGVTALRM),
+            Self::Winch => wrap(nix::libc::SIGWINCH),
+            Self::Xcpu => wrap(nix::libc::SIGXCPU),
+            Self::Xfsz => wrap(nix::libc::SIGXFSZ),
+
+            Self::Rtmin(n) => {
+                let range = rt_range();
+                if let Some(number) = range.start().checked_add(n) {
+                    if range.contains(&number) {
+                        return wrap(number);
+                    }
+                }
+                None
+            }
+            Self::Rtmax(n) => {
+                let range = rt_range();
+                if let Some(number) = range.end().checked_add(n) {
+                    if range.contains(&number) {
+                        return wrap(number);
+                    }
+                }
+                None
+            }
+        }
+    }
+}

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -632,6 +632,15 @@ impl System for VirtualSystem {
         Ok(self.state.borrow().times)
     }
 
+    fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
+        let _ = number;
+        todo!()
+    }
+
+    fn signal_number_from_name(&self, _name: signal::Name) -> Option<signal::Number> {
+        todo!()
+    }
+
     fn sigmask(
         &mut self,
         how: SigmaskHow,

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -671,10 +671,13 @@ impl System for VirtualSystem {
         Ok(())
     }
 
-    fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> Result<SignalHandling> {
+    fn sigaction(
+        &mut self,
+        signal: signal::Number,
+        action: SignalHandling,
+    ) -> Result<SignalHandling> {
         let mut process = self.current_process_mut();
-        let number = signal::Number::from_signal_virtual(signal);
-        Ok(process.set_signal_handling(number, action))
+        Ok(process.set_signal_handling(signal, action))
     }
 
     fn caught_signals(&mut self) -> Vec<Signal> {
@@ -2126,9 +2129,7 @@ mod tests {
         system
             .sigmask(SigmaskHow::SIG_BLOCK, Some(&set), None)
             .unwrap();
-        system
-            .sigaction(Signal::SIGCHLD, SignalHandling::Catch)
-            .unwrap();
+        system.sigaction(SIGCHLD, SignalHandling::Catch).unwrap();
         system
     }
 
@@ -2557,9 +2558,7 @@ mod tests {
     #[test]
     fn exiting_child_sends_sigchld_to_parent() {
         let (mut system, mut executor) = virtual_system_with_executor();
-        system
-            .sigaction(Signal::SIGCHLD, SignalHandling::Catch)
-            .unwrap();
+        system.sigaction(SIGCHLD, SignalHandling::Catch).unwrap();
 
         let child_process = system.new_child_process().unwrap();
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1847,7 +1847,7 @@ mod tests {
         assert_eq!(
             system.current_process().state(),
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGINT,
+                signal: SIGINT,
                 core_dump: false
             })
         );
@@ -1890,7 +1890,7 @@ mod tests {
             assert_eq!(
                 process.state,
                 ProcessState::Halted(ProcessResult::Signaled {
-                    signal: Signal::SIGTERM,
+                    signal: SIGTERM,
                     core_dump: false
                 })
             );
@@ -1924,21 +1924,21 @@ mod tests {
         assert_eq!(
             state.processes[&system.process_id].state,
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGQUIT,
+                signal: SIGQUIT,
                 core_dump: true
             })
         );
         assert_eq!(
             state.processes[&Pid(10)].state,
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGQUIT,
+                signal: SIGQUIT,
                 core_dump: true
             })
         );
         assert_eq!(
             state.processes[&Pid(11)].state,
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGQUIT,
+                signal: SIGQUIT,
                 core_dump: true
             })
         );
@@ -1977,14 +1977,14 @@ mod tests {
         assert_eq!(
             state.processes[&Pid(11)].state,
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGHUP,
+                signal: SIGHUP,
                 core_dump: false
             })
         );
         assert_eq!(
             state.processes[&Pid(21)].state,
             ProcessState::Halted(ProcessResult::Signaled {
-                signal: Signal::SIGHUP,
+                signal: SIGHUP,
                 core_dump: false
             })
         );
@@ -2472,7 +2472,7 @@ mod tests {
             Ok(Some((
                 pid,
                 ProcessState::Halted(ProcessResult::Signaled {
-                    signal: Signal::SIGKILL,
+                    signal: SIGKILL,
                     core_dump: false
                 })
             )))
@@ -2501,10 +2501,7 @@ mod tests {
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
-        assert_eq!(
-            result,
-            Ok(Some((pid, ProcessState::stopped(Signal::SIGSTOP))))
-        );
+        assert_eq!(result, Ok(Some((pid, ProcessState::stopped(SIGSTOP)))));
     }
 
     #[test]

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -67,7 +67,6 @@ use super::OFlag;
 use super::Result;
 use super::SigSet;
 use super::SigmaskHow;
-use super::Signal;
 use super::TimeSpec;
 use super::Times;
 use super::AT_FDCWD;
@@ -680,11 +679,8 @@ impl System for VirtualSystem {
         Ok(process.set_signal_handling(signal, action))
     }
 
-    fn caught_signals(&mut self) -> Vec<Signal> {
+    fn caught_signals(&mut self) -> Vec<signal::Number> {
         std::mem::take(&mut self.current_process_mut().caught_signals)
-            .into_iter()
-            .filter_map(signal::Number::to_signal_virtual)
-            .collect()
     }
 
     /// Sends a signal to the target process.
@@ -1276,6 +1272,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures_executor::LocalPool;
     use futures_util::FutureExt;
+    use nix::sys::signal::Signal;
     use std::ffi::CString;
     use std::ffi::OsString;
     use std::future::pending;
@@ -2157,7 +2154,7 @@ mod tests {
             Some(&SigSet::empty()),
         );
         assert_eq!(result, Err(Errno::EINTR));
-        assert_eq!(system.caught_signals(), [Signal::SIGCHLD]);
+        assert_eq!(system.caught_signals(), [SIGCHLD]);
     }
 
     #[test]
@@ -2567,7 +2564,7 @@ mod tests {
         executor.run_until(future);
         executor.run_until_stalled();
 
-        assert_eq!(env.system.caught_signals(), [Signal::SIGCHLD]);
+        assert_eq!(env.system.caught_signals(), [SIGCHLD]);
     }
 
     #[test]

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -673,7 +673,8 @@ impl System for VirtualSystem {
 
     fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> Result<SignalHandling> {
         let mut process = self.current_process_mut();
-        Ok(process.set_signal_handling(signal, action))
+        let number = signal.try_into()?;
+        Ok(process.set_signal_handling(number, action))
     }
 
     fn caught_signals(&mut self) -> Vec<Signal> {

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -673,12 +673,15 @@ impl System for VirtualSystem {
 
     fn sigaction(&mut self, signal: Signal, action: SignalHandling) -> Result<SignalHandling> {
         let mut process = self.current_process_mut();
-        let number = signal.try_into()?;
+        let number = signal::Number::from_signal_virtual(signal);
         Ok(process.set_signal_handling(number, action))
     }
 
     fn caught_signals(&mut self) -> Vec<Signal> {
         std::mem::take(&mut self.current_process_mut().caught_signals)
+            .into_iter()
+            .filter_map(signal::Number::to_signal_virtual)
+            .collect()
     }
 
     /// Sends a signal to the target process.

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -98,6 +98,7 @@ use std::future::poll_fn;
 use std::future::Future;
 use std::io::SeekFrom;
 use std::mem::MaybeUninit;
+use std::num::NonZeroI32;
 use std::ops::DerefMut as _;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
@@ -633,12 +634,14 @@ impl System for VirtualSystem {
     }
 
     fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
-        let _ = number;
-        todo!()
+        let non_zero = NonZeroI32::new(number)?;
+        let name = signal::Name::try_from_raw_virtual(number)?;
+        Some((name, signal::Number::from_raw_unchecked(non_zero)))
     }
 
-    fn signal_number_from_name(&self, _name: signal::Name) -> Option<signal::Number> {
-        todo!()
+    #[inline(always)]
+    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
+        name.to_raw_virtual()
     }
 
     fn sigmask(

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -371,7 +371,7 @@ impl Process {
         for signal in Signal::iterator() {
             if self.pending_signals.contains(signal) && !self.blocked_signals.contains(signal) {
                 self.pending_signals.remove(signal);
-                result |= self.deliver_signal(signal);
+                result |= self.deliver_signal(signal::Number::from_signal_virtual(signal));
             }
         }
         result
@@ -408,8 +408,8 @@ impl Process {
     /// that case, the caller must send a SIGCHLD to the parent process of this
     /// process.
     #[must_use = "send SIGCHLD if process state has changed"]
-    fn deliver_signal(&mut self, signal: Signal) -> SignalResult {
-        let number = signal::Number::from_signal_virtual(signal);
+    fn deliver_signal(&mut self, number: signal::Number) -> SignalResult {
+        let signal = number.to_signal_virtual().unwrap_or(Signal::SIGSYS);
         let handling = if signal == Signal::SIGKILL || signal == Signal::SIGSTOP {
             SignalHandling::Default
         } else {
@@ -469,7 +469,7 @@ impl Process {
             self.pending_signals.add(signal);
             SignalResult::default()
         } else {
-            self.deliver_signal(signal)
+            self.deliver_signal(signal::Number::from_signal_virtual(signal))
         };
 
         result.process_state_changed |= process_state_changed;

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -394,3 +394,16 @@ impl Name {
         }
     }
 }
+
+// TODO Remove this
+/// Temporary implementation of conversion
+impl TryFrom<Signal> for Number {
+    type Error = UnknownNameError;
+    fn try_from(signal: Signal) -> Result<Self, Self::Error> {
+        use crate::system::System as _;
+        unsafe { crate::RealSystem::new() }
+            .validate_signal(signal as RawNumber)
+            .and_then(|(name, _real_number)| name.to_raw_virtual())
+            .ok_or(UnknownNameError)
+    }
+}

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -16,8 +16,9 @@
 
 //! Functions about signals
 
-use super::super::Signal::{self, *};
-pub use crate::signal::*;
+use super::super::Signal;
+pub(super) use crate::signal::*;
+use std::num::NonZeroI32;
 
 /// Default effect of a signal delivered to a process.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -37,40 +38,359 @@ impl SignalEffect {
     #[must_use]
     pub fn of(signal: Signal) -> Self {
         match signal {
-            SIGHUP => Self::Terminate { core_dump: false },
-            SIGINT => Self::Terminate { core_dump: false },
-            SIGQUIT => Self::Terminate { core_dump: true },
-            SIGILL => Self::Terminate { core_dump: true },
-            SIGTRAP => Self::Terminate { core_dump: true },
-            SIGABRT => Self::Terminate { core_dump: true },
-            SIGBUS => Self::Terminate { core_dump: true },
-            // SIGEMT => Self::Terminate { core_dump: false },
-            SIGFPE => Self::Terminate { core_dump: true },
-            SIGKILL => Self::Terminate { core_dump: false },
-            SIGUSR1 => Self::Terminate { core_dump: false },
-            SIGSEGV => Self::Terminate { core_dump: true },
-            SIGUSR2 => Self::Terminate { core_dump: false },
-            SIGPIPE => Self::Terminate { core_dump: false },
-            SIGALRM => Self::Terminate { core_dump: false },
-            SIGTERM => Self::Terminate { core_dump: false },
-            // SIGSTKFLT => Self::Terminate { core_dump: false },
-            SIGCHLD => Self::None,
-            SIGCONT => Self::Resume,
-            SIGSTOP => Self::Suspend,
-            SIGTSTP => Self::Suspend,
-            SIGTTIN => Self::Suspend,
-            SIGTTOU => Self::Suspend,
-            SIGURG => Self::None,
-            SIGXCPU => Self::Terminate { core_dump: true },
-            SIGXFSZ => Self::Terminate { core_dump: true },
-            SIGVTALRM => Self::Terminate { core_dump: false },
-            SIGPROF => Self::Terminate { core_dump: false },
-            SIGWINCH => Self::None,
-            SIGIO => Self::Terminate { core_dump: false },
-            // SIGPWR => Self::Terminate { core_dump: false },
-            // SIGINFO => Self::Terminate { core_dump: false },
-            SIGSYS => Self::Terminate { core_dump: true },
+            Signal::SIGHUP => Self::Terminate { core_dump: false },
+            Signal::SIGINT => Self::Terminate { core_dump: false },
+            Signal::SIGQUIT => Self::Terminate { core_dump: true },
+            Signal::SIGILL => Self::Terminate { core_dump: true },
+            Signal::SIGTRAP => Self::Terminate { core_dump: true },
+            Signal::SIGABRT => Self::Terminate { core_dump: true },
+            Signal::SIGBUS => Self::Terminate { core_dump: true },
+            // Signal::SIGEMT => Self::Terminate { core_dump: false },
+            Signal::SIGFPE => Self::Terminate { core_dump: true },
+            Signal::SIGKILL => Self::Terminate { core_dump: false },
+            Signal::SIGUSR1 => Self::Terminate { core_dump: false },
+            Signal::SIGSEGV => Self::Terminate { core_dump: true },
+            Signal::SIGUSR2 => Self::Terminate { core_dump: false },
+            Signal::SIGPIPE => Self::Terminate { core_dump: false },
+            Signal::SIGALRM => Self::Terminate { core_dump: false },
+            Signal::SIGTERM => Self::Terminate { core_dump: false },
+            // Signal::SIGSTKFLT => Self::Terminate { core_dump: false },
+            Signal::SIGCHLD => Self::None,
+            Signal::SIGCONT => Self::Resume,
+            Signal::SIGSTOP => Self::Suspend,
+            Signal::SIGTSTP => Self::Suspend,
+            Signal::SIGTTIN => Self::Suspend,
+            Signal::SIGTTOU => Self::Suspend,
+            Signal::SIGURG => Self::None,
+            Signal::SIGXCPU => Self::Terminate { core_dump: true },
+            Signal::SIGXFSZ => Self::Terminate { core_dump: true },
+            Signal::SIGVTALRM => Self::Terminate { core_dump: false },
+            Signal::SIGPROF => Self::Terminate { core_dump: false },
+            Signal::SIGWINCH => Self::None,
+            Signal::SIGIO => Self::Terminate { core_dump: false },
+            // Signal::SIGPWR => Self::Terminate { core_dump: false },
+            // Signal::SIGINFO => Self::Terminate { core_dump: false },
+            Signal::SIGSYS => Self::Terminate { core_dump: true },
             _ => Self::Terminate { core_dump: false },
+        }
+    }
+}
+
+/// Signal number for `SIGABRT` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGABRT` is 6.
+pub const SIGABRT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(6) });
+
+/// Signal number for `SIGALRM` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGALRM` is 14.
+pub const SIGALRM: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(14) });
+
+/// Signal number for `SIGBUS` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGBUS: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(101) });
+
+/// Signal number for `SIGCHLD` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGCHLD: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(102) });
+
+/// Signal number for `SIGCLD` in the virtual system
+///
+/// Currently, this is the same as `SIGCHLD`.
+pub const SIGCLD: Number = SIGCHLD;
+
+/// Signal number for `SIGCONT` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGCONT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(103) });
+
+/// Signal number for `SIGEMT` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGEMT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(104) });
+
+/// Signal number for `SIGFPE` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGFPE: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(105) });
+
+/// Signal number for `SIGHUP` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGHUP` is 1.
+pub const SIGHUP: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(1) });
+
+/// Signal number for `SIGILL` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGILL: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(106) });
+
+/// Signal number for `SIGINFO` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGINFO: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(107) });
+
+/// Signal number for `SIGINT` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGINT` is 2.
+pub const SIGINT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(2) });
+
+/// Signal number for `SIGIO` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGIO: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(108) });
+
+/// Signal number for `SIGIOT` in the virtual system
+///
+/// Currently, this is the same as `SIGABRT`.
+pub const SIGIOT: Number = SIGABRT;
+
+/// Signal number for `SIGKILL` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGKILL` is 9.
+pub const SIGKILL: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(9) });
+
+/// Signal number for `SIGLOST` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGLOST: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(109) });
+
+/// Signal number for `SIGPIPE` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGPIPE: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(110) });
+
+/// Signal number for `SIGPOLL` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGPOLL: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(111) });
+
+/// Signal number for `SIGPROF` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGPROF: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(112) });
+
+/// Signal number for `SIGPWR` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGPWR: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(113) });
+
+/// Signal number for `SIGQUIT` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGQUIT` is 3.
+pub const SIGQUIT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(3) });
+
+/// Signal number for `SIGSEGV` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGSEGV: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(114) });
+
+/// Signal number for `SIGSTKFLT` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGSTKFLT: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(115) });
+
+/// Signal number for `SIGSTOP` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGSTOP: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(116) });
+
+/// Signal number for `SIGSYS` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGSYS: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(117) });
+
+/// Signal number for `SIGTERM` in the virtual system
+///
+/// POSIX effectively requires that the signal number for `SIGTERM` is 15.
+pub const SIGTERM: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(15) });
+
+/// Signal number for `SIGTHR` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGTHR: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(118) });
+
+/// Signal number for `SIGTRAP` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGTRAP: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(119) });
+
+/// Signal number for `SIGTSTP` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGTSTP: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(120) });
+
+/// Signal number for `SIGTTIN` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGTTIN: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(121) });
+
+/// Signal number for `SIGTTOU` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGTTOU: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(122) });
+
+/// Signal number for `SIGURG` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGURG: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(123) });
+
+/// Signal number for `SIGUSR1` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGUSR1: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(124) });
+
+/// Signal number for `SIGUSR2` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGUSR2: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(125) });
+
+/// Signal number for `SIGVTALRM` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGVTALRM: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(126) });
+
+/// Signal number for `SIGWINCH` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGWINCH: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(127) });
+
+/// Signal number for `SIGXCPU` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGXCPU: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(128) });
+
+/// Signal number for `SIGXFSZ` in the virtual system
+///
+/// Note that this is not the same as the signal number in the real system.
+pub const SIGXFSZ: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(129) });
+
+/// Signal number for `SIGRTMIN` in the virtual system
+///
+/// The current implementation supports nine real-time signals (201 through 209).
+pub const SIGRTMIN: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(201) });
+
+/// Signal number for `SIGRTMAX` in the virtual system
+///
+/// The current implementation supports nine real-time signals (201 through 209).
+pub const SIGRTMAX: Number = Number::from_raw_unchecked(unsafe { NonZeroI32::new_unchecked(209) });
+
+/// Range of the real-time signals supported by the virtual system.
+const RT_RANGE: std::ops::RangeInclusive<RawNumber> = SIGRTMIN.as_raw()..=SIGRTMAX.as_raw();
+
+impl Name {
+    pub(super) fn to_raw_virtual(self) -> Option<Number> {
+        fn rt(base: Number, n: RawNumber) -> Option<Number> {
+            let number = base.as_raw().checked_add(n)?;
+            let non_zero = NonZeroI32::new(number)?;
+            RT_RANGE
+                .contains(&number)
+                .then(|| Number::from_raw_unchecked(non_zero))
+        }
+
+        match self {
+            Self::Abrt => Some(SIGABRT),
+            Self::Alrm => Some(SIGALRM),
+            Self::Bus => Some(SIGBUS),
+            Self::Chld => Some(SIGCHLD),
+            Self::Cld => Some(SIGCLD),
+            Self::Cont => Some(SIGCONT),
+            Self::Emt => Some(SIGEMT),
+            Self::Fpe => Some(SIGFPE),
+            Self::Hup => Some(SIGHUP),
+            Self::Ill => Some(SIGILL),
+            Self::Info => Some(SIGINFO),
+            Self::Int => Some(SIGINT),
+            Self::Io => Some(SIGIO),
+            Self::Iot => Some(SIGIOT),
+            Self::Kill => Some(SIGKILL),
+            Self::Lost => Some(SIGLOST),
+            Self::Pipe => Some(SIGPIPE),
+            Self::Poll => Some(SIGPOLL),
+            Self::Prof => Some(SIGPROF),
+            Self::Pwr => Some(SIGPWR),
+            Self::Quit => Some(SIGQUIT),
+            Self::Segv => Some(SIGSEGV),
+            Self::Stkflt => Some(SIGSTKFLT),
+            Self::Stop => Some(SIGSTOP),
+            Self::Sys => Some(SIGSYS),
+            Self::Term => Some(SIGTERM),
+            Self::Thr => Some(SIGTHR),
+            Self::Trap => Some(SIGTRAP),
+            Self::Tstp => Some(SIGTSTP),
+            Self::Ttin => Some(SIGTTIN),
+            Self::Ttou => Some(SIGTTOU),
+            Self::Urg => Some(SIGURG),
+            Self::Usr1 => Some(SIGUSR1),
+            Self::Usr2 => Some(SIGUSR2),
+            Self::Vtalrm => Some(SIGVTALRM),
+            Self::Winch => Some(SIGWINCH),
+            Self::Xcpu => Some(SIGXCPU),
+            Self::Xfsz => Some(SIGXFSZ),
+            Self::Rtmin(n) => rt(SIGRTMIN, n),
+            Self::Rtmax(n) => rt(SIGRTMAX, n),
+        }
+    }
+
+    /// Returns the name for the raw signal number for the virtual system.
+    ///
+    /// This function returns `None` if the given number is not a valid signal.
+    pub(super) fn try_from_raw_virtual(number: RawNumber) -> Option<Self> {
+        match () {
+            () if number == SIGABRT.as_raw() => Some(Self::Abrt),
+            () if number == SIGALRM.as_raw() => Some(Self::Alrm),
+            () if number == SIGBUS.as_raw() => Some(Self::Bus),
+            () if number == SIGCHLD.as_raw() => Some(Self::Chld),
+            () if number == SIGCLD.as_raw() => Some(Self::Cld),
+            () if number == SIGCONT.as_raw() => Some(Self::Cont),
+            () if number == SIGEMT.as_raw() => Some(Self::Emt),
+            () if number == SIGFPE.as_raw() => Some(Self::Fpe),
+            () if number == SIGHUP.as_raw() => Some(Self::Hup),
+            () if number == SIGILL.as_raw() => Some(Self::Ill),
+            () if number == SIGINFO.as_raw() => Some(Self::Info),
+            () if number == SIGINT.as_raw() => Some(Self::Int),
+            () if number == SIGIO.as_raw() => Some(Self::Io),
+            () if number == SIGIOT.as_raw() => Some(Self::Iot),
+            () if number == SIGKILL.as_raw() => Some(Self::Kill),
+            () if number == SIGLOST.as_raw() => Some(Self::Lost),
+            () if number == SIGPIPE.as_raw() => Some(Self::Pipe),
+            () if number == SIGPOLL.as_raw() => Some(Self::Poll),
+            () if number == SIGPROF.as_raw() => Some(Self::Prof),
+            () if number == SIGPWR.as_raw() => Some(Self::Pwr),
+            () if number == SIGQUIT.as_raw() => Some(Self::Quit),
+            () if number == SIGSEGV.as_raw() => Some(Self::Segv),
+            () if number == SIGSTKFLT.as_raw() => Some(Self::Stkflt),
+            () if number == SIGSTOP.as_raw() => Some(Self::Stop),
+            () if number == SIGSYS.as_raw() => Some(Self::Sys),
+            () if number == SIGTERM.as_raw() => Some(Self::Term),
+            () if number == SIGTHR.as_raw() => Some(Self::Thr),
+            () if number == SIGTRAP.as_raw() => Some(Self::Trap),
+            () if number == SIGTSTP.as_raw() => Some(Self::Tstp),
+            () if number == SIGTTIN.as_raw() => Some(Self::Ttin),
+            () if number == SIGTTOU.as_raw() => Some(Self::Ttou),
+            () if number == SIGURG.as_raw() => Some(Self::Urg),
+            () if number == SIGUSR1.as_raw() => Some(Self::Usr1),
+            () if number == SIGUSR2.as_raw() => Some(Self::Usr2),
+            () if number == SIGVTALRM.as_raw() => Some(Self::Vtalrm),
+            () if number == SIGWINCH.as_raw() => Some(Self::Winch),
+            () if number == SIGXCPU.as_raw() => Some(Self::Xcpu),
+            () if number == SIGXFSZ.as_raw() => Some(Self::Xfsz),
+            () if RT_RANGE.contains(&number) => {
+                // Return a name relative to `Rtmin` or `Rtmax`,
+                // whichever is closer to the given number.
+                let incr = number - SIGRTMIN.as_raw();
+                debug_assert!(incr >= 0);
+                let decr = number - SIGRTMAX.as_raw();
+                debug_assert!(decr <= 0);
+                debug_assert!(decr > RawNumber::MIN);
+                if incr <= -decr {
+                    Some(Self::Rtmin(incr))
+                } else {
+                    Some(Self::Rtmax(decr))
+                }
+            }
+            _ => None,
         }
     }
 }

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -17,6 +17,7 @@
 //! Functions about signals
 
 use super::super::Signal::{self, *};
+pub use crate::signal::*;
 
 /// Default effect of a signal delivered to a process.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -396,14 +396,23 @@ impl Name {
 }
 
 // TODO Remove this
-/// Temporary implementation of conversion
-impl TryFrom<Signal> for Number {
-    type Error = UnknownNameError;
-    fn try_from(signal: Signal) -> Result<Self, Self::Error> {
+impl Number {
+    /// Converts a signal number in the real system to a signal number in the virtual system.
+    pub(super) fn from_signal_virtual(signal: Signal) -> Self {
         use crate::system::System as _;
         unsafe { crate::RealSystem::new() }
             .validate_signal(signal as RawNumber)
             .and_then(|(name, _real_number)| name.to_raw_virtual())
-            .ok_or(UnknownNameError)
+            .unwrap()
+    }
+
+    /// Converts a signal number in the virtual system to a signal number in the real system.
+    pub(super) fn to_signal_virtual(self) -> Option<Signal> {
+        use crate::system::System as _;
+        unsafe { crate::RealSystem::new() }
+            .signal_number_from_name(Name::try_from_raw_virtual(self.as_raw())?)?
+            .as_raw()
+            .try_into()
+            .ok()
     }
 }

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -20,62 +20,6 @@ use super::super::Signal;
 pub(super) use crate::signal::*;
 use std::num::NonZeroI32;
 
-/// Default effect of a signal delivered to a process.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SignalEffect {
-    /// Does nothing.
-    None,
-    /// Terminates the process.
-    Terminate { core_dump: bool },
-    /// Suspends the process.
-    Suspend,
-    /// Resumes the process.
-    Resume,
-}
-
-impl SignalEffect {
-    /// Returns the default effect for the specified signal.
-    #[must_use]
-    pub fn of(signal: Signal) -> Self {
-        match signal {
-            Signal::SIGHUP => Self::Terminate { core_dump: false },
-            Signal::SIGINT => Self::Terminate { core_dump: false },
-            Signal::SIGQUIT => Self::Terminate { core_dump: true },
-            Signal::SIGILL => Self::Terminate { core_dump: true },
-            Signal::SIGTRAP => Self::Terminate { core_dump: true },
-            Signal::SIGABRT => Self::Terminate { core_dump: true },
-            Signal::SIGBUS => Self::Terminate { core_dump: true },
-            // Signal::SIGEMT => Self::Terminate { core_dump: false },
-            Signal::SIGFPE => Self::Terminate { core_dump: true },
-            Signal::SIGKILL => Self::Terminate { core_dump: false },
-            Signal::SIGUSR1 => Self::Terminate { core_dump: false },
-            Signal::SIGSEGV => Self::Terminate { core_dump: true },
-            Signal::SIGUSR2 => Self::Terminate { core_dump: false },
-            Signal::SIGPIPE => Self::Terminate { core_dump: false },
-            Signal::SIGALRM => Self::Terminate { core_dump: false },
-            Signal::SIGTERM => Self::Terminate { core_dump: false },
-            // Signal::SIGSTKFLT => Self::Terminate { core_dump: false },
-            Signal::SIGCHLD => Self::None,
-            Signal::SIGCONT => Self::Resume,
-            Signal::SIGSTOP => Self::Suspend,
-            Signal::SIGTSTP => Self::Suspend,
-            Signal::SIGTTIN => Self::Suspend,
-            Signal::SIGTTOU => Self::Suspend,
-            Signal::SIGURG => Self::None,
-            Signal::SIGXCPU => Self::Terminate { core_dump: true },
-            Signal::SIGXFSZ => Self::Terminate { core_dump: true },
-            Signal::SIGVTALRM => Self::Terminate { core_dump: false },
-            Signal::SIGPROF => Self::Terminate { core_dump: false },
-            Signal::SIGWINCH => Self::None,
-            Signal::SIGIO => Self::Terminate { core_dump: false },
-            // Signal::SIGPWR => Self::Terminate { core_dump: false },
-            // Signal::SIGINFO => Self::Terminate { core_dump: false },
-            Signal::SIGSYS => Self::Terminate { core_dump: true },
-            _ => Self::Terminate { core_dump: false },
-        }
-    }
-}
-
 /// Signal number for `SIGABRT` in the virtual system
 ///
 /// POSIX effectively requires that the signal number for `SIGABRT` is 6.
@@ -414,5 +358,65 @@ impl Number {
             .as_raw()
             .try_into()
             .ok()
+    }
+}
+
+/// Default effect of a signal delivered to a process.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SignalEffect {
+    /// Does nothing.
+    None,
+    /// Terminates the process.
+    Terminate { core_dump: bool },
+    /// Suspends the process.
+    Suspend,
+    /// Resumes the process.
+    Resume,
+}
+
+impl SignalEffect {
+    /// Returns the default effect for the specified signal.
+    ///
+    /// This function returns `Terminate { core_dump: true }` for `Rtmin(n)` and
+    /// `Rtmax(n)` whatever `n` is.
+    #[must_use]
+    pub const fn of(signal: Name) -> Self {
+        match signal {
+            Name::Abrt => Self::Terminate { core_dump: true },
+            Name::Alrm => Self::Terminate { core_dump: false },
+            Name::Bus => Self::Terminate { core_dump: true },
+            Name::Chld | Name::Cld => Self::None,
+            Name::Cont => Self::Resume,
+            Name::Emt => Self::Terminate { core_dump: false },
+            Name::Fpe => Self::Terminate { core_dump: true },
+            Name::Hup => Self::Terminate { core_dump: false },
+            Name::Ill => Self::Terminate { core_dump: true },
+            Name::Info => Self::Terminate { core_dump: false },
+            Name::Int => Self::Terminate { core_dump: false },
+            Name::Io => Self::Terminate { core_dump: false },
+            Name::Iot => Self::Terminate { core_dump: true },
+            Name::Kill => Self::Terminate { core_dump: false },
+            Name::Lost => Self::Terminate { core_dump: false },
+            Name::Pipe => Self::Terminate { core_dump: false },
+            Name::Poll => Self::Terminate { core_dump: false },
+            Name::Prof => Self::Terminate { core_dump: false },
+            Name::Pwr => Self::Terminate { core_dump: false },
+            Name::Quit => Self::Terminate { core_dump: true },
+            Name::Segv => Self::Terminate { core_dump: true },
+            Name::Stkflt => Self::Terminate { core_dump: false },
+            Name::Stop => Self::Suspend,
+            Name::Sys => Self::Terminate { core_dump: true },
+            Name::Term => Self::Terminate { core_dump: false },
+            Name::Thr => Self::Terminate { core_dump: false },
+            Name::Trap => Self::Terminate { core_dump: true },
+            Name::Tstp | Name::Ttin | Name::Ttou => Self::Suspend,
+            Name::Urg => Self::None,
+            Name::Usr1 | Name::Usr2 => Self::Terminate { core_dump: false },
+            Name::Vtalrm => Self::Terminate { core_dump: false },
+            Name::Winch => Self::None,
+            Name::Xcpu => Self::Terminate { core_dump: true },
+            Name::Xfsz => Self::Terminate { core_dump: true },
+            Name::Rtmin(_) | Name::Rtmax(_) => Self::Terminate { core_dump: false },
+        }
     }
 }

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -36,7 +36,7 @@
 mod cond;
 mod state;
 
-pub use self::cond::{Condition, OldCondition, ParseConditionError, Signal};
+pub use self::cond::{Condition, Signal};
 pub use self::state::{Action, SetActionError, TrapState};
 use self::state::{EnterSubshellOption, GrandState};
 use crate::signal;
@@ -442,19 +442,6 @@ mod tests {
                 .insert(signal, handling)
                 .unwrap_or(SignalHandling::Default))
         }
-    }
-
-    #[test]
-    fn condition_display() {
-        assert_eq!(OldCondition::Exit.to_string(), "EXIT");
-        assert_eq!(OldCondition::Signal(Signal::SIGINT).to_string(), "INT");
-    }
-
-    #[test]
-    fn condition_from_str() {
-        assert_eq!("EXIT".parse(), Ok(OldCondition::Exit));
-        assert_eq!("TERM".parse(), Ok(OldCondition::Signal(Signal::SIGTERM)));
-        assert_eq!("FOO".parse::<OldCondition>(), Err(ParseConditionError));
     }
 
     #[test]

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -396,6 +396,7 @@ impl<'a> IntoIterator for &'a TrapSet {
 mod tests {
     use super::*;
     use crate::job::ProcessState;
+    use crate::system::r#virtual::{SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
     use crate::tests::in_virtual_system;
     use crate::System;
     use std::collections::HashMap;
@@ -1018,10 +1019,7 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(
-                process.signal_handling(Signal::SIGINT),
-                SignalHandling::Ignore
-            );
+            assert_eq!(process.signal_handling(SIGINT), SignalHandling::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -1046,10 +1044,7 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(
-                process.signal_handling(Signal::SIGQUIT),
-                SignalHandling::Ignore
-            );
+            assert_eq!(process.signal_handling(SIGQUIT), SignalHandling::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -1085,18 +1080,9 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(
-                process.signal_handling(Signal::SIGTSTP),
-                SignalHandling::Ignore
-            );
-            assert_eq!(
-                process.signal_handling(Signal::SIGTTIN),
-                SignalHandling::Ignore
-            );
-            assert_eq!(
-                process.signal_handling(Signal::SIGTTOU),
-                SignalHandling::Ignore
-            );
+            assert_eq!(process.signal_handling(SIGTSTP), SignalHandling::Ignore);
+            assert_eq!(process.signal_handling(SIGTTIN), SignalHandling::Ignore);
+            assert_eq!(process.signal_handling(SIGTTOU), SignalHandling::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -1119,18 +1105,9 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(
-                process.signal_handling(Signal::SIGTSTP),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                process.signal_handling(Signal::SIGTTIN),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                process.signal_handling(Signal::SIGTTOU),
-                SignalHandling::Default
-            );
+            assert_eq!(process.signal_handling(SIGTSTP), SignalHandling::Default);
+            assert_eq!(process.signal_handling(SIGTTIN), SignalHandling::Default);
+            assert_eq!(process.signal_handling(SIGTTOU), SignalHandling::Default);
         })
     }
 

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -36,7 +36,7 @@
 mod cond;
 mod state;
 
-pub use self::cond::{Condition, Signal};
+pub use self::cond::Condition;
 pub use self::state::{Action, SetActionError, TrapState};
 use self::state::{EnterSubshellOption, GrandState};
 use crate::signal;

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -36,7 +36,7 @@
 mod cond;
 mod state;
 
-pub use self::cond::{OldCondition, ParseConditionError, Signal};
+pub use self::cond::{Condition, OldCondition, ParseConditionError, Signal};
 pub use self::state::{Action, SetActionError, TrapState};
 use self::state::{EnterSubshellOption, GrandState};
 use crate::system::{Errno, SignalHandling};

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -945,10 +945,7 @@ mod tests {
                     false,
                 )
                 .unwrap();
-            env.system
-                .kill(env.main_pid, Some(Signal::SIGINT))
-                .await
-                .unwrap();
+            env.system.kill(env.main_pid, Some(SIGINT)).await.unwrap();
             env.traps.enter_subshell(&mut env.system, true, false);
 
             let state = state.borrow();
@@ -970,10 +967,7 @@ mod tests {
                     false,
                 )
                 .unwrap();
-            env.system
-                .kill(env.main_pid, Some(Signal::SIGQUIT))
-                .await
-                .unwrap();
+            env.system.kill(env.main_pid, Some(SIGQUIT)).await.unwrap();
             env.traps.enter_subshell(&mut env.system, true, false);
 
             let state = state.borrow();
@@ -1007,7 +1001,7 @@ mod tests {
                     .unwrap();
             }
             env.traps.enable_stopper_handlers(&mut env.system).unwrap();
-            for signal in [Signal::SIGTSTP, Signal::SIGTTIN, Signal::SIGTTOU] {
+            for signal in [SIGTSTP, SIGTTIN, SIGTTOU] {
                 env.system.kill(env.main_pid, Some(signal)).await.unwrap();
             }
             env.traps.enter_subshell(&mut env.system, false, true);

--- a/yash-env/src/trap/cond.rs
+++ b/yash-env/src/trap/cond.rs
@@ -18,9 +18,11 @@
 
 #[cfg(doc)]
 use super::state::Action;
+use super::SignalSystem;
 use crate::signal;
 #[doc(no_inline)]
 pub use nix::sys::signal::Signal;
+use std::borrow::Cow;
 use std::ffi::c_int;
 
 /// Condition under which an [`Action`] is executed
@@ -147,6 +149,22 @@ impl From<Condition> for signal::RawNumber {
         match cond {
             Condition::Exit => 0,
             Condition::Signal(number) => number.as_raw(),
+        }
+    }
+}
+
+impl Condition {
+    /// Converts this `Condition` to a `String`.
+    ///
+    /// The result is an uppercase string representing the condition such as
+    /// `"EXIT"` and `"TERM"`. Signal names are obtained from
+    /// [`signal::Name::as_string`]. This function depends on the signal system
+    /// to convert signal numbers to names.
+    #[must_use]
+    pub fn to_string<S: SignalSystem>(&self, system: &S) -> Cow<'static, str> {
+        match self {
+            Self::Exit => Cow::Borrowed("EXIT"),
+            Self::Signal(number) => system.signal_name_from_number(*number).as_string(),
         }
     }
 }

--- a/yash-env/src/trap/cond.rs
+++ b/yash-env/src/trap/cond.rs
@@ -20,9 +20,6 @@
 use super::state::Action;
 use super::SignalSystem;
 use crate::signal;
-// TODO Remove this
-#[doc(no_inline)]
-pub use nix::sys::signal::Signal;
 use std::borrow::Cow;
 
 /// Condition under which an [`Action`] is executed

--- a/yash-env/src/trap/cond.rs
+++ b/yash-env/src/trap/cond.rs
@@ -20,99 +20,10 @@
 use super::state::Action;
 use super::SignalSystem;
 use crate::signal;
+// TODO Remove this
 #[doc(no_inline)]
 pub use nix::sys::signal::Signal;
 use std::borrow::Cow;
-use std::ffi::c_int;
-
-/// Condition under which an [`Action`] is executed
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum OldCondition {
-    /// When the shell exits
-    Exit,
-    /// When the specified signal is delivered to the shell process
-    Signal(Signal),
-}
-
-/// Conversion from `Signal` to `Condition`
-impl From<Signal> for OldCondition {
-    fn from(signal: Signal) -> Self {
-        Self::Signal(signal)
-    }
-}
-
-/// Conversion from `Condition` to `String`
-///
-/// The result is an uppercase string representing the condition such as
-/// `"EXIT"` and `"TERM"`.
-impl std::fmt::Display for OldCondition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OldCondition::Exit => "EXIT".fmt(f),
-            OldCondition::Signal(signal) => {
-                let full_name = signal.as_str();
-                let name = full_name.strip_prefix("SIG").unwrap_or(full_name);
-                name.fmt(f)
-            }
-        }
-    }
-}
-
-// TODO Remove this
-/// Error in conversion from string to [`Condition`]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ParseConditionError;
-
-/// Conversion from `String` to `Condition`
-///
-/// This implementation supports parsing uppercase strings like `"EXIT"` and
-/// `"TERM"` as well as signal numbers like `"9"` and `"15"`. The number `"0"`
-/// denotes [`Condition::Exit`].
-impl std::str::FromStr for OldCondition {
-    type Err = ParseConditionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // TODO Make case-insensitive
-        // TODO Allow SIG-prefix
-        // TODO Support real-time signals
-
-        if let Ok(number) = s.parse::<c_int>() {
-            if number == 0 {
-                return Ok(Self::Exit);
-            }
-            return match number.try_into() {
-                Ok(signal) => Ok(Self::Signal(signal)),
-                Err(_) => Err(ParseConditionError),
-            };
-        }
-
-        match s {
-            "EXIT" => Ok(Self::Exit),
-            _ => match format!("SIG{s}").parse() {
-                Ok(signal) => Ok(Self::Signal(signal)),
-                Err(_) => Err(ParseConditionError),
-            },
-        }
-    }
-}
-
-#[test]
-fn condition_from_str() {
-    assert_eq!("EXIT".parse(), Ok(OldCondition::Exit));
-    assert_eq!("TERM".parse(), Ok(OldCondition::Signal(Signal::SIGTERM)));
-    assert_eq!("INT".parse(), Ok(OldCondition::Signal(Signal::SIGINT)));
-
-    assert_eq!("0".parse(), Ok(OldCondition::Exit));
-    assert_eq!("1".parse(), Ok(OldCondition::Signal(Signal::SIGHUP)));
-    assert_eq!("9".parse(), Ok(OldCondition::Signal(Signal::SIGKILL)));
-
-    assert_eq!("XXXXX".parse::<OldCondition>(), Err(ParseConditionError));
-    assert_eq!(
-        "999999999".parse::<OldCondition>(),
-        Err(ParseConditionError)
-    );
-    assert_eq!("-123".parse::<OldCondition>(), Err(ParseConditionError));
-}
 
 /// Condition under which an [`Action`] is executed
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/yash-env/src/trap/cond.rs
+++ b/yash-env/src/trap/cond.rs
@@ -25,7 +25,7 @@ pub use nix::sys::signal::Signal;
 
 /// Condition under which an [`Action`] is executed
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Condition {
+pub enum OldCondition {
     /// When the shell exits
     Exit,
     /// When the specified signal is delivered to the shell process
@@ -33,7 +33,7 @@ pub enum Condition {
 }
 
 /// Conversion from `Signal` to `Condition`
-impl From<Signal> for Condition {
+impl From<Signal> for OldCondition {
     fn from(signal: Signal) -> Self {
         Self::Signal(signal)
     }
@@ -43,11 +43,11 @@ impl From<Signal> for Condition {
 ///
 /// The result is an uppercase string representing the condition such as
 /// `"EXIT"` and `"TERM"`.
-impl std::fmt::Display for Condition {
+impl std::fmt::Display for OldCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Condition::Exit => "EXIT".fmt(f),
-            Condition::Signal(signal) => {
+            OldCondition::Exit => "EXIT".fmt(f),
+            OldCondition::Signal(signal) => {
                 let full_name = signal.as_str();
                 let name = full_name.strip_prefix("SIG").unwrap_or(full_name);
                 name.fmt(f)
@@ -65,7 +65,7 @@ pub struct ParseConditionError;
 /// This implementation supports parsing uppercase strings like `"EXIT"` and
 /// `"TERM"` as well as signal numbers like `"9"` and `"15"`. The number `"0"`
 /// denotes [`Condition::Exit`].
-impl std::str::FromStr for Condition {
+impl std::str::FromStr for OldCondition {
     type Err = ParseConditionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -95,15 +95,18 @@ impl std::str::FromStr for Condition {
 
 #[test]
 fn condition_from_str() {
-    assert_eq!("EXIT".parse(), Ok(Condition::Exit));
-    assert_eq!("TERM".parse(), Ok(Condition::Signal(Signal::SIGTERM)));
-    assert_eq!("INT".parse(), Ok(Condition::Signal(Signal::SIGINT)));
+    assert_eq!("EXIT".parse(), Ok(OldCondition::Exit));
+    assert_eq!("TERM".parse(), Ok(OldCondition::Signal(Signal::SIGTERM)));
+    assert_eq!("INT".parse(), Ok(OldCondition::Signal(Signal::SIGINT)));
 
-    assert_eq!("0".parse(), Ok(Condition::Exit));
-    assert_eq!("1".parse(), Ok(Condition::Signal(Signal::SIGHUP)));
-    assert_eq!("9".parse(), Ok(Condition::Signal(Signal::SIGKILL)));
+    assert_eq!("0".parse(), Ok(OldCondition::Exit));
+    assert_eq!("1".parse(), Ok(OldCondition::Signal(Signal::SIGHUP)));
+    assert_eq!("9".parse(), Ok(OldCondition::Signal(Signal::SIGKILL)));
 
-    assert_eq!("XXXXX".parse::<Condition>(), Err(ParseConditionError));
-    assert_eq!("999999999".parse::<Condition>(), Err(ParseConditionError));
-    assert_eq!("-123".parse::<Condition>(), Err(ParseConditionError));
+    assert_eq!("XXXXX".parse::<OldCondition>(), Err(ParseConditionError));
+    assert_eq!(
+        "999999999".parse::<OldCondition>(),
+        Err(ParseConditionError)
+    );
+    assert_eq!("-123".parse::<OldCondition>(), Err(ParseConditionError));
 }

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -16,10 +16,9 @@
 
 //! Items that manage the state of a single signal.
 
-use super::cond::OldCondition;
-use super::SignalSystem;
 #[cfg(doc)]
 use super::TrapSet;
+use super::{Condition, SignalSystem};
 use crate::system::{Errno, SignalHandling};
 use std::collections::btree_map::{Entry, VacantEntry};
 use std::rc::Rc;
@@ -187,7 +186,7 @@ impl GrandState {
     /// Updates the entry with the new action.
     pub fn set_action<S: SignalSystem>(
         system: &mut S,
-        entry: Entry<OldCondition, GrandState>,
+        entry: Entry<Condition, GrandState>,
         action: Action,
         origin: Location,
         override_ignore: bool,
@@ -202,7 +201,7 @@ impl GrandState {
 
         match entry {
             Entry::Vacant(vacant) => {
-                if let OldCondition::Signal(signal) = cond {
+                if let Condition::Signal(signal) = cond {
                     if !override_ignore {
                         let initial_handling =
                             system.set_signal_handling(signal, SignalHandling::Ignore)?;
@@ -234,7 +233,7 @@ impl GrandState {
                     return Err(SetActionError::InitiallyIgnored);
                 }
 
-                if let OldCondition::Signal(signal) = cond {
+                if let Condition::Signal(signal) = cond {
                     let old_handler = state.internal_handler.max((&state.current_setting).into());
                     let new_handler = state.internal_handler.max(handling);
                     if old_handler != new_handler {
@@ -260,12 +259,12 @@ impl GrandState {
     /// The condition of the given entry must be a signal.
     pub fn set_internal_handler<S: SignalSystem>(
         system: &mut S,
-        entry: Entry<OldCondition, GrandState>,
+        entry: Entry<Condition, GrandState>,
         handling: SignalHandling,
     ) -> Result<(), Errno> {
         let signal = match *entry.key() {
-            OldCondition::Signal(signal) => signal,
-            OldCondition::Exit => panic!("exit condition cannot have an internal handler"),
+            Condition::Signal(signal) => signal,
+            Condition::Exit => panic!("exit condition cannot have an internal handler"),
         };
 
         match entry {
@@ -305,7 +304,7 @@ impl GrandState {
     pub fn enter_subshell<S: SignalSystem>(
         &mut self,
         system: &mut S,
-        cond: OldCondition,
+        cond: Condition,
         option: EnterSubshellOption,
     ) -> Result<(), Errno> {
         let old_setting = (&self.current_setting).into();
@@ -325,7 +324,7 @@ impl GrandState {
             EnterSubshellOption::Ignore => SignalHandling::Ignore,
         };
         if old_handler != new_handler {
-            if let OldCondition::Signal(signal) = cond {
+            if let Condition::Signal(signal) = cond {
                 system.set_signal_handling(signal, new_handler)?;
             }
         }
@@ -349,11 +348,11 @@ impl GrandState {
     /// This function panics if the condition is not a signal.
     pub fn ignore<S: SignalSystem>(
         system: &mut S,
-        vacant: VacantEntry<OldCondition, GrandState>,
+        vacant: VacantEntry<Condition, GrandState>,
     ) -> Result<(), Errno> {
         let signal = match *vacant.key() {
-            OldCondition::Signal(signal) => signal,
-            OldCondition::Exit => panic!("exit condition cannot be ignored"),
+            Condition::Signal(signal) => signal,
+            Condition::Exit => panic!("exit condition cannot be ignored"),
         };
         let initial_handling = system.set_signal_handling(signal, SignalHandling::Ignore)?;
         vacant.insert(GrandState {
@@ -387,9 +386,9 @@ impl GrandState {
 
 #[cfg(test)]
 mod tests {
-    use super::super::cond::Signal;
     use super::super::tests::DummySystem;
     use super::*;
+    use crate::system::r#virtual::{SIGCHLD, SIGQUIT, SIGTSTP, SIGTTOU, SIGUSR1};
     use assert_matches::assert_matches;
     use std::collections::BTreeMap;
 
@@ -397,14 +396,14 @@ mod tests {
     fn setting_trap_to_ignore_without_override_ignore() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
 
         let result =
             GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].get_state(),
+            map[&SIGCHLD.into()].get_state(),
             (
                 Some(&TrapState {
                     action: Action::Ignore,
@@ -414,21 +413,21 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn setting_trap_to_ignore_with_override_ignore() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
 
         let result =
             GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), true);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].get_state(),
+            map[&SIGCHLD.into()].get_state(),
             (
                 Some(&TrapState {
                     action: Action::Ignore,
@@ -438,14 +437,14 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn setting_trap_to_command() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let action = Action::Command("echo".into());
         let origin = Location::dummy("origin");
 
@@ -453,7 +452,7 @@ mod tests {
             GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].get_state(),
+            map[&SIGCHLD.into()].get_state(),
             (
                 Some(&TrapState {
                     action,
@@ -463,24 +462,24 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Catch);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Catch);
     }
 
     #[test]
     fn setting_trap_to_default() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("foo");
         GrandState::set_action(&mut system, entry, Action::Ignore, origin, false).unwrap();
 
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("bar");
         let result =
             GrandState::set_action(&mut system, entry, Action::Default, origin.clone(), false);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].get_state(),
+            map[&SIGCHLD.into()].get_state(),
             (
                 Some(&TrapState {
                     action: Action::Default,
@@ -490,41 +489,41 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Default);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Default);
     }
 
     #[test]
     fn resetting_trap_from_ignore_no_override() {
         let mut system = DummySystem::default();
-        system.0.insert(Signal::SIGCHLD, SignalHandling::Ignore);
+        system.0.insert(SIGCHLD, SignalHandling::Ignore);
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("foo");
         let result = GrandState::set_action(&mut system, entry, Action::Ignore, origin, false);
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
 
         // Idempotence
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("bar");
         let result = GrandState::set_action(&mut system, entry, Action::Ignore, origin, false);
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
 
-        assert_eq!(map[&Signal::SIGCHLD.into()].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(map[&SIGCHLD.into()].get_state(), (None, None));
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn resetting_trap_from_ignore_override() {
         let mut system = DummySystem::default();
-        system.0.insert(Signal::SIGCHLD, SignalHandling::Ignore);
+        system.0.insert(SIGCHLD, SignalHandling::Ignore);
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
         let result =
             GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), true);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].get_state(),
+            map[&SIGCHLD.into()].get_state(),
             (
                 Some(&TrapState {
                     action: Action::Ignore,
@@ -534,93 +533,93 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn internal_handler_ignore() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
 
         let result = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Ignore);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].internal_handler(),
+            map[&SIGCHLD.into()].internal_handler(),
             SignalHandling::Ignore
         );
-        assert_eq!(map[&Signal::SIGCHLD.into()].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(map[&SIGCHLD.into()].get_state(), (None, None));
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn internal_handler_catch() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
 
         let result = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Catch);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].internal_handler(),
+            map[&SIGCHLD.into()].internal_handler(),
             SignalHandling::Catch
         );
-        assert_eq!(map[&Signal::SIGCHLD.into()].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Catch);
+        assert_eq!(map[&SIGCHLD.into()].get_state(), (None, None));
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Catch);
     }
 
     #[test]
     fn action_ignore_and_internal_handler_catch() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
         let _ = GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false);
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
 
         let result = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Catch);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].internal_handler(),
+            map[&SIGCHLD.into()].internal_handler(),
             SignalHandling::Catch
         );
-        assert_matches!(map[&Signal::SIGCHLD.into()].get_state(), (Some(state), None) => {
+        assert_matches!(map[&SIGCHLD.into()].get_state(), (Some(state), None) => {
             assert_eq!(state.action, Action::Ignore);
             assert_eq!(state.origin, origin);
         });
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Catch);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Catch);
     }
 
     #[test]
     fn action_catch_and_internal_handler_ignore() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
         let _ = GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false);
-        let entry = map.entry(Signal::SIGCHLD.into());
+        let entry = map.entry(SIGCHLD.into());
 
         let result = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Ignore);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].internal_handler(),
+            map[&SIGCHLD.into()].internal_handler(),
             SignalHandling::Ignore
         );
-        assert_matches!(map[&Signal::SIGCHLD.into()].get_state(), (Some(state), None) => {
+        assert_matches!(map[&SIGCHLD.into()].get_state(), (Some(state), None) => {
             assert_eq!(state.action, action);
             assert_eq!(state.origin, origin);
         });
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Catch);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Catch);
     }
 
     #[test]
     fn set_internal_handler_for_initially_defaulted_signal_then_allow_override() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let entry = map.entry(Signal::SIGTTOU.into());
+        let entry = map.entry(SIGTTOU.into());
         let _ = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Ignore);
-        let entry = map.entry(Signal::SIGTTOU.into());
+        let entry = map.entry(SIGTTOU.into());
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
 
@@ -628,11 +627,11 @@ mod tests {
             GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false);
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGTTOU.into()].internal_handler(),
+            map[&SIGTTOU.into()].internal_handler(),
             SignalHandling::Ignore
         );
         assert_eq!(
-            map[&Signal::SIGTTOU.into()].get_state(),
+            map[&SIGTTOU.into()].get_state(),
             (
                 Some(&TrapState {
                     action,
@@ -642,15 +641,15 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGTTOU], SignalHandling::Catch);
+        assert_eq!(system.0[&SIGTTOU], SignalHandling::Catch);
     }
 
     #[test]
     fn set_internal_handler_for_initially_ignored_signal_then_reject_override() {
         let mut system = DummySystem::default();
-        system.0.insert(Signal::SIGTTOU, SignalHandling::Ignore);
+        system.0.insert(SIGTTOU, SignalHandling::Ignore);
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGTTOU.into();
+        let cond = SIGTTOU.into();
         let entry = map.entry(cond);
         let _ = GrandState::set_internal_handler(&mut system, entry, SignalHandling::Ignore);
         let entry = map.entry(cond);
@@ -661,14 +660,14 @@ mod tests {
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
         assert_eq!(map[&cond].internal_handler(), SignalHandling::Ignore);
         assert_eq!(map[&cond].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGTTOU], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGTTOU], SignalHandling::Ignore);
     }
 
     #[test]
     fn enter_subshell_with_internal_handler_keeping_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         GrandState::set_internal_handler(&mut system, map.entry(cond), SignalHandling::Catch)
             .unwrap();
 
@@ -680,14 +679,14 @@ mod tests {
         assert_eq!(result, Ok(()));
         assert_eq!(map[&cond].internal_handler(), SignalHandling::Catch);
         assert_eq!(map[&cond].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Catch);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Catch);
     }
 
     #[test]
     fn enter_subshell_with_internal_handler_clearing_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         GrandState::set_internal_handler(&mut system, entry, SignalHandling::Catch).unwrap();
 
@@ -698,18 +697,18 @@ mod tests {
         );
         assert_eq!(result, Ok(()));
         assert_eq!(
-            map[&Signal::SIGCHLD.into()].internal_handler(),
+            map[&SIGCHLD.into()].internal_handler(),
             SignalHandling::Default
         );
         assert_eq!(map[&cond].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Default);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Default);
     }
 
     #[test]
     fn enter_subshell_with_ignore_and_no_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false).unwrap();
@@ -732,14 +731,14 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn enter_subshell_with_ignore_clearing_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false).unwrap();
@@ -764,14 +763,14 @@ mod tests {
                 None
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Ignore);
     }
 
     #[test]
     fn enter_subshell_with_command_and_no_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
@@ -795,14 +794,14 @@ mod tests {
                 }),
             )
         );
-        assert_eq!(system.0[&Signal::SIGCHLD], SignalHandling::Default);
+        assert_eq!(system.0[&SIGCHLD], SignalHandling::Default);
     }
 
     #[test]
     fn enter_subshell_with_command_keeping_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGTSTP.into();
+        let cond = SIGTSTP.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
@@ -828,14 +827,14 @@ mod tests {
                 }),
             )
         );
-        assert_eq!(system.0[&Signal::SIGTSTP], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGTSTP], SignalHandling::Ignore);
     }
 
     #[test]
     fn enter_subshell_with_command_clearing_internal_handler() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGTSTP.into();
+        let cond = SIGTSTP.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
@@ -861,14 +860,14 @@ mod tests {
                 }),
             )
         );
-        assert_eq!(system.0[&Signal::SIGTSTP], SignalHandling::Default);
+        assert_eq!(system.0[&SIGTSTP], SignalHandling::Default);
     }
 
     #[test]
     fn enter_subshell_with_command_ignoring() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGQUIT.into();
+        let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
@@ -892,21 +891,21 @@ mod tests {
                 }),
             )
         );
-        assert_eq!(system.0[&Signal::SIGQUIT], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGQUIT], SignalHandling::Ignore);
     }
 
     #[test]
     fn ignoring_initially_defaulted_signal() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGQUIT.into();
+        let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let vacant = assert_matches!(entry, Entry::Vacant(vacant) => vacant);
 
         let result = GrandState::ignore(&mut system, vacant);
         assert_eq!(result, Ok(()));
         assert_eq!(map[&cond].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGQUIT], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGQUIT], SignalHandling::Ignore);
 
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
@@ -918,16 +917,16 @@ mod tests {
     #[test]
     fn ignoring_initially_ignored_signal() {
         let mut system = DummySystem::default();
-        system.0.insert(Signal::SIGQUIT, SignalHandling::Ignore);
+        system.0.insert(SIGQUIT, SignalHandling::Ignore);
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGQUIT.into();
+        let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let vacant = assert_matches!(entry, Entry::Vacant(vacant) => vacant);
 
         let result = GrandState::ignore(&mut system, vacant);
         assert_eq!(result, Ok(()));
         assert_eq!(map[&cond].get_state(), (None, None));
-        assert_eq!(system.0[&Signal::SIGQUIT], SignalHandling::Ignore);
+        assert_eq!(system.0[&SIGQUIT], SignalHandling::Ignore);
 
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
@@ -940,7 +939,7 @@ mod tests {
     fn clearing_parent_setting() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGCHLD.into();
+        let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
@@ -958,7 +957,7 @@ mod tests {
     fn marking_as_caught_and_handling() {
         let mut system = DummySystem::default();
         let mut map = BTreeMap::new();
-        let cond = Signal::SIGUSR1.into();
+        let cond = SIGUSR1.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prints its error message in prettier format.
 - `command::simple_command::replace_current_process` now uses `System::shell_path`
   to find the shell executable when it needs to fall back to the shell.
+- `trap::run_trap_if_caught` now takes a `yash_env::signal::Number` argument
+  instead of a `yash_env::trap::Signal`.
 
 ### Fixed
 

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -92,9 +92,10 @@ mod tests {
     use futures_util::FutureExt;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
+    use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::trap::Action;
     use yash_env::trap::Signal;
-    use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
 
     #[test]
@@ -117,7 +118,7 @@ mod tests {
             .processes
             .get_mut(&system.process_id)
             .unwrap()
-            .raise_signal(Signal::SIGUSR1);
+            .raise_signal(SIGUSR1);
 
         let command: syntax::Command = "echo main".parse().unwrap();
         let result = command.execute(&mut env).now_or_never().unwrap();

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -95,7 +95,6 @@ mod tests {
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::trap::Action;
-    use yash_env::trap::Signal;
     use yash_syntax::source::Location;
 
     #[test]
@@ -106,7 +105,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Signal::SIGUSR1,
+                SIGUSR1,
                 Action::Command("echo USR1".into()),
                 Location::dummy(""),
                 false,

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -88,8 +88,8 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::option::State::On;
-    use yash_env::trap::Signal;
-    use yash_env::VirtualSystem;
+    use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::r#virtual::SIGSTOP;
     use yash_syntax::syntax::CompoundCommand;
 
     #[test]
@@ -193,19 +193,19 @@ mod tests {
             let command: CompoundCommand = "(suspend foo)".parse().unwrap();
             let result = command.execute(&mut env).await;
             assert_eq!(result, Continue(()));
-            assert_eq!(env.exit_status, ExitStatus::from(Signal::SIGSTOP));
+            assert_eq!(env.exit_status, ExitStatus::from(SIGSTOP));
 
             let state = state.borrow();
             let (&pid, process) = state.processes.last_key_value().unwrap();
             assert_ne!(pid, env.main_pid);
             assert_ne!(process.pgid(), env.main_pgid);
-            assert_eq!(process.state(), ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(process.state(), ProcessState::stopped(SIGSTOP));
 
             assert_eq!(env.jobs.len(), 1);
             let job = env.jobs.iter().next().unwrap().1;
             assert_eq!(job.pid, pid);
             assert!(job.job_controlled);
-            assert_eq!(job.state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(job.state, ProcessState::stopped(SIGSTOP));
             assert!(job.state_changed);
             assert_eq!(job.name, "suspend foo");
         })

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -221,7 +221,7 @@ mod tests {
                 env.traps
                     .set_action(
                         &mut env.system,
-                        yash_env::trap::Condition::Exit,
+                        yash_env::trap::OldCondition::Exit,
                         yash_env::trap::Action::Command("echo exiting".into()),
                         Location::dummy(""),
                         false,

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -221,7 +221,7 @@ mod tests {
                 env.traps
                     .set_action(
                         &mut env.system,
-                        yash_env::trap::OldCondition::Exit,
+                        yash_env::trap::Condition::Exit,
                         yash_env::trap::Action::Command("echo exiting".into()),
                         Location::dummy(""),
                         false,

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -281,10 +281,14 @@ mod tests {
     }
 
     fn ignore_sigttin(env: &mut Env) {
+        let signal = env
+            .system
+            .signal_number_from_name(yash_env::signal::Name::Ttin)
+            .unwrap();
         env.traps
             .set_action(
                 &mut env.system,
-                yash_env::trap::Signal::SIGTTIN,
+                signal,
                 yash_env::trap::Action::Ignore,
                 Location::dummy(""),
                 false,

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -345,7 +345,7 @@ mod tests {
     use yash_env::option::State::On;
     use yash_env::semantics::Field;
     use yash_env::system::r#virtual::FileBody;
-    use yash_env::trap::Signal;
+    use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::VirtualSystem;
 
     #[test]
@@ -627,12 +627,12 @@ mod tests {
             let pipeline: syntax::Pipeline = "return -n 0 | suspend x".parse().unwrap();
             let result = pipeline.execute(&mut env).await;
             assert_eq!(result, Continue(()));
-            assert_eq!(env.exit_status, ExitStatus::from(Signal::SIGSTOP));
+            assert_eq!(env.exit_status, ExitStatus::from(SIGSTOP));
 
             assert_eq!(env.jobs.len(), 1);
             let job = env.jobs.iter().next().unwrap().1;
             assert!(job.job_controlled);
-            assert_eq!(job.state, ProcessState::stopped(Signal::SIGSTOP));
+            assert_eq!(job.state, ProcessState::stopped(SIGSTOP));
             assert!(job.state_changed);
             assert_eq!(job.name, "return -n 0 | suspend x");
         })

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -177,6 +177,7 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::trap::Action;
     use yash_env::trap::Signal;
     use yash_syntax::source::Location;
@@ -316,7 +317,7 @@ mod tests {
             .processes
             .get_mut(&system.process_id)
             .unwrap()
-            .raise_signal(Signal::SIGUSR1);
+            .raise_signal(SIGUSR1);
         let mut lexer = Lexer::from_memory("echo $?", Source::Unknown);
         let rel = ReadEvalLoop::new(&mut env, &mut lexer);
         let result = rel.run().now_or_never().unwrap();

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -179,7 +179,6 @@ mod tests {
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::trap::Action;
-    use yash_env::trap::Signal;
     use yash_syntax::source::Location;
     use yash_syntax::source::Source;
 
@@ -306,7 +305,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Signal::SIGUSR1,
+                SIGUSR1,
                 Action::Command("echo USR1".into()),
                 Location::dummy(""),
                 false,

--- a/yash-semantics/src/tests.rs
+++ b/yash-semantics/src/tests.rs
@@ -38,8 +38,8 @@ use yash_env::semantics::Field;
 use yash_env::system::r#virtual::FileBody;
 use yash_env::system::r#virtual::INode;
 use yash_env::system::r#virtual::SystemState;
+use yash_env::system::r#virtual::SIGSTOP;
 use yash_env::system::Errno;
-use yash_env::trap::Signal;
 use yash_env::variable::Scalar;
 use yash_env::variable::Scope;
 use yash_env::Env;
@@ -211,10 +211,7 @@ fn suspend_builtin_main(
     _args: Vec<Field>,
 ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
     Box::pin(async move {
-        env.system
-            .kill(Pid(0), Some(Signal::SIGSTOP))
-            .await
-            .unwrap();
+        env.system.kill(Pid(0), Some(SIGSTOP)).await.unwrap();
         yash_env::builtin::Result::default()
     })
 }

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -52,7 +52,7 @@ use std::rc::Rc;
 use yash_env::semantics::Divert;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
-use yash_env::trap::OldCondition;
+use yash_env::trap::Condition;
 #[cfg(doc)]
 use yash_env::trap::TrapSet;
 use yash_env::Env;
@@ -76,8 +76,8 @@ use yash_syntax::source::Source;
 /// specification mentions the intended behavior for the `Divert::Return` case,
 /// implying that the diversion should be passed on to the caller.)
 #[must_use]
-async fn run_trap(env: &mut Env, cond: OldCondition, code: Rc<str>, origin: Location) -> Result {
-    let condition = cond.to_string();
+async fn run_trap(env: &mut Env, cond: Condition, code: Rc<str>, origin: Location) -> Result {
+    let condition = cond.to_string(&env.system).into_owned();
     let mut lexer = Lexer::from_memory(&code, Source::Trap { condition, origin });
     let mut env = env.push_frame(Frame::Trap(cond));
 

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -52,7 +52,7 @@ use std::rc::Rc;
 use yash_env::semantics::Divert;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
-use yash_env::trap::Condition;
+use yash_env::trap::OldCondition;
 #[cfg(doc)]
 use yash_env::trap::TrapSet;
 use yash_env::Env;
@@ -76,7 +76,7 @@ use yash_syntax::source::Source;
 /// specification mentions the intended behavior for the `Divert::Return` case,
 /// implying that the diversion should be passed on to the caller.)
 #[must_use]
-async fn run_trap(env: &mut Env, cond: Condition, code: Rc<str>, origin: Location) -> Result {
+async fn run_trap(env: &mut Env, cond: OldCondition, code: Rc<str>, origin: Location) -> Result {
     let condition = cond.to_string();
     let mut lexer = Lexer::from_memory(&code, Source::Trap { condition, origin });
     let mut env = env.push_frame(Frame::Trap(cond));

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -19,6 +19,7 @@
 use super::run_trap;
 use std::rc::Rc;
 use yash_env::trap::Action;
+use yash_env::trap::Condition;
 use yash_env::trap::OldCondition;
 use yash_env::Env;
 
@@ -32,7 +33,7 @@ use yash_env::Env;
 /// with a `Break(divert)` where `divert.exit_status()` is `Some` exit status,
 /// that exit status is set to `env.exit_status`.
 pub async fn run_exit_trap(env: &mut Env) {
-    let Some(state) = env.traps.get_state(OldCondition::Exit).0 else {
+    let Some(state) = env.traps.get_state(Condition::Exit).0 else {
         return;
     };
     let Action::Command(command) = &state.action else {
@@ -78,7 +79,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("echo exit trap executed".into()),
                 Location::dummy(""),
                 false,
@@ -106,7 +107,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("check".into()),
                 Location::dummy(""),
                 false,
@@ -122,7 +123,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("return -n 123".into()),
                 Location::dummy(""),
                 false,
@@ -143,7 +144,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("echo $?; echo $?".into()),
                 Location::dummy(""),
                 false,
@@ -162,7 +163,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("return -n 53; return".into()),
                 Location::dummy(""),
                 false,
@@ -181,7 +182,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("exit 31".into()),
                 Location::dummy(""),
                 false,
@@ -200,7 +201,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                OldCondition::Exit,
+                Condition::Exit,
                 Action::Command("echo; exit".into()),
                 Location::dummy(""),
                 false,

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -19,7 +19,7 @@
 use super::run_trap;
 use std::rc::Rc;
 use yash_env::trap::Action;
-use yash_env::trap::Condition;
+use yash_env::trap::OldCondition;
 use yash_env::Env;
 
 /// Executes the EXIT trap.
@@ -32,7 +32,7 @@ use yash_env::Env;
 /// with a `Break(divert)` where `divert.exit_status()` is `Some` exit status,
 /// that exit status is set to `env.exit_status`.
 pub async fn run_exit_trap(env: &mut Env) {
-    let Some(state) = env.traps.get_state(Condition::Exit).0 else {
+    let Some(state) = env.traps.get_state(OldCondition::Exit).0 else {
         return;
     };
     let Action::Command(command) = &state.action else {
@@ -41,7 +41,7 @@ pub async fn run_exit_trap(env: &mut Env) {
 
     let command = Rc::clone(command);
     let origin = state.origin.clone();
-    let result = run_trap(env, Condition::Exit, command, origin).await;
+    let result = run_trap(env, OldCondition::Exit, command, origin).await;
     env.apply_result(result);
 }
 
@@ -78,7 +78,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("echo exit trap executed".into()),
                 Location::dummy(""),
                 false,
@@ -96,7 +96,7 @@ mod tests {
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
-                assert_matches!(&env.stack[0], Frame::Trap(Condition::Exit));
+                assert_matches!(&env.stack[0], Frame::Trap(OldCondition::Exit));
                 Default::default()
             })
         }
@@ -106,7 +106,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("check".into()),
                 Location::dummy(""),
                 false,
@@ -122,7 +122,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("return -n 123".into()),
                 Location::dummy(""),
                 false,
@@ -143,7 +143,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("echo $?; echo $?".into()),
                 Location::dummy(""),
                 false,
@@ -162,7 +162,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("return -n 53; return".into()),
                 Location::dummy(""),
                 false,
@@ -181,7 +181,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("exit 31".into()),
                 Location::dummy(""),
                 false,
@@ -200,7 +200,7 @@ mod tests {
         env.traps
             .set_action(
                 &mut env.system,
-                Condition::Exit,
+                OldCondition::Exit,
                 Action::Command("echo; exit".into()),
                 Location::dummy(""),
                 false,

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -20,7 +20,6 @@ use super::run_trap;
 use std::rc::Rc;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
-use yash_env::trap::OldCondition;
 use yash_env::Env;
 
 /// Executes the EXIT trap.
@@ -42,7 +41,7 @@ pub async fn run_exit_trap(env: &mut Env) {
 
     let command = Rc::clone(command);
     let origin = state.origin.clone();
-    let result = run_trap(env, OldCondition::Exit, command, origin).await;
+    let result = run_trap(env, Condition::Exit, command, origin).await;
     env.apply_result(result);
 }
 
@@ -97,7 +96,7 @@ mod tests {
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
-                assert_matches!(&env.stack[0], Frame::Trap(OldCondition::Exit));
+                assert_matches!(&env.stack[0], Frame::Trap(Condition::Exit));
                 Default::default()
             })
         }


### PR DESCRIPTION
This is part of #353, and rework of #365.

This PR removes the use of `nix::signal::Signal` in the `yash_env::System` API. The definition of `Signal` is dependent on the underlying system, so it should not be used outside `RealSystem`. Instead, new neutral items are added in the `yash_env::signal` module.

The new `Number` type replaces the most use of `Signal`. The `RealSystem` and `VirtualSystem` now have different `Number` spaces so that the `VirtualSystem` no longer has to depend on the `RealSystem`'s signal number. The other uses of `Signal`s are replaced by `Name`s, which is more abstract than `Number`s.

This PR also adds (partial) support for real-time signals.

To fully support real-time signals, we also need to eliminate the use of `SigSet`, which is not the scope of this pull request.

----

- Defining new items
    - [x] Define new signal items (`Number` and `Name`)
    - [x] Implement `From<Number>` for `ExitStatus`
    - [x] Implement `System::signal_number_from_name` and `System::validate_signal_number`
    - [x] Implement `SystemEx:signal_name_from_number`
    - [x] Implement `SystemEx:signal_number_from_exit_status`
    - [x] Implement new job state reporting ~~which depends on `System` and will replace `yash_env::job::fmt`~~
- Updating existing items
    - [x] Use `Number` in virtual `Process`
    - [x] Let `ProcessResult` contain `Number` and update the implementation of `From<ProcessResult>` for `ExitStatus`, etc.
        - This change requires first removing the old `yash::job::fmt`, which depends on the old `ProcessResult` definition.
    - [x] Let `yash_env::trap::Condition` contain `Number` and update dependent implementations accordingly
    - [x] Change the signature of `System::sigaction`
    - [x] Change the signature of `System::caught_signals`
    - [x] Change the signature of `System::kill`
    - [x] Change the signature of `SelectSystem::set_signal_handling`
    - [x] Change the signature of `SharedSystem::wait_for_signals`
    - [x] Change the signature of `SharedSystem::wait_for_signal`
- Updating built-ins
    - [x] Update the fg built-in implementation
    - [x] Update the kill built-in implementation
    - [x] Update the set built-in test
    - [x] Update the trap built-in implementation
    - [x] Update the wait built-in implementation
    - [x] Update the jobs built-in implementation
- Removing old items
    - [x] Remove the old `yash::job::fmt` items
    - [x] Remove `ProcessState::from_wait_status` by inlining the function
    - [x] Remove `impl TryFrom<Signal> for signal::Number`
    - [x] Remove `impl From<Signal> for ExitStatus`
    - [x] Remove the old signal items
- Refactoring
    - [x] Split `yash_builtin::trap::Command::execute` into smaller functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for real-time signals in the kill built-in.
  - Introduced new entities for improved signal handling and job control.

- **Improvements**
  - Enhanced signal parsing and handling logic for better maintainability and clarity.
  - Updated signal-related functions to use more precise data types and error handling.

- **Bug Fixes**
  - Corrected various function signatures and return types to improve consistency and error reporting.

- **Documentation**
  - Updated documentation to reflect changes in signal handling and job control mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->