### PR TITLE
Make more crates build on non-Unix targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,20 +60,20 @@ jobs:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - name: Test yash-arith
-      run: cargo test --package yash-arith
+      run: cargo test --all-features --package yash-arith
     - name: Test yash-fnmatch
-      run: cargo test --package yash-fnmatch
+      run: cargo test --all-features --package yash-fnmatch
     - name: Test yash-quote
-      run: cargo test --package yash-quote
+      run: cargo test --all-features --package yash-quote
     - name: Test yash-syntax
-      run: cargo test --package yash-syntax
+      run: cargo test --all-features --package yash-syntax
     - name: Test yash-env
-      run: cargo test --package yash-env
+      run: cargo test --all-features --package yash-env
     - name: Test yash-env-test-helper
-      run: cargo test --package yash-env-test-helper
+      run: cargo test --all-features --package yash-env-test-helper
     - name: Test yash-semantics
-      run: cargo test --package yash-semantics
+      run: cargo test --all-features --package yash-semantics
     - name: Test yash-prompt
-      run: cargo test --package yash-prompt
+      run: cargo test --all-features --package yash-prompt
     - name: Test yash-builtin
-      run: cargo test --package yash-builtin
+      run: cargo test --all-features --package yash-builtin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,3 +67,13 @@ jobs:
       run: cargo test --package yash-quote
     - name: Test yash-syntax
       run: cargo test --package yash-syntax
+    - name: Test yash-env
+      run: cargo test --package yash-env
+    - name: Test yash-env-test-helper
+      run: cargo test --package yash-env-test-helper
+    - name: Test yash-semantics
+      run: cargo test --package yash-semantics
+    - name: Test yash-prompt
+      run: cargo test --package yash-prompt
+    - name: Test yash-builtin
+      run: cargo test --package yash-builtin

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - Unreleased
 
+### Added
+
+- This crate now builds on non-Unix platforms.
+
 ### Changed
 
 - All APIs that handle `std::path::Path` and `std::path::PathBuf` now use

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -105,7 +105,8 @@
 //! # Implementation notes
 //!
 //! The `-p` option depends on [`System::confstr_path`] to obtain the standard
-//! search path. See [`RealSystem::confstr_path`] for the supported platforms.
+//! search path. See the source code of [`RealSystem::confstr_path`] for the
+//! platforms supported on the real system.
 //!
 //! The [`type`] built-in is equivalent to the `command` built-in with the `-V`
 //! option.
@@ -116,8 +117,10 @@ use crate::common::report_error;
 use enumset::EnumSet;
 use enumset::EnumSetType;
 use yash_env::semantics::Field;
+#[cfg(all(doc, unix))]
+use yash_env::system::real::RealSystem;
 #[cfg(doc)]
-use yash_env::system::{real::RealSystem, System};
+use yash_env::system::System;
 use yash_env::Env;
 
 /// Category of command name resolution

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- This crate now builds on non-Unix platforms. However,
+  `system::real::RealSystem` is only available on Unix platforms.
 - The `OfdAccess`, `OpenFlag`, `FdFlag`, `Mode`, `RawMode`, `Uid`, `RawUid`,
   `Gid`, `RawGid`, `FileType`, `Stat`, and `SigmaskOp` types in the `system`
   module

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   private.
 - The `system::fd_set` module
 - `impl TryFrom<semantics::ExitStatus> for nix::sys::signal::Signal`
+- `impl From<job::Pid> for nix::unistd::Pid`
+- `impl From<nix::unistd::Pid> for job::Pid`
 - `impl From<system::resource::LimitPair> for nix::libc::rlimit`
 - `impl From<nix::libc::rlimit> for system::resource::LimitPair`
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -21,13 +21,15 @@ either = "1.9.0"
 enumset = "1.1.2"
 futures-util = "0.3.28"
 itertools = "0.13.0"
