### PR TITLE
Replace OsStr with UnixStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unix_path"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8e291873ae77c4c8d9c9b34d0bee68a35b048fb39c263a5155e0e353783eaf"
+dependencies = [
+ "unix_str",
+]
+
+[[package]]
+name = "unix_str"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ace0b4755d0a2959962769239d56267f8a024fef2d9b32666b3dcd0946b0906"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +573,8 @@ dependencies = [
  "strum",
  "tempfile",
  "thiserror",
+ "unix_path",
+ "unix_str",
  "yash-quote",
  "yash-syntax",
 ]

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,14 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `yash_builtin::ulimit::Error::Unknown` variant now contains a
-  `yash_env::system::Errno` instead of a `std::io::Error`.
-- The `getrlimit` and `setrlimit` methods of the
-  `yash_builtin::ulimit::set::Env` trait now return an error of type `Errno`
+- All APIs that handle `std::path::Path` and `std::path::PathBuf` now use
+  `yash_env::path::Path` and `yash_env::path::PathBuf` instead.
+    - `cd::assign::new_pwd`
+    - `cd::assign::set_pwd`
+    - `cd::canonicalize::NonExistingDirectoryError::missing`
+    - `cd::canonicalize::canonicalize`
+    - `cd::cdpath::search`
+    - `cd::chdir::chdir`
+    - `cd::chdir::failure_message`
+    - `cd::chdir::report_failure`
+    - `cd::print::print_path`
+    - `cd::shorten::shorten`
+    - `cd::target::TargetError::NonExistingDirectory::missing`
+    - `cd::target::TargetError::NonExistingDirectory::target`
+    - `cd::target::target`
+- The `ulimit::Error::Unknown` variant now contains a `yash_env::system::Errno`
   instead of a `std::io::Error`.
-- The `show_one` and `show_all` functions in the `yash_builtin::ulimit::show`
-  module now takes a function that returns an error of type `Errno` instead of
-  `std::io::Error`.
+- The `getrlimit` and `setrlimit` methods of the `ulimit::set::Env` trait now
+  return an error of type `Errno` instead of a `std::io::Error`.
+- The `show_one` and `show_all` functions in the `ulimit::show` module now takes
+  a function that returns an error of type `Errno` instead of `std::io::Error`.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
 

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -147,7 +147,7 @@
 use crate::common::report_error;
 use crate::common::report_failure;
 use crate::Result;
-use std::path::Path;
+use yash_env::path::Path;
 use yash_env::semantics::Field;
 use yash_env::variable::PWD;
 use yash_env::Env;

--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -18,8 +18,8 @@
 
 use super::Mode;
 use crate::common::arrange_message_and_divert;
-use std::path::Path;
-use std::path::PathBuf;
+use yash_env::path::Path;
+use yash_env::path::PathBuf;
 use yash_env::variable::AssignError;
 use yash_env::variable::Scope::Global;
 use yash_env::variable::Value::Scalar;
