### PR TITLE
Remove AtFlags from public API

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `system::Mode` is no longer a re-export of `nix::sys::stat::Mode`.
+- The `system::System::fstatat` method now takes a `follow_symlinks: bool`
+  parameter instead of an `AtFlags` parameter.
 - The `system::System::open` method has been redefined to take `OfdAccess` and
   `OpenFlag` parameters instead of `nix::fcntl::OFlag`.
 - The `system::System::umask` method now takes and returns a value of the new
@@ -42,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- The `system` module no longer reexports `nix::fcntl::OFlag`.
+- The `system` module no longer reexports `nix::fcntl::AtFlags` and
+  `nix::fcntl::OFlag`.
 - The `fcntl_getfl` and `fcntl_setfl` methods from the `System` trait
 - The `system::Errno` struct's `last` and `clear` methods are no longer public.
 

--- a/yash-env/src/pwd.rs
+++ b/yash-env/src/pwd.rs
@@ -17,7 +17,6 @@
 //! Working directory path handling
 
 use super::Env;
-use crate::system::AtFlags;
 use crate::system::Errno;
 use crate::system::AT_FDCWD;
 use crate::variable::AssignError;
@@ -72,11 +71,10 @@ impl Env {
             let Ok(cstr_pwd) = CString::new(pwd.as_bytes()) else {
                 return false;
             };
-            const AT_FLAGS: AtFlags = AtFlags::empty();
-            let Ok(s1) = self.system.fstatat(AT_FDCWD, &cstr_pwd, AT_FLAGS) else {
+            let Ok(s1) = self.system.fstatat(AT_FDCWD, &cstr_pwd, true) else {
                 return false;
             };
-            let Ok(s2) = self.system.fstatat(AT_FDCWD, c".", AT_FLAGS) else {
+            let Ok(s2) = self.system.fstatat(AT_FDCWD, c".", true) else {
                 return false;
             };
             same_files(&s1, &s2)

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -63,8 +63,6 @@ use crate::trap::SignalSystem;
 use crate::Env;
 use enumset::EnumSet;
 #[doc(no_inline)]
-pub use nix::fcntl::AtFlags;
-#[doc(no_inline)]
 pub use nix::fcntl::FdFlag;
 #[doc(no_inline)]
 pub use nix::sys::signal::SigmaskHow;
@@ -97,7 +95,7 @@ pub trait System: Debug {
     fn fstat(&self, fd: Fd) -> Result<FileStat>;
 
     /// Retrieves metadata of a file.
-    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat>;
+    fn fstatat(&self, dir_fd: Fd, path: &CStr, follow_symlinks: bool) -> Result<FileStat>;
 
     /// Whether there is an executable file at the specified path.
     #[must_use]

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -22,7 +22,6 @@ mod signal;
 
 use super::resource::LimitPair;
 use super::resource::Resource;
-use super::AtFlags;
 use super::ChildProcessStarter;
 use super::Dir;
 use super::DirEntry;
@@ -49,6 +48,7 @@ use crate::job::ProcessState;
 use crate::SignalHandling;
 use enumset::EnumSet;
 use nix::errno::Errno as NixErrno;
+use nix::fcntl::AtFlags;
 use nix::libc::DIR;
 use nix::libc::{S_IFDIR, S_IFMT, S_IFREG};
 use nix::sys::stat::stat;
@@ -188,7 +188,12 @@ impl System for RealSystem {
         Ok(nix::sys::stat::fstat(fd.0)?)
     }
 
-    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat> {
+    fn fstatat(&self, dir_fd: Fd, path: &CStr, follow_symlinks: bool) -> Result<FileStat> {
+        let flags = if follow_symlinks {
+            AtFlags::empty()
+        } else {
+            AtFlags::AT_SYMLINK_NOFOLLOW
+        };
         Ok(nix::sys::stat::fstatat(dir_fd.0, path, flags)?)
     }
 

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -42,7 +42,6 @@ use crate::job::ProcessState;
 #[cfg(doc)]
 use crate::Env;
 use enumset::EnumSet;
-use nix::fcntl::AtFlags;
 use nix::fcntl::FdFlag;
 use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::FileStat;
@@ -305,8 +304,8 @@ impl System for &SharedSystem {
     fn fstat(&self, fd: Fd) -> Result<FileStat> {
         self.0.borrow().fstat(fd)
     }
-    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat> {
-        self.0.borrow().fstatat(dir_fd, path, flags)
+    fn fstatat(&self, dir_fd: Fd, path: &CStr, follow_symlinks: bool) -> Result<FileStat> {
+        self.0.borrow().fstatat(dir_fd, path, follow_symlinks)
     }
     fn is_executable_file(&self, path: &CStr) -> bool {
         self.0.borrow().is_executable_file(path)
@@ -487,8 +486,8 @@ impl System for SharedSystem {
         (&self).fstat(fd)
     }
     #[inline]
-    fn fstatat(&self, dir_fd: Fd, path: &CStr, flags: AtFlags) -> Result<FileStat> {
-        (&self).fstatat(dir_fd, path, flags)
+    fn fstatat(&self, dir_fd: Fd, path: &CStr, follow_symlinks: bool) -> Result<FileStat> {
+        (&self).fstatat(dir_fd, path, follow_symlinks)
     }
     #[inline]
     fn is_executable_file(&self, path: &CStr) -> bool {

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -58,7 +58,6 @@ use std::iter::Once;
 use std::marker::PhantomData;
 use yash_env::option::State::Off;
 use yash_env::semantics::Field;
-use yash_env::system::AtFlags;
 use yash_env::system::AT_FDCWD;
 use yash_env::Env;
 use yash_env::System;
@@ -207,13 +206,12 @@ impl SearchEnv<'_> {
     }
 
     fn file_exists(&mut self) -> bool {
-        let path = match CString::new(self.prefix.as_str()) {
-            Ok(path) => path,
-            Err(_) => return false,
+        let Ok(path) = CString::new(self.prefix.as_str()) else {
+            return false;
         };
         self.env
             .system
-            .fstatat(AT_FDCWD, &path, AtFlags::empty())
+            .fstatat(AT_FDCWD, &path, /* follow symlinks */ true)
             .is_ok()
     }
 


### PR DESCRIPTION
This pull request is part of #353 and removes the `AtFlags` type from the `yash_env::system` module interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated file system operations to enhance usability with direct boolean options for following symbolic links.
  
- **Bug Fixes**
  - Improved error handling in the `file_exists` method, making it more concise and readable.

- **Refactor**
  - Streamlined method signatures across various system implementations to replace flag types with clearer boolean parameters.

- **Tests**
  - Updated test cases to reflect the new boolean handling for symbolic links across multiple methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->