-nix = { version = "0.27.0", features = ["fs", "poll", "process", "signal", "term", "user"] }
 slab = "0.4.9"
 strum = { version = "0.26.2", features = ["derive"] }
 tempfile = "3.8.0"
 thiserror = "1.0.47"
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
 yash-syntax = { path = "../yash-syntax", version = "0.10.0", features = ["annotate-snippets"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27.0", features = ["fs", "poll", "process", "signal", "term", "user"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -103,22 +103,6 @@ impl std::ops::Neg for Pid {
     }
 }
 
-/// This conversion depends a type declared in the `nix` crate, which is not
-/// covered by the semantic versioning policy of this crate.
-impl From<Pid> for nix::unistd::Pid {
-    fn from(pid: Pid) -> Self {
-        Self::from_raw(pid.0)
-    }
-}
-
-/// This conversion depends a type declared in the `nix` crate, which is not
-/// covered by the semantic versioning policy of this crate.
-impl From<nix::unistd::Pid> for Pid {
-    fn from(pid: nix::unistd::Pid) -> Self {
-        Self(pid.as_raw())
-    }
-}
-
 impl Pid {
     /// Sentinel value for the [`kill`] and [`wait`]system calls specifying all
     /// processes in the process group of the calling process.

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -46,6 +46,7 @@ use self::semantics::ExitStatus;
 use self::stack::Frame;
 use self::stack::Stack;
 pub use self::system::r#virtual::VirtualSystem;
+#[cfg(unix)]
 pub use self::system::real::RealSystem;
 use self::system::Errno;
 pub use self::system::SharedSystem;

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -47,7 +47,7 @@ pub use self::open_flag::OfdAccess;
 pub use self::open_flag::OpenFlag;
 #[cfg(doc)]
 use self::r#virtual::VirtualSystem;
-#[cfg(doc)]
+#[cfg(all(doc, unix))]
 use self::real::RealSystem;
 use self::resource::LimitPair;
 use self::resource::Resource;

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -21,6 +21,7 @@ mod fd_flag;
 mod file_system;
 mod id;
 mod open_flag;
+#[cfg(unix)]
 pub mod real;
 pub mod resource;
 mod select;

--- a/yash-env/src/system/errno.rs
+++ b/yash-env/src/system/errno.rs
@@ -394,6 +394,10 @@ impl From<RawErrno> for Errno {
     }
 }
 
+/// Converts [`Errno`] to [`nix::Error`].
+///
+/// This conversion is only available on Unix-like systems.
+#[cfg(unix)]
 impl From<Errno> for nix::Error {
     #[inline]
     fn from(errno: Errno) -> Self {
@@ -401,6 +405,10 @@ impl From<Errno> for nix::Error {
     }
 }
 
+/// Converts [`nix::Error`] to [`Errno`].
+///
+/// This conversion is only available on Unix-like systems.
+#[cfg(unix)]
 impl From<nix::Error> for Errno {
     #[inline]
     fn from(error: nix::Error) -> Self {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -15,6 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! Implementation of `System` that actually interacts with the system.
+//!
+//! This module is implemented on Unix-like targets only. It provides an
+//! implementation of the `System` trait that interacts with the underlying
+//! operating system. This implementation is intended to be used in a real
+//! environment, such as a shell running on a Unix-like operating system.
 
 mod errno;
 mod file_system;

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- This crate now builds on non-Unix platforms.
 - Error types in the `expansion` module (some of which are reexported in the
   `assign` module) have been extended for more informative error messages:
     - The `ErrorCause::footer` method has been added.


### PR DESCRIPTION
This pull request makes it possible to build most crates on non-Unix platforms. The `RealSystem` is excluded from the build on non-Unix platforms, so the other parts of the code will build successfully.

This change improves the portability of the codebase and also helps ensure that the underlying system is only accessed through the `RealSystem` interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded support for building on non-Unix platforms, improving compatibility across various operating systems.
	- Enhanced error handling in the `expansion` module with additional informative messages.

- **Bug Fixes**
	- Improved process ID handling by utilizing direct system calls for better performance.

- **Documentation**
	- Updated CHANGELOGs to reflect new features and enhancements across multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->