@@ -51,7 +51,7 @@ pub async fn set_oldpwd(env: &mut Env, value: String) {
 /// This function examines the stack to find the command location that invoked
 /// the cd built-in.
 pub async fn set_pwd(env: &mut Env, path: PathBuf) {
-    let value = path.into_os_string().into_string().unwrap_or_default();
+    let value = path.into_unix_string().into_string().unwrap_or_default();
     set_variable(env, PWD, value).await
 }
 

--- a/yash-builtin/src/cd/cdpath.rs
+++ b/yash-builtin/src/cd/cdpath.rs
@@ -17,10 +17,9 @@
 //! Part of the cd built-in that searches `$CDPATH`
 
 use std::ffi::CString;
-use std::ffi::OsString;
-use std::os::unix::ffi::OsStringExt;
-use std::path::Path;
-use std::path::PathBuf;
+use yash_env::path::Path;
+use yash_env::path::PathBuf;
+use yash_env::str::UnixString;
 use yash_env::variable::CDPATH;
 use yash_env::Env;
 use yash_env::System;
@@ -66,9 +65,9 @@ pub fn search(env: &Env, path: &Path) -> Option<PathBuf> {
 /// This function requires the ownership of the given path to create a temporary
 /// `CString` used in the underlying system call.
 fn ensure_directory<S: System>(system: &S, path: PathBuf) -> Option<PathBuf> {
-    match CString::new(path.into_os_string().into_vec()) {
+    match CString::new(path.into_unix_string().into_vec()) {
         Ok(path) if system.is_directory(&path) => {
-            Some(OsString::from_vec(path.into_bytes()).into())
+            Some(UnixString::from_vec(path.into_bytes()).into())
         }
         _ => None,
     }

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -20,9 +20,8 @@ use crate::common::arrange_message_and_divert;
 use std::borrow::Cow;
 use std::ffi::CString;
 use std::ffi::NulError;
-use std::os::unix::ffi::OsStringExt;
-use std::path::Path;
 use thiserror::Error;
+use yash_env::path::Path;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 #[cfg(doc)]
@@ -56,7 +55,7 @@ impl From<NulError> for Error {
 }
 
 pub fn chdir(env: &mut Env, path: &Path) -> Result<(), Error> {
-    let c_path = CString::new(path.to_owned().into_os_string().into_vec())?;
+    let c_path = CString::new(path.as_unix_str().as_bytes())?;
     Ok(env.system.chdir(&c_path)?)
 }
 

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -18,7 +18,7 @@
 
 use super::target::Origin;
 use crate::common::arrange_message_and_divert;
-use std::path::Path;
+use yash_env::path::Path;
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_syntax::source::pretty::AnnotationType;

--- a/yash-builtin/src/cd/shorten.rs
+++ b/yash-builtin/src/cd/shorten.rs
@@ -24,7 +24,7 @@
 //! target path does not start with `$PWD`.
 
 use super::Mode;
-use std::path::Path;
+use yash_env::path::Path;
 
 /// Simplifies the target path.
 ///

--- a/yash-builtin/src/cd/target.rs
+++ b/yash-builtin/src/cd/target.rs
@@ -19,9 +19,9 @@
 use super::Command;
 use super::Mode;
 use std::borrow::Cow;
-use std::path::Path;
-use std::path::PathBuf;
 use thiserror::Error;
+use yash_env::path::Path;
+use yash_env::path::PathBuf;
 use yash_env::variable::HOME;
 use yash_env::variable::OLDPWD;
 use yash_env::Env;

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -23,14 +23,12 @@ use crate::common::{output, report_failure, to_single_message};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::ffi::OsStr;
-use std::os::unix::ffi::OsStrExt as _;
-use std::os::unix::ffi::OsStringExt as _;
-use std::path::PathBuf;
 use std::rc::Rc;
 use yash_env::builtin::Type;
+use yash_env::path::PathBuf;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::str::UnixStr;
 use yash_env::Env;
 use yash_env::System;
 use yash_quote::quoted;
@@ -132,8 +130,8 @@ fn normalize_target<E: NormalizeEnv>(env: &E, target: &mut Target) -> Result<(),
             }
             if !path.as_bytes().starts_with(b"/") {
                 let mut absolute_path = env.pwd()?;
-                absolute_path.push(OsStr::from_bytes(path.as_bytes()));
-                *path = CString::new(absolute_path.into_os_string().into_vec()).map_err(|_| ())?;
+                absolute_path.push(UnixStr::from_bytes(path.as_bytes()));
+                *path = CString::new(absolute_path.into_unix_string().into_vec()).map_err(drop)?;
             }
             Ok(())
         }

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -89,9 +89,8 @@ impl yash_semantics::command_search::SearchEnv for SearchEnv<'_> {
 mod tests {
     use super::*;
     use enumset::EnumSet;
-    use std::ffi::OsString;
-    use std::os::unix::ffi::OsStringExt as _;
     use yash_env::builtin::Type::Special;
+    use yash_env::str::UnixString;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::variable::Scope;
     use yash_env::variable::PATH;
@@ -137,7 +136,7 @@ mod tests {
     #[test]
     fn standard_path_with_invalid_utf8() {
         let system = Box::new(VirtualSystem::new());
-        system.state.borrow_mut().path = OsString::from_vec(vec![0x80]);
+        system.state.borrow_mut().path = UnixString::from_vec(vec![0x80]);
         let env = &mut Env::with_system(system);
         let params = &Search {
             standard_path: true,

--- a/yash-builtin/src/pwd/semantics.rs
+++ b/yash-builtin/src/pwd/semantics.rs
@@ -53,7 +53,7 @@ pub fn compute(env: &Env, mode: Mode) -> Result {
         .system
         .getcwd()
         .map_err(Error::SystemError)?
-        .into_os_string()
+        .into_unix_string()
         .into_string()
         .map_err(|_| Error::SystemError(Errno::EILSEQ))?;
     cwd.push('\n');
@@ -64,8 +64,8 @@ pub fn compute(env: &Env, mode: Mode) -> Result {
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::path::PathBuf;
     use std::rc::Rc;
+    use yash_env::path::PathBuf;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::Inode;
     use yash_env::variable::Scope::Global;

--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -23,12 +23,11 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::num::NonZeroU64;
 use std::ops::ControlFlow;
-use std::os::unix::ffi::OsStringExt as _;
-use std::path::PathBuf;
 use std::rc::Rc;
 use yash_env::input::Echo;
 use yash_env::input::FdReader;
 use yash_env::io::Fd;
+use yash_env::path::PathBuf;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
@@ -102,7 +101,7 @@ fn find_and_open_file(env: &mut Env, filename: &str) -> Result<Fd, Errno> {
     // and return the first successfully opened file descriptor.
     dirs.filter_map(|dir| {
         let path = PathBuf::from_iter([dir, filename])
-            .into_os_string()
+            .into_unix_string()
             .into_vec();
         let c_path = CString::new(path).ok()?;
         open_file(&mut env.system, &c_path).ok()
@@ -166,9 +165,9 @@ mod tests {
     use enumset::EnumSet;
     use futures_util::FutureExt as _;
     use std::cell::RefCell;
-    use std::path::Path;
     use std::rc::Rc;
     use yash_env::io::MIN_INTERNAL_FD;
+    use yash_env::path::Path;
     use yash_env::system::r#virtual::Inode;
     use yash_env::system::FdFlag;
     use yash_env::variable::Scope;

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -25,8 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mode argument.
 - The `job::RawPid` type has been added to represent the contents of `job::Pid`.
 - The `stack::Frame` enum now has the `InitFile` variant.
+- The crate now re-exports `unix_path` as `path` and `unix_str` as `str`.
 - External dependencies:
     - enumset 1.1.2 (previously an internal dependency)
+    - unix_path 1.0.1
+    - unix_str 1.0.0
 - Internal dependencies:
     - bitflags 2.6.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -37,6 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `system::FdFlag` is no longer a re-export of `nix::fcntl::FdFlag`.
 - `system::Mode` is no longer a re-export of `nix::sys::stat::Mode`.
+- All APIs that handle `std::path::Path`, `std::path::PathBuf`, `std::ffi::OsStr`,
+  and `std::ffi::OsString` now use `path::Path`, `path::PathBuf`, `str::OsStr`,
+  and `str::OsString` instead.
+    - `system::DirEntry::name`
+    - `system::System::confstr_path`
+    - `system::System::getcwd`
+    - `system::System::getpwnam_dir`
+    - `system::System::open_tmpfile`
+    - `system::virtual::FileBody::Directory::files`
+    - `system::virtual::FileBody::Symlink::target`
+    - `system::virtual::FileSystem::get`
+    - `system::virtual::FileSystem::save`
+    - `system::virtual::Process::chdir`
+    - `system::virtual::SystemState::home_dirs`
+    - `system::virtual::SystemState::path`
+    - `system::virtual::VirtualDir::new`
 - The `fstat` and `fstatat` methods of `system::System` now return a `Stat`
   instead of a `nix::sys::stat::FileStat`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -26,6 +26,8 @@ slab = "0.4.9"
 strum = { version = "0.26.2", features = ["derive"] }
 tempfile = "3.8.0"
 thiserror = "1.0.47"
+unix_path = "1.0.1"
+unix_str = "1.0.0"
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
 yash-syntax = { path = "../yash-syntax", version = "0.10.0", features = ["annotate-snippets"] }
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -65,6 +65,8 @@ use std::ops::ControlFlow::{self, Break, Continue};
 use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
+pub use unix_path as path;
+pub use unix_str as str;
 use yash_syntax::alias::AliasSet;
 
 /// Whole shell execution environment.

--- a/yash-env/src/pwd.rs
+++ b/yash-env/src/pwd.rs
@@ -17,6 +17,7 @@
 //! Working directory path handling
 
 use super::Env;
+use crate::path::Path;
 use crate::system::Errno;
 use crate::system::AT_FDCWD;
 use crate::variable::AssignError;
@@ -24,7 +25,6 @@ use crate::variable::Scope::Global;
 use crate::variable::PWD;
 use crate::System;
 use std::ffi::CString;
-use std::path::Path;
 use thiserror::Error;
 
 /// Tests whether a path contains a dot (`.`) or dot-dot (`..`) component.
@@ -95,7 +95,7 @@ impl Env {
             let dir = self
                 .system
                 .getcwd()?
-                .into_os_string()
+                .into_unix_string()
                 .into_string()
                 .map_err(|_| Errno::EILSEQ)?;
             let mut var = self.variables.get_or_new(PWD, Global);
@@ -109,12 +109,12 @@ impl Env {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::path::PathBuf;
     use crate::system::r#virtual::FileBody;
     use crate::system::r#virtual::Inode;
     use crate::variable::Value;
     use crate::VirtualSystem;
     use std::cell::RefCell;
-    use std::path::PathBuf;
     use std::rc::Rc;
 
     #[test]

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -57,8 +57,11 @@ use crate::io::Fd;
 use crate::io::MIN_INTERNAL_FD;
 use crate::job::Pid;
 use crate::job::ProcessState;
+use crate::path::Path;
+use crate::path::PathBuf;
 use crate::semantics::ExitStatus;
 use crate::signal;
+use crate::str::UnixString;
 #[cfg(doc)]
 use crate::subshell::Subshell;
 use crate::trap::SignalSystem;
@@ -68,12 +71,9 @@ use std::convert::Infallible;
 use std::ffi::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::ffi::OsString;
 use std::fmt::Debug;
 use std::future::Future;
 use std::io::SeekFrom;
-use std::path::Path;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 use std::time::Instant;
@@ -437,7 +437,7 @@ pub trait System: Debug {
     /// expected to be found.
     ///
     /// This is a thin wrapper around the `confstr(_CS_PATH, …)`.
-    fn confstr_path(&self) -> Result<OsString>;
+    fn confstr_path(&self) -> Result<UnixString>;
 
     /// Returns the path to the shell executable.
     ///

--- a/yash-env/src/system/file_system.rs
+++ b/yash-env/src/system/file_system.rs
@@ -17,8 +17,8 @@
 //! Items about file systems
 
 use super::{Gid, Result, Uid};
+use crate::str::UnixStr;
 use bitflags::bitflags;
-use std::ffi::OsStr;
 use std::fmt::Debug;
 use yash_syntax::syntax::Fd;
 
@@ -40,7 +40,7 @@ pub const AT_FDCWD: Fd = Fd(RAW_AT_FDCWD);
 #[non_exhaustive]
 pub struct DirEntry<'a> {
     /// Filename
-    pub name: &'a OsStr,
+    pub name: &'a UnixStr,
 }
 
 /// Trait for enumerating directory entries

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -26,6 +26,8 @@ use super::LimitPair;
 use super::Mode;
 use super::OfdAccess;
 use super::OpenFlag;
+use super::Path;
+use super::PathBuf;
 use super::Resource;
 use super::Result;
 use super::SelectSystem;
@@ -38,6 +40,7 @@ use super::System;
 use super::SystemEx;
 use super::Times;
 use super::Uid;
+use super::UnixString;
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::job::ProcessState;
@@ -49,12 +52,9 @@ use std::convert::Infallible;
 use std::ffi::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::ffi::OsString;
 use std::future::poll_fn;
 use std::future::Future;
 use std::io::SeekFrom;
-use std::path::Path;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Poll;
@@ -462,7 +462,7 @@ impl System for &SharedSystem {
     fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
         self.0.borrow().getpwnam_dir(name)
     }
-    fn confstr_path(&self) -> Result<OsString> {
+    fn confstr_path(&self) -> Result<UnixString> {
         self.0.borrow().confstr_path()
     }
     fn shell_path(&self) -> CString {
@@ -689,7 +689,7 @@ impl System for SharedSystem {
         (&self).getpwnam_dir(name)
     }
     #[inline]
-    fn confstr_path(&self) -> Result<OsString> {
+    fn confstr_path(&self) -> Result<UnixString> {
         (&self).confstr_path()
     }
     #[inline]

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -26,6 +26,8 @@ use crate::io::Fd;
 use crate::job::Pid;
 use crate::job::ProcessResult;
 use crate::job::ProcessState;
+use crate::path::Path;
+use crate::path::PathBuf;
 use crate::system::resource::LimitPair;
 use crate::system::resource::Resource;
 use crate::system::resource::INFINITY;
@@ -40,8 +42,6 @@ use std::ffi::CString;
 use std::fmt::Debug;
 use std::ops::BitOr;
 use std::ops::BitOrAssign;
-use std::path::Path;
-use std::path::PathBuf;
 use std::rc::Weak;
 use std::task::Waker;
 

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -37,12 +37,11 @@
 use assert_matches::assert_matches;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::os::unix::ffi::OsStringExt;
-use std::path::PathBuf;
 use std::rc::Rc;
 use yash_env::builtin::Builtin;
 use yash_env::builtin::Type::{Elective, Extension, Mandatory, Special, Substitutive};
 use yash_env::function::Function;
+use yash_env::path::PathBuf;
 use yash_env::variable::Expansion;
 use yash_env::variable::PATH;
 use yash_env::Env;
@@ -222,7 +221,10 @@ pub fn search_path<E: PathEnv>(env: &mut E, name: &str) -> Option<CString> {
     env.path()
         .split()
         .filter_map(|dir| {
-            CString::new(PathBuf::from_iter([dir, name]).into_os_string().into_vec()).ok()
+            let candidate = PathBuf::from_iter([dir, name])
+                .into_unix_string()
+                .into_vec();
+            CString::new(candidate).ok()
         })
         .find(|path| env.is_executable_file(path))
 }

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -288,10 +288,9 @@ mod tests {
     use super::*;
     use crate::expansion::AttrChar;
     use crate::expansion::Origin;
-    use std::ffi::OsStr;
-    use std::os::unix::ffi::OsStrExt;
-    use std::path::Path;
     use std::rc::Rc;
+    use yash_env::path::Path;
+    use yash_env::str::UnixStr;
     use yash_env::system::Mode;
     use yash_env::VirtualSystem;
     use yash_syntax::source::Location;
@@ -518,7 +517,7 @@ mod tests {
 
     #[test]
     fn broken_utf8_byte_in_directory_entry_name() {
-        let mut env = env_with_dummy_files([OsStr::from_bytes(b"foo/\xFF")]);
+        let mut env = env_with_dummy_files([UnixStr::from_bytes(b"foo/\xFF")]);
         let f = dummy_attr_field("foo/*");
         let mut i = glob(&mut env, f);
         assert_eq!(i.next().unwrap().value, "foo/*");

--- a/yash-semantics/src/expansion/initial/tilde.rs
+++ b/yash-semantics/src/expansion/initial/tilde.rs
@@ -43,7 +43,7 @@ pub fn expand(name: &str, env: &Env) -> Vec<AttrChar> {
         into_attr_chars(result.chars())
     } else {
         if let Ok(Some(path)) = env.system.getpwnam_dir(name) {
-            if let Ok(path) = path.into_os_string().into_string() {
+            if let Ok(path) = path.into_unix_string().into_string() {
                 return into_attr_chars(path.chars());
             }
         }
@@ -54,7 +54,7 @@ pub fn expand(name: &str, env: &Env) -> Vec<AttrChar> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use yash_env::path::PathBuf;
     use yash_env::variable::Scope;
     use yash_env::variable::Value;
     use yash_env::VirtualSystem;

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -17,8 +17,8 @@
 //! Here-documents
 
 use super::ErrorCause;
-use std::path::Path;
 use yash_env::io::Fd;
+use yash_env::path::Path;
 use yash_env::system::Errno;
 use yash_env::Env;
 use yash_env::System;


### PR DESCRIPTION
The OsStr type in std behaves differently depending on the target platform. Since yash is a Unix shell, we should use types that have consistent behaviors across platforms. This pull request introduces `unix_str` and `unix_path` as dependencies that are used in place of OsStr(ing) and Path(Buf) from std.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and path management within the `yash_builtin` module, improving consistency and robustness.
	- Updated handling of paths across various modules to utilize custom Unix-specific types, increasing compatibility with Unix-like environments.

- **Bug Fixes**
	- Adjusted path representation and error handling to ensure more accurate processing of file paths in Unix contexts.

- **Documentation**
	- Updates to the CHANGELOG to reflect significant structural changes and API improvements regarding path and string handling.

- **Refactor**
	- Consolidated imports and streamlined path handling logic throughout various modules for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->