### PR TITLE
Use Duration in System::select

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `system::Mode` type.
 - The `system::System::sigmask` method now takes a `SigmaskOp` parameter instead
   of a `nix::sys::signal::SigmaskHow` parameter.
+- The `system::System::select` method now takes a `Duration` instead of a
+  `nix::sys::time::TimeSpec` for the optional timeout parameter.
 - The `dup`, `fcntl_getfl`, and `fcntl_setfl` methods now operate on an
   `EnumSet<FdFlag>` parameter instead of an `nix::fcntl::FdFlag` parameter.
 - The `flags: enumset::EnumSet<FdFlag>` field of
@@ -58,8 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - The `system` module no longer reexports `nix::fcntl::AtFlags`,
-  `nix::fcntl::OFlag`, `nix::sys::stat::FileStat`, `nix::sys::stat::SFlag`, and
-  `nix::sys::signal::SigmaskHow`.
+  `nix::fcntl::OFlag`, `nix::sys::stat::FileStat`, `nix::sys::stat::SFlag`,
+  `nix::sys::signal::SigmaskHow`, and `nix::sys::time::TimeSpec`.
 - The `fcntl_getfl` and `fcntl_setfl` methods from the `System` trait
 - The `system::Errno` struct's `last` and `clear` methods are no longer public.
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -66,8 +66,6 @@ use crate::subshell::Subshell;
 use crate::trap::SignalSystem;
 use crate::Env;
 use enumset::EnumSet;
-#[doc(no_inline)]
-pub use nix::sys::time::TimeSpec;
 use std::convert::Infallible;
 use std::ffi::c_int;
 use std::ffi::CStr;
@@ -79,6 +77,7 @@ use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::time::Duration;
 use std::time::Instant;
 
 /// API to the system-managed parts of the environment.
@@ -345,7 +344,7 @@ pub trait System: Debug {
         &mut self,
         readers: &mut FdSet,
         writers: &mut FdSet,
-        timeout: Option<&TimeSpec>,
+        timeout: Option<Duration>,
         signal_mask: Option<&[signal::Number]>,
     ) -> Result<c_int>;
 

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -45,7 +45,6 @@ use crate::job::ProcessState;
 #[cfg(doc)]
 use crate::Env;
 use enumset::EnumSet;
-use nix::sys::time::TimeSpec;
 use std::cell::RefCell;
 use std::convert::Infallible;
 use std::ffi::c_int;
@@ -60,6 +59,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Poll;
+use std::time::Duration;
 use std::time::Instant;
 
 /// System shared by a reference counter.
@@ -410,7 +410,7 @@ impl System for &SharedSystem {
         &mut self,
         readers: &mut FdSet,
         writers: &mut FdSet,
-        timeout: Option<&TimeSpec>,
+        timeout: Option<Duration>,
         signal_mask: Option<&[signal::Number]>,
     ) -> Result<c_int> {
         (**self.0.borrow_mut()).select(readers, writers, timeout, signal_mask)
@@ -620,7 +620,7 @@ impl System for SharedSystem {
         &mut self,
         readers: &mut FdSet,
         writers: &mut FdSet,
-        timeout: Option<&TimeSpec>,
+        timeout: Option<Duration>,
         signal_mask: Option<&[signal::Number]>,
     ) -> Result<c_int> {
         (&mut &*self).select(readers, writers, timeout, signal_mask)


### PR DESCRIPTION
This is part of #353.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated timeout handling to use the `Duration` type for better clarity and usability.
	- Introduced a new utility function for converting `Duration` to a `timespec` structure.

- **Bug Fixes**
	- Improved timeout handling logic in the `SelectSystem` and `VirtualSystem` implementations, enhancing efficiency.

- **Documentation**
	- Removed unnecessary references to `TimeSpec` to streamline the codebase. 

- **Refactor**
	- Simplified method signatures and internal logic to consistently use `Duration` across the system module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->