### PR TITLE
Change prompt for continued commands

### DIFF
--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0-beta.2] - Unreleased
 
+### Added
+
+- Internal dependencies:
+    - yash-prompt 0.1.0
+
 ### Changed
 
 - External dependency versions:
     - Rust 1.75.0 → 1.77.0
+- The shell now shows the prompt before reading the input in the interactive mode.
+  To achieve this, the `startup::prepare_input` function now applies the
+  `yash_prompt::Prompter` decorator to the returned source input.
 - The first argument to `startup::prepare_input` is now `env: &'a RefCell<&mut Env>`
   instead of `system: &mut SharedSystem`. This change is to allow the function to
   construct `yash_env::input::Echo` for the returned source input.

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This new trait implementation allows more types to be used as input
       sources, especially when it is used with a decorator that requires
       another input source.
+- `input::Context::is_first_line`
+    - This new method allows changing the behavior of the input function
+      depending on whether the current line is the first line of the input.
 
 ### Changed
 
@@ -155,8 +158,8 @@ This version contains variety of fixes.
 - `parser::lex::TokenId::is_clause_delimiter`
 - `impl std::error::Error for parser::Error`
 - `source::pretty::MessageBase`
-   - `impl MessageBase for parser::Error`
-   - `impl<'a, T: MessageBase> From<&'a T> for source::pretty::Message<'a>`
+    - `impl MessageBase for parser::Error`
+    - `impl<'a, T: MessageBase> From<&'a T> for source::pretty::Message<'a>`
 
 ### Changed
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `input::Context::is_first_line`
     - This new method allows changing the behavior of the input function
       depending on whether the current line is the first line of the input.
+    - The corresponding setter method `set_is_first_line` is also added.
 
 ### Changed
 

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -19,16 +19,31 @@
 use async_trait::async_trait;
 use std::ops::DerefMut;
 
-/// Current state in which source code is read.
+/// Parameter passed to the input function
 ///
-/// The context is passed to the input function so that it can read the input in a
-/// context-dependent way.
-///
-/// Currently, this structure is empty. It may be extended to provide with some useful data in
-/// future versions.
-#[derive(Debug, Default)]
+/// The context is passed to the [input function](Input::next_line) so that it
+/// can read the input in a context-dependent way.
+#[derive(Debug)]
 #[non_exhaustive]
-pub struct Context;
+pub struct Context {
+    pub(crate) is_first_line: bool,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            is_first_line: true,
+        }
+    }
+}
+
+impl Context {
+    /// Whether the current line is the first line of the input
+    #[must_use]
+    pub fn is_first_line(&self) -> bool {
+        self.is_first_line
+    }
+}
 
 /// Error returned by the [Input] function.
 pub type Error = std::io::Error;
@@ -94,36 +109,39 @@ mod tests {
     #[test]
     fn memory_empty_source() {
         let mut input = Memory::new("");
+        let context = Context::default();
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "");
     }
 
     #[test]
     fn memory_one_line() {
         let mut input = Memory::new("one\n");
+        let context = Context::default();
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "one\n");
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "");
     }
 
     #[test]
     fn memory_three_lines() {
         let mut input = Memory::new("one\ntwo\nthree");
+        let context = Context::default();
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "one\n");
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "two\n");
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "three");
 
-        let line = input.next_line(&Context).now_or_never().unwrap().unwrap();
+        let line = input.next_line(&context).now_or_never().unwrap().unwrap();
         assert_eq!(line, "");
     }
 }

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -26,7 +26,7 @@ use std::ops::DerefMut;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Context {
-    pub(crate) is_first_line: bool,
+    is_first_line: bool,
 }
 
 impl Default for Context {
@@ -39,9 +39,19 @@ impl Default for Context {
 
 impl Context {
     /// Whether the current line is the first line of the input
+    #[inline]
     #[must_use]
     pub fn is_first_line(&self) -> bool {
         self.is_first_line
+    }
+
+    /// Sets whether the current line is the first line of the input
+    ///
+    /// This method is used by the lexer to set the flag. It can also be used in
+    /// tests to simulate a non-first line. The default value is `true`.
+    #[inline]
+    pub fn set_is_first_line(&mut self, is_first_line: bool) {
+        self.is_first_line = is_first_line;
     }
 }
 

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -212,7 +212,10 @@ impl<'a> LexerCore<'a> {
 
             // Read more input
             let index = self.next_index();
-            match self.input.next_line(&Context).await {
+            let context = Context {
+                is_first_line: self.raw_code.value.borrow().is_empty(),
+            };
+            match self.input.next_line(&context).await {
                 Ok(line) => {
                     if line.is_empty() {
                         // End of input
@@ -879,6 +882,34 @@ mod tests {
         assert_eq!(e.location.code.start_line_number, line);
         assert_eq!(e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 0..0);
+    }
+
+    #[test]
+    fn lexer_core_peek_char_context_is_first_line() {
+        // In this test case, this mock input function will be called twice.
+        struct InputMock {
+            first: bool,
+        }
+        #[async_trait::async_trait(?Send)]
+        impl Input for InputMock {
+            async fn next_line(&mut self, context: &Context) -> crate::input::Result {
+                assert_eq!(context.is_first_line(), self.first);
+                self.first = false;
+                Ok("\n".to_owned())
+            }
+        }
+
+        let input = InputMock { first: true };
+        let line = NonZeroU64::new(42).unwrap();
+        let mut lexer = LexerCore::new(Box::new(input), line, Source::Unknown);
+
+        let peek = lexer.peek_char().now_or_never().unwrap();
+        assert_matches!(peek, Ok(PeekChar::Char(_)));
+        lexer.consume_char();
+
+        let peek = lexer.peek_char().now_or_never().unwrap();
+        assert_matches!(peek, Ok(PeekChar::Char(_)));
+        lexer.consume_char();
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -212,10 +212,7 @@ impl<'a> LexerCore<'a> {
 
             // Read more input
             let index = self.next_index();
-            let context = Context {
-                is_first_line: self.raw_code.value.borrow().is_empty(),
-            };
-            match self.input.next_line(&context).await {
+            match self.input.next_line(&self.input_context()).await {
                 Ok(line) => {
                     if line.is_empty() {
                         // End of input
@@ -241,6 +238,13 @@ impl<'a> LexerCore<'a> {
                 }
             }
         }
+    }
+
+    /// Returns the input context for the next character.
+    fn input_context(&self) -> Context {
+        let mut context = Context::default();
+        context.set_is_first_line(self.raw_code.value.borrow().is_empty());
+        context
     }
 
     /// Consumes the next character.


### PR DESCRIPTION
This is part of #372.

When a command is continued to a next line, the interactive shell should issue a prompt with the `$PS2` variable instead of `$PS1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced shell prompt behavior with new `PS2` variable for continuation prompts.
  - Improved context handling with new methods to check and set if the current input line is the first.

- **Dependency Updates**
  - Internal dependency on `yash-prompt 0.1.0`.
  - External dependency update to Rust 1.77.0.

- **Bug Fixes**
  - Corrected prompt display timing in interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->