### PR TITLE
Allow `SharedSystem` to be used behind a non-mutable reference

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable initial value constants in the `variable` module:
   `IFS_INITIAL_VALUE`, `OPTIND_INITIAL_VALUE`, `PS1_INITIAL_VALUE_NON_ROOT`,
   `PS1_INITIAL_VALUE_ROOT`, `PS2_INITIAL_VALUE`, `PS4_INITIAL_VALUE`
+- `impl System for &SharedSystem` and `impl trap::SignalSystem for &SharedSystem`
+    - This allows `SharedSystem` to be used as a system behind a non-mutable reference.
 
 ### Changed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Rust 1.70.0 → 1.77.0
 - Internal dependency versions:
     - annotate-snippets 0.10.0 → 0.11.4
+- All inherent methods of `SharedSystem` now take `&self` instead of `&mut self`:
+    - `SharedSystem::read_async`
+    - `SharedSystem::write_all`
+    - `SharedSystem::print_error`
 
 ### Deprecated
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -20,6 +20,7 @@ mod errno;
 pub mod fd_set;
 pub mod real;
 pub mod resource;
+mod select;
 pub mod r#virtual;
 
 pub use self::errno::Errno;
@@ -32,6 +33,8 @@ use self::r#virtual::VirtualSystem;
 use self::real::RealSystem;
 use self::resource::LimitPair;
 use self::resource::Resource;
+use self::select::SelectSystem;
+use self::select::SignalStatus;
 use crate::io::Fd;
 use crate::io::MIN_INTERNAL_FD;
 use crate::job::Pid;
@@ -57,10 +60,6 @@ pub use nix::sys::stat::{FileStat, Mode, SFlag};
 #[doc(no_inline)]
 pub use nix::sys::time::TimeSpec;
 use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::cmp::Reverse;
-use std::collections::binary_heap::PeekMut;
-use std::collections::BinaryHeap;
 use std::convert::Infallible;
 use std::ffi::c_int;
 use std::ffi::CStr;
@@ -70,15 +69,10 @@ use std::ffi::OsString;
 use std::fmt::Debug;
 use std::future::Future;
 use std::io::SeekFrom;
-use std::ops::Deref;
-use std::ops::DerefMut;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::rc::Weak;
-use std::task::Waker;
-use std::time::Duration;
 use std::time::Instant;
 
 /// API to the system-managed parts of the environment.
