### PR TITLE
Remove nix dependency from Resource public API

### DIFF
--- a/yash-builtin/src/ulimit.rs
+++ b/yash-builtin/src/ulimit.rs
@@ -145,7 +145,7 @@
 
 use crate::common::{output, report_error, report_simple_failure};
 use yash_env::semantics::Field;
-use yash_env::system::resource::{rlim_t, Resource};
+use yash_env::system::resource::{Limit, Resource};
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_env::System as _;
@@ -175,7 +175,7 @@ pub enum SetLimitType {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SetLimitValue {
     /// Numeric value (not scaled)
-    Number(rlim_t),
+    Number(Limit),
     /// No limit
     Unlimited,
     /// Current soft limit

--- a/yash-builtin/src/ulimit/resource.rs
+++ b/yash-builtin/src/ulimit/resource.rs
@@ -16,7 +16,7 @@
 
 //! Extension of [`Resource`] for the `ulimit` built-in
 
-use yash_env::system::resource::{rlim_t, Resource};
+use yash_env::system::resource::{Limit, Resource};
 
 /// Extension of [`Resource`] for use in the `ulimit` built-in
 pub trait ResourceExt {
@@ -41,7 +41,7 @@ pub trait ResourceExt {
     /// which means that the user sees and sets the limit in kilobytes, but the
     /// underlying system call operates in bytes.
     #[must_use]
-    fn scale(&self) -> rlim_t;
+    fn scale(&self) -> Limit;
 }
 
 impl ResourceExt for Resource {
@@ -95,7 +95,7 @@ impl ResourceExt for Resource {
         }
     }
 
-    fn scale(&self) -> rlim_t {
+    fn scale(&self) -> Limit {
         match self {
             Self::AS | Self::DATA | Self::MEMLOCK | Self::RSS | Self::STACK | Self::SWAP => 1 << 10,
             Self::CORE | Self::FSIZE => 1 << 9,

--- a/yash-builtin/src/ulimit/set.rs
+++ b/yash-builtin/src/ulimit/set.rs
@@ -17,7 +17,7 @@
 //! Setting resource limits
 
 use super::{Error, ResourceExt as _, SetLimitType, SetLimitValue};
-use yash_env::system::resource::{LimitPair, Resource, RLIM_INFINITY};
+use yash_env::system::resource::{LimitPair, Resource, INFINITY};
 use yash_env::system::Errno;
 use yash_env::System;
 
@@ -62,9 +62,9 @@ pub fn set<E: Env>(
     let new_limit = match new_limit {
         SetLimitValue::Number(limit) => limit
             .checked_mul(resource.scale())
-            .filter(|limit| *limit != RLIM_INFINITY)
+            .filter(|limit| *limit != INFINITY)
             .ok_or(Error::Overflow)?,
-        SetLimitValue::Unlimited => RLIM_INFINITY,
+        SetLimitValue::Unlimited => INFINITY,
         SetLimitValue::CurrentSoft => old_limits.soft,
         SetLimitValue::CurrentHard => old_limits.hard,
     };
@@ -99,7 +99,7 @@ pub fn set<E: Env>(
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use yash_env::system::resource::{rlim_t, RLIM_INFINITY};
+    use yash_env::system::resource::Limit;
     use yash_env::VirtualSystem;
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
             limits,
             LimitPair {
                 soft: 0,
-                hard: RLIM_INFINITY
+                hard: INFINITY
             }
         );
     }
@@ -182,8 +182,8 @@ mod tests {
         assert_eq!(
             limits,
             LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY
+                soft: INFINITY,
+                hard: INFINITY
             }
         );
     }
@@ -358,7 +358,7 @@ mod tests {
             &mut system,
             Resource::FSIZE,
             SetLimitType::Both,
-            SetLimitValue::Number(rlim_t::MAX / 2),
+            SetLimitValue::Number(Limit::MAX / 2),
         );
         assert_matches!(result, Err(Error::Overflow));
     }
@@ -370,7 +370,7 @@ mod tests {
             &mut system,
             Resource::CPU,
             SetLimitType::Both,
-            SetLimitValue::Number(RLIM_INFINITY),
+            SetLimitValue::Number(INFINITY),
         );
         assert_matches!(result, Err(Error::Overflow));
     }

--- a/yash-builtin/src/ulimit/show.rs
+++ b/yash-builtin/src/ulimit/show.rs
@@ -20,22 +20,24 @@ use super::Error;
 use super::ResourceExt as _;
 use super::ShowLimitType;
 use std::fmt::Write as _;
-use yash_env::system::resource::rlim_t;
+use yash_env::system::resource::Limit as RawLimit;
 use yash_env::system::resource::LimitPair;
 use yash_env::system::resource::Resource;
-use yash_env::system::resource::RLIM_INFINITY;
+use yash_env::system::resource::INFINITY;
 use yash_env::system::Errno;
 
-/// A wrapper for `rlim_t` that implements `Display`.
+/// Wrapper for the raw limit value for implementing `std::fmt::Display`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct Limit {
-    value: rlim_t,
-    scale: rlim_t,
+    /// Raw limit value
+    value: RawLimit,
+    /// Scale to divide the raw limit value when displaying
+    scale: RawLimit,
 }
 
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.value == RLIM_INFINITY {
+        if self.value == INFINITY {
             "unlimited".fmt(f)
         } else {
             (self.value / self.scale).fmt(f)
@@ -107,8 +109,8 @@ mod tests {
     fn show_all_infinity() {
         let getrlimit = |_: Resource| {
             Ok(LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY,
+                soft: INFINITY,
+                hard: INFINITY,
             })
         };
         let result = show_all(getrlimit, ShowLimitType::Soft);
@@ -182,8 +184,8 @@ mod tests {
     fn show_one_infinite() {
         let getrlimit = |_: Resource| {
             Ok(LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY,
+                soft: INFINITY,
+                hard: INFINITY,
             })
         };
         let result = show_one(getrlimit, Resource::DATA, ShowLimitType::Soft).unwrap();

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nix::sys::signal::SigmaskHow`, and `nix::sys::time::TimeSpec`.
 - The `fcntl_getfl` and `fcntl_setfl` methods from the `System` trait
 - The `system::Errno` struct's `last` and `clear` methods are no longer public.
+- The `system::resource::Resource::as_raw_type` method is no longer public.
 - All the fields of the `system::virtual::OpenFileDescription` struct are now
   private.
 - `impl TryFrom<semantics::ExitStatus> for nix::sys::signal::Signal`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter.
 - The `getrlimit` and `setrlimit` methods of `system::System` now returns an
   error of type `system::Errno` instead of `std::io::Error`.
+- In the `system::resource` module:
+    - The `rlim_t` type has been renamed to `Limit`.
+    - The `RLIM_INFINITY` constant has been renamed to `INFINITY`.
 - The `flags: enumset::EnumSet<FdFlag>` field of
   `yash_env::system::virtual::FdBody` has replaced
   the `flag: nix::fcntl::FdFlag` field.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All the fields of the `system::virtual::OpenFileDescription` struct are now
   private.
 - `impl TryFrom<semantics::ExitStatus> for nix::sys::signal::Signal`
+- `impl From<system::resource::LimitPair> for nix::libc::rlimit`
+- `impl From<nix::libc::rlimit> for system::resource::LimitPair`
 
 ## [0.2.1] - 2024-07-12
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -454,20 +454,20 @@ pub trait System: Debug {
     /// resource. The soft limit is the current limit, and the hard limit is the
     /// maximum value that the soft limit can be set to.
     ///
-    /// When no limit is set, the limit value is [`RLIM_INFINITY`].
+    /// When no limit is set, the limit value is [`INFINITY`].
     ///
     /// This is a thin wrapper around the `getrlimit` system call.
     ///
-    /// [`RLIM_INFINITY`]: self::resource::RLIM_INFINITY
+    /// [`INFINITY`]: self::resource::INFINITY
     fn getrlimit(&self, resource: Resource) -> Result<LimitPair>;
 
     /// Sets the limits for the specified resource.
     ///
-    /// Specify [`RLIM_INFINITY`] as the limit value to remove the limit.
+    /// Specify [`INFINITY`] as the limit value to remove the limit.
     ///
     /// This is a thin wrapper around the `setrlimit` system call.
     ///
-    /// [`RLIM_INFINITY`]: self::resource::RLIM_INFINITY
+    /// [`INFINITY`]: self::resource::INFINITY
     fn setrlimit(&mut self, resource: Resource, limits: LimitPair) -> Result<()>;
 }
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -19,6 +19,7 @@
 mod errno;
 mod file_system;
 mod open_flag;
+mod resource;
 mod signal;
 
 use super::resource::LimitPair;

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -495,7 +495,7 @@ impl System for RealSystem {
             let new_action = handling.to_sigaction();
 
             let mut old_action = MaybeUninit::<nix::libc::sigaction>::uninit();
-            let old_mask_ptr = std::ptr::addr_of_mut!((*old_action.as_mut_ptr()).sa_mask);
+            let old_mask_ptr = addr_of_mut!((*old_action.as_mut_ptr()).sa_mask);
             // POSIX requires *all* sigset_t objects to be initialized before use.
             nix::libc::sigemptyset(old_mask_ptr).errno_if_m1()?;
 
@@ -767,15 +767,22 @@ impl System for RealSystem {
 
         let mut limits = MaybeUninit::<nix::libc::rlimit>::uninit();
         unsafe { nix::libc::getrlimit(raw_resource as _, limits.as_mut_ptr()) }.errno_if_m1()?;
-        let limits = unsafe { limits.assume_init() };
-        Ok(limits.into())
+        Ok(LimitPair {
+            soft: unsafe { addr_of!((*limits.as_ptr()).rlim_cur).read() },
+            hard: unsafe { addr_of!((*limits.as_ptr()).rlim_max).read() },
+        })
     }
 
     fn setrlimit(&mut self, resource: Resource, limits: LimitPair) -> Result<()> {
         let raw_resource = resource.as_raw_type().ok_or(Errno::EINVAL)?;
 
-        let limits = limits.into();
-        unsafe { nix::libc::setrlimit(raw_resource as _, &limits) }.errno_if_m1()?;
+        let mut rlimit = MaybeUninit::<nix::libc::rlimit>::uninit();
+        unsafe {
+            addr_of_mut!((*rlimit.as_mut_ptr()).rlim_cur).write(limits.soft);
+            addr_of_mut!((*rlimit.as_mut_ptr()).rlim_max).write(limits.hard);
+        }
+
+        unsafe { nix::libc::setrlimit(raw_resource as _, rlimit.as_ptr()) }.errno_if_m1()?;
         Ok(())
     }
 }

--- a/yash-env/src/system/real/resource.rs
+++ b/yash-env/src/system/real/resource.rs
@@ -1,0 +1,105 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Extension to [`crate::system::resource`] for the real system
+
+use super::super::resource::Resource;
+
+impl Resource {
+    /// Returns the platform-specific constant value of this resource type.
+    ///
+    /// This method returns `None` if the resource type is not available on the
+    /// current platform.
+    #[must_use]
+    pub(super) const fn as_raw_type(&self) -> Option<std::ffi::c_int> {
+        match *self {
+            #[cfg(not(any(target_env = "newlib", target_os = "redox")))]
+            Self::AS => Some(nix::libc::RLIMIT_AS as _),
+            Self::CORE => Some(nix::libc::RLIMIT_CORE as _),
+            Self::CPU => Some(nix::libc::RLIMIT_CPU as _),
+            Self::DATA => Some(nix::libc::RLIMIT_DATA as _),
+            Self::FSIZE => Some(nix::libc::RLIMIT_FSIZE as _),
+            #[cfg(target_os = "freebsd")]
+            Self::KQUEUES => Some(nix::libc::RLIMIT_KQUEUES as _),
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+            Self::LOCKS => Some(nix::libc::RLIMIT_LOCKS as _),
+            #[cfg(any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "watchos",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "nto"
+            ))]
+            Self::MEMLOCK => Some(nix::libc::RLIMIT_MEMLOCK as _),
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+            Self::MSGQUEUE => Some(nix::libc::RLIMIT_MSGQUEUE as _),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            Self::NICE => Some(nix::libc::RLIMIT_NICE as _),
+            Self::NOFILE => Some(nix::libc::RLIMIT_NOFILE as _),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "watchos",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "nto"
+            ))]
+            Self::NPROC => Some(nix::libc::RLIMIT_NPROC as _),
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "watchos",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "nto"
+            ))]
+            Self::RSS => Some(nix::libc::RLIMIT_RSS as _),
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+            Self::RTPRIO => Some(nix::libc::RLIMIT_RTPRIO as _),
+            #[cfg(target_os = "linux")]
+            Self::RTTIME => Some(nix::libc::RLIMIT_RTTIME as _),
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
+            Self::SBSIZE => Some(nix::libc::RLIMIT_SBSIZE as _),
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+            Self::SIGPENDING => Some(nix::libc::RLIMIT_SIGPENDING as _),
+            Self::STACK => Some(nix::libc::RLIMIT_STACK as _),
+            #[cfg(target_os = "freebsd")]
+            Self::SWAP => Some(nix::libc::RLIMIT_SWAP as _),
+            _ => None,
+        }
+    }
+}

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -25,13 +25,12 @@
 /// Unsigned integer type for resource limits
 ///
 /// The size of this type may vary depending on the platform.
-#[allow(non_camel_case_types)]
-pub type rlim_t = nix::libc::rlim_t;
+pub type Limit = nix::libc::rlim_t;
 
 /// Constant to specify an unlimited resource limit
 ///
 /// The value of this constant is platform-specific.
-pub const RLIM_INFINITY: rlim_t = nix::libc::RLIM_INFINITY;
+pub const INFINITY: Limit = nix::libc::RLIM_INFINITY;
 
 // No platforms are known to define `RLIM_SAVED_CUR` and `RLIM_SAVED_MAX` that
 // have different values from `RLIM_INFINITY`, so they are not defined here.
@@ -207,18 +206,19 @@ impl Resource {
 /// Pair of soft and hard limits
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct LimitPair {
-    pub soft: rlim_t,
-    pub hard: rlim_t,
+    pub soft: Limit,
+    pub hard: Limit,
 }
 
 impl LimitPair {
     /// Returns `true` if the soft limit exceeds the hard limit
     #[must_use]
     pub fn soft_exceeds_hard(&self) -> bool {
-        self.hard != RLIM_INFINITY && (self.soft == RLIM_INFINITY || self.soft > self.hard)
+        self.hard != INFINITY && (self.soft == INFINITY || self.soft > self.hard)
     }
 }
 
+// TODO Remove this
 impl From<LimitPair> for nix::libc::rlimit {
     fn from(limits: LimitPair) -> Self {
         Self {
@@ -228,6 +228,7 @@ impl From<LimitPair> for nix::libc::rlimit {
     }
 }
 
+// TODO Remove this
 impl From<nix::libc::rlimit> for LimitPair {
     fn from(limits: nix::libc::rlimit) -> Self {
         Self {

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -50,12 +50,13 @@ pub const INFINITY: Limit = RLIM_INFINITY;
 /// Resource type definition
 ///
 /// A `Resource` value represents a resource whose limit can be retrieved or
-/// set using `getrlimit` and `setrlimit`.
+/// set using [`getrlimit`] and [`setrlimit`].
 ///
 /// This enum contains all possible resource types that may or may not be
-/// available depending on the platform. To see if a resource is available on
-/// the current platform, check the result of
-/// [`as_raw_type`](Self::as_raw_type).
+/// available depending on the platform.
+///
+/// [`getrlimit`]: super::System::getrlimit
+/// [`setrlimit`]: super::System::setrlimit
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Resource {
@@ -127,90 +128,6 @@ impl Resource {
         Self::STACK,
         Self::SWAP,
     ];
-
-    /// Returns the platform-specific constant value of this resource type.
-    ///
-    /// This method returns `None` if the resource type is not available on the
-    /// current platform.
-    #[must_use]
-    pub const fn as_raw_type(&self) -> Option<std::ffi::c_int> {
-        match *self {
-            #[cfg(not(any(target_env = "newlib", target_os = "redox")))]
-            Self::AS => Some(nix::libc::RLIMIT_AS as _),
-            Self::CORE => Some(nix::libc::RLIMIT_CORE as _),
-            Self::CPU => Some(nix::libc::RLIMIT_CPU as _),
-            Self::DATA => Some(nix::libc::RLIMIT_DATA as _),
-            Self::FSIZE => Some(nix::libc::RLIMIT_FSIZE as _),
-            #[cfg(target_os = "freebsd")]
-            Self::KQUEUES => Some(nix::libc::RLIMIT_KQUEUES as _),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::LOCKS => Some(nix::libc::RLIMIT_LOCKS as _),
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "openbsd",
-                target_os = "netbsd",
-                target_os = "linux",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "nto"
-            ))]
-            Self::MEMLOCK => Some(nix::libc::RLIMIT_MEMLOCK as _),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::MSGQUEUE => Some(nix::libc::RLIMIT_MSGQUEUE as _),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            Self::NICE => Some(nix::libc::RLIMIT_NICE as _),
-            Self::NOFILE => Some(nix::libc::RLIMIT_NOFILE as _),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "openbsd",
-                target_os = "netbsd",
-                target_os = "linux",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "nto"
-            ))]
-            Self::NPROC => Some(nix::libc::RLIMIT_NPROC as _),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "openbsd",
-                target_os = "netbsd",
-                target_os = "linux",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "nto"
-            ))]
-            Self::RSS => Some(nix::libc::RLIMIT_RSS as _),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::RTPRIO => Some(nix::libc::RLIMIT_RTPRIO as _),
-            #[cfg(target_os = "linux")]
-            Self::RTTIME => Some(nix::libc::RLIMIT_RTTIME as _),
-            #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
-            Self::SBSIZE => Some(nix::libc::RLIMIT_SBSIZE as _),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::SIGPENDING => Some(nix::libc::RLIMIT_SIGPENDING as _),
-            Self::STACK => Some(nix::libc::RLIMIT_STACK as _),
-            #[cfg(target_os = "freebsd")]
-            Self::SWAP => Some(nix::libc::RLIMIT_SWAP as _),
-            _ => None,
-        }
-    }
 }
 
 /// Pair of soft and hard limits

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -227,23 +227,3 @@ impl LimitPair {
         self.hard != INFINITY && (self.soft == INFINITY || self.soft > self.hard)
     }
 }
-
-// TODO Remove this
-impl From<LimitPair> for nix::libc::rlimit {
-    fn from(limits: LimitPair) -> Self {
-        Self {
-            rlim_cur: limits.soft,
-            rlim_max: limits.hard,
-        }
-    }
-}
-
-// TODO Remove this
-impl From<nix::libc::rlimit> for LimitPair {
-    fn from(limits: nix::libc::rlimit) -> Self {
-        Self {
-            soft: limits.rlim_cur,
-            hard: limits.rlim_max,
-        }
-    }
-}

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -22,15 +22,25 @@
 //! [`getrlimit`]: super::System::getrlimit
 //! [`setrlimit`]: super::System::setrlimit
 
+#[cfg(unix)]
+type RawLimit = nix::libc::rlim_t;
+#[cfg(not(unix))]
+type RawLimit = u64;
+
 /// Unsigned integer type for resource limits
 ///
 /// The size of this type may vary depending on the platform.
-pub type Limit = nix::libc::rlim_t;
+pub type Limit = RawLimit;
+
+#[cfg(unix)]
+const RLIM_INFINITY: Limit = nix::libc::RLIM_INFINITY;
+#[cfg(not(unix))]
+const RLIM_INFINITY: Limit = Limit::MAX;
 
 /// Constant to specify an unlimited resource limit
 ///
 /// The value of this constant is platform-specific.
-pub const INFINITY: Limit = nix::libc::RLIM_INFINITY;
+pub const INFINITY: Limit = RLIM_INFINITY;
 
 // No platforms are known to define `RLIM_SAVED_CUR` and `RLIM_SAVED_MAX` that
 // have different values from `RLIM_INFINITY`, so they are not defined here.

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -55,7 +55,7 @@ pub use self::process::*;
 pub use self::signal::*;
 use super::resource::LimitPair;
 use super::resource::Resource;
-use super::resource::RLIM_INFINITY;
+use super::resource::INFINITY;
 use super::Dir;
 use super::Errno;
 use super::FdFlag;
@@ -1021,8 +1021,8 @@ impl System for VirtualSystem {
             .get(&resource)
             .copied()
             .unwrap_or(LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY,
+                soft: INFINITY,
+                hard: INFINITY,
             }))
     }
 
@@ -2639,8 +2639,8 @@ mod tests {
         assert_eq!(
             result,
             LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY,
+                soft: INFINITY,
+                hard: INFINITY,
             },
         );
     }
@@ -2684,8 +2684,8 @@ mod tests {
         assert_eq!(
             result,
             LimitPair {
-                soft: RLIM_INFINITY,
-                hard: RLIM_INFINITY,
+                soft: INFINITY,
+                hard: INFINITY,
             },
         );
     }

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -28,7 +28,7 @@ use crate::job::ProcessResult;
 use crate::job::ProcessState;
 use crate::system::resource::LimitPair;
 use crate::system::resource::Resource;
-use crate::system::resource::RLIM_INFINITY;
+use crate::system::resource::INFINITY;
 use crate::system::SelectSystem;
 use crate::SignalHandling;
 use std::cell::Cell;
@@ -275,10 +275,10 @@ impl Process {
             .resource_limits
             .get(&Resource::NOFILE)
             .map(|l| l.soft)
-            .unwrap_or(RLIM_INFINITY);
+            .unwrap_or(INFINITY);
 
         #[allow(clippy::unnecessary_cast)]
-        if limit == RLIM_INFINITY || (fd.0 as u64) < limit as u64 {
+        if limit == INFINITY || (fd.0 as u64) < limit as u64 {
             Ok(self.fds.insert(fd, body))
         } else {
             Err(body)


### PR DESCRIPTION
This is part of #353.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in resource limit handling by introducing a new `Limit` type.
	- Standardized infinite resource limits by replacing `RLIM_INFINITY` with `INFINITY`.

- **Bug Fixes**
	- Improved error handling in `getrlimit` and `setrlimit` methods with specific error types.

- **Documentation**
	- Updated references in documentation comments to reflect the new `INFINITY` constant.

- **Chores**
	- Refined the structure and naming conventions in resource management for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->