### PR TITLE
Improve parameter expansion error message

### DIFF
--- a/check-release.sh
+++ b/check-release.sh
@@ -20,9 +20,12 @@ ls "$package" | grep -q '^LICENSE' || {
     printf 'error: no LICENSE file found\n' >&2
 }
 
-grep -Fqx "## [$version] - $today" "$package/CHANGELOG.md" || {
-    success=false
-    printf 'error: release date for version %s is not set to %s in CHANGELOG.md\n' "$version" "$today" >&2
-}
+for changelog in "$package"/CHANGELOG*.md; do
+    grep -Fqx "## [$version] - $today" "$changelog" || {
+        success=false
+        printf 'error: release date for version %s is not set to %s in %s\n' \
+            "$version" "$today" "$changelog" >&2
+    }
+done
 
 "$success" # return the final exit status

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -533,6 +533,7 @@ impl From<AssignReadOnlyError> for yash_semantics::expansion::AssignReadOnlyErro
             name: e.name,
             new_value: e.new_value,
             read_only_location: e.read_only_location,
+            vacancy: None,
         }
     }
 }

--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -8,6 +8,12 @@ implementing library crate are in [CHANGELOG-lib.md](CHANGELOG-lib.md).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.3] - Unreleased
+
+### Changed
+
+- Improved error messages for some parameter expansion errors.
+
 ## [0.1.0-beta.2] - 2024-07-13
 
 ### Changed
