### PR TITLE
Show $PS2 prompt for continuation lines in the read built-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "thiserror",
  "yash-env",
  "yash-env-test-helper",
+ "yash-prompt",
  "yash-quote",
  "yash-semantics",
  "yash-syntax",

--- a/check-extra.sh
+++ b/check-extra.sh
@@ -18,11 +18,15 @@ cargo tomlfmt --dryrun --path yash-syntax/Cargo.toml
 
 # Make sure we don't have any unnecessary dependencies in Cargo.toml.
 RUSTFLAGS='-D unused_crate_dependencies' cargo check --lib --all-features
+RUSTFLAGS='-D unused_crate_dependencies' cargo check --package 'yash-builtin' --no-default-features
+RUSTFLAGS='-D unused_crate_dependencies' cargo check --package 'yash-builtin' --no-default-features --features yash-semantics
+RUSTFLAGS='-D unused_crate_dependencies' cargo check --package 'yash-syntax' --no-default-features
 
 # Make sure the crates can be built with all combinations of features.
 cargo build --package 'yash-arith' --all-targets
 cargo build --package 'yash-builtin' --all-targets
 cargo build --package 'yash-builtin' --all-targets --no-default-features
+cargo build --package 'yash-builtin' --all-targets --no-default-features --features yash-semantics
 cargo build --package 'yash-cli' --all-targets
 cargo build --package 'yash-env' --all-targets
 cargo build --package 'yash-env-test-helper' --all-targets

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The read built-in now shows a prompt when reading a continued line.
 - The break and continue built-ins now return `ExitStatus::ERROR` for syntax
   errors and `ExitStatus::FAILURE` for semantic errors. Previously, they always
   returned `ExitStatus::ERROR` for both types of errors, while the documentation

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -14,7 +14,9 @@ keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
 
 [features]
-default = ["yash-semantics"]
+default = ["yash-prompt", "yash-semantics"]
+# yash-prompt is used in the read built-in, which requires yash-semantics.
+yash-prompt = ["dep:yash-prompt", "yash-semantics"]
 yash-semantics = ["dep:yash-semantics", "dep:enumset"]
 
 [dependencies]
@@ -23,6 +25,7 @@ enumset = { version = "1.1.2", optional = true }
 itertools = "0.13.0"
 thiserror = "1.0.47"
 yash-env = { path = "../yash-env", version = "0.2.0" }
+yash-prompt = { path = "../yash-prompt", version = "0.1.0", optional = true }
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
 yash-semantics = { path = "../yash-semantics", version = "0.2.0", optional = true }
 yash-syntax = { path = "../yash-syntax", version = "0.9.0" }

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -51,6 +51,8 @@
 //! value of the `PS2` variable as a prompt if the shell is interactive and the
 //! input is from a terminal.
 //!
+//! Prompting requires the optional `yash-prompt` feature.
+//!
 //! # Options
 //!
 //! The **`-r`** option disables the interpretation of backslashes.

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The break and continue built-ins no longer allow exiting a trap.
+- The read built-in now shows a prompt when reading a continued line.
 
 ## [0.1.0-beta.1] - 2024-06-09
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Env::is_interactive`
 - `impl yash_system::alias::Glossary for Env`
 - `input::Echo`
     - This is a decorator of `Input` that implements the behavior of the verbose shell option.

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -40,7 +40,7 @@ use self::job::Pid;
 use self::job::ProcessState;
 use self::option::On;
 use self::option::OptionSet;
-use self::option::{AllExport, ErrExit, Monitor};
+use self::option::{AllExport, ErrExit, Interactive, Monitor};
 use self::semantics::Divert;
 use self::semantics::ExitStatus;
 use self::stack::Frame;
@@ -301,6 +301,17 @@ impl Env {
         let final_fd = self.system.move_fd_internal(first_fd);
         self.tty = final_fd.ok();
         final_fd
+    }
+
+    /// Tests whether the current environment is an interactive shell.
+    ///
+    /// This function returns true if and only if:
+    ///
+    /// - the [`Interactive`] option is `On` in `self.options`, and
+    /// - the current context is not in a subshell (no `Frame::Subshell` in `self.stack`).
+    #[must_use]
+    pub fn is_interactive(&self) -> bool {
+        self.options.get(Interactive) == On && !self.stack.contains(&Frame::Subshell)
     }
 
     /// Tests whether the shell is performing job control.

--- a/yash-prompt/src/lib.rs
+++ b/yash-prompt/src/lib.rs
@@ -27,6 +27,8 @@
 //! used to create an interactive shell prompt. The prompter internally uses
 //! the following functions to expand prompt strings:
 //!
+//! - [`fetch_posix`]: Fetches the value of a variable defined by POSIX for
+//!   a prompt string.
 //! - [`expand_posix`]: Expands a prompt string in a POSIX-compliant manner.
 //! - `expand_ex`: Expands a prompt string with yash-specific expansions.
 //!   (This function is not yet implemented.)
@@ -70,4 +72,5 @@ pub use expand_posix::expand_posix;
 // TODO Yash-specific prompt expansion
 
 mod prompter;
+pub use prompter::fetch_posix;
 pub use prompter::Prompter;

--- a/yash-prompt/src/prompter.rs
+++ b/yash-prompt/src/prompter.rs
@@ -84,7 +84,6 @@ pub fn fetch_posix(variables: &VariableSet, context: &Context) -> String {
     // TODO context.location;
     let location = Location::dummy("");
 
-    // TODO Yash-specific prompt variables
     let var = if context.is_first_line() { PS1 } else { PS2 };
     // https://github.com/rust-lang/rust-clippy/issues/13031
     match variables.get(var).map(|v| v.expand(&location)) {
@@ -92,6 +91,8 @@ pub fn fetch_posix(variables: &VariableSet, context: &Context) -> String {
         _ => Default::default(),
     }
 }
+
+// TODO pub fn fetch_ex: yash-specific prompt variables
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `read` built-in now displays a prompt for continued lines in interactive mode.
  - Added method to check if the environment is interactive.

- **Improvements**
  - Enhanced prompt functionality for better user interaction.
  
- **Documentation**
  - Updated changelogs to reflect new features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->