### PR TITLE
Replace SigSet with Signal array in System

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -43,11 +43,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `system::System::caught_signals`
     - `system::System::kill`
     - `system::System::sigaction`
+    - `system::System::sigmask`
+    - `system::System::select`
+    - `system::virtual::Process::blocked_signals`
+    - `system::virtual::Process::pending_signals`
+    - `system::virtual::Process::block_signals`
     - `system::virtual::Process::signal_handling`
     - `system::virtual::Process::set_signal_handling`
     - `trap::TrapSet::catch_signal`
     - `trap::TrapSet::take_caught_signal`
     - `trap::TrapSet::take_signal_if_caught`
+- `system::System::sigmask` now takes three parameters:
+    1. `&mut self,`
+    2. `op: Option<(SigmaskHow, &[signal::Number])>,`
+    3. `old_mask: Option<&mut Vec<signal::Number>>,`
 - `system::virtual::SignalEffect::of` now takes a `signal::Number` parameter
   instead of a `trap::Signal`. This function is now `const`.
 - The type parameter constraint for `subshell::Subshell` is now

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -474,7 +474,6 @@ mod tests {
     use futures_executor::LocalPool;
     use futures_util::task::LocalSpawnExt as _;
     use futures_util::FutureExt as _;
-    use nix::sys::signal::Signal;
     use std::cell::RefCell;
     use yash_syntax::source::Location;
 
@@ -519,7 +518,7 @@ mod tests {
             {
                 let mut state = state.borrow_mut();
                 let process = state.processes.get_mut(&env.main_pid).unwrap();
-                assert!(process.blocked_signals().contains(Signal::SIGCHLD));
+                assert!(process.blocked_signals().contains(&SIGCHLD));
                 let _ = process.raise_signal(SIGCHLD);
             }
             env.wait_for_signal(SIGCHLD).await;
@@ -558,7 +557,7 @@ mod tests {
         {
             let mut state = system.state.borrow_mut();
             let process = state.processes.get_mut(&system.process_id).unwrap();
-            assert!(process.blocked_signals().contains(Signal::SIGCHLD));
+            assert!(process.blocked_signals().contains(&SIGCHLD));
             let _ = process.raise_signal(SIGCHLD);
         }
 

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -16,7 +16,6 @@
 
 //! Functions about signals
 
-use super::super::Signal;
 pub(super) use crate::signal::*;
 use std::num::NonZeroI32;
 
@@ -336,28 +335,6 @@ impl Name {
             }
             _ => None,
         }
-    }
-}
-
-// TODO Remove this
-impl Number {
-    /// Converts a signal number in the real system to a signal number in the virtual system.
-    pub(super) fn from_signal_virtual(signal: Signal) -> Self {
-        use crate::system::System as _;
-        unsafe { crate::RealSystem::new() }
-            .validate_signal(signal as RawNumber)
-            .and_then(|(name, _real_number)| name.to_raw_virtual())
-            .unwrap()
-    }
-
-    /// Converts a signal number in the virtual system to a signal number in the real system.
-    pub(super) fn to_signal_virtual(self) -> Option<Signal> {
-        use crate::system::System as _;
-        unsafe { crate::RealSystem::new() }
-            .signal_number_from_name(Name::try_from_raw_virtual(self.as_raw())?)?
-            .as_raw()
-            .try_into()
-            .ok()
     }
 }
 


### PR DESCRIPTION
This commit replaces the SigSet type with an array of Signal in the System trait. This change is necessary because the SigSet type is specific to the nix crate, and the System trait should not depend on specific types from external crates.

This commit also updates the implementations of the System trait to reflect this change. SelectSystem::wait_mask is now an optional Vec of Signal, and virtual Process now uses a BTreeSet of Signal instead of SigSet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced signal handling by replacing `SigSet` with `Vec<signal::Number>` for better flexibility and performance.
  - Updated signal manipulation methods to improve consistency and reliability across the system.
  
- **New Features**
  - Introduced `all_signals()` function to iterate over all signal numbers.
  - Added `sigset_to_vec()` function to convert signal sets to vectors.

- **Bug Fixes**
  - Improved signal blocking and unblocking logic to ensure accurate signal handling in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->