@@ -36,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
+[0.1.0-beta.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.3
 [0.1.0-beta.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.1
 [0.1.0-alpha.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-alpha.1

--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -1,39 +1,18 @@
 # Changelog
 
-All notable changes to `yash-cli` will be documented in this file.
+All notable changes to the shell are documented in this file.
+
+This file lists changes to the shell binary as a whole. Changes to the
+implementing library crate are in [CHANGELOG-lib.md](CHANGELOG-lib.md).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.0-beta.2] - 2024-07-13
 
-### Added
-
-- Internal dependencies:
-    - yash-prompt 0.1.0
-
 ### Changed
 
-- External dependency versions:
-    - Rust 1.75.0 → 1.77.0
-- Internal dependency versions:
-    - yash-builtin 0.2.0 → 0.3.0
-    - yash-semantics 0.2.0 → 0.3.0
-    - yash-syntax 0.9.0 → 0.10.0
 - The shell now shows the prompt before reading the input in the interactive mode.
-  To achieve this, the `startup::prepare_input` function now applies the
-  `yash_prompt::Prompter` decorator to the returned source input.
-- The first argument to `startup::prepare_input` is now `env: &'a RefCell<&mut Env>`
-  instead of `system: &mut SharedSystem`. This change is to allow the function to
-  construct `yash_env::input::Echo` for the returned source input.
-
-### Removed
-
-- `startup::SourceInput::verbose`
-    - The caller of `startup::prepare_input` is no longer responsible for setting
-      the `verbose` flag of the read-eval loop. The behavior of the verbose option
-      is now implemented in `yash_env::input::Echo`, which is included in
-      the `startup::SourceInput::input` field.
 
 ### Fixed
 
@@ -48,11 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- External dependency versions
-    - yash-builtin 0.1.0 → 0.2.0
-    - yash-env 0.1.0 → 0.2.0
-    - yash-semantics 0.1.0 → 0.2.0
-    - yash-syntax 0.8.0 → 0.9.0
 - The shell now enables blocking reads on the standard input if it is a terminal
   or a pipe as [required by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sh.html#tag_20_117_06).
 
@@ -60,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial implementation of the `yash-cli` crate
+- Initial release of the shell
 
 [0.1.0-beta.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.1

--- a/yash-cli/CHANGELOG-lib.md
+++ b/yash-cli/CHANGELOG-lib.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to the `yash-cli` library crate are documented in this file.
+
+This file lists changes to the library crate, which is unlikely to be of interest
+to users of the shell.
+For changes to the shell binary as a whole, see [CHANGELOG-bin.md](CHANGELOG-bin.md).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0-beta.2] - 2024-07-13
+
+### Added
+
+- Internal dependencies:
+    - yash-prompt 0.1.0
+
+### Changed
+
+- External dependency versions:
+    - Rust 1.75.0 → 1.77.0
+- Internal dependency versions:
+    - yash-builtin 0.2.0 → 0.3.0
+    - yash-semantics 0.2.0 → 0.3.0
+    - yash-syntax 0.9.0 → 0.10.0
+- The shell now shows the prompt before reading the input in the interactive mode.
+  To achieve this, the `startup::prepare_input` function now applies the
+  `yash_prompt::Prompter` decorator to the returned source input.
+- The first argument to `startup::prepare_input` is now `env: &'a RefCell<&mut Env>`
+  instead of `system: &mut SharedSystem`. This change is to allow the function to
+  construct `yash_env::input::Echo` for the returned source input.
+
+### Removed
+
+- `startup::SourceInput::verbose`
+    - The caller of `startup::prepare_input` is no longer responsible for setting
+      the `verbose` flag of the read-eval loop. The behavior of the verbose option
+      is now implemented in `yash_env::input::Echo`, which is included in
+      the `startup::SourceInput::input` field.
+
+## [0.1.0-beta.1] - 2024-06-09
+
+### Changed
+
+- External dependency versions
+    - yash-builtin 0.1.0 → 0.2.0
+    - yash-env 0.1.0 → 0.2.0
+    - yash-semantics 0.1.0 → 0.2.0
+    - yash-syntax 0.8.0 → 0.9.0
+- The shell now enables blocking reads on the standard input if it is a terminal
+  or a pipe as [required by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sh.html#tag_20_117_06).
+
+## [0.1.0-alpha.1] - 2024-04-13
+
+### Added
+
+- Initial implementation of the `yash-cli` crate
+
+[0.1.0-beta.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.2
+[0.1.0-beta.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.1
+[0.1.0-alpha.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-alpha.1

--- a/yash-cli/README.md
+++ b/yash-cli/README.md
@@ -8,7 +8,8 @@ programs.
 [![yash-cli at docs.rs](https://docs.rs/yash-cli/badge.svg)](https://docs.rs/yash-cli)
 [![Build status](https://github.com/magicant/yash-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/magicant/yash-rs/actions/workflows/rust.yml)
 
-- [Changelog](CHANGELOG.md)
+- [Changelog for the entire shell binary](CHANGELOG-bin.md)
+- [Changelog for the library crate](CHANGELOG-lib.md)
 
 ## License
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,34 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Error types in the `expansion` module (which are reexported in the `assign`
-  module) have been extended for more informative error messages:
-    - The `ErrorCause::additional_message` and `ErrorCause::footer` methods have
-      been added.
+- Error types in the `expansion` module (some of which are reexported in the
+  `assign` module) have been extended for more informative error messages:
+    - The `ErrorCause::footer` method has been added.
     - The `Error` struct now has non-default implementation of the
       `MessageBase::footers` method.
-- Likewise, the following error items are also extended:
     - The `AssignReadOnlyError` struct now has a `vacancy: Option<Vacancy>`
       field.
-    - `expansion::initial::VacantError` now has a `name: String` field.
-    - The `expansion::initial::NonassignableErrorCause` enum is a successor to
-      the previous `NonassignableError` enum. The new `NotVariable` variant has
-      a `name: String` field.
+    - The `initial::VacantError` struct now has a `name: String` field.
+    - The `initial::NonassignableErrorCause` enum is a successor to the previous
+      `NonassignableError` enum. The new `NotVariable` variant has a `name:
+      String` field.
 
 ### Changed
 
-- The `expansion::ErrorCause` enum has been extended for more informative error
-  messages:
-    - The variant `UnsetParameter` now has a `name: String` field.
-    - The `message` and `label` methods return more informative messages for
-      these variants.
-- The `expansion::initial::NonassignableError` enum has been replaced with a
-  struct of the same name so that it can have a `Vacancy` field.
-
-### Deprecated
-
-- The `expansion::ErrorCause::related_location` method has been deprecated in
-  favor of the `additional_message` method.
+- Error types in the `expansion` module (some of which are reexported in the
+  `assign` module) have been extended for more informative error messages:
+    - The `ErrorCause::UnsetParameter` variant now has a `name: String` field.
+    - The `message` and `label` methods of `ErrorCause` return more informative
+      messages for the `UnsetParameter` and `VacantExpansion` variants.
+    - The `expansion::initial::NonassignableError` enum has been replaced with a
+      struct of the same name so that it can have a `Vacancy` field.
+    - The `MessageBase::additional_annotations` method implementation for the
+      `Error` struct has been extended to produce more annotations for errors
+      with `Vacancy` information.
 
 ## [0.3.0] - 2024-07-13
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `Error` struct now has non-default implementation of the
       `MessageBase::footers` method.
 - Likewise, the following error items are also extended:
+    - The `AssignReadOnlyError` struct now has a `vacancy: Option<Vacancy>`
+      field.
     - `expansion::initial::VacantError` now has a `name: String` field.
     - The `expansion::initial::NonassignableErrorCause` enum is a successor to
       the previous `NonassignableError` enum. The new `NotVariable` variant has

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Unreleased
+
+### Added
+
+- Error types in the `expansion` module (which are reexported in the `assign`
+  module) have been extended for more informative error messages:
+    - The `ErrorCause::footer` method has been added.
+    - The `Error` struct now has non-default implementation of the
+      `MessageBase::footers` method.
+
+### Changed
+
+- The `expansion::ErrorCause` enum has been extended for more informative error
+  messages:
+    - The variant `UnsetParameter` now has a `name` field of type `String`.
+    - The `message` and `label` methods return more informative messages for
+      these variants.
+
 ## [0.3.0] - 2024-07-13
 
 ### Added
@@ -86,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.3.0
 [0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.2.0
 [0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.1.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `ErrorCause::footer` method has been added.
     - The `Error` struct now has non-default implementation of the
       `MessageBase::footers` method.
-- Likewise, the following error types are also extended:
+- Likewise, the following error items are also extended:
     - `expansion::initial::VacantError` now has a `name: String` field.
+    - `expansion::initial::NonassignableError::NotVariable` now has a `name:
+      String` field.
 
 ### Changed
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `ErrorCause::footer` method has been added.
     - The `Error` struct now has non-default implementation of the
       `MessageBase::footers` method.
+- Likewise, the following error types are also extended:
+    - `expansion::initial::VacantError` now has a `name: String` field.
 
 ### Changed
 
 - The `expansion::ErrorCause` enum has been extended for more informative error
   messages:
-    - The variant `UnsetParameter` now has a `name` field of type `String`.
+    - The variant `UnsetParameter` now has a `name: String` field.
     - The `message` and `label` methods return more informative messages for
       these variants.
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -11,13 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Error types in the `expansion` module (which are reexported in the `assign`
   module) have been extended for more informative error messages:
-    - The `ErrorCause::footer` method has been added.
+    - The `ErrorCause::additional_message` and `ErrorCause::footer` methods have
+      been added.
     - The `Error` struct now has non-default implementation of the
       `MessageBase::footers` method.
 - Likewise, the following error items are also extended:
     - `expansion::initial::VacantError` now has a `name: String` field.
-    - `expansion::initial::NonassignableError::NotVariable` now has a `name:
-      String` field.
+    - The `expansion::initial::NonassignableErrorCause` enum is a successor to
+      the previous `NonassignableError` enum. The new `NotVariable` variant has
+      a `name: String` field.
 
 ### Changed
 
@@ -26,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The variant `UnsetParameter` now has a `name: String` field.
     - The `message` and `label` methods return more informative messages for
       these variants.
+- The `expansion::initial::NonassignableError` enum has been replaced with a
+  struct of the same name so that it can have a `Vacancy` field.
+
+### Deprecated
+
+- The `expansion::ErrorCause::related_location` method has been deprecated in
+  favor of the `additional_message` method.
 
 ## [0.3.0] - 2024-07-13
 

--- a/yash-semantics/src/assign.rs
+++ b/yash-semantics/src/assign.rs
@@ -67,6 +67,7 @@ pub async fn perform_assignment(
                 name: assign.name.clone(),
                 new_value: e.new_value,
                 read_only_location: e.read_only_location,
+                vacancy: None,
             }),
             location: e.assigned_location.unwrap(),
         })?;
@@ -179,6 +180,7 @@ mod tests {
             assert_eq!(error.name, "v");
             assert_eq!(error.new_value, Value::scalar("new"));
             assert_eq!(error.read_only_location, location);
+            assert_eq!(error.vacancy, None);
         });
         assert_eq!(e.location, Location::dummy("v=new"));
     }

--- a/yash-semantics/src/command/compound_command/for_loop.rs
+++ b/yash-semantics/src/command/compound_command/for_loop.rs
@@ -94,6 +94,7 @@ pub async fn execute(
                     name: name.value,
                     new_value: error.new_value,
                     read_only_location: error.read_only_location,
+                    vacancy: None,
                 });
                 let location = name.origin;
                 let error = Error { cause, location };

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -83,6 +83,7 @@ use self::initial::ArithError;
 use self::initial::Expand;
 use self::initial::Expand as _;
 use self::initial::NonassignableError;
+use self::initial::Vacancy;
 use self::initial::VacantError;
 use self::quote_removal::skip_quotes;
 use self::split::Ifs;
@@ -109,10 +110,17 @@ pub use yash_env::semantics::Field;
 pub struct AssignReadOnlyError {
     /// Name of the read-only variable
     pub name: String,
-    /// Value that was being assigned.
+    /// Value that was being assigned
     pub new_value: Value,
-    /// Location where the variable was made read-only.
+    /// Location where the variable was made read-only
     pub read_only_location: Location,
+    /// State of the variable before the assignment
+    ///
+    /// If this assignment error occurred in a parameter expansion as in
+    /// `${foo=bar}` or `${foo:=bar}`, this field is `Some`, and the value is
+    /// the state of the variable before the assignment. In other cases, this
+    /// field is `None`.
+    pub vacancy: Option<Vacancy>,
 }
 
 /// Types of errors that may occur in the word expansion.
@@ -441,6 +449,7 @@ mod tests {
                 name: "foo".into(),
                 new_value: "value".into(),
                 read_only_location: Location::dummy("ROL"),
+                vacancy: None,
             }),
             location: Location {
                 range: 2..4,

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -169,7 +169,7 @@ impl ErrorCause {
             ArithError(e) => e.to_string().into(),
             AssignReadOnly(e) => e.to_string().into(),
             UnsetParameter { name } => format!("parameter {name:?} is not set").into(),
-            VacantExpansion(e) => e.vacancy.description().into(),
+            VacantExpansion(e) => format!("{}: {}", e.name, e.vacancy).into(),
             NonassignableParameter(e) => e.to_string().into(),
         }
     }

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -246,6 +246,7 @@ impl<'a> yash_arith::Env for VarEnv<'a> {
                 name: name.to_owned(),
                 new_value: e.new_value,
                 read_only_location: e.read_only_location,
+                vacancy: None,
             })
     }
 }

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -84,7 +84,9 @@ impl Expand for ParamRef<'_> {
             // Check for nounset option error //
             if value.is_none() && env.inner.options.get(Unset) == Off {
                 return Err(Error {
-                    cause: ErrorCause::UnsetParameter,
+                    cause: ErrorCause::UnsetParameter {
+                        name: self.name.to_owned(),
+                    },
                     location: self.location.clone(),
                 });
             }
@@ -319,11 +321,12 @@ pub mod tests {
         let mut env = yash_env::Env::new_virtual();
         env.options.set(Unset, Off);
         let mut env = Env::new(&mut env);
-        let param = param("foo");
+        let name = "foo".to_owned();
+        let param = param(&name);
         let param = ParamRef::from(&param);
 
         let e = param.expand(&mut env).now_or_never().unwrap().unwrap_err();
-        assert_eq!(e.cause, ErrorCause::UnsetParameter);
+        assert_eq!(e.cause, ErrorCause::UnsetParameter { name });
         assert_eq!(e.location, Location::dummy(""));
     }
 

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -76,7 +76,8 @@ impl Expand for ParamRef<'_> {
 
         // Switch //
         if let Modifier::Switch(switch) = self.modifier {
-            if let Some(result) = switch::apply(env, switch, name, &mut value, self.location).await
+            if let Some(result) =
+                switch::apply(env, switch, self.name, name, &mut value, self.location).await
             {
                 return result;
             }

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -218,6 +218,7 @@ async fn assign(
                 name: name.to_owned(),
                 new_value: e.new_value,
                 read_only_location: e.read_only_location,
+                vacancy: Some(vacancy),
             });
             Error { cause, location }
         })?;
@@ -581,7 +582,7 @@ mod tests {
             word: "foo".parse().unwrap(),
         };
         let name = Some(Name::Variable("var"));
-        let mut value = None;
+        let mut value = save_var.value.clone();
         let location = Location::dummy("somewhere");
 
         let result = apply(&mut env, &switch, "var", name, &mut value, &location)
@@ -593,6 +594,7 @@ mod tests {
                 assert_eq!(e.name, "var");
                 assert_eq!(e.new_value, Value::scalar("foo"));
                 assert_eq!(e.read_only_location, Location::dummy("read-only"));
+                assert_eq!(e.vacancy, Some(Vacancy::EmptyScalar));
             });
         });
         assert_eq!(env.inner.variables.get("var"), Some(&save_var));


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `yash-cli` shell binary updated to version `0.1.0-beta.2` with improved prompt display and error messaging.
  - Enhanced error types in `yash-semantics` module for more informative messages.

- **Documentation**
  - Updated `yash-cli` documentation to clarify changes for binary and library crate.
  - Improved changelog file organization for better clarity.

- **Bug Fixes**
  - Fixed issues with `yash-cli` built-ins like `break`, `continue`, `read`, `source`, and `set`.

- **Chores**
  - Enhanced script to check release dates in multiple `CHANGELOG` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->