### PR TITLE
Redefine FdFlag

### DIFF
--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -163,6 +163,7 @@ async fn report_find_and_open_file_failure(
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
+    use enumset::EnumSet;
     use futures_util::FutureExt as _;
     use std::cell::RefCell;
     use std::path::Path;
@@ -259,7 +260,7 @@ mod tests {
 
         let process = system.current_process();
         let fd_body = process.get_fd(fd).unwrap();
-        assert_eq!(fd_body.flag, FdFlag::FD_CLOEXEC);
+        assert_eq!(fd_body.flags, EnumSet::only(FdFlag::CloseOnExec));
     }
 
     #[test]

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The `OfdAccess`, `OpenFlag`, `Mode`, `RawMode`, `Uid`, `RawUid`, `Gid`, and
-  `RawGid` types in the `system` module
+- The `OfdAccess`, `OpenFlag`, `FdFlag`, `Mode`, `RawMode`, `Uid`, `RawUid`,
+  `Gid`, and `RawGid` types in the `system` module
 - The `System` trait now has the `ofd_access`, `get_and_set_nonblocking`,
   `getuid`, `geteuid`, `getgid`, and `getegid` methods.
 - `Mode` has been moved from `system::virtual` to `system` and now has constants
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `system::FdFlag` is no longer a re-export of `nix::fcntl::FdFlag`.
 - `system::Mode` is no longer a re-export of `nix::sys::stat::Mode`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`
   parameter instead of an `AtFlags` parameter.
@@ -35,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OpenFlag` parameters instead of `nix::fcntl::OFlag`.
 - The `system::System::umask` method now takes and returns a value of the new
   `system::Mode` type.
+- The `dup`, `fcntl_getfl`, and `fcntl_setfl` methods now operate on an
+  `EnumSet<FdFlag>` parameter instead of an `nix::fcntl::FdFlag` parameter.
+- The `flags: enumset::EnumSet<FdFlag>` field of
+  `yash_env::system::virtual::FdBody` has replaced
+  the `flag: nix::fcntl::FdFlag` field.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -17,6 +17,7 @@
 //! [System] and its implementors.
 
 mod errno;
+mod fd_flag;
 pub mod fd_set;
 mod file_system;
 mod id;

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -31,6 +31,7 @@ pub mod r#virtual;
 pub use self::errno::Errno;
 pub use self::errno::RawErrno;
 pub use self::errno::Result;
+pub use self::fd_flag::FdFlag;
 use self::fd_set::FdSet;
 pub use self::file_system::Dir;
 pub use self::file_system::DirEntry;
@@ -63,8 +64,6 @@ use crate::subshell::Subshell;
 use crate::trap::SignalSystem;
 use crate::Env;
 use enumset::EnumSet;
-#[doc(no_inline)]
-pub use nix::fcntl::FdFlag;
 #[doc(no_inline)]
 pub use nix::sys::signal::SigmaskHow;
 #[doc(no_inline)]
@@ -120,7 +119,7 @@ pub trait System: Debug {
     /// new FD.
     ///
     /// If successful, returns `Ok(new_fd)`. On error, returns `Err(_)`.
-    fn dup(&mut self, from: Fd, to_min: Fd, flags: FdFlag) -> Result<Fd>;
+    fn dup(&mut self, from: Fd, to_min: Fd, flags: EnumSet<FdFlag>) -> Result<Fd>;
 
     /// Duplicates a file descriptor.
     ///
@@ -165,12 +164,12 @@ pub trait System: Debug {
     /// Returns the attributes for the file descriptor.
     ///
     /// This is a thin wrapper around the `fcntl` system call.
-    fn fcntl_getfd(&self, fd: Fd) -> Result<FdFlag>;
+    fn fcntl_getfd(&self, fd: Fd) -> Result<EnumSet<FdFlag>>;
 
     /// Sets attributes for the file descriptor.
     ///
     /// This is a thin wrapper around the `fcntl` system call.
-    fn fcntl_setfd(&mut self, fd: Fd, flags: FdFlag) -> Result<()>;
+    fn fcntl_setfd(&mut self, fd: Fd, flags: EnumSet<FdFlag>) -> Result<()>;
 
     /// Tests if a file descriptor is associated with a terminal device.
     fn isatty(&self, fd: Fd) -> Result<bool>;
@@ -565,7 +564,7 @@ pub trait SystemEx: System {
             return Ok(from);
         }
 
-        let new = self.dup(from, MIN_INTERNAL_FD, FdFlag::FD_CLOEXEC);
+        let new = self.dup(from, MIN_INTERNAL_FD, FdFlag::CloseOnExec.into());
         self.close(from).ok();
         new
     }

--- a/yash-env/src/system/fd_flag.rs
+++ b/yash-env/src/system/fd_flag.rs
@@ -1,0 +1,28 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines attributes for file descriptors
+
+use enumset::EnumSetType;
+
+/// Attributes for file descriptors
+#[derive(Debug, EnumSetType, Hash)]
+#[non_exhaustive]
+pub enum FdFlag {
+    /// Close the file descriptor upon execution of an exec family function
+    CloseOnExec,
+    // TODO CloseOnFork,
+}

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -20,6 +20,7 @@ use super::signal;
 use super::ChildProcessStarter;
 use super::Dir;
 use super::Errno;
+use super::FdFlag;
 use super::FdSet;
 use super::Gid;
 use super::LimitPair;
@@ -42,7 +43,6 @@ use crate::job::ProcessState;
 #[cfg(doc)]
 use crate::Env;
 use enumset::EnumSet;
-use nix::fcntl::FdFlag;
 use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::FileStat;
 use nix::sys::time::TimeSpec;
@@ -316,7 +316,7 @@ impl System for &SharedSystem {
     fn pipe(&mut self) -> Result<(Fd, Fd)> {
         self.0.borrow_mut().pipe()
     }
-    fn dup(&mut self, from: Fd, to_min: Fd, flags: FdFlag) -> Result<Fd> {
+    fn dup(&mut self, from: Fd, to_min: Fd, flags: EnumSet<FdFlag>) -> Result<Fd> {
         self.0.borrow_mut().dup(from, to_min, flags)
     }
     fn dup2(&mut self, from: Fd, to: Fd) -> Result<Fd> {
@@ -343,10 +343,10 @@ impl System for &SharedSystem {
     fn get_and_set_nonblocking(&mut self, fd: Fd, nonblocking: bool) -> Result<bool> {
         self.0.borrow_mut().get_and_set_nonblocking(fd, nonblocking)
     }
-    fn fcntl_getfd(&self, fd: Fd) -> Result<FdFlag> {
+    fn fcntl_getfd(&self, fd: Fd) -> Result<EnumSet<FdFlag>> {
         self.0.borrow().fcntl_getfd(fd)
     }
-    fn fcntl_setfd(&mut self, fd: Fd, flags: FdFlag) -> Result<()> {
+    fn fcntl_setfd(&mut self, fd: Fd, flags: EnumSet<FdFlag>) -> Result<()> {
         self.0.borrow_mut().fcntl_setfd(fd, flags)
     }
     fn isatty(&self, fd: Fd) -> Result<bool> {
@@ -502,7 +502,7 @@ impl System for SharedSystem {
         (&mut &*self).pipe()
     }
     #[inline]
-    fn dup(&mut self, from: Fd, to_min: Fd, flags: FdFlag) -> Result<Fd> {
+    fn dup(&mut self, from: Fd, to_min: Fd, flags: EnumSet<FdFlag>) -> Result<Fd> {
         (&mut &*self).dup(from, to_min, flags)
     }
     #[inline]
@@ -536,11 +536,11 @@ impl System for SharedSystem {
         (&mut &*self).get_and_set_nonblocking(fd, nonblocking)
     }
     #[inline]
-    fn fcntl_getfd(&self, fd: Fd) -> Result<FdFlag> {
+    fn fcntl_getfd(&self, fd: Fd) -> Result<EnumSet<FdFlag>> {
         (&self).fcntl_getfd(fd)
     }
     #[inline]
-    fn fcntl_setfd(&mut self, fd: Fd, flags: FdFlag) -> Result<()> {
+    fn fcntl_setfd(&mut self, fd: Fd, flags: EnumSet<FdFlag>) -> Result<()> {
         (&mut &*self).fcntl_setfd(fd, flags)
     }
     #[inline]

--- a/yash-env/src/system/virtual/io.rs
+++ b/yash-env/src/system/virtual/io.rs
@@ -20,6 +20,7 @@ use super::super::Errno;
 use super::FdFlag;
 use super::FileBody;
 use super::INode;
+use enumset::EnumSet;
 use nix::unistd::Whence;
 use std::cell::RefCell;
 use std::fmt::Debug;
@@ -240,12 +241,13 @@ pub struct FdBody {
     /// Underlying open file description.
     pub open_file_description: Rc<RefCell<OpenFileDescription>>,
     /// Flags for this file descriptor
-    pub flag: FdFlag,
+    pub flags: EnumSet<FdFlag>,
 }
 
 impl PartialEq for FdBody {
     fn eq(&self, rhs: &Self) -> bool {
-        Rc::ptr_eq(&self.open_file_description, &rhs.open_file_description) && self.flag == rhs.flag
+        Rc::ptr_eq(&self.open_file_description, &rhs.open_file_description)
+            && self.flags == rhs.flags
     }
 }
 

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -595,7 +595,7 @@ mod tests {
     use super::*;
     use crate::system::r#virtual::file_system::{FileBody, INode, Mode};
     use crate::system::r#virtual::io::OpenFileDescription;
-    use crate::system::FdFlag;
+    use enumset::EnumSet;
     use futures_util::task::LocalSpawnExt;
     use futures_util::FutureExt;
     use std::collections::VecDeque;
@@ -654,11 +654,11 @@ mod tests {
 
         let reader = FdBody {
             open_file_description: Rc::new(RefCell::new(reader)),
-            flag: FdFlag::empty(),
+            flags: EnumSet::empty(),
         };
         let writer = FdBody {
             open_file_description: Rc::new(RefCell::new(writer)),
-            flag: FdFlag::empty(),
+            flags: EnumSet::empty(),
         };
 
         let reader = process.open_fd(reader).unwrap();

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -19,6 +19,7 @@
 use crate::trap::run_exit_trap;
 
 use super::Command;
+use enumset::EnumSet;
 use itertools::Itertools;
 use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
@@ -34,7 +35,6 @@ use yash_env::stack::Frame;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
 use yash_env::system::Errno;
-use yash_env::system::FdFlag;
 use yash_env::system::SystemEx;
 use yash_env::Env;
 use yash_env::System;
@@ -306,7 +306,7 @@ impl PipeSet {
             if writer != Fd::STDOUT {
                 if self.read_previous == Some(Fd::STDOUT) {
                     self.read_previous =
-                        Some(env.system.dup(Fd::STDOUT, Fd(0), FdFlag::empty())?);
+                        Some(env.system.dup(Fd::STDOUT, Fd(0), EnumSet::empty())?);
                 }
                 env.system.dup2(writer, Fd::STDOUT)?;
                 env.system.close(writer)?;
@@ -652,8 +652,8 @@ mod tests {
         assert_eq!(pipes.next, Some((Fd(3), Fd(4))));
         let state = state.borrow();
         let process = &state.processes[&process_id];
-        assert_eq!(process.fds().get(&Fd(3)).unwrap().flag, FdFlag::empty());
-        assert_eq!(process.fds().get(&Fd(4)).unwrap().flag, FdFlag::empty());
+        assert_eq!(process.fds().get(&Fd(3)).unwrap().flags, EnumSet::empty());
+        assert_eq!(process.fds().get(&Fd(4)).unwrap().flags, EnumSet::empty());
     }
 
     #[test]
@@ -671,9 +671,9 @@ mod tests {
         assert_eq!(pipes.next, Some((Fd(4), Fd(5))));
         let state = state.borrow();
         let process = &state.processes[&process_id];
-        assert_eq!(process.fds().get(&Fd(3)).unwrap().flag, FdFlag::empty());
-        assert_eq!(process.fds().get(&Fd(4)).unwrap().flag, FdFlag::empty());
-        assert_eq!(process.fds().get(&Fd(5)).unwrap().flag, FdFlag::empty());
+        assert_eq!(process.fds().get(&Fd(3)).unwrap().flags, EnumSet::empty());
+        assert_eq!(process.fds().get(&Fd(4)).unwrap().flags, EnumSet::empty());
+        assert_eq!(process.fds().get(&Fd(5)).unwrap().flags, EnumSet::empty());
     }
 
     #[test]
@@ -691,7 +691,7 @@ mod tests {
         assert_eq!(pipes.next, None);
         let state = state.borrow();
         let process = &state.processes[&process_id];
-        assert_eq!(process.fds().get(&Fd(3)).unwrap().flag, FdFlag::empty());
+        assert_eq!(process.fds().get(&Fd(3)).unwrap().flags, EnumSet::empty());
     }
 
     // TODO test PipeSet::move_to_stdin_stdout


### PR DESCRIPTION
This pull request is part of https://github.com/magicant/yash-rs/issues/353 and replaces the `FdFlag` type with a platform-independent definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced flag management for file descriptors, allowing for multiple flags to be used simultaneously.

- **Bug Fixes**
  - Updated assertions across tests to reflect the new `EnumSet` type for file descriptor flags, improving accuracy and consistency.

- **Refactor**
  - Renamed flag fields and updated related logic to utilize `EnumSet<FdFlag>`, improving flexibility and clarity in flag handling.

- **Documentation**
  - Revised comments and documentation to align with changes in flag naming conventions, enhancing readability and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->