### PR TITLE
Replace SigmaskHow with SigmaskOp

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -52,8 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- The `system` module no longer reexports `nix::fcntl::AtFlags` and
-  `nix::fcntl::OFlag`.
+- The `system` module no longer reexports `nix::fcntl::AtFlags`,
+  `nix::fcntl::OFlag`, and `nix::sys::signal::SigmaskHow`.
 - The `fcntl_getfl` and `fcntl_setfl` methods from the `System` trait
 - The `system::Errno` struct's `last` and `clear` methods are no longer public.
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OpenFlag` parameters instead of `nix::fcntl::OFlag`.
 - The `system::System::umask` method now takes and returns a value of the new
   `system::Mode` type.
+- The `system::System::sigmask` method now takes a `SigmaskOp` parameter instead
+  of a `nix::sys::signal::SigmaskHow` parameter.
 - The `dup`, `fcntl_getfl`, and `fcntl_setfl` methods now operate on an
   `EnumSet<FdFlag>` parameter instead of an `nix::fcntl::FdFlag` parameter.
 - The `flags: enumset::EnumSet<FdFlag>` field of

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `OfdAccess`, `OpenFlag`, `FdFlag`, `Mode`, `RawMode`, `Uid`, `RawUid`,
-  `Gid`, and `RawGid` types in the `system` module
+  `Gid`, `RawGid`, and `SigmaskOp` types in the `system` module
 - The `System` trait now has the `ofd_access`, `get_and_set_nonblocking`,
   `getuid`, `geteuid`, `getgid`, and `getegid` methods.
 - `Mode` has been moved from `system::virtual` to `system` and now has constants

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -33,7 +33,7 @@ use crate::signal;
 use crate::stack::Frame;
 use crate::system::ChildProcessTask;
 use crate::system::Errno;
-use crate::system::SigmaskHow::{SIG_BLOCK, SIG_SETMASK};
+use crate::system::SigmaskOp;
 use crate::system::System;
 use crate::system::SystemEx;
 use crate::Env;
@@ -286,7 +286,10 @@ impl<'a> MaskGuard<'a> {
         let success = self
             .env
             .system
-            .sigmask(Some((SIG_BLOCK, &[sigint, sigquit])), Some(&mut old_mask))
+            .sigmask(
+                Some((SigmaskOp::Add, &[sigint, sigquit])),
+                Some(&mut old_mask),
+            )
             .is_ok();
         if success {
             self.old_mask = Some(old_mask);
@@ -300,7 +303,7 @@ impl<'a> Drop for MaskGuard<'a> {
         if let Some(old_mask) = &self.old_mask {
             self.env
                 .system
-                .sigmask(Some((SIG_SETMASK, old_mask)), None)
+                .sigmask(Some((SigmaskOp::Set, old_mask)), None)
                 .ok();
         }
     }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -491,7 +491,19 @@ pub struct Times {
     pub children_system: f64,
 }
 
-/// How to handle a signal.
+/// Operation applied to the signal blocking mask
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum SigmaskOp {
+    /// Add signals to the mask (`SIG_BLOCK`)
+    Add,
+    /// Remove signals from the mask (`SIG_UNBLOCK`)
+    Remove,
+    /// Set the mask to the given signals (`SIG_SETMASK`)
+    Set,
+}
+
+/// How to handle a signal
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum SignalHandling {
     /// Perform the default action for the signal.

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -65,8 +65,6 @@ use crate::trap::SignalSystem;
 use crate::Env;
 use enumset::EnumSet;
 #[doc(no_inline)]
-pub use nix::sys::signal::SigmaskHow;
-#[doc(no_inline)]
 pub use nix::sys::stat::{FileStat, SFlag};
 #[doc(no_inline)]
 pub use nix::sys::time::TimeSpec;

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -30,6 +30,7 @@ use super::OpenFlag;
 use super::Resource;
 use super::Result;
 use super::SelectSystem;
+use super::SigmaskOp;
 use super::SignalHandling;
 use super::SignalStatus;
 use super::SignalSystem;
@@ -43,7 +44,6 @@ use crate::job::ProcessState;
 #[cfg(doc)]
 use crate::Env;
 use enumset::EnumSet;
-use nix::sys::signal::SigmaskHow;
 use nix::sys::stat::FileStat;
 use nix::sys::time::TimeSpec;
 use std::cell::RefCell;
@@ -384,7 +384,7 @@ impl System for &SharedSystem {
     }
     fn sigmask(
         &mut self,
-        op: Option<(SigmaskHow, &[signal::Number])>,
+        op: Option<(SigmaskOp, &[signal::Number])>,
         old_mask: Option<&mut Vec<signal::Number>>,
     ) -> Result<()> {
         (**self.0.borrow_mut()).sigmask(op, old_mask)
@@ -590,7 +590,7 @@ impl System for SharedSystem {
     #[inline]
     fn sigmask(
         &mut self,
-        op: Option<(SigmaskHow, &[signal::Number])>,
+        op: Option<(SigmaskOp, &[signal::Number])>,
         old_mask: Option<&mut Vec<signal::Number>>,
     ) -> Result<()> {
         (&mut &*self).sigmask(op, old_mask)


### PR DESCRIPTION
This is part of #353.

This pull request replaces the `nix::sys::signal::SigmaskHow` enum with the new `yash_env::system::SigmaskOp` enum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `SigmaskOp` type for enhanced signal masking operations, replacing the previous `SigmaskHow` type, simplifying and clarifying signal handling.
	- Expanded the `System` trait with new methods for improved functionality in handling user and system signals.

- **Bug Fixes**
	- Updated signal handling logic to ensure consistency and clarity in blocking, unblocking, and setting signal masks across various implementations.

- **Documentation**
	- Revised documentation to accurately reflect changes and provide clearer guidance on the new `SigmaskOp` operations.

- **Tests**
	- Updated test cases to align with the new signal handling definitions, ensuring relevance and accuracy in the testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->