@@ -768,16 +762,16 @@ impl SharedSystem {
 
     fn set_nonblocking(&mut self, fd: Fd) -> Result<OFlag> {
         let mut inner = self.0.borrow_mut();
-        let flags = inner.system.fcntl_getfl(fd)?;
+        let flags = inner.fcntl_getfl(fd)?;
         if !flags.contains(OFlag::O_NONBLOCK) {
-            inner.system.fcntl_setfl(fd, flags | OFlag::O_NONBLOCK)?;
+            inner.fcntl_setfl(fd, flags | OFlag::O_NONBLOCK)?;
         }
         Ok(flags)
     }
 
     fn reset_nonblocking(&mut self, fd: Fd, old_flags: OFlag) {
         if !old_flags.contains(OFlag::O_NONBLOCK) {
-            let _: Result<()> = self.0.borrow_mut().system.fcntl_setfl(fd, old_flags);
+            let _: Result<()> = self.0.borrow_mut().fcntl_setfl(fd, old_flags);
         }
     }
 
@@ -796,10 +790,10 @@ impl SharedSystem {
 
         let result = poll_fn(|context| {
             let mut inner = self.0.borrow_mut();
-            match inner.system.read(fd, buffer) {
+            match inner.read(fd, buffer) {
                 Err(Errno::EAGAIN) => {
                     *waker.borrow_mut() = Some(context.waker().clone());
-                    inner.io.wait_for_reading(fd, &waker);
+                    inner.add_reader(fd, Rc::downgrade(&waker));
                     Poll::Pending
                 }
                 result => Poll::Ready(result),
@@ -836,7 +830,7 @@ impl SharedSystem {
 
         let result = poll_fn(|context| {
             let mut inner = self.0.borrow_mut();
-            match inner.system.write(fd, buffer) {
+            match inner.write(fd, buffer) {
                 Ok(count) => {
                     written += count;
                     buffer = &buffer[count..];
@@ -849,7 +843,7 @@ impl SharedSystem {
             }
 
             *waker.borrow_mut() = Some(context.waker().clone());
-            inner.io.wait_for_writing(fd, &waker);
+            inner.add_writer(fd, Rc::downgrade(&waker));
             Poll::Pending
         })
         .await;
@@ -879,8 +873,7 @@ impl SharedSystem {
                 return Poll::Ready(());
             }
             *waker.borrow_mut() = Some(context.waker().clone());
-            let waker = Rc::downgrade(&waker);
-            system.time.push(Timeout { target, waker });
+            system.add_timeout(target, Rc::downgrade(&waker));
             Poll::Pending
         })
         .await
@@ -898,7 +891,7 @@ impl SharedSystem {
     /// [`Env::wait_for_signals`] rather than calling this function directly
     /// so that the trap set can remember the caught signal.
     pub async fn wait_for_signals(&self) -> Rc<[signal::Number]> {
-        let status = self.0.borrow_mut().signal.wait_for_signals();
+        let status = self.0.borrow_mut().add_signal_waker();
         poll_fn(|context| {
             let mut status = status.borrow_mut();
             let dummy_status = SignalStatus::Expected(None);
@@ -1127,406 +1120,6 @@ impl SignalSystem for SharedSystem {
     }
 }
 
-/// [System] extended with internal state to support asynchronous functions.
-///
-/// `SelectSystem` wraps a `System` instance and manages the internal state for
-/// asynchronous I/O, signal handling, and timer functions. It coordinates
-/// wakers for asynchronous I/O, signals, and timers to call `select` with the
-/// appropriate arguments and wake up the wakers when the corresponding events
-/// occur.
-#[derive(Debug)]
-pub(crate) struct SelectSystem {
-    /// System instance that performs actual system calls
-    system: Box<dyn System>,
-    /// Helper for `select`ing on file descriptors
-    io: AsyncIo,
-    /// Helper for `select`ing on time
-    time: AsyncTime,
-    /// Helper for `select`ing on signals
-    signal: AsyncSignal,
-    /// Set of signals passed to `select`
-    ///
-    /// This is the mask the shell inherited from the parent shell minus the
-    /// signals the shell wants to catch.
-    wait_mask: Option<Vec<signal::Number>>,
-}
-
-impl Deref for SelectSystem {
-    type Target = Box<dyn System>;
-    fn deref(&self) -> &Box<dyn System> {
-        &self.system
-    }
-}
-
-impl DerefMut for SelectSystem {
-    fn deref_mut(&mut self) -> &mut Box<dyn System> {
-        &mut self.system
-    }
-}
-
-impl SelectSystem {
-    /// Creates a new `SelectSystem` that wraps the given `System`.
-    pub fn new(system: Box<dyn System>) -> Self {
-        SelectSystem {
-            system,
-            io: AsyncIo::new(),
-            time: AsyncTime::new(),
-            signal: AsyncSignal::new(),
-            wait_mask: None,
-        }
-    }
-
-    /// Calls `sigmask` and updates `self.wait_mask`.
-    fn sigmask(&mut self, how: SigmaskHow, signal: signal::Number) -> Result<()> {
-        match &mut self.wait_mask {
-            None => {
-                // This is the first call to sigmask. We need to get the current
-                // signal mask (which is the mask inherited from the parent shell) and
-                // remove the signal from it.
-                let mut mask = Vec::new();
-                self.system
-                    .sigmask(Some((how, &[signal])), Some(&mut mask))?;
-                mask.retain(|&s| s != signal);
-                self.wait_mask = Some(mask);
-            }
-            Some(wait_mask) => {
-                // We have already called sigmask. We just need to update the mask.
-                self.system.sigmask(Some((how, &[signal])), None)?;
-                wait_mask.retain(|&s| s != signal);
-            }
-        }
-        Ok(())
-    }
-
-    /// Implements signal handler update.
-    ///
-    /// See [`SharedSystem::set_signal_handling`].
-    pub fn set_signal_handling(
-        &mut self,
-        signal: signal::Number,
-        handling: SignalHandling,
-    ) -> Result<SignalHandling> {
-        // The order of sigmask and sigaction is important to prevent the signal
-        // from being caught. The signal must be caught only when the select
-        // function temporarily unblocks the signal. This is to avoid race
-        // condition.
-        match handling {
-            SignalHandling::Default | SignalHandling::Ignore => {
-                let old_handling = self.system.sigaction(signal, handling)?;
-                self.sigmask(SigmaskHow::SIG_UNBLOCK, signal)?;
-                Ok(old_handling)
-            }
-            SignalHandling::Catch => {
-                self.sigmask(SigmaskHow::SIG_BLOCK, signal)?;
-                self.system.sigaction(signal, handling)
-            }
-        }
-    }
-
-    fn wake_timeouts(&mut self) {
-        if !self.time.is_empty() {
-            let now = self.now();
-            self.time.wake_if_passed(now);
-        }
-        self.time.gc();
-    }
-
-    fn wake_on_signals(&mut self) {
-        let signals = self.system.caught_signals();
-        if signals.is_empty() {
-            self.signal.gc()
-        } else {
-            self.signal.wake(&signals.into())
-        }
-    }
-
-    /// Implements the select function for `SharedSystem`.
-    ///
-    /// See [`SharedSystem::select`].
-    pub fn select(&mut self, poll: bool) -> Result<()> {
-        let mut readers = self.io.readers();
-        let mut writers = self.io.writers();
-        let timeout = if poll {
-            Some(TimeSpec::from(Duration::ZERO))
-        } else {
-            self.time.first_target().map(|t| {
-                let now = self.now();
-                let duration = t.saturating_duration_since(now);
-                TimeSpec::from(duration)
-            })
-        };
-
-        let inner_result = self.system.select(
-            &mut readers,
-            &mut writers,
-            timeout.as_ref(),
-            self.wait_mask.as_deref(),
-        );
-        let final_result = match inner_result {
-            Ok(_) => {
-                self.io.wake(readers, writers);
-                Ok(())
-            }
-            Err(Errno::EBADF) => {
-                // Some of the readers and writers are invalid but we cannot
-                // tell which, so we wake up everything.
-                self.io.wake_all();
-                Err(Errno::EBADF)
-            }
-            Err(Errno::EINTR) => Ok(()),
-            Err(error) => Err(error),
-        };
-        self.io.gc();
-        self.wake_timeouts();
-        self.wake_on_signals();
-        final_result
-    }
-}
-
-/// Helper for `select`ing on file descriptors
-///
-/// An `AsyncIo` is a set of [`Waker`]s that are waiting for an FD to be ready for
-/// reading or writing. It computes the set of FDs to pass to the `select` system
-/// call and wakes the corresponding wakers when the FDs are ready.
-#[derive(Clone, Debug, Default)]
-struct AsyncIo {
-    readers: Vec<FdAwaiter>,
-    writers: Vec<FdAwaiter>,
-}
-
-#[derive(Clone, Debug)]
-struct FdAwaiter {
-    fd: Fd,
-    waker: Weak<RefCell<Option<Waker>>>,
-}
-
-/// Wakes the waker when `FdAwaiter` is dropped.
-impl Drop for FdAwaiter {
-    fn drop(&mut self) {
-        if let Some(waker) = self.waker.upgrade() {
-            if let Some(waker) = waker.borrow_mut().take() {
-                waker.wake();
-            }
-        }
-    }
-}
-
-impl AsyncIo {
-    /// Returns a new empty `AsyncIo`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns a set of FDs waiting for reading.
-    ///
-    /// The return value should be passed to the `select` or `pselect` system
-    /// call.
-    pub fn readers(&self) -> FdSet {
-        let mut set = FdSet::new();
-        for reader in &self.readers {
-            set.insert(reader.fd)
-                .expect("file descriptor out of supported range");
-        }
-        set
-    }
-
-    /// Returns a set of FDs waiting for writing.
-    ///
-    /// The return value should be passed to the `select` or `pselect` system
-    /// call.
-    pub fn writers(&self) -> FdSet {
-        let mut set = FdSet::new();
-        for writer in &self.writers {
-            set.insert(writer.fd)
-                .expect("file descriptor out of supported range");
-        }
-        set
-    }
-
-    /// Adds an awaiter for reading.
-    pub fn wait_for_reading(&mut self, fd: Fd, waker: &Rc<RefCell<Option<Waker>>>) {
-        let waker = Rc::downgrade(waker);
-        self.readers.push(FdAwaiter { fd, waker });
-    }
-
-    /// Adds an awaiter for writing.
-    pub fn wait_for_writing(&mut self, fd: Fd, waker: &Rc<RefCell<Option<Waker>>>) {
-        let waker = Rc::downgrade(waker);
-        self.writers.push(FdAwaiter { fd, waker });
-    }
-
-    /// Wakes awaiters that are ready for reading/writing.
-    ///
-    /// FDs in `readers` and `writers` are considered ready and corresponding
-    /// awaiters are woken. Once woken, awaiters are removed from `self`.
-    pub fn wake(&mut self, readers: FdSet, writers: FdSet) {
-        self.readers.retain(|awaiter| !readers.contains(awaiter.fd));
-        self.writers.retain(|awaiter| !writers.contains(awaiter.fd));
-    }
-
-    /// Wakes and removes all awaiters.
-    pub fn wake_all(&mut self) {
-        self.readers.clear();
-        self.writers.clear();
-    }
-
-    /// Discards `FdAwaiter`s having a defunct waker.
-    pub fn gc(&mut self) {
-        let is_alive = |awaiter: &FdAwaiter| awaiter.waker.strong_count() > 0;
-        self.readers.retain(is_alive);
-        self.writers.retain(is_alive);
-    }
-}
-
-/// Helper for `select`ing on time
-///
-/// An `AsyncTime` is a set of [`Waker`]s that are waiting for a specific time
-/// to come. It wakes the wakers when the time is reached.
-#[derive(Clone, Debug, Default)]
-struct AsyncTime {
-    timeouts: BinaryHeap<Reverse<Timeout>>,
-}
-
-#[derive(Clone, Debug)]
-struct Timeout {
-    target: Instant,
-    waker: Weak<RefCell<Option<Waker>>>,
-}
-
-impl PartialEq for Timeout {
-    fn eq(&self, rhs: &Self) -> bool {
-        self.target == rhs.target
-    }
-}
-
-impl Eq for Timeout {}
-
-impl PartialOrd for Timeout {
-    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        Some(self.cmp(rhs))
-    }
-}
-
-impl Ord for Timeout {
-    fn cmp(&self, rhs: &Self) -> Ordering {
-        self.target.cmp(&rhs.target)
-    }
-}
-
-/// Wakes the waker when `Timeout` is dropped.
-impl Drop for Timeout {
-    fn drop(&mut self) {
-        if let Some(waker) = self.waker.upgrade() {
-            if let Some(waker) = waker.borrow_mut().take() {
-                waker.wake();
-            }
-        }
-    }
-}
-
-impl AsyncTime {
-    #[must_use]
-    fn new() -> Self {
-        Self::default()
-    }
-
-    #[must_use]
-    fn is_empty(&self) -> bool {
-        self.timeouts.is_empty()
-    }
-
-    fn push(&mut self, timeout: Timeout) {
-        self.timeouts.push(Reverse(timeout))
-    }
-
-    #[must_use]
-    fn first_target(&self) -> Option<Instant> {
-        self.timeouts.peek().map(|timeout| timeout.0.target)
-    }
-
-    fn wake_if_passed(&mut self, now: Instant) {
-        while let Some(timeout) = self.timeouts.peek_mut() {
-            if !timeout.0.passed(now) {
-                break;
-            }
-            PeekMut::pop(timeout);
-        }
-    }
-
-    fn gc(&mut self) {
-        self.timeouts.retain(|t| t.0.waker.strong_count() > 0);
-    }
-}
-
-impl Timeout {
-    fn passed(&self, now: Instant) -> bool {
-        self.target <= now
-    }
-}
-
-/// Helper for `select`ing on signals
-///
-/// An `AsyncSignal` is a set of [`Waker`]s that are waiting for a signal to be
-/// caught by the current process. It wakes the wakers when signals are caught.
-#[derive(Clone, Debug, Default)]
-struct AsyncSignal {
-    awaiters: Vec<Weak<RefCell<SignalStatus>>>,
-}
-
-#[derive(Clone, Debug)]
-enum SignalStatus {
-    Expected(Option<Waker>),
-    Caught(Rc<[signal::Number]>),
-}
-
-impl AsyncSignal {
-    /// Returns a new empty `AsyncSignal`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Removes internal weak pointers whose `SignalStatus` has gone.
-    pub fn gc(&mut self) {
-        self.awaiters.retain(|awaiter| awaiter.strong_count() > 0);
-    }
-
-    /// Adds an awaiter for signals.
-    ///
-    /// This function returns a reference-counted
-    /// `SignalStatus::Expected(None)`. The caller must set a waker to the
-    /// returned `SignalStatus::Expected`. When signals are caught, the waker is
-    /// woken and replaced with `SignalStatus::Caught(signals)`. The caller can
-    /// replace the waker in the `SignalStatus::Expected` with another if the
-    /// previous waker gets expired and the caller wants to be woken again.
-    pub fn wait_for_signals(&mut self) -> Rc<RefCell<SignalStatus>> {
-        let status = Rc::new(RefCell::new(SignalStatus::Expected(None)));
-        self.awaiters.push(Rc::downgrade(&status));
-        status
-    }
-
-    /// Wakes awaiters for caught signals.
-    ///
-    /// This function wakes up all wakers in pending `SignalStatus`es and
-    /// removes them from `self`.
-    ///
-    /// This function borrows `SignalStatus`es returned from `wait_for_signals`
-    /// so you must not have conflicting borrows.
-    pub fn wake(&mut self, signals: &Rc<[signal::Number]>) {
-        for status in self.awaiters.drain(..) {
-            let Some(status) = status.upgrade() else {
-                continue;
-            };
-            let mut status_ref = status.borrow_mut();
-            let new_status = SignalStatus::Caught(Rc::clone(signals));
-            let old_status = std::mem::replace(&mut *status_ref, new_status);
-            drop(status_ref);
-            if let SignalStatus::Expected(Some(waker)) = old_status {
-                waker.wake();
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::r#virtual::VirtualSystem;
@@ -1534,12 +1127,12 @@ mod tests {
     use super::r#virtual::{SIGCHLD, SIGINT, SIGTERM, SIGUSR1};
     use super::*;
     use assert_matches::assert_matches;
-    use futures_util::task::noop_waker;
     use futures_util::task::noop_waker_ref;
     use futures_util::FutureExt;
     use std::future::Future;
     use std::rc::Rc;
     use std::task::Context;
+    use std::time::Duration;
 
     #[test]
     fn shared_system_read_async_ready() {
@@ -1879,134 +1472,5 @@ mod tests {
         let poll = future.as_mut().poll(&mut context);
         assert_eq!(poll, Poll::Pending);
         assert_eq!(state.borrow().now, Some(start));
-    }
-
-    #[test]
-    fn async_io_has_no_default_readers_or_writers() {
-        let async_io = AsyncIo::new();
-        assert_eq!(async_io.readers(), FdSet::new());
-        assert_eq!(async_io.writers(), FdSet::new());
-    }
-
-    #[test]
-    fn async_io_non_empty_readers_and_writers() {
-        let mut async_io = AsyncIo::new();
-        let waker = Rc::new(RefCell::new(Some(noop_waker())));
-        async_io.wait_for_reading(Fd::STDIN, &waker);
-        async_io.wait_for_writing(Fd::STDOUT, &waker);
-        async_io.wait_for_writing(Fd::STDERR, &waker);
-
-        let mut expected_readers = FdSet::new();
-        expected_readers.insert(Fd::STDIN).unwrap();
-        let mut expected_writers = FdSet::new();
-        expected_writers.insert(Fd::STDOUT).unwrap();
-        expected_writers.insert(Fd::STDERR).unwrap();
-        assert_eq!(async_io.readers(), expected_readers);
-        assert_eq!(async_io.writers(), expected_writers);
-    }
-
-    #[test]
-    fn async_io_wake() {
-        let mut async_io = AsyncIo::new();
-        let waker = Rc::new(RefCell::new(Some(noop_waker())));
-        async_io.wait_for_reading(Fd(3), &waker);
-        async_io.wait_for_reading(Fd(4), &waker);
-        async_io.wait_for_writing(Fd(4), &waker);
-        let mut fds = FdSet::new();
-        fds.insert(Fd(4)).unwrap();
-        async_io.wake(fds, fds);
-
-        let mut expected_readers = FdSet::new();
-        expected_readers.insert(Fd(3)).unwrap();
-        assert_eq!(async_io.readers(), expected_readers);
-        assert_eq!(async_io.writers(), FdSet::new());
-    }
-
-    #[test]
-    fn async_io_wake_all() {
-        let mut async_io = AsyncIo::new();
-        let waker = Rc::new(RefCell::new(Some(noop_waker())));
-        async_io.wait_for_reading(Fd::STDIN, &waker);
-        async_io.wait_for_writing(Fd::STDOUT, &waker);
-        async_io.wait_for_writing(Fd::STDERR, &waker);
-        async_io.wake_all();
-        assert_eq!(async_io.readers(), FdSet::new());
-        assert_eq!(async_io.writers(), FdSet::new());
-    }
-
-    #[test]
-    fn async_time_first_target() {
-        let mut async_time = AsyncTime::new();
-        let now = Instant::now();
-        assert_eq!(async_time.first_target(), None);
-
-        async_time.push(Timeout {
-            target: now + Duration::from_secs(2),
-            waker: Weak::default(),
-        });
-        async_time.push(Timeout {
-            target: now + Duration::from_secs(1),
-            waker: Weak::default(),
-        });
-        async_time.push(Timeout {
-            target: now + Duration::from_secs(3),
-            waker: Weak::default(),
-        });
-        assert_eq!(
-            async_time.first_target(),
-            Some(now + Duration::from_secs(1))
-        );
-    }
-
-    #[test]
-    fn async_time_wake_if_passed() {
-        let mut async_time = AsyncTime::new();
-        let now = Instant::now();
-        let waker = Rc::new(RefCell::new(Some(noop_waker())));
-        async_time.push(Timeout {
-            target: now,
-            waker: Rc::downgrade(&waker),
-        });
-        async_time.push(Timeout {
-            target: now + Duration::new(1, 0),
-            waker: Rc::downgrade(&waker),
-        });
-        async_time.push(Timeout {
-            target: now + Duration::new(1, 1),
-            waker: Rc::downgrade(&waker),
-        });
-        async_time.push(Timeout {
-            target: now + Duration::new(2, 0),
-            waker: Rc::downgrade(&waker),
-        });
-        assert_eq!(async_time.timeouts.len(), 4);
-
-        async_time.wake_if_passed(now + Duration::new(1, 0));
-        assert_eq!(
-            async_time.timeouts.pop().unwrap().0.target,
-            now + Duration::new(1, 1)
-        );
-        assert_eq!(
-            async_time.timeouts.pop().unwrap().0.target,
-            now + Duration::new(2, 0)
-        );
-        assert!(async_time.timeouts.is_empty(), "{:?}", async_time.timeouts);
-    }
-
-    #[test]
-    fn async_signal_wake() {
-        let mut async_signal = AsyncSignal::new();
-        let status_1 = async_signal.wait_for_signals();
-        let status_2 = async_signal.wait_for_signals();
-        *status_1.borrow_mut() = SignalStatus::Expected(Some(noop_waker()));
-        *status_2.borrow_mut() = SignalStatus::Expected(Some(noop_waker()));
-
-        async_signal.wake(&(Rc::new([SIGCHLD, SIGUSR1]) as Rc<[signal::Number]>));
-        assert_matches!(&*status_1.borrow(), SignalStatus::Caught(signals) => {
-            assert_eq!(**signals, [SIGCHLD, SIGUSR1]);
-        });
-        assert_matches!(&*status_2.borrow(), SignalStatus::Caught(signals) => {
-            assert_eq!(**signals, [SIGCHLD, SIGUSR1]);
-        });
     }
 }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -21,6 +21,7 @@ pub mod fd_set;
 pub mod real;
 pub mod resource;
 mod select;
+mod shared;
 pub mod r#virtual;
 
 pub use self::errno::Errno;
@@ -35,6 +36,7 @@ use self::resource::LimitPair;
 use self::resource::Resource;
 use self::select::SelectSystem;
 use self::select::SignalStatus;
+pub use self::shared::SharedSystem;
 use crate::io::Fd;
 use crate::io::MIN_INTERNAL_FD;
 use crate::job::Pid;
@@ -45,8 +47,6 @@ use crate::signal;
 use crate::subshell::Subshell;
 use crate::trap::SignalSystem;
 use crate::Env;
-use futures_util::future::poll_fn;
-use futures_util::task::Poll;
 #[doc(no_inline)]
 pub use nix::fcntl::AtFlags;
 #[doc(no_inline)]
@@ -59,7 +59,6 @@ pub use nix::sys::signal::SigmaskHow;
 pub use nix::sys::stat::{FileStat, Mode, SFlag};
 #[doc(no_inline)]
 pub use nix::sys::time::TimeSpec;
-use std::cell::RefCell;
 use std::convert::Infallible;
 use std::ffi::c_int;
 use std::ffi::CStr;
@@ -72,7 +71,6 @@ use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::time::Instant;
 
 /// API to the system-managed parts of the environment.
@@ -694,432 +692,6 @@ pub trait SystemEx: System {
 
 impl<T: System + ?Sized> SystemEx for T {}
 
-/// System shared by a reference counter.
-///
-/// A `SharedSystem` is a reference-counted container of a [`System`] instance
-/// accompanied with an internal state for supporting asynchronous interactions
-/// with the system. As it is reference-counted, cloning a `SharedSystem`
-/// instance only increments the reference count without cloning the backing
-/// system instance. This behavior allows calling `SharedSystem`'s methods
-/// concurrently from different `async` tasks that each have a `SharedSystem`
-/// instance sharing the same state.
-///
-/// `SharedSystem` implements [`System`] by delegating to the contained system
-/// instance. You should avoid calling some of the `System` methods, however.
-/// Prefer `async` functions provided by `SharedSystem` (e.g.,
-/// [`read_async`](Self::read_async)) over raw system functions (e.g.,
-/// [`read`](System::read)).
-///
-/// The following example illustrates how multiple concurrent tasks are run in a
-/// single-threaded pool:
-///
-/// ```
-/// # use yash_env::{SharedSystem, System, VirtualSystem};
-/// # use futures_util::task::LocalSpawnExt;
-/// let mut system = SharedSystem::new(Box::new(VirtualSystem::new()));
-/// let mut system2 = system.clone();
-/// let mut system3 = system.clone();
-/// let (reader, writer) = system.pipe().unwrap();
-/// let mut executor = futures_executor::LocalPool::new();
-///
-/// // We add a task that tries to read from the pipe, but nothing has been
-/// // written to it, so the task is stalled.
-/// let read_task = executor.spawner().spawn_local_with_handle(async move {
-///     let mut buffer = [0; 1];
-///     system.read_async(reader, &mut buffer).await.unwrap();
-///     buffer[0]
-/// });
-/// executor.run_until_stalled();
-///
-/// // Let's add a task that writes to the pipe.
-/// executor.spawner().spawn_local(async move {
-///     system2.write_all(writer, &[123]).await.unwrap();
-/// });
-/// executor.run_until_stalled();
-///
-/// // The write task has written a byte to the pipe, but the read task is still
-/// // stalled. We need to wake it up by calling `select`.
-/// system3.select(false).unwrap();
-///
-/// // Now the read task can proceed to the end.
-/// let number = executor.run_until(read_task.unwrap());
-/// assert_eq!(number, 123);
-/// ```
-///
-/// If there is a child process in the [`VirtualSystem`], you should call
-/// [`SystemState::select_all`](self::virtual::SystemState::select_all) in
-/// addition to [`SharedSystem::select`] so that the child process task is woken
-/// up when needed.
-/// (TBD code example)
-#[derive(Clone, Debug)]
-pub struct SharedSystem(pub(crate) Rc<RefCell<SelectSystem>>);
-
-impl SharedSystem {
-    /// Creates a new shared system.
-    pub fn new(system: Box<dyn System>) -> Self {
-        SharedSystem(Rc::new(RefCell::new(SelectSystem::new(system))))
-    }
-
-    fn set_nonblocking(&mut self, fd: Fd) -> Result<OFlag> {
-        let mut inner = self.0.borrow_mut();
-        let flags = inner.fcntl_getfl(fd)?;
-        if !flags.contains(OFlag::O_NONBLOCK) {
-            inner.fcntl_setfl(fd, flags | OFlag::O_NONBLOCK)?;
-        }
-        Ok(flags)
-    }
-
-    fn reset_nonblocking(&mut self, fd: Fd, old_flags: OFlag) {
-        if !old_flags.contains(OFlag::O_NONBLOCK) {
-            let _: Result<()> = self.0.borrow_mut().fcntl_setfl(fd, old_flags);
-        }
-    }
-
-    /// Reads from the file descriptor.
-    ///
-    /// This function waits for one or more bytes to be available for reading.
-    /// If successful, returns the number of bytes read.
-    pub async fn read_async(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
-        let flags = self.set_nonblocking(fd)?;
-
-        // We need to retain a strong reference to the waker outside the poll_fn
-        // function because SelectSystem only retains a weak reference to it.
-        // This allows SelectSystem to discard defunct wakers if this async task
-        // is aborted.
-        let waker = Rc::new(RefCell::new(None));
-
-        let result = poll_fn(|context| {
-            let mut inner = self.0.borrow_mut();
-            match inner.read(fd, buffer) {
-                Err(Errno::EAGAIN) => {
-                    *waker.borrow_mut() = Some(context.waker().clone());
-                    inner.add_reader(fd, Rc::downgrade(&waker));
-                    Poll::Pending
-                }
-                result => Poll::Ready(result),
-            }
-        })
-        .await;
-
-        self.reset_nonblocking(fd, flags);
-
-        result
-    }
-
-    /// Writes to the file descriptor.
-    ///
-    /// This function calls [`System::write`] repeatedly until the whole
-    /// `buffer` is written to the FD. If the `buffer` is empty, `write` is not
-    /// called at all, so any error that would be returned from `write` is not
-    /// returned.
-    ///
-    /// This function silently ignores signals that may interrupt writes.
-    pub async fn write_all(&mut self, fd: Fd, mut buffer: &[u8]) -> Result<usize> {
-        if buffer.is_empty() {
-            return Ok(0);
-        }
-
-        let flags = self.set_nonblocking(fd)?;
-        let mut written = 0;
-
-        // We need to retain a strong reference to the waker outside the poll_fn
-        // function because SelectSystem only retains a weak reference to it.
-        // This allows SelectSystem to discard defunct wakers if this async task
-        // is aborted.
-        let waker = Rc::new(RefCell::new(None));
-
-        let result = poll_fn(|context| {
-            let mut inner = self.0.borrow_mut();
-            match inner.write(fd, buffer) {
-                Ok(count) => {
-                    written += count;
-                    buffer = &buffer[count..];
-                    if buffer.is_empty() {
-                        return Poll::Ready(Ok(written));
-                    }
-                }
-                Err(Errno::EAGAIN | Errno::EINTR) => (),
-                Err(error) => return Poll::Ready(Err(error)),
-            }
-
-            *waker.borrow_mut() = Some(context.waker().clone());
-            inner.add_writer(fd, Rc::downgrade(&waker));
-            Poll::Pending
-        })
-        .await;
-
-        self.reset_nonblocking(fd, flags);
-
-        result
-    }
-
-    /// Convenience function for printing a message to the standard error
-    pub async fn print_error(&mut self, message: &str) {
-        _ = self.write_all(Fd::STDERR, message.as_bytes()).await;
-    }
-
-    /// Waits until the specified time point.
-    pub async fn wait_until(&self, target: Instant) {
-        // We need to retain a strong reference to the waker outside the poll_fn
-        // function because SelectSystem only retains a weak reference to it.
-        // This allows SelectSystem to discard defunct wakers if this async task
-        // is aborted.
-        let waker = Rc::new(RefCell::new(None));
-
-        poll_fn(|context| {
-            let mut system = self.0.borrow_mut();
-            let now = system.now();
-            if now >= target {
-                return Poll::Ready(());
-            }
-            *waker.borrow_mut() = Some(context.waker().clone());
-            system.add_timeout(target, Rc::downgrade(&waker));
-            Poll::Pending
-        })
-        .await
-    }
-
-    /// Waits for some signals to be delivered to this process.
-    ///
-    /// Before calling this function, you need to [set signal
-    /// handling](Self::set_signal_handling) to `Catch`. Without doing so, this
-    /// function cannot detect the receipt of the signals.
-    ///
-    /// Returns an array of signals that were caught.
-    ///
-    /// If this `SharedSystem` is part of an [`Env`], you should call
-    /// [`Env::wait_for_signals`] rather than calling this function directly
-    /// so that the trap set can remember the caught signal.
-    pub async fn wait_for_signals(&self) -> Rc<[signal::Number]> {
-        let status = self.0.borrow_mut().add_signal_waker();
-        poll_fn(|context| {
-            let mut status = status.borrow_mut();
-            let dummy_status = SignalStatus::Expected(None);
-            let old_status = std::mem::replace(&mut *status, dummy_status);
-            match old_status {
-                SignalStatus::Caught(signals) => Poll::Ready(signals),
-                SignalStatus::Expected(_) => {
-                    *status = SignalStatus::Expected(Some(context.waker().clone()));
-                    Poll::Pending
-                }
-            }
-        })
-        .await
-    }
-
-    /// Waits for a signal to be delivered to this process.
-    ///
-    /// Before calling this function, you need to [set signal
-    /// handling](Self::set_signal_handling) to `Catch`.
-    /// Without doing so, this function cannot detect the receipt of the signal.
-    ///
-    /// If this `SharedSystem` is part of an [`Env`], you should call
-    /// [`Env::wait_for_signal`] rather than calling this function directly
-    /// so that the trap set can remember the caught signal.
-    pub async fn wait_for_signal(&self, signal: signal::Number) {
-        while !self.wait_for_signals().await.contains(&signal) {}
-    }
-
-    /// Waits for a next event to occur.
-    ///
-    /// This function calls [`System::select`] with arguments computed from the
-    /// current internal state of the `SharedSystem`. It will wake up tasks
-    /// waiting for the file descriptor to be ready in
-    /// [`read_async`](Self::read_async) and [`write_all`](Self::write_all) or
-    /// for a signal to be caught in [`wait_for_signal`](Self::wait_for_signal).
-    /// If no tasks are woken for FDs or signals and `poll` is false, this
-    /// function will block until the first task waiting for a specific time
-    /// point is woken.
-    ///
-    /// If poll is true, this function does not block, so it may not wake up any
-    /// tasks.
-    ///
-    /// This function may wake up a task even if the condition it is expecting
-    /// has not yet been met.
-    pub fn select(&self, poll: bool) -> Result<()> {
-        self.0.borrow_mut().select(poll)
-    }
-}
-
-impl System for SharedSystem {
-    fn fstat(&self, fd: Fd) -> Result<FileStat> {
-        self.0.borrow().fstat(fd)
-    }
-    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat> {
-        self.0.borrow().fstatat(dir_fd, path, flags)
-    }
-    fn is_executable_file(&self, path: &CStr) -> bool {
-        self.0.borrow().is_executable_file(path)
-    }
-    fn is_directory(&self, path: &CStr) -> bool {
-        self.0.borrow().is_directory(path)
-    }
-    fn pipe(&mut self) -> Result<(Fd, Fd)> {
-        self.0.borrow_mut().pipe()
-    }
-    fn dup(&mut self, from: Fd, to_min: Fd, flags: FdFlag) -> Result<Fd> {
-        self.0.borrow_mut().dup(from, to_min, flags)
-    }
-    fn dup2(&mut self, from: Fd, to: Fd) -> Result<Fd> {
-        self.0.borrow_mut().dup2(from, to)
-    }
-    fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> Result<Fd> {
-        self.0.borrow_mut().open(path, option, mode)
-    }
-    fn open_tmpfile(&mut self, parent_dir: &Path) -> Result<Fd> {
-        self.0.borrow_mut().open_tmpfile(parent_dir)
-    }
-    fn close(&mut self, fd: Fd) -> Result<()> {
-        self.0.borrow_mut().close(fd)
-    }
-    fn fcntl_getfl(&self, fd: Fd) -> Result<OFlag> {
-        self.0.borrow().fcntl_getfl(fd)
-    }
-    fn fcntl_setfl(&mut self, fd: Fd, flags: OFlag) -> Result<()> {
-        self.0.borrow_mut().fcntl_setfl(fd, flags)
-    }
-    fn fcntl_getfd(&self, fd: Fd) -> Result<FdFlag> {
-        self.0.borrow().fcntl_getfd(fd)
-    }
-    fn fcntl_setfd(&mut self, fd: Fd, flags: FdFlag) -> Result<()> {
-        self.0.borrow_mut().fcntl_setfd(fd, flags)
-    }
-    fn isatty(&self, fd: Fd) -> Result<bool> {
-        self.0.borrow().isatty(fd)
-    }
-    fn read(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
-        self.0.borrow_mut().read(fd, buffer)
-    }
-    fn write(&mut self, fd: Fd, buffer: &[u8]) -> Result<usize> {
-        self.0.borrow_mut().write(fd, buffer)
-    }
-    fn lseek(&mut self, fd: Fd, position: SeekFrom) -> Result<u64> {
-        self.0.borrow_mut().lseek(fd, position)
-    }
-    fn fdopendir(&mut self, fd: Fd) -> Result<Box<dyn Dir>> {
-        self.0.borrow_mut().fdopendir(fd)
-    }
-    fn opendir(&mut self, path: &CStr) -> Result<Box<dyn Dir>> {
-        self.0.borrow_mut().opendir(path)
-    }
-    fn umask(&mut self, mask: Mode) -> Mode {
-        self.0.borrow_mut().umask(mask)
-    }
-    fn now(&self) -> Instant {
-        self.0.borrow().now()
-    }
-    fn times(&self) -> Result<Times> {
-        self.0.borrow().times()
-    }
-    fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
-        self.0.borrow().validate_signal(number)
-    }
-    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
-        self.0.borrow().signal_number_from_name(name)
-    }
-    fn sigmask(
-        &mut self,
-        op: Option<(SigmaskHow, &[signal::Number])>,
-        old_mask: Option<&mut Vec<signal::Number>>,
-    ) -> Result<()> {
-        (**self.0.borrow_mut()).sigmask(op, old_mask)
-    }
-    fn sigaction(
-        &mut self,
-        signal: signal::Number,
-        action: SignalHandling,
-    ) -> Result<SignalHandling> {
-        self.0.borrow_mut().sigaction(signal, action)
-    }
-    fn caught_signals(&mut self) -> Vec<signal::Number> {
-        self.0.borrow_mut().caught_signals()
-    }
-    fn kill(
-        &mut self,
-        target: Pid,
-        signal: Option<signal::Number>,
-    ) -> Pin<Box<(dyn Future<Output = Result<()>>)>> {
-        self.0.borrow_mut().kill(target, signal)
-    }
-    fn select(
-        &mut self,
-        readers: &mut FdSet,
-        writers: &mut FdSet,
-        timeout: Option<&TimeSpec>,
-        signal_mask: Option<&[signal::Number]>,
-    ) -> Result<c_int> {
-        (**self.0.borrow_mut()).select(readers, writers, timeout, signal_mask)
-    }
-    fn getpid(&self) -> Pid {
-        self.0.borrow().getpid()
-    }
-    fn getppid(&self) -> Pid {
-        self.0.borrow().getppid()
-    }
-    fn getpgrp(&self) -> Pid {
-        self.0.borrow().getpgrp()
-    }
-    fn setpgid(&mut self, pid: Pid, pgid: Pid) -> Result<()> {
-        self.0.borrow_mut().setpgid(pid, pgid)
-    }
-    fn tcgetpgrp(&self, fd: Fd) -> Result<Pid> {
-        self.0.borrow().tcgetpgrp(fd)
-    }
-    fn tcsetpgrp(&mut self, fd: Fd, pgid: Pid) -> Result<()> {
-        self.0.borrow_mut().tcsetpgrp(fd, pgid)
-    }
-    fn new_child_process(&mut self) -> Result<ChildProcessStarter> {
-        self.0.borrow_mut().new_child_process()
-    }
-    fn wait(&mut self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {
-        self.0.borrow_mut().wait(target)
-    }
-    fn execve(&mut self, path: &CStr, args: &[CString], envs: &[CString]) -> Result<Infallible> {
-        self.0.borrow_mut().execve(path, args, envs)
-    }
-    fn getcwd(&self) -> Result<PathBuf> {
-        self.0.borrow().getcwd()
-    }
-    fn chdir(&mut self, path: &CStr) -> Result<()> {
-        self.0.borrow_mut().chdir(path)
-    }
-    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
-        self.0.borrow().getpwnam_dir(name)
-    }
-    fn confstr_path(&self) -> Result<OsString> {
-        self.0.borrow().confstr_path()
-    }
-    fn shell_path(&self) -> CString {
-        self.0.borrow().shell_path()
-    }
-    fn getrlimit(&self, resource: Resource) -> std::io::Result<LimitPair> {
-        self.0.borrow().getrlimit(resource)
-    }
-    fn setrlimit(&mut self, resource: Resource, limits: LimitPair) -> std::io::Result<()> {
-        self.0.borrow_mut().setrlimit(resource, limits)
-    }
-}
-
-impl SignalSystem for SharedSystem {
-    #[inline]
-    fn signal_name_from_number(&self, number: signal::Number) -> signal::Name {
-        SystemEx::signal_name_from_number(self, number)
-    }
-
-    #[inline]
-    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
-        System::signal_number_from_name(self, name)
-    }
-
-    fn set_signal_handling(
-        &mut self,
-        signal: signal::Number,
-        handling: SignalHandling,
-    ) -> Result<SignalHandling> {
-        self.0.borrow_mut().set_signal_handling(signal, handling)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::r#virtual::VirtualSystem;
@@ -1132,6 +704,7 @@ mod tests {
     use std::future::Future;
     use std::rc::Rc;
     use std::task::Context;
+    use std::task::Poll;
     use std::time::Duration;
 
     #[test]

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -1,0 +1,601 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! [`SelectSystem`] and related items
+
+use super::fd_set::FdSet;
+use super::signal;
+use super::Errno;
+use super::Result;
+use super::SignalHandling;
+use super::System;
+use crate::io::Fd;
+use nix::sys::signal::SigmaskHow;
+use nix::sys::time::TimeSpec;
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::cmp::Reverse;
+use std::collections::binary_heap::PeekMut;
+use std::collections::BinaryHeap;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::rc::Rc;
+use std::rc::Weak;
+use std::task::Waker;
+use std::time::Duration;
+use std::time::Instant;
+
+/// [System] extended with internal state to support asynchronous functions.
+///
+/// `SelectSystem` wraps a `System` instance and manages the internal state for
+/// asynchronous I/O, signal handling, and timer functions. It coordinates
+/// wakers for asynchronous I/O, signals, and timers to call `select` with the
+/// appropriate arguments and wake up the wakers when the corresponding events
+/// occur.
+#[derive(Debug)]
+pub struct SelectSystem {
+    /// System instance that performs actual system calls
+    system: Box<dyn System>,
+    /// Helper for `select`ing on file descriptors
+    io: AsyncIo,
+    /// Helper for `select`ing on time
+    time: AsyncTime,
+    /// Helper for `select`ing on signals
+    signal: AsyncSignal,
+    /// Set of signals passed to `select`
+    ///
+    /// This is the mask the shell inherited from the parent shell minus the
+    /// signals the shell wants to catch.
+    wait_mask: Option<Vec<signal::Number>>,
+}
+
+impl Deref for SelectSystem {
+    type Target = Box<dyn System>;
+    fn deref(&self) -> &Box<dyn System> {
+        &self.system
+    }
+}
+
+impl DerefMut for SelectSystem {
+    fn deref_mut(&mut self) -> &mut Box<dyn System> {
+        &mut self.system
+    }
+}
+
+impl SelectSystem {
+    /// Creates a new `SelectSystem` that wraps the given `System`.
+    pub fn new(system: Box<dyn System>) -> Self {
+        SelectSystem {
+            system,
+            io: AsyncIo::new(),
+            time: AsyncTime::new(),
+            signal: AsyncSignal::new(),
+            wait_mask: None,
+        }
+    }
+
+    /// Calls `sigmask` and updates `self.wait_mask`.
+    fn sigmask(&mut self, how: SigmaskHow, signal: signal::Number) -> Result<()> {
+        match &mut self.wait_mask {
+            None => {
+                // This is the first call to sigmask. We need to get the current
+                // signal mask (which is the mask inherited from the parent shell) and
+                // remove the signal from it.
+                let mut mask = Vec::new();
+                self.system
+                    .sigmask(Some((how, &[signal])), Some(&mut mask))?;
+                mask.retain(|&s| s != signal);
+                self.wait_mask = Some(mask);
+            }
+            Some(wait_mask) => {
+                // We have already called sigmask. We just need to update the mask.
+                self.system.sigmask(Some((how, &[signal])), None)?;
+                wait_mask.retain(|&s| s != signal);
+            }
+        }
+        Ok(())
+    }
+
+    /// Implements signal handler update.
+    ///
+    /// See [`SharedSystem::set_signal_handling`].
+    pub fn set_signal_handling(
+        &mut self,
+        signal: signal::Number,
+        handling: SignalHandling,
+    ) -> Result<SignalHandling> {
+        // The order of sigmask and sigaction is important to prevent the signal
+        // from being caught. The signal must be caught only when the select
+        // function temporarily unblocks the signal. This is to avoid race
+        // condition.
+        match handling {
+            SignalHandling::Default | SignalHandling::Ignore => {
+                let old_handling = self.system.sigaction(signal, handling)?;
+                self.sigmask(SigmaskHow::SIG_UNBLOCK, signal)?;
+                Ok(old_handling)
+            }
+            SignalHandling::Catch => {
+                self.sigmask(SigmaskHow::SIG_BLOCK, signal)?;
+                self.system.sigaction(signal, handling)
+            }
+        }
+    }
+
+    /// Registers a waker to be woken when the specified file descriptor is ready for reading.
+    pub fn add_reader(&mut self, fd: Fd, waker: Weak<RefCell<Option<Waker>>>) {
+        self.io.wait_for_reading(fd, waker)
+    }
+
+    /// Registers a waker to be woken when the specified file descriptor is ready for writing.
+    pub fn add_writer(&mut self, fd: Fd, waker: Weak<RefCell<Option<Waker>>>) {
+        self.io.wait_for_writing(fd, waker)
+    }
+
+    /// Registers a waker to be woken when the specified time is reached.
+    pub fn add_timeout(&mut self, target: Instant, waker: Weak<RefCell<Option<Waker>>>) {
+        self.time.push(Timeout { target, waker })
+    }
+
+    /// Registers an awaiter for signals.
+    ///
+    /// This function returns a reference-counted
+    /// `SignalStatus::Expected(None)`. The caller must set a waker to the
+    /// returned `SignalStatus::Expected`. When signals are caught, the waker is
+    /// woken and replaced with `SignalStatus::Caught(signals)`. The caller can
+    /// replace the waker in the `SignalStatus::Expected` with another if the
+    /// previous waker gets expired and the caller wants to be woken again.
+    pub fn add_signal_waker(&mut self) -> Rc<RefCell<SignalStatus>> {
+        self.signal.wait_for_signals()
+    }
+
+    fn wake_timeouts(&mut self) {
+        if !self.time.is_empty() {
+            let now = self.now();
+            self.time.wake_if_passed(now);
+        }
+        self.time.gc();
+    }
+
+    fn wake_on_signals(&mut self) {
+        let signals = self.system.caught_signals();
+        if signals.is_empty() {
+            self.signal.gc()
+        } else {
+            self.signal.wake(&signals.into())
+        }
+    }
+
+    /// Implements the select function for `SharedSystem`.
+    ///
+    /// See [`SharedSystem::select`].
+    pub fn select(&mut self, poll: bool) -> Result<()> {
+        let mut readers = self.io.readers();
+        let mut writers = self.io.writers();
+        let timeout = if poll {
+            Some(TimeSpec::from(Duration::ZERO))
+        } else {
+            self.time.first_target().map(|t| {
+                let now = self.now();
+                let duration = t.saturating_duration_since(now);
+                TimeSpec::from(duration)
+            })
+        };
+
+        let inner_result = self.system.select(
+            &mut readers,
+            &mut writers,
+            timeout.as_ref(),
+            self.wait_mask.as_deref(),
+        );
+        let final_result = match inner_result {
+            Ok(_) => {
+                self.io.wake(readers, writers);
+                Ok(())
+            }
+            Err(Errno::EBADF) => {
+                // Some of the readers and writers are invalid but we cannot
+                // tell which, so we wake up everything.
+                self.io.wake_all();
+                Err(Errno::EBADF)
+            }
+            Err(Errno::EINTR) => Ok(()),
+            Err(error) => Err(error),
+        };
+        self.io.gc();
+        self.wake_timeouts();
+        self.wake_on_signals();
+        final_result
+    }
+}
+
+/// Helper for `select`ing on file descriptors
+///
+/// An `AsyncIo` is a set of [`Waker`]s that are waiting for an FD to be ready for
+/// reading or writing. It computes the set of FDs to pass to the `select` system
+/// call and wakes the corresponding wakers when the FDs are ready.
+#[derive(Clone, Debug, Default)]
+struct AsyncIo {
+    readers: Vec<FdAwaiter>,
+    writers: Vec<FdAwaiter>,
+}
+
+#[derive(Clone, Debug)]
+struct FdAwaiter {
+    fd: Fd,
+    waker: Weak<RefCell<Option<Waker>>>,
+}
+
+/// Wakes the waker when `FdAwaiter` is dropped.
+impl Drop for FdAwaiter {
+    fn drop(&mut self) {
+        if let Some(waker) = self.waker.upgrade() {
+            if let Some(waker) = waker.borrow_mut().take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+impl AsyncIo {
+    /// Returns a new empty `AsyncIo`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a set of FDs waiting for reading.
+    ///
+    /// The return value should be passed to the `select` or `pselect` system
+    /// call.
+    pub fn readers(&self) -> FdSet {
+        let mut set = FdSet::new();
+        for reader in &self.readers {
+            set.insert(reader.fd)
+                .expect("file descriptor out of supported range");
+        }
+        set
+    }
+
+    /// Returns a set of FDs waiting for writing.
+    ///
+    /// The return value should be passed to the `select` or `pselect` system
+    /// call.
+    pub fn writers(&self) -> FdSet {
+        let mut set = FdSet::new();
+        for writer in &self.writers {
+            set.insert(writer.fd)
+                .expect("file descriptor out of supported range");
+        }
+        set
+    }
+
+    /// Adds an awaiter for reading.
+    pub fn wait_for_reading(&mut self, fd: Fd, waker: Weak<RefCell<Option<Waker>>>) {
+        self.readers.push(FdAwaiter { fd, waker });
+    }
+
+    /// Adds an awaiter for writing.
+    pub fn wait_for_writing(&mut self, fd: Fd, waker: Weak<RefCell<Option<Waker>>>) {
+        self.writers.push(FdAwaiter { fd, waker });
+    }
+
+    /// Wakes awaiters that are ready for reading/writing.
+    ///
+    /// FDs in `readers` and `writers` are considered ready and corresponding
+    /// awaiters are woken. Once woken, awaiters are removed from `self`.
+    pub fn wake(&mut self, readers: FdSet, writers: FdSet) {
+        self.readers.retain(|awaiter| !readers.contains(awaiter.fd));
+        self.writers.retain(|awaiter| !writers.contains(awaiter.fd));
+    }
+
+    /// Wakes and removes all awaiters.
+    pub fn wake_all(&mut self) {
+        self.readers.clear();
+        self.writers.clear();
+    }
+
+    /// Discards `FdAwaiter`s having a defunct waker.
+    pub fn gc(&mut self) {
+        let is_alive = |awaiter: &FdAwaiter| awaiter.waker.strong_count() > 0;
+        self.readers.retain(is_alive);
+        self.writers.retain(is_alive);
+    }
+}
+
+/// Helper for `select`ing on time
+///
+/// An `AsyncTime` is a set of [`Waker`]s that are waiting for a specific time
+/// to come. It wakes the wakers when the time is reached.
+#[derive(Clone, Debug, Default)]
+struct AsyncTime {
+    timeouts: BinaryHeap<Reverse<Timeout>>,
+}
+
+#[derive(Clone, Debug)]
+struct Timeout {
+    target: Instant,
+    waker: Weak<RefCell<Option<Waker>>>,
+}
+
+impl PartialEq for Timeout {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.target == rhs.target
+    }
+}
+
+impl Eq for Timeout {}
+
+impl PartialOrd for Timeout {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+    }
+}
+
+impl Ord for Timeout {
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        self.target.cmp(&rhs.target)
+    }
+}
+
+/// Wakes the waker when `Timeout` is dropped.
+impl Drop for Timeout {
+    fn drop(&mut self) {
+        if let Some(waker) = self.waker.upgrade() {
+            if let Some(waker) = waker.borrow_mut().take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+impl AsyncTime {
+    #[must_use]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    fn is_empty(&self) -> bool {
+        self.timeouts.is_empty()
+    }
+
+    fn push(&mut self, timeout: Timeout) {
+        self.timeouts.push(Reverse(timeout))
+    }
+
+    #[must_use]
+    fn first_target(&self) -> Option<Instant> {
+        self.timeouts.peek().map(|timeout| timeout.0.target)
+    }
+
+    fn wake_if_passed(&mut self, now: Instant) {
+        while let Some(timeout) = self.timeouts.peek_mut() {
+            if !timeout.0.passed(now) {
+                break;
+            }
+            PeekMut::pop(timeout);
+        }
+    }
+
+    fn gc(&mut self) {
+        self.timeouts.retain(|t| t.0.waker.strong_count() > 0);
+    }
+}
+
+impl Timeout {
+    fn passed(&self, now: Instant) -> bool {
+        self.target <= now
+    }
+}
+
+/// Helper for `select`ing on signals
+///
+/// An `AsyncSignal` is a set of [`Waker`]s that are waiting for a signal to be
+/// caught by the current process. It wakes the wakers when signals are caught.
+#[derive(Clone, Debug, Default)]
+struct AsyncSignal {
+    awaiters: Vec<Weak<RefCell<SignalStatus>>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum SignalStatus {
+    Expected(Option<Waker>),
+    Caught(Rc<[signal::Number]>),
+}
+
+impl AsyncSignal {
+    /// Returns a new empty `AsyncSignal`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Removes internal weak pointers whose `SignalStatus` has gone.
+    pub fn gc(&mut self) {
+        self.awaiters.retain(|awaiter| awaiter.strong_count() > 0);
+    }
+
+    /// Adds an awaiter for signals.
+    ///
+    /// This function returns a reference-counted
+    /// `SignalStatus::Expected(None)`. The caller must set a waker to the
+    /// returned `SignalStatus::Expected`. When signals are caught, the waker is
+    /// woken and replaced with `SignalStatus::Caught(signals)`. The caller can
+    /// replace the waker in the `SignalStatus::Expected` with another if the
+    /// previous waker gets expired and the caller wants to be woken again.
+    pub fn wait_for_signals(&mut self) -> Rc<RefCell<SignalStatus>> {
+        let status = Rc::new(RefCell::new(SignalStatus::Expected(None)));
+        self.awaiters.push(Rc::downgrade(&status));
+        status
+    }
+
+    /// Wakes awaiters for caught signals.
+    ///
+    /// This function wakes up all wakers in pending `SignalStatus`es and
+    /// removes them from `self`.
+    ///
+    /// This function borrows `SignalStatus`es returned from `wait_for_signals`
+    /// so you must not have conflicting borrows.
+    pub fn wake(&mut self, signals: &Rc<[signal::Number]>) {
+        for status in self.awaiters.drain(..) {
+            let Some(status) = status.upgrade() else {
+                continue;
+            };
+            let mut status_ref = status.borrow_mut();
+            let new_status = SignalStatus::Caught(Rc::clone(signals));
+            let old_status = std::mem::replace(&mut *status_ref, new_status);
+            drop(status_ref);
+            if let SignalStatus::Expected(Some(waker)) = old_status {
+                waker.wake();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::r#virtual::{SIGCHLD, SIGUSR1};
+    use super::*;
+    use assert_matches::assert_matches;
+    use futures_util::task::noop_waker;
+
+    #[test]
+    fn async_io_has_no_default_readers_or_writers() {
+        let async_io = AsyncIo::new();
+        assert_eq!(async_io.readers(), FdSet::new());
+        assert_eq!(async_io.writers(), FdSet::new());
+    }
+
+    #[test]
+    fn async_io_non_empty_readers_and_writers() {
+        let mut async_io = AsyncIo::new();
+        let waker = Rc::new(RefCell::new(Some(noop_waker())));
+        async_io.wait_for_reading(Fd::STDIN, Rc::downgrade(&waker));
+        async_io.wait_for_writing(Fd::STDOUT, Rc::downgrade(&waker));
+        async_io.wait_for_writing(Fd::STDERR, Rc::downgrade(&waker));
+
+        let mut expected_readers = FdSet::new();
+        expected_readers.insert(Fd::STDIN).unwrap();
+        let mut expected_writers = FdSet::new();
+        expected_writers.insert(Fd::STDOUT).unwrap();
+        expected_writers.insert(Fd::STDERR).unwrap();
+        assert_eq!(async_io.readers(), expected_readers);
+        assert_eq!(async_io.writers(), expected_writers);
+    }
+
+    #[test]
+    fn async_io_wake() {
+        let mut async_io = AsyncIo::new();
+        let waker = Rc::new(RefCell::new(Some(noop_waker())));
+        async_io.wait_for_reading(Fd(3), Rc::downgrade(&waker));
+        async_io.wait_for_reading(Fd(4), Rc::downgrade(&waker));
+        async_io.wait_for_writing(Fd(4), Rc::downgrade(&waker));
+        let mut fds = FdSet::new();
+        fds.insert(Fd(4)).unwrap();
+        async_io.wake(fds, fds);
+
+        let mut expected_readers = FdSet::new();
+        expected_readers.insert(Fd(3)).unwrap();
+        assert_eq!(async_io.readers(), expected_readers);
+        assert_eq!(async_io.writers(), FdSet::new());
+    }
+
+    #[test]
+    fn async_io_wake_all() {
+        let mut async_io = AsyncIo::new();
+        let waker = Rc::new(RefCell::new(Some(noop_waker())));
+        async_io.wait_for_reading(Fd::STDIN, Rc::downgrade(&waker));
+        async_io.wait_for_writing(Fd::STDOUT, Rc::downgrade(&waker));
+        async_io.wait_for_writing(Fd::STDERR, Rc::downgrade(&waker));
+        async_io.wake_all();
+        assert_eq!(async_io.readers(), FdSet::new());
+        assert_eq!(async_io.writers(), FdSet::new());
+    }
+
+    #[test]
+    fn async_time_first_target() {
+        let mut async_time = AsyncTime::new();
+        let now = Instant::now();
+        assert_eq!(async_time.first_target(), None);
+
+        async_time.push(Timeout {
+            target: now + Duration::from_secs(2),
+            waker: Weak::default(),
+        });
+        async_time.push(Timeout {
+            target: now + Duration::from_secs(1),
+            waker: Weak::default(),
+        });
+        async_time.push(Timeout {
+            target: now + Duration::from_secs(3),
+            waker: Weak::default(),
+        });
+        assert_eq!(
+            async_time.first_target(),
+            Some(now + Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn async_time_wake_if_passed() {
+        let mut async_time = AsyncTime::new();
+        let now = Instant::now();
+        let waker = Rc::new(RefCell::new(Some(noop_waker())));
+        async_time.push(Timeout {
+            target: now,
+            waker: Rc::downgrade(&waker),
+        });
+        async_time.push(Timeout {
+            target: now + Duration::new(1, 0),
+            waker: Rc::downgrade(&waker),
+        });
+        async_time.push(Timeout {
+            target: now + Duration::new(1, 1),
+            waker: Rc::downgrade(&waker),
+        });
+        async_time.push(Timeout {
+            target: now + Duration::new(2, 0),
+            waker: Rc::downgrade(&waker),
+        });
+        assert_eq!(async_time.timeouts.len(), 4);
+
+        async_time.wake_if_passed(now + Duration::new(1, 0));
+        assert_eq!(
+            async_time.timeouts.pop().unwrap().0.target,
+            now + Duration::new(1, 1)
+        );
+        assert_eq!(
+            async_time.timeouts.pop().unwrap().0.target,
+            now + Duration::new(2, 0)
+        );
+        assert!(async_time.timeouts.is_empty(), "{:?}", async_time.timeouts);
+    }
+
+    #[test]
+    fn async_signal_wake() {
+        let mut async_signal = AsyncSignal::new();
+        let status_1 = async_signal.wait_for_signals();
+        let status_2 = async_signal.wait_for_signals();
+        *status_1.borrow_mut() = SignalStatus::Expected(Some(noop_waker()));
+        *status_2.borrow_mut() = SignalStatus::Expected(Some(noop_waker()));
+
+        async_signal.wake(&(Rc::new([SIGCHLD, SIGUSR1]) as Rc<[signal::Number]>));
+        assert_matches!(&*status_1.borrow(), SignalStatus::Caught(signals) => {
+            assert_eq!(**signals, [SIGCHLD, SIGUSR1]);
+        });
+        assert_matches!(&*status_2.borrow(), SignalStatus::Caught(signals) => {
+            assert_eq!(**signals, [SIGCHLD, SIGUSR1]);
+        });
+    }
+}

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -126,7 +126,7 @@ impl SharedSystem {
         SharedSystem(Rc::new(RefCell::new(SelectSystem::new(system))))
     }
 
-    fn set_nonblocking(&mut self, fd: Fd) -> Result<OFlag> {
+    fn set_nonblocking(&self, fd: Fd) -> Result<OFlag> {
         let mut inner = self.0.borrow_mut();
         let flags = inner.fcntl_getfl(fd)?;
         if !flags.contains(OFlag::O_NONBLOCK) {
@@ -135,7 +135,7 @@ impl SharedSystem {
         Ok(flags)
     }
 
-    fn reset_nonblocking(&mut self, fd: Fd, old_flags: OFlag) {
+    fn reset_nonblocking(&self, fd: Fd, old_flags: OFlag) {
         if !old_flags.contains(OFlag::O_NONBLOCK) {
             let _: Result<()> = self.0.borrow_mut().fcntl_setfl(fd, old_flags);
         }
@@ -145,7 +145,7 @@ impl SharedSystem {
     ///
     /// This function waits for one or more bytes to be available for reading.
     /// If successful, returns the number of bytes read.
-    pub async fn read_async(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
+    pub async fn read_async(&self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
         let flags = self.set_nonblocking(fd)?;
 
         // We need to retain a strong reference to the waker outside the poll_fn
@@ -180,7 +180,7 @@ impl SharedSystem {
     /// returned.
     ///
     /// This function silently ignores signals that may interrupt writes.
-    pub async fn write_all(&mut self, fd: Fd, mut buffer: &[u8]) -> Result<usize> {
+    pub async fn write_all(&self, fd: Fd, mut buffer: &[u8]) -> Result<usize> {
         if buffer.is_empty() {
             return Ok(0);
         }
@@ -220,7 +220,7 @@ impl SharedSystem {
     }
 
     /// Convenience function for printing a message to the standard error
-    pub async fn print_error(&mut self, message: &str) {
+    pub async fn print_error(&self, message: &str) {
         _ = self.write_all(Fd::STDERR, message.as_bytes()).await;
     }
 

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -1,0 +1,487 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! [`SharedSystem`] and related items
+
+use super::signal;
+use super::ChildProcessStarter;
+use super::Dir;
+use super::Errno;
+use super::FdSet;
+use super::LimitPair;
+use super::Resource;
+use super::Result;
+use super::SelectSystem;
+use super::SignalHandling;
+use super::SignalStatus;
+use super::SignalSystem;
+use super::System;
+use super::SystemEx;
+use super::Times;
+use crate::io::Fd;
+use crate::job::Pid;
+use crate::job::ProcessState;
+#[cfg(doc)]
+use crate::Env;
+use nix::fcntl::AtFlags;
+use nix::fcntl::FdFlag;
+use nix::fcntl::OFlag;
+use nix::sys::signal::SigmaskHow;
+use nix::sys::stat::{FileStat, Mode};
+use nix::sys::time::TimeSpec;
+use std::cell::RefCell;
+use std::convert::Infallible;
+use std::ffi::c_int;
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::ffi::OsString;
+use std::future::poll_fn;
+use std::future::Future;
+use std::io::SeekFrom;
+use std::path::Path;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::Poll;
+use std::time::Instant;
+
+/// System shared by a reference counter.
+///
+/// A `SharedSystem` is a reference-counted container of a [`System`] instance
+/// accompanied with an internal state for supporting asynchronous interactions
+/// with the system. As it is reference-counted, cloning a `SharedSystem`
+/// instance only increments the reference count without cloning the backing
+/// system instance. This behavior allows calling `SharedSystem`'s methods
+/// concurrently from different `async` tasks that each have a `SharedSystem`
+/// instance sharing the same state.
+///
+/// `SharedSystem` implements [`System`] by delegating to the contained system
+/// instance. You should avoid calling some of the `System` methods, however.
+/// Prefer `async` functions provided by `SharedSystem` (e.g.,
+/// [`read_async`](Self::read_async)) over raw system functions (e.g.,
+/// [`read`](System::read)).
+///
+/// The following example illustrates how multiple concurrent tasks are run in a
+/// single-threaded pool:
+///
+/// ```
+/// # use yash_env::{SharedSystem, System, VirtualSystem};
+/// # use futures_util::task::LocalSpawnExt;
+/// let mut system = SharedSystem::new(Box::new(VirtualSystem::new()));
+/// let mut system2 = system.clone();
+/// let mut system3 = system.clone();
+/// let (reader, writer) = system.pipe().unwrap();
+/// let mut executor = futures_executor::LocalPool::new();
+///
+/// // We add a task that tries to read from the pipe, but nothing has been
+/// // written to it, so the task is stalled.
+/// let read_task = executor.spawner().spawn_local_with_handle(async move {
+///     let mut buffer = [0; 1];
+///     system.read_async(reader, &mut buffer).await.unwrap();
+///     buffer[0]
+/// });
+/// executor.run_until_stalled();
+///
+/// // Let's add a task that writes to the pipe.
+/// executor.spawner().spawn_local(async move {
+///     system2.write_all(writer, &[123]).await.unwrap();
+/// });
+/// executor.run_until_stalled();
+///
+/// // The write task has written a byte to the pipe, but the read task is still
+/// // stalled. We need to wake it up by calling `select`.
+/// system3.select(false).unwrap();
+///
+/// // Now the read task can proceed to the end.
+/// let number = executor.run_until(read_task.unwrap());
+/// assert_eq!(number, 123);
+/// ```
+///
+/// If there is a child process in the [`VirtualSystem`], you should call
+/// [`SystemState::select_all`](super::virtual::SystemState::select_all) in
+/// addition to [`SharedSystem::select`] so that the child process task is woken
+/// up when needed.
+/// (TBD code example)
+///
+/// [`VirtualSystem`]: crate::system::virtual::VirtualSystem
+#[derive(Clone, Debug)]
+pub struct SharedSystem(pub(super) Rc<RefCell<SelectSystem>>);
+
+impl SharedSystem {
+    /// Creates a new shared system.
+    pub fn new(system: Box<dyn System>) -> Self {
+        SharedSystem(Rc::new(RefCell::new(SelectSystem::new(system))))
+    }
+
+    fn set_nonblocking(&mut self, fd: Fd) -> Result<OFlag> {
+        let mut inner = self.0.borrow_mut();
+        let flags = inner.fcntl_getfl(fd)?;
+        if !flags.contains(OFlag::O_NONBLOCK) {
+            inner.fcntl_setfl(fd, flags | OFlag::O_NONBLOCK)?;
+        }
+        Ok(flags)
+    }
+
+    fn reset_nonblocking(&mut self, fd: Fd, old_flags: OFlag) {
+        if !old_flags.contains(OFlag::O_NONBLOCK) {
+            let _: Result<()> = self.0.borrow_mut().fcntl_setfl(fd, old_flags);
+        }
+    }
+
+    /// Reads from the file descriptor.
+    ///
+    /// This function waits for one or more bytes to be available for reading.
+    /// If successful, returns the number of bytes read.
+    pub async fn read_async(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
+        let flags = self.set_nonblocking(fd)?;
+
+        // We need to retain a strong reference to the waker outside the poll_fn
+        // function because SelectSystem only retains a weak reference to it.
+        // This allows SelectSystem to discard defunct wakers if this async task
+        // is aborted.
+        let waker = Rc::new(RefCell::new(None));
+
+        let result = poll_fn(|context| {
+            let mut inner = self.0.borrow_mut();
+            match inner.read(fd, buffer) {
+                Err(Errno::EAGAIN) => {
+                    *waker.borrow_mut() = Some(context.waker().clone());
+                    inner.add_reader(fd, Rc::downgrade(&waker));
+                    Poll::Pending
+                }
+                result => Poll::Ready(result),
+            }
+        })
+        .await;
+
+        self.reset_nonblocking(fd, flags);
+
+        result
+    }
+
+    /// Writes to the file descriptor.
+    ///
+    /// This function calls [`System::write`] repeatedly until the whole
+    /// `buffer` is written to the FD. If the `buffer` is empty, `write` is not
+    /// called at all, so any error that would be returned from `write` is not
+    /// returned.
+    ///
+    /// This function silently ignores signals that may interrupt writes.
+    pub async fn write_all(&mut self, fd: Fd, mut buffer: &[u8]) -> Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+
+        let flags = self.set_nonblocking(fd)?;
+        let mut written = 0;
+
+        // We need to retain a strong reference to the waker outside the poll_fn
+        // function because SelectSystem only retains a weak reference to it.
+        // This allows SelectSystem to discard defunct wakers if this async task
+        // is aborted.
+        let waker = Rc::new(RefCell::new(None));
+
+        let result = poll_fn(|context| {
+            let mut inner = self.0.borrow_mut();
+            match inner.write(fd, buffer) {
+                Ok(count) => {
+                    written += count;
+                    buffer = &buffer[count..];
+                    if buffer.is_empty() {
+                        return Poll::Ready(Ok(written));
+                    }
+                }
+                Err(Errno::EAGAIN | Errno::EINTR) => (),
+                Err(error) => return Poll::Ready(Err(error)),
+            }
+
+            *waker.borrow_mut() = Some(context.waker().clone());
+            inner.add_writer(fd, Rc::downgrade(&waker));
+            Poll::Pending
+        })
+        .await;
+
+        self.reset_nonblocking(fd, flags);
+
+        result
+    }
+
+    /// Convenience function for printing a message to the standard error
+    pub async fn print_error(&mut self, message: &str) {
+        _ = self.write_all(Fd::STDERR, message.as_bytes()).await;
+    }
+
+    /// Waits until the specified time point.
+    pub async fn wait_until(&self, target: Instant) {
+        // We need to retain a strong reference to the waker outside the poll_fn
+        // function because SelectSystem only retains a weak reference to it.
+        // This allows SelectSystem to discard defunct wakers if this async task
+        // is aborted.
+        let waker = Rc::new(RefCell::new(None));
+
+        poll_fn(|context| {
+            let mut system = self.0.borrow_mut();
+            let now = system.now();
+            if now >= target {
+                return Poll::Ready(());
+            }
+            *waker.borrow_mut() = Some(context.waker().clone());
+            system.add_timeout(target, Rc::downgrade(&waker));
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Waits for some signals to be delivered to this process.
+    ///
+    /// Before calling this function, you need to [set signal
+    /// handling](Self::set_signal_handling) to `Catch`. Without doing so, this
+    /// function cannot detect the receipt of the signals.
+    ///
+    /// Returns an array of signals that were caught.
+    ///
+    /// If this `SharedSystem` is part of an [`Env`], you should call
+    /// [`Env::wait_for_signals`] rather than calling this function directly
+    /// so that the trap set can remember the caught signal.
+    pub async fn wait_for_signals(&self) -> Rc<[signal::Number]> {
+        let status = self.0.borrow_mut().add_signal_waker();
+        poll_fn(|context| {
+            let mut status = status.borrow_mut();
+            let dummy_status = SignalStatus::Expected(None);
+            let old_status = std::mem::replace(&mut *status, dummy_status);
+            match old_status {
+                SignalStatus::Caught(signals) => Poll::Ready(signals),
+                SignalStatus::Expected(_) => {
+                    *status = SignalStatus::Expected(Some(context.waker().clone()));
+                    Poll::Pending
+                }
+            }
+        })
+        .await
+    }
+
+    /// Waits for a signal to be delivered to this process.
+    ///
+    /// Before calling this function, you need to [set signal
+    /// handling](Self::set_signal_handling) to `Catch`.
+    /// Without doing so, this function cannot detect the receipt of the signal.
+    ///
+    /// If this `SharedSystem` is part of an [`Env`], you should call
+    /// [`Env::wait_for_signal`] rather than calling this function directly
+    /// so that the trap set can remember the caught signal.
+    pub async fn wait_for_signal(&self, signal: signal::Number) {
+        while !self.wait_for_signals().await.contains(&signal) {}
+    }
+
+    /// Waits for a next event to occur.
+    ///
+    /// This function calls [`System::select`] with arguments computed from the
+    /// current internal state of the `SharedSystem`. It will wake up tasks
+    /// waiting for the file descriptor to be ready in
+    /// [`read_async`](Self::read_async) and [`write_all`](Self::write_all) or
+    /// for a signal to be caught in [`wait_for_signal`](Self::wait_for_signal).
+    /// If no tasks are woken for FDs or signals and `poll` is false, this
+    /// function will block until the first task waiting for a specific time
+    /// point is woken.
+    ///
+    /// If poll is true, this function does not block, so it may not wake up any
+    /// tasks.
+    ///
+    /// This function may wake up a task even if the condition it is expecting
+    /// has not yet been met.
+    pub fn select(&self, poll: bool) -> Result<()> {
+        self.0.borrow_mut().select(poll)
+    }
+}
+
+impl System for SharedSystem {
+    fn fstat(&self, fd: Fd) -> Result<FileStat> {
+        self.0.borrow().fstat(fd)
+    }
+    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat> {
+        self.0.borrow().fstatat(dir_fd, path, flags)
+    }
+    fn is_executable_file(&self, path: &CStr) -> bool {
+        self.0.borrow().is_executable_file(path)
+    }
+    fn is_directory(&self, path: &CStr) -> bool {
+        self.0.borrow().is_directory(path)
+    }
+    fn pipe(&mut self) -> Result<(Fd, Fd)> {
+        self.0.borrow_mut().pipe()
+    }
+    fn dup(&mut self, from: Fd, to_min: Fd, flags: FdFlag) -> Result<Fd> {
+        self.0.borrow_mut().dup(from, to_min, flags)
+    }
+    fn dup2(&mut self, from: Fd, to: Fd) -> Result<Fd> {
+        self.0.borrow_mut().dup2(from, to)
+    }
+    fn open(&mut self, path: &CStr, option: OFlag, mode: Mode) -> Result<Fd> {
+        self.0.borrow_mut().open(path, option, mode)
+    }
+    fn open_tmpfile(&mut self, parent_dir: &Path) -> Result<Fd> {
+        self.0.borrow_mut().open_tmpfile(parent_dir)
+    }
+    fn close(&mut self, fd: Fd) -> Result<()> {
+        self.0.borrow_mut().close(fd)
+    }
+    fn fcntl_getfl(&self, fd: Fd) -> Result<OFlag> {
+        self.0.borrow().fcntl_getfl(fd)
+    }
+    fn fcntl_setfl(&mut self, fd: Fd, flags: OFlag) -> Result<()> {
+        self.0.borrow_mut().fcntl_setfl(fd, flags)
+    }
+    fn fcntl_getfd(&self, fd: Fd) -> Result<FdFlag> {
+        self.0.borrow().fcntl_getfd(fd)
+    }
+    fn fcntl_setfd(&mut self, fd: Fd, flags: FdFlag) -> Result<()> {
+        self.0.borrow_mut().fcntl_setfd(fd, flags)
+    }
+    fn isatty(&self, fd: Fd) -> Result<bool> {
+        self.0.borrow().isatty(fd)
+    }
+    fn read(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {
+        self.0.borrow_mut().read(fd, buffer)
+    }
+    fn write(&mut self, fd: Fd, buffer: &[u8]) -> Result<usize> {
+        self.0.borrow_mut().write(fd, buffer)
+    }
+    fn lseek(&mut self, fd: Fd, position: SeekFrom) -> Result<u64> {
+        self.0.borrow_mut().lseek(fd, position)
+    }
+    fn fdopendir(&mut self, fd: Fd) -> Result<Box<dyn Dir>> {
+        self.0.borrow_mut().fdopendir(fd)
+    }
+    fn opendir(&mut self, path: &CStr) -> Result<Box<dyn Dir>> {
+        self.0.borrow_mut().opendir(path)
+    }
+    fn umask(&mut self, mask: Mode) -> Mode {
+        self.0.borrow_mut().umask(mask)
+    }
+    fn now(&self) -> Instant {
+        self.0.borrow().now()
+    }
+    fn times(&self) -> Result<Times> {
+        self.0.borrow().times()
+    }
+    fn validate_signal(&self, number: signal::RawNumber) -> Option<(signal::Name, signal::Number)> {
+        self.0.borrow().validate_signal(number)
+    }
+    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
+        self.0.borrow().signal_number_from_name(name)
+    }
+    fn sigmask(
+        &mut self,
+        op: Option<(SigmaskHow, &[signal::Number])>,
+        old_mask: Option<&mut Vec<signal::Number>>,
+    ) -> Result<()> {
+        (**self.0.borrow_mut()).sigmask(op, old_mask)
+    }
+    fn sigaction(
+        &mut self,
+        signal: signal::Number,
+        action: SignalHandling,
+    ) -> Result<SignalHandling> {
+        self.0.borrow_mut().sigaction(signal, action)
+    }
+    fn caught_signals(&mut self) -> Vec<signal::Number> {
+        self.0.borrow_mut().caught_signals()
+    }
+    fn kill(
+        &mut self,
+        target: Pid,
+        signal: Option<signal::Number>,
+    ) -> Pin<Box<(dyn Future<Output = Result<()>>)>> {
+        self.0.borrow_mut().kill(target, signal)
+    }
+    fn select(
+        &mut self,
+        readers: &mut FdSet,
+        writers: &mut FdSet,
+        timeout: Option<&TimeSpec>,
+        signal_mask: Option<&[signal::Number]>,
+    ) -> Result<c_int> {
+        (**self.0.borrow_mut()).select(readers, writers, timeout, signal_mask)
+    }
+    fn getpid(&self) -> Pid {
+        self.0.borrow().getpid()
+    }
+    fn getppid(&self) -> Pid {
+        self.0.borrow().getppid()
+    }
+    fn getpgrp(&self) -> Pid {
+        self.0.borrow().getpgrp()
+    }
+    fn setpgid(&mut self, pid: Pid, pgid: Pid) -> Result<()> {
+        self.0.borrow_mut().setpgid(pid, pgid)
+    }
+    fn tcgetpgrp(&self, fd: Fd) -> Result<Pid> {
+        self.0.borrow().tcgetpgrp(fd)
+    }
+    fn tcsetpgrp(&mut self, fd: Fd, pgid: Pid) -> Result<()> {
+        self.0.borrow_mut().tcsetpgrp(fd, pgid)
+    }
+    fn new_child_process(&mut self) -> Result<ChildProcessStarter> {
+        self.0.borrow_mut().new_child_process()
+    }
+    fn wait(&mut self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {
+        self.0.borrow_mut().wait(target)
+    }
+    fn execve(&mut self, path: &CStr, args: &[CString], envs: &[CString]) -> Result<Infallible> {
+        self.0.borrow_mut().execve(path, args, envs)
+    }
+    fn getcwd(&self) -> Result<PathBuf> {
+        self.0.borrow().getcwd()
+    }
+    fn chdir(&mut self, path: &CStr) -> Result<()> {
+        self.0.borrow_mut().chdir(path)
+    }
+    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
+        self.0.borrow().getpwnam_dir(name)
+    }
+    fn confstr_path(&self) -> Result<OsString> {
+        self.0.borrow().confstr_path()
+    }
+    fn shell_path(&self) -> CString {
+        self.0.borrow().shell_path()
+    }
+    fn getrlimit(&self, resource: Resource) -> std::io::Result<LimitPair> {
+        self.0.borrow().getrlimit(resource)
+    }
+    fn setrlimit(&mut self, resource: Resource, limits: LimitPair) -> std::io::Result<()> {
+        self.0.borrow_mut().setrlimit(resource, limits)
+    }
+}
+
+impl SignalSystem for SharedSystem {
+    #[inline]
+    fn signal_name_from_number(&self, number: signal::Number) -> signal::Name {
+        SystemEx::signal_name_from_number(self, number)
+    }
+
+    #[inline]
+    fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
+        System::signal_number_from_name(self, name)
+    }
+
+    fn set_signal_handling(
+        &mut self,
+        signal: signal::Number,
+        handling: SignalHandling,
+    ) -> Result<SignalHandling> {
+        self.0.borrow_mut().set_signal_handling(signal, handling)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `SelectSystem` for asynchronous I/O, signal handling, and timers coordination.
  - Added support for managing asynchronous events via `AsyncIo`, `AsyncTime`, and `AsyncSignal`.

- **Bug Fixes**
  - Improved efficiency of handling I/O, signals, and timers.

- **Refactor**
  - Integrated `SharedSystem` methods into `SelectSystem`.

- **Tests**
  - Enhanced and added tests for new asynchronous components and functionalities.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->