### PR TITLE
Rename SignalHandling to Disposition

### DIFF
--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -165,17 +165,21 @@ pub enum Command {
 pub mod syntax;
 // TODO pub mod semantics;
 
-/// Enables or disables stopper handlers depending on the `Interactive` and
-/// `Monitor` option states. The handlers are disabled in subshells.
-fn update_stopper_handlers(env: &mut Env) {
+/// Enables or disables the internal dispositions for the "stopper" signals
+/// depending on the `Interactive` and `Monitor` option states. The dispositions
+/// are disabled in subshells.
+fn update_internal_dispositions_for_stoppers(env: &mut Env) {
     if env.options.get(Interactive) == State::On
         && env.options.get(Monitor) == State::On
         && !env.stack.contains(&Subshell)
     {
-        _ = env.traps.enable_stopper_handlers(&mut env.system)
+        env.traps
+            .enable_internal_dispositions_for_stoppers(&mut env.system)
     } else {
-        _ = env.traps.disable_stopper_handlers(&mut env.system)
+        env.traps
+            .disable_internal_dispositions_for_stoppers(&mut env.system)
     }
+    .ok();
 }
 
 /// Modifies shell options and positional parameters.
@@ -188,7 +192,7 @@ fn modify(
     for (option, state) in options {
         env.options.set(option, state);
     }
-    update_stopper_handlers(env);
+    update_internal_dispositions_for_stoppers(env);
 
     // Modify positional parameters
     if let Some(fields) = positional_params {
@@ -437,7 +441,7 @@ xtrace           off
     }
 
     #[test]
-    fn stopper_handlers_not_enabled_in_non_interactive_shell() {
+    fn internal_dispositions_not_enabled_for_stoppers_in_non_interactive_shell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
@@ -454,7 +458,7 @@ xtrace           off
     }
 
     #[test]
-    fn stopper_handlers_not_enabled_in_subshell() {
+    fn internal_dispositions_not_enabled_for_stoppers_in_subshell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -412,8 +412,8 @@ xtrace           off
         expected_options.extend([Interactive, Monitor]);
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
-        let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, Disposition::Ignore);
+        let disposition = state.processes[&env.main_pid].disposition(SIGTSTP);
+        assert_eq!(disposition, Disposition::Ignore);
     }
 
     #[test]
@@ -432,8 +432,8 @@ xtrace           off
         expected_options.set(Interactive, On);
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
-        let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, Disposition::Default);
+        let disposition = state.processes[&env.main_pid].disposition(SIGTSTP);
+        assert_eq!(disposition, Disposition::Default);
     }
 
     #[test]
@@ -449,8 +449,8 @@ xtrace           off
         expected_options.set(Monitor, On);
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
-        let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, Disposition::Default);
+        let disposition = state.processes[&env.main_pid].disposition(SIGTSTP);
+        assert_eq!(disposition, Disposition::Default);
     }
 
     #[test]
@@ -468,7 +468,7 @@ xtrace           off
         expected_options.extend([Interactive, Monitor]);
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
-        let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, Disposition::Default);
+        let disposition = state.processes[&env.main_pid].disposition(SIGTSTP);
+        assert_eq!(disposition, Disposition::Default);
     }
 }

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -262,7 +262,7 @@ mod tests {
     use yash_env::option::OptionSet;
     use yash_env::option::State::*;
     use yash_env::system::r#virtual::SIGTSTP;
-    use yash_env::system::SignalHandling;
+    use yash_env::system::Disposition;
     use yash_env::variable::Scope;
     use yash_env::variable::Value;
     use yash_env::VirtualSystem;
@@ -413,7 +413,7 @@ xtrace           off
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
         let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, SignalHandling::Ignore);
+        assert_eq!(handling, Disposition::Ignore);
     }
 
     #[test]
@@ -433,7 +433,7 @@ xtrace           off
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
         let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, SignalHandling::Default);
+        assert_eq!(handling, Disposition::Default);
     }
 
     #[test]
@@ -450,7 +450,7 @@ xtrace           off
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
         let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, SignalHandling::Default);
+        assert_eq!(handling, Disposition::Default);
     }
 
     #[test]
@@ -469,6 +469,6 @@ xtrace           off
         assert_eq!(env.options, expected_options);
         let state = state.borrow();
         let handling = state.processes[&env.main_pid].signal_handling(SIGTSTP);
-        assert_eq!(handling, SignalHandling::Default);
+        assert_eq!(handling, Disposition::Default);
     }
 }

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -349,7 +349,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGUSR1), Disposition::Ignore);
+        assert_eq!(process.disposition(SIGUSR1), Disposition::Ignore);
     }
 
     #[test]
@@ -362,7 +362,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGUSR2), Disposition::Catch);
+        assert_eq!(process.disposition(SIGUSR2), Disposition::Catch);
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGPIPE), Disposition::Default);
+        assert_eq!(process.disposition(SIGPIPE), Disposition::Default);
     }
 
     #[test]
@@ -482,7 +482,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         system
             .current_process_mut()
-            .set_signal_handling(SIGINT, Disposition::Ignore);
+            .set_disposition(SIGINT, Disposition::Ignore);
         let mut env = Env::with_system(Box::new(system.clone()));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
@@ -494,7 +494,7 @@ mod tests {
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
         assert_eq!(
-            system.current_process().signal_handling(SIGINT),
+            system.current_process().disposition(SIGINT),
             Disposition::Ignore
         );
     }

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -333,7 +333,7 @@ mod tests {
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::system::r#virtual::{SIGINT, SIGPIPE, SIGUSR1, SIGUSR2};
-    use yash_env::system::SignalHandling;
+    use yash_env::system::Disposition;
     use yash_env::Env;
     use yash_env::VirtualSystem;
     use yash_env_test_helper::assert_stderr;
@@ -349,7 +349,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGUSR1), SignalHandling::Ignore);
+        assert_eq!(process.signal_handling(SIGUSR1), Disposition::Ignore);
     }
 
     #[test]
@@ -362,7 +362,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGUSR2), SignalHandling::Catch);
+        assert_eq!(process.signal_handling(SIGUSR2), Disposition::Catch);
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         let process = &state.borrow().processes[&pid];
-        assert_eq!(process.signal_handling(SIGPIPE), SignalHandling::Default);
+        assert_eq!(process.signal_handling(SIGPIPE), Disposition::Default);
     }
 
     #[test]
@@ -482,7 +482,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         system
             .current_process_mut()
-            .set_signal_handling(SIGINT, SignalHandling::Ignore);
+            .set_signal_handling(SIGINT, Disposition::Ignore);
         let mut env = Env::with_system(Box::new(system.clone()));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
@@ -495,7 +495,7 @@ mod tests {
         assert_stderr(&system.state, |stderr| assert_eq!(stderr, ""));
         assert_eq!(
             system.current_process().signal_handling(SIGINT),
-            SignalHandling::Ignore
+            Disposition::Ignore
         );
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -57,8 +57,8 @@ pub enum Error {
 /// If there is no job to wait for, this function returns
 /// `Err(Error::NothingToWait)` immediately.
 pub async fn wait_for_any_job_or_trap(env: &mut Env) -> Result<(), Error> {
-    // We need to set the signal handling before calling `wait` so we don't miss
-    // any `SIGCHLD` that may arrive between `wait` and `wait_for_signals`.
+    // We need to install the signal handler before calling `wait` so we don't
+    // miss any `SIGCHLD` that may arrive between `wait` and `wait_for_signals`.
     // See also Env::wait_for_subshell.
     env.traps.enable_sigchld_handler(&mut env.system)?;
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -57,10 +57,11 @@ pub enum Error {
 /// If there is no job to wait for, this function returns
 /// `Err(Error::NothingToWait)` immediately.
 pub async fn wait_for_any_job_or_trap(env: &mut Env) -> Result<(), Error> {
-    // We need to install the signal handler before calling `wait` so we don't
-    // miss any `SIGCHLD` that may arrive between `wait` and `wait_for_signals`.
-    // See also Env::wait_for_subshell.
-    env.traps.enable_sigchld_handler(&mut env.system)?;
+    // We need to install the internal disposition before calling `wait` so we
+    // don't miss any `SIGCHLD` that may arrive between `wait` and
+    // `wait_for_signals`.  See also Env::wait_for_subshell.
+    env.traps
+        .enable_internal_disposition_for_sigchld(&mut env.system)?;
 
     loop {
         // Poll for a job state change. Note that this `wait` call returns

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -35,7 +35,7 @@ use std::cell::RefCell;
 use std::num::NonZeroU64;
 use std::ops::ControlFlow::{Break, Continue};
 use yash_env::signal;
-use yash_env::system::{Errno, SignalHandling};
+use yash_env::system::{Disposition, Errno};
 use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::System;
@@ -130,7 +130,7 @@ pub fn main() -> ! {
         .system
         .signal_number_from_name(signal::Name::Pipe)
         .unwrap();
-    _ = env.system.sigaction(sigpipe, SignalHandling::Default);
+    _ = env.system.sigaction(sigpipe, Disposition::Default);
 
     let system = env.system.clone();
     let mut pool = futures_executor::LocalPool::new();

--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -49,9 +49,9 @@ pub fn auto_interactive<S: System>(system: &S, run: &Run) -> bool {
 /// Get the environment ready for performing the work.
 ///
 /// This function takes the parsed command-line arguments and applies them to
-/// the environment. It also sets up signal handlers and prepares built-ins and
-/// variables. The function returns the work to be performed, which is extracted
-/// from the `run` argument.
+/// the environment. It also sets up signal dispositions and prepares built-ins
+/// and variables. The function returns the work to be performed, which is
+/// extracted from the `run` argument.
 ///
 /// This function is _pure_ in that all system calls are performed by the
 /// `System` trait object (`env.system`).
@@ -74,11 +74,15 @@ pub fn configure_environment(env: &mut Env, run: Run) -> Work {
     env.arg0 = run.arg0;
     env.variables.positional_params_mut().values = run.positional_params;
 
-    // Initialize signal handlers
+    // Configure internal dispositions for signals
     if env.options.get(Interactive) == On {
-        env.traps.enable_terminator_handlers(&mut env.system).ok();
+        env.traps
+            .enable_internal_dispositions_for_terminators(&mut env.system)
+            .ok();
         if env.options.get(Monitor) == On {
-            env.traps.enable_stopper_handlers(&mut env.system).ok();
+            env.traps
+                .enable_internal_dispositions_for_stoppers(&mut env.system)
+                .ok();
         }
     }
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `system::SignalHandling` has been renamed to `system::Disposition`.
 - In the `trap::SignalSystem` trait, the `set_signal_handling` method has been
   renamed to `set_disposition`.
+- In the `system::virtual::Process` struct, the following methods have been
+  renamed:
+    - `signal_handling` → `disposition`
+    - `set_signal_handling` → `set_disposition`
 - The `fstat` and `fstatat` methods of `system::System` now return a `Stat`
   instead of a `nix::sys::stat::FileStat`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `system::virtual::SystemState::home_dirs`
     - `system::virtual::SystemState::path`
     - `system::virtual::VirtualDir::new`
+- `system::SignalHandling` has been renamed to `system::Disposition`.
 - The `fstat` and `fstatat` methods of `system::System` now return a `Stat`
   instead of a `nix::sys::stat::FileStat`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -56,12 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `system::virtual::SystemState::path`
     - `system::virtual::VirtualDir::new`
 - `system::SignalHandling` has been renamed to `system::Disposition`.
-- In the `trap::SignalSystem` trait, the `set_signal_handling` method has been
-  renamed to `set_disposition`.
 - In the `system::virtual::Process` struct, the following methods have been
   renamed:
     - `signal_handling` → `disposition`
     - `set_signal_handling` → `set_disposition`
+- In the `trap::SignalSystem` trait, the `set_signal_handling` method has been
+  renamed to `set_disposition`.
+- In the `trap::TrapSet` struct, the following methods have been renamed:
+    - `enable_sigchld_handler` → `enable_internal_disposition_for_sigchld`
+    - `enable_terminator_handlers` → `enable_internal_dispositions_for_terminators`
+    - `enable_stopper_handlers` → `enable_internal_dispositions_for_stoppers`
+    - `disable_terminator_handlers` → `disable_internal_dispositions_for_terminators`
+    - `disable_stopper_handlers` → `disable_internal_dispositions_for_stoppers`
+    - `disable_internal_handlers` → `disable_internal_dispositions`
 - The `fstat` and `fstatat` methods of `system::System` now return a `Stat`
   instead of a `nix::sys::stat::FileStat`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `system::virtual::SystemState::path`
     - `system::virtual::VirtualDir::new`
 - `system::SignalHandling` has been renamed to `system::Disposition`.
+- In the `trap::SignalSystem` trait, the `set_signal_handling` method has been
+  renamed to `set_disposition`.
 - The `fstat` and `fstatat` methods of `system::System` now return a `Stat`
   instead of a `nix::sys::stat::FileStat`.
 - The `system::System::fstatat` method now takes a `follow_symlinks: bool`

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -349,9 +349,10 @@ impl Env {
     /// [`wait_for_subshell_to_finish`](Self::wait_for_subshell_to_finish)
     /// instead.
     pub async fn wait_for_subshell(&mut self, target: Pid) -> Result<(Pid, ProcessState), Errno> {
-        // We need to set the signal handling before calling `wait` so we don't
+        // We need to set the internal disposition before calling `wait` so we don't
         // miss any `SIGCHLD` that may arrive between `wait` and `wait_for_signal`.
-        self.traps.enable_sigchld_handler(&mut self.system)?;
+        self.traps
+            .enable_internal_disposition_for_sigchld(&mut self.system)?;
 
         let sigchld = self
             .system

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -106,7 +106,7 @@ where
     /// passed to the task in the subshell environment.
     ///
     /// If the parent process is a job-controlling interactive shell, but the
-    /// subshell is not job-controlled, the subshell's signal handlings for
+    /// subshell is not job-controlled, the subshell's signal dispositions for
     /// SIGTSTP, SIGTTIN, and SIGTTOU are set to `Ignore`. This is to prevent
     /// the subshell from being stopped by a job-stopping signal. Were the
     /// subshell stopped, you could never resume it since it is not
@@ -119,7 +119,7 @@ where
     /// Makes the subshell ignore SIGINT and SIGQUIT.
     ///
     /// If `ignore` is true and the subshell is not job-controlled, the subshell
-    /// sets its signal handlings for SIGINT and SIGQUIT to `Ignore`.
+    /// sets its signal dispositions for SIGINT and SIGQUIT to `Ignore`.
     ///
     /// The default is `false`.
     pub fn ignore_sigint_sigquit(mut self, ignore: bool) -> Self {
@@ -160,10 +160,10 @@ where
         // the child from being killed by those signals until the child starts
         // ignoring them.
         let mut mask_guard = MaskGuard::new(env);
-        let ignores_sigint_sigquit = self.ignores_sigint_sigquit
+        let ignore_sigint_sigquit = self.ignores_sigint_sigquit
             && job_control.is_none()
             && mask_guard.block_sigint_sigquit();
-        let keeps_stopper_handlers = job_control.is_none();
+        let keep_internal_dispositions_for_stoppers = job_control.is_none();
 
         // Define the child process task
         const ME: Pid = Pid(0);
@@ -189,8 +189,8 @@ where
 
                 env.traps.enter_subshell(
                     &mut env.system,
-                    ignores_sigint_sigquit,
-                    keeps_stopper_handlers,
+                    ignore_sigint_sigquit,
+                    keep_internal_dispositions_for_stoppers,
                 );
 
                 (self.task)(env, job_control).await
@@ -691,13 +691,14 @@ mod tests {
     }
 
     #[test]
-    fn stopper_handlers_kept_in_uncontrolled_subshell_of_controlling_interactive_shell() {
+    fn internal_dispositions_for_stoppers_kept_in_uncontrolled_subshell_of_controlling_interactive_shell(
+    ) {
         in_virtual_system(|mut parent_env, state| async move {
             parent_env.options.set(Interactive, On);
             parent_env.options.set(Monitor, On);
             parent_env
                 .traps
-                .enable_stopper_handlers(&mut parent_env.system)
+                .enable_internal_dispositions_for_stoppers(&mut parent_env.system)
                 .unwrap();
             stub_tty(&state);
 
@@ -720,13 +721,13 @@ mod tests {
     }
 
     #[test]
-    fn stopper_handlers_reset_in_controlled_subshell_of_controlling_interactive_shell() {
+    fn internal_dispositions_for_stoppers_reset_in_controlled_subshell_of_interactive_shell() {
         in_virtual_system(|mut parent_env, state| async move {
             parent_env.options.set(Interactive, On);
             parent_env.options.set(Monitor, On);
             parent_env
                 .traps
-                .enable_stopper_handlers(&mut parent_env.system)
+                .enable_internal_dispositions_for_stoppers(&mut parent_env.system)
                 .unwrap();
             stub_tty(&state);
 
@@ -750,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn stopper_handlers_not_set_in_subshell_of_non_controlling_interactive_shell() {
+    fn internal_dispositions_for_stoppers_unset_in_subshell_of_non_controlling_interactive_shell() {
         in_virtual_system(|mut parent_env, state| async move {
             parent_env.options.set(Interactive, On);
             stub_tty(&state);
@@ -774,7 +775,8 @@ mod tests {
     }
 
     #[test]
-    fn stopper_handlers_not_set_in_uncontrolled_subshell_of_controlling_non_interactive_shell() {
+    fn internal_dispositions_for_stoppers_unset_in_uncontrolled_subshell_of_controlling_non_interactive_shell(
+    ) {
         in_virtual_system(|mut parent_env, state| async move {
             parent_env.options.set(Monitor, On);
             stub_tty(&state);

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -626,8 +626,8 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&child_pid];
-            assert_eq!(process.signal_handling(SIGINT), Disposition::Default);
-            assert_eq!(process.signal_handling(SIGQUIT), Disposition::Default);
+            assert_eq!(process.disposition(SIGINT), Disposition::Default);
+            assert_eq!(process.disposition(SIGQUIT), Disposition::Default);
         })
     }
 
@@ -662,8 +662,8 @@ mod tests {
             assert!(!parent_process.blocked_signals().contains(&SIGINT));
             assert!(!parent_process.blocked_signals().contains(&SIGQUIT));
             let child_process = &state.processes[&child_pid];
-            assert_eq!(child_process.signal_handling(SIGINT), Disposition::Ignore);
-            assert_eq!(child_process.signal_handling(SIGQUIT), Disposition::Ignore);
+            assert_eq!(child_process.disposition(SIGINT), Disposition::Ignore);
+            assert_eq!(child_process.disposition(SIGQUIT), Disposition::Ignore);
         })
     }
 
@@ -685,8 +685,8 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&child_pid];
-            assert_eq!(process.signal_handling(SIGINT), Disposition::Default);
-            assert_eq!(process.signal_handling(SIGQUIT), Disposition::Default);
+            assert_eq!(process.disposition(SIGINT), Disposition::Default);
+            assert_eq!(process.disposition(SIGQUIT), Disposition::Default);
         })
     }
 
@@ -713,9 +713,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Ignore);
-            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Ignore);
-            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Ignore);
+            assert_eq!(child_process.disposition(SIGTSTP), Disposition::Ignore);
+            assert_eq!(child_process.disposition(SIGTTIN), Disposition::Ignore);
+            assert_eq!(child_process.disposition(SIGTTOU), Disposition::Ignore);
         })
     }
 
@@ -743,9 +743,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTOU), Disposition::Default);
         })
     }
 
@@ -767,9 +767,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTOU), Disposition::Default);
         })
     }
 
@@ -791,9 +791,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
-            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.disposition(SIGTTOU), Disposition::Default);
         })
     }
 }

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -319,8 +319,8 @@ mod tests {
     use crate::system::r#virtual::Inode;
     use crate::system::r#virtual::SystemState;
     use crate::system::r#virtual::{SIGCHLD, SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
+    use crate::system::Disposition;
     use crate::system::Errno;
-    use crate::system::SignalHandling;
     use crate::tests::in_virtual_system;
     use crate::trap::Action;
     use assert_matches::assert_matches;
@@ -626,8 +626,8 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&child_pid];
-            assert_eq!(process.signal_handling(SIGINT), SignalHandling::Default);
-            assert_eq!(process.signal_handling(SIGQUIT), SignalHandling::Default);
+            assert_eq!(process.signal_handling(SIGINT), Disposition::Default);
+            assert_eq!(process.signal_handling(SIGQUIT), Disposition::Default);
         })
     }
 
@@ -662,14 +662,8 @@ mod tests {
             assert!(!parent_process.blocked_signals().contains(&SIGINT));
             assert!(!parent_process.blocked_signals().contains(&SIGQUIT));
             let child_process = &state.processes[&child_pid];
-            assert_eq!(
-                child_process.signal_handling(SIGINT),
-                SignalHandling::Ignore
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGQUIT),
-                SignalHandling::Ignore
-            );
+            assert_eq!(child_process.signal_handling(SIGINT), Disposition::Ignore);
+            assert_eq!(child_process.signal_handling(SIGQUIT), Disposition::Ignore);
         })
     }
 
@@ -691,8 +685,8 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&child_pid];
-            assert_eq!(process.signal_handling(SIGINT), SignalHandling::Default);
-            assert_eq!(process.signal_handling(SIGQUIT), SignalHandling::Default);
+            assert_eq!(process.signal_handling(SIGINT), Disposition::Default);
+            assert_eq!(process.signal_handling(SIGQUIT), Disposition::Default);
         })
     }
 
@@ -719,18 +713,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(
-                child_process.signal_handling(SIGTSTP),
-                SignalHandling::Ignore
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTIN),
-                SignalHandling::Ignore
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTOU),
-                SignalHandling::Ignore
-            );
+            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Ignore);
+            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Ignore);
+            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Ignore);
         })
     }
 
@@ -758,18 +743,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(
-                child_process.signal_handling(SIGTSTP),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTIN),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTOU),
-                SignalHandling::Default
-            );
+            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
         })
     }
 
@@ -791,18 +767,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(
-                child_process.signal_handling(SIGTSTP),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTIN),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTOU),
-                SignalHandling::Default
-            );
+            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
         })
     }
 
@@ -824,18 +791,9 @@ mod tests {
 
             let state = state.borrow();
             let child_process = &state.processes[&child_pid];
-            assert_eq!(
-                child_process.signal_handling(SIGTSTP),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTIN),
-                SignalHandling::Default
-            );
-            assert_eq!(
-                child_process.signal_handling(SIGTTOU),
-                SignalHandling::Default
-            );
+            assert_eq!(child_process.signal_handling(SIGTSTP), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTIN), Disposition::Default);
+            assert_eq!(child_process.signal_handling(SIGTTOU), Disposition::Default);
         })
     }
 }

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -237,7 +237,7 @@ pub trait System: Debug {
     /// Gets and/or sets the signal blocking mask.
     ///
     /// This is a low-level function used internally by
-    /// [`SharedSystem::set_signal_handling`]. You should not call this function
+    /// [`SharedSystem::set_disposition`]. You should not call this function
     /// directly, or you will disrupt the behavior of `SharedSystem`. The
     /// description below applies if you want to do everything yourself without
     /// depending on `SharedSystem`.
@@ -256,7 +256,7 @@ pub trait System: Debug {
     /// Gets and sets the disposition for a signal.
     ///
     /// This is a low-level function used internally by
-    /// [`SharedSystem::set_signal_handling`]. You should not call this function
+    /// [`SharedSystem::set_disposition`]. You should not call this function
     /// directly, or you will disrupt the behavior of `SharedSystem`. The
     /// description below applies if you want to do everything yourself without
     /// depending on `SharedSystem`.

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -32,6 +32,7 @@ use super::resource::Resource;
 use super::ChildProcessStarter;
 use super::Dir;
 use super::DirEntry;
+use super::Disposition;
 #[cfg(doc)]
 use super::Env;
 use super::Errno;
@@ -42,7 +43,6 @@ use super::OfdAccess;
 use super::OpenFlag;
 use super::Result;
 use super::SigmaskOp;
-use super::SignalHandling;
 use super::Stat;
 use super::System;
 use super::Times;
@@ -504,11 +504,7 @@ impl System for RealSystem {
         }
     }
 
-    fn sigaction(
-        &mut self,
-        signal: signal::Number,
-        handling: SignalHandling,
-    ) -> Result<SignalHandling> {
+    fn sigaction(&mut self, signal: signal::Number, handling: Disposition) -> Result<Disposition> {
         unsafe {
             let new_action = handling.to_sigaction();
 
@@ -524,7 +520,7 @@ impl System for RealSystem {
             )
             .errno_if_m1()?;
 
-            let old_handling = SignalHandling::from_sigaction(&old_action);
+            let old_handling = Disposition::from_sigaction(&old_action);
             Ok(old_handling)
         }
     }

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -16,7 +16,7 @@
 
 //! Signal implementation for the real system
 
-use super::SignalHandling;
+use super::Disposition;
 pub use crate::signal::*;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
@@ -421,17 +421,17 @@ pub(super) fn sigset_to_vec(set: *const nix::libc::sigset_t, vec: &mut Vec<Numbe
     );
 }
 
-impl SignalHandling {
-    /// Converts the signal handling to `sigaction` for the real system.
+impl Disposition {
+    /// Converts the signal disposition to `sigaction` for the real system.
     ///
     /// This function returns the `sigaction` in an `MaybeUninit` because the
     /// `sigaction` structure may contain platform-dependent extra fields that
     /// are not initialized by this function.
     pub(super) fn to_sigaction(self) -> MaybeUninit<nix::libc::sigaction> {
         let handler = match self {
-            SignalHandling::Default => nix::libc::SIG_DFL,
-            SignalHandling::Ignore => nix::libc::SIG_IGN,
-            SignalHandling::Catch => super::catch_signal as *const extern "C" fn(c_int) as _,
+            Disposition::Default => nix::libc::SIG_DFL,
+            Disposition::Ignore => nix::libc::SIG_IGN,
+            Disposition::Catch => super::catch_signal as *const extern "C" fn(c_int) as _,
         };
 
         let mut sa = MaybeUninit::<nix::libc::sigaction>::uninit();
@@ -451,7 +451,7 @@ impl SignalHandling {
         sa
     }
 
-    /// Converts the `sigaction` to the signal handling for the real system.
+    /// Converts the `sigaction` to the signal disposition for the real system.
     pub(super) unsafe fn from_sigaction(sa: &MaybeUninit<nix::libc::sigaction>) -> Self {
         #[cfg(not(target_os = "aix"))]
         let handler = addr_of!((*sa.as_ptr()).sa_sigaction).read();

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -107,10 +107,10 @@ impl SelectSystem {
         Ok(())
     }
 
-    /// Implements signal handler update.
+    /// Implements signal disposition update.
     ///
     /// See [`SharedSystem::set_disposition`].
-    pub fn set_signal_handling(
+    pub fn set_disposition(
         &mut self,
         signal: signal::Number,
         handling: Disposition,

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -17,10 +17,10 @@
 //! [`SelectSystem`] and related items
 
 use super::signal;
+use super::Disposition;
 use super::Errno;
 use super::Result;
 use super::SigmaskOp;
-use super::SignalHandling;
 use super::System;
 use crate::io::Fd;
 use std::cell::RefCell;
@@ -113,19 +113,19 @@ impl SelectSystem {
     pub fn set_signal_handling(
         &mut self,
         signal: signal::Number,
-        handling: SignalHandling,
-    ) -> Result<SignalHandling> {
+        handling: Disposition,
+    ) -> Result<Disposition> {
         // The order of sigmask and sigaction is important to prevent the signal
         // from being caught. The signal must be caught only when the select
         // function temporarily unblocks the signal. This is to avoid race
         // condition.
         match handling {
-            SignalHandling::Default | SignalHandling::Ignore => {
+            Disposition::Default | Disposition::Ignore => {
                 let old_handling = self.system.sigaction(signal, handling)?;
                 self.sigmask(SigmaskOp::Remove, signal)?;
                 Ok(old_handling)
             }
-            SignalHandling::Catch => {
+            Disposition::Catch => {
                 self.sigmask(SigmaskOp::Add, signal)?;
                 self.system.sigaction(signal, handling)
             }

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -109,7 +109,7 @@ impl SelectSystem {
 
     /// Implements signal handler update.
     ///
-    /// See [`SharedSystem::set_signal_handling`].
+    /// See [`SharedSystem::set_disposition`].
     pub fn set_signal_handling(
         &mut self,
         signal: signal::Number,

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -714,7 +714,7 @@ impl SignalSystem for &SharedSystem {
         signal: signal::Number,
         disposition: Disposition,
     ) -> Result<Disposition> {
-        self.0.borrow_mut().set_signal_handling(signal, disposition)
+        self.0.borrow_mut().set_disposition(signal, disposition)
     }
 }
 
@@ -735,7 +735,7 @@ impl SignalSystem for SharedSystem {
         signal: signal::Number,
         disposition: Disposition,
     ) -> Result<Disposition> {
-        self.0.borrow_mut().set_signal_handling(signal, disposition)
+        self.0.borrow_mut().set_disposition(signal, disposition)
     }
 }
 

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -235,8 +235,8 @@ impl SharedSystem {
 
     /// Waits for some signals to be delivered to this process.
     ///
-    /// Before calling this function, you need to [set signal
-    /// handling](Self::set_signal_handling) to `Catch`. Without doing so, this
+    /// Before calling this function, you need to [set the signal
+    /// disposition](Self::set_disposition) to `Catch`. Without doing so, this
     /// function cannot detect the receipt of the signals.
     ///
     /// Returns an array of signals that were caught.
@@ -263,8 +263,8 @@ impl SharedSystem {
 
     /// Waits for a signal to be delivered to this process.
     ///
-    /// Before calling this function, you need to [set signal
-    /// handling](Self::set_signal_handling) to `Catch`.
+    /// Before calling this function, you need to [set the signal
+    /// disposition](Self::set_disposition) to `Catch`.
     /// Without doing so, this function cannot detect the receipt of the signal.
     ///
     /// If this `SharedSystem` is part of an [`Env`], you should call
@@ -709,7 +709,7 @@ impl SignalSystem for &SharedSystem {
         System::signal_number_from_name(*self, name)
     }
 
-    fn set_signal_handling(
+    fn set_disposition(
         &mut self,
         signal: signal::Number,
         disposition: Disposition,
@@ -730,7 +730,7 @@ impl SignalSystem for SharedSystem {
     }
 
     #[inline]
-    fn set_signal_handling(
+    fn set_disposition(
         &mut self,
         signal: signal::Number,
         disposition: Disposition,
@@ -918,15 +918,9 @@ mod tests {
         let process_id = system.process_id;
         let state = Rc::clone(&system.state);
         let mut system = SharedSystem::new(Box::new(system));
-        system
-            .set_signal_handling(SIGCHLD, Disposition::Catch)
-            .unwrap();
-        system
-            .set_signal_handling(SIGINT, Disposition::Catch)
-            .unwrap();
-        system
-            .set_signal_handling(SIGUSR1, Disposition::Catch)
-            .unwrap();
+        system.set_disposition(SIGCHLD, Disposition::Catch).unwrap();
+        system.set_disposition(SIGINT, Disposition::Catch).unwrap();
+        system.set_disposition(SIGUSR1, Disposition::Catch).unwrap();
 
         let mut context = Context::from_waker(noop_waker_ref());
         let mut future = Box::pin(system.wait_for_signals());
@@ -960,9 +954,7 @@ mod tests {
         let process_id = system.process_id;
         let state = Rc::clone(&system.state);
         let mut system = SharedSystem::new(Box::new(system));
-        system
-            .set_signal_handling(SIGCHLD, Disposition::Catch)
-            .unwrap();
+        system.set_disposition(SIGCHLD, Disposition::Catch).unwrap();
 
         let mut context = Context::from_waker(noop_waker_ref());
         let mut future = Box::pin(system.wait_for_signal(SIGCHLD));
@@ -989,12 +981,8 @@ mod tests {
         let process_id = system.process_id;
         let state = Rc::clone(&system.state);
         let mut system = SharedSystem::new(Box::new(system));
-        system
-            .set_signal_handling(SIGINT, Disposition::Catch)
-            .unwrap();
-        system
-            .set_signal_handling(SIGTERM, Disposition::Catch)
-            .unwrap();
+        system.set_disposition(SIGINT, Disposition::Catch).unwrap();
+        system.set_disposition(SIGTERM, Disposition::Catch).unwrap();
 
         let mut context = Context::from_waker(noop_waker_ref());
         let mut future = Box::pin(system.wait_for_signal(SIGINT));
@@ -1019,12 +1007,8 @@ mod tests {
         let process_id = system.process_id;
         let state = Rc::clone(&system.state);
         let mut system = SharedSystem::new(Box::new(system));
-        system
-            .set_signal_handling(SIGINT, Disposition::Catch)
-            .unwrap();
-        system
-            .set_signal_handling(SIGTERM, Disposition::Catch)
-            .unwrap();
+        system.set_disposition(SIGINT, Disposition::Catch).unwrap();
+        system.set_disposition(SIGTERM, Disposition::Catch).unwrap();
 
         {
             let mut state = state.borrow_mut();
@@ -1052,7 +1036,7 @@ mod tests {
         let mut system_3 = system_1.clone();
         let (reader, writer) = system_1.pipe().unwrap();
         system_2
-            .set_signal_handling(SIGCHLD, Disposition::Catch)
+            .set_disposition(SIGCHLD, Disposition::Catch)
             .unwrap();
 
         let mut buffer = [0];

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -635,7 +635,7 @@ impl System for VirtualSystem {
         disposition: Disposition,
     ) -> Result<Disposition> {
         let mut process = self.current_process_mut();
-        Ok(process.set_signal_handling(signal, disposition))
+        Ok(process.set_disposition(signal, disposition))
     }
 
     fn caught_signals(&mut self) -> Vec<signal::Number> {

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -57,6 +57,7 @@ use super::resource::LimitPair;
 use super::resource::Resource;
 use super::resource::INFINITY;
 use super::Dir;
+use super::Disposition;
 use super::Errno;
 use super::FdFlag;
 use super::Gid;
@@ -64,7 +65,6 @@ use super::OfdAccess;
 use super::OpenFlag;
 use super::Result;
 use super::SigmaskOp;
-use super::SignalHandling;
 use super::Stat;
 use super::Times;
 use super::Uid;
@@ -632,10 +632,10 @@ impl System for VirtualSystem {
     fn sigaction(
         &mut self,
         signal: signal::Number,
-        action: SignalHandling,
-    ) -> Result<SignalHandling> {
+        disposition: Disposition,
+    ) -> Result<Disposition> {
         let mut process = self.current_process_mut();
-        Ok(process.set_signal_handling(signal, action))
+        Ok(process.set_signal_handling(signal, disposition))
     }
 
     fn caught_signals(&mut self) -> Vec<signal::Number> {
@@ -2066,7 +2066,7 @@ mod tests {
         system
             .sigmask(Some((SigmaskOp::Add, &[SIGCHLD])), None)
             .unwrap();
-        system.sigaction(SIGCHLD, SignalHandling::Catch).unwrap();
+        system.sigaction(SIGCHLD, Disposition::Catch).unwrap();
         system
     }
 
@@ -2484,7 +2484,7 @@ mod tests {
     #[test]
     fn exiting_child_sends_sigchld_to_parent() {
         let (mut system, mut executor) = virtual_system_with_executor();
-        system.sigaction(SIGCHLD, SignalHandling::Catch).unwrap();
+        system.sigaction(SIGCHLD, Disposition::Catch).unwrap();
 
         let child_process = system.new_child_process().unwrap();
 

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -47,7 +47,7 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use yash_syntax::source::Location;
 
-/// System interface for signal handling configuration.
+/// System interface for signal handling configuration
 pub trait SignalSystem {
     /// Returns the name of a signal from its number.
     #[must_use]
@@ -76,12 +76,12 @@ pub trait SignalSystem {
 
     /// Sets how a signal is handled.
     ///
-    /// This function updates the signal blocking mask and the signal action for
-    /// the specified signal, and returns the previous action.
-    fn set_signal_handling(
+    /// This function updates the signal blocking mask and the disposition for
+    /// the specified signal, and returns the previous disposition.
+    fn set_disposition(
         &mut self,
         signal: signal::Number,
-        handling: Disposition,
+        disposition: Disposition,
     ) -> Result<Disposition, Errno>;
 }
 
@@ -206,7 +206,7 @@ impl TrapSet {
         Iter { inner }
     }
 
-    /// Updates signal handlings on entering a subshell.
+    /// Updates signal dispositions on entering a subshell.
     ///
     /// ## Resetting non-ignore traps
     ///
@@ -227,19 +227,19 @@ impl TrapSet {
     ///
     /// ## Ignoring SIGINT and SIGQUIT
     ///
-    /// If `ignore_sigint_sigquit` is true, this function sets the signal
-    /// handlings for SIGINT and SIGQUIT to `Ignore`.
+    /// If `ignore_sigint_sigquit` is true, this function sets the dispositions
+    /// for SIGINT and SIGQUIT to `Ignore`.
     ///
     /// ## Ignoring SIGTSTP, SIGTTIN, and SIGTTOU
     ///
     /// If `keep_stopper_handlers` is true and the stopper handlers have been
     /// [enabled](Self::enable_stopper_handlers), this function leaves the
-    /// signal handlings for SIGTSTP, SIGTTIN, and SIGTTOU set to `Ignore`.
+    /// dispositions for SIGTSTP, SIGTTIN, and SIGTTOU set to `Ignore`.
     ///
     /// ## Errors
     ///
     /// This function ignores any errors that may occur when setting signal
-    /// handlings.
+    /// dispositions.
     pub fn enter_subshell<S: SignalSystem>(
         &mut self,
         system: &mut S,
@@ -319,14 +319,14 @@ impl TrapSet {
     fn set_internal_handler<S: SignalSystem>(
         &mut self,
         signal: signal::Name,
-        handling: Disposition,
+        disposition: Disposition,
         system: &mut S,
     ) -> Result<(), Errno> {
         let number = system
             .signal_number_from_name(signal)
             .unwrap_or_else(|| panic!("missing support for signal {signal}"));
         let entry = self.traps.entry(Condition::Signal(number));
-        GrandState::set_internal_handler(system, entry, handling)
+        GrandState::set_internal_handler(system, entry, disposition)
     }
 
     /// Installs an internal handler for `SIGCHLD`.
@@ -446,7 +446,7 @@ mod tests {
             VirtualSystem::new().signal_number_from_name(name)
         }
 
-        fn set_signal_handling(
+        fn set_disposition(
             &mut self,
             signal: signal::Number,
             disposition: Disposition,

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -964,7 +964,7 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(process.signal_handling(SIGINT), Disposition::Ignore);
+            assert_eq!(process.disposition(SIGINT), Disposition::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -986,7 +986,7 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(process.signal_handling(SIGQUIT), Disposition::Ignore);
+            assert_eq!(process.disposition(SIGQUIT), Disposition::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -1022,9 +1022,9 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(process.signal_handling(SIGTSTP), Disposition::Ignore);
-            assert_eq!(process.signal_handling(SIGTTIN), Disposition::Ignore);
-            assert_eq!(process.signal_handling(SIGTTOU), Disposition::Ignore);
+            assert_eq!(process.disposition(SIGTSTP), Disposition::Ignore);
+            assert_eq!(process.disposition(SIGTTIN), Disposition::Ignore);
+            assert_eq!(process.disposition(SIGTTOU), Disposition::Ignore);
             assert_eq!(process.state(), ProcessState::Running);
         })
     }
@@ -1047,9 +1047,9 @@ mod tests {
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
-            assert_eq!(process.signal_handling(SIGTSTP), Disposition::Default);
-            assert_eq!(process.signal_handling(SIGTTIN), Disposition::Default);
-            assert_eq!(process.signal_handling(SIGTTOU), Disposition::Default);
+            assert_eq!(process.disposition(SIGTSTP), Disposition::Default);
+            assert_eq!(process.disposition(SIGTTIN), Disposition::Default);
+            assert_eq!(process.disposition(SIGTTOU), Disposition::Default);
         })
     }
 

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -119,8 +119,8 @@ impl Setting {
         )
     }
 
-    pub fn from_initial_handling(handling: Disposition) -> Self {
-        match handling {
+    pub fn from_initial_disposition(disposition: Disposition) -> Self {
+        match disposition {
             Disposition::Default | Disposition::Catch => Self::InitiallyDefaulted,
             Disposition::Ignore => Self::InitiallyIgnored,
         }
@@ -282,7 +282,7 @@ impl GrandState {
             Entry::Vacant(vacant) => {
                 let initial_disposition = system.set_disposition(signal, disposition)?;
                 vacant.insert(GrandState {
-                    current_setting: Setting::from_initial_handling(initial_disposition),
+                    current_setting: Setting::from_initial_disposition(initial_disposition),
                     parent_setting: None,
                     internal_disposition: disposition,
                 });
@@ -367,7 +367,7 @@ impl GrandState {
         };
         let initial_disposition = system.set_disposition(signal, Disposition::Ignore)?;
         vacant.insert(GrandState {
-            current_setting: Setting::from_initial_handling(initial_disposition),
+            current_setting: Setting::from_initial_disposition(initial_disposition),
             parent_setting: None,
             internal_disposition: Disposition::Default,
         });

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -203,9 +203,9 @@ impl GrandState {
             Entry::Vacant(vacant) => {
                 if let Condition::Signal(signal) = cond {
                     if !override_ignore {
-                        let initial_handling =
-                            system.set_signal_handling(signal, Disposition::Ignore)?;
-                        if initial_handling == Disposition::Ignore {
+                        let initial_disposition =
+                            system.set_disposition(signal, Disposition::Ignore)?;
+                        if initial_disposition == Disposition::Ignore {
                             vacant.insert(GrandState {
                                 current_setting: Setting::InitiallyIgnored,
                                 parent_setting: None,
@@ -216,7 +216,7 @@ impl GrandState {
                     }
 
                     if override_ignore || handling != Disposition::Ignore {
-                        system.set_signal_handling(signal, handling)?;
+                        system.set_disposition(signal, handling)?;
                     }
                 }
 
@@ -237,7 +237,7 @@ impl GrandState {
                     let old_handler = state.internal_handler.max((&state.current_setting).into());
                     let new_handler = state.internal_handler.max(handling);
                     if old_handler != new_handler {
-                        system.set_signal_handling(signal, new_handler)?;
+                        system.set_disposition(signal, new_handler)?;
                     }
                 }
 
@@ -271,9 +271,9 @@ impl GrandState {
             Entry::Vacant(_) if handling == Disposition::Default => (),
 
             Entry::Vacant(vacant) => {
-                let initial_handling = system.set_signal_handling(signal, handling)?;
+                let initial_disposition = system.set_disposition(signal, handling)?;
                 vacant.insert(GrandState {
-                    current_setting: Setting::from_initial_handling(initial_handling),
+                    current_setting: Setting::from_initial_handling(initial_disposition),
                     parent_setting: None,
                     internal_handler: handling,
                 });
@@ -285,7 +285,7 @@ impl GrandState {
                 let old_handler = state.internal_handler.max(setting);
                 let new_handler = handling.max(setting);
                 if old_handler != new_handler {
-                    system.set_signal_handling(signal, new_handler)?;
+                    system.set_disposition(signal, new_handler)?;
                 }
                 state.internal_handler = handling;
             }
@@ -325,7 +325,7 @@ impl GrandState {
         };
         if old_handler != new_handler {
             if let Condition::Signal(signal) = cond {
-                system.set_signal_handling(signal, new_handler)?;
+                system.set_disposition(signal, new_handler)?;
             }
         }
         self.internal_handler = match option {
@@ -354,9 +354,9 @@ impl GrandState {
             Condition::Signal(signal) => signal,
             Condition::Exit => panic!("exit condition cannot be ignored"),
         };
-        let initial_handling = system.set_signal_handling(signal, Disposition::Ignore)?;
+        let initial_disposition = system.set_disposition(signal, Disposition::Ignore)?;
         vacant.insert(GrandState {
-            current_setting: Setting::from_initial_handling(initial_handling),
+            current_setting: Setting::from_initial_handling(initial_disposition),
             parent_setting: None,
             internal_handler: Disposition::Default,
         });

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -155,10 +155,10 @@ pub fn to_c_strings(s: Vec<Field>) -> Vec<CString> {
 /// Substitutes the currently executing shell process with the external utility.
 ///
 /// This function performs the very last step of the simple command execution.
-/// It disables the internal signal handlers and calls the `execve` system call.
-/// If the call fails, it prints an error message to the standard error and
-/// updates `env.exit_status`, in which case the caller should immediately exit
-/// the current process with the exit status.
+/// It disables the internal signal dispositions and calls the `execve` system
+/// call. If the call fails, it prints an error message to the standard error
+/// and updates `env.exit_status`, in which case the caller should immediately
+/// exit the current process with the exit status.
 ///
 /// If the `execve` call fails with `ENOEXEC`, this function falls back on
 /// invoking the shell with the given arguments, so that the shell can interpret
@@ -170,7 +170,9 @@ pub async fn replace_current_process(
     args: Vec<CString>,
     location: Location,
 ) {
-    env.traps.disable_internal_handlers(&mut env.system).ok();
+    env.traps
+        .disable_internal_dispositions(&mut env.system)
+        .ok();
 
     let envs = env.variables.env_c_strings();
     let result = env.system.execve(path.as_c_str(), &args, &envs);


### PR DESCRIPTION
This pull request renames the `SignalHandling` enum to `Disposition` and also renames related functions and variables. The word "disposition" is used in the POSIX standard to exclusively describe the action taken when a signal is received. The previous name `SignalHandling` was misleading because it could be interpreted as handling the signal itself, which is not the case. This change makes the code more readable and consistent with the POSIX standard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved terminology in signal management, changing from "handlers" to "dispositions" across the system for enhanced clarity.

- **Bug Fixes**
	- Updated signal management logic to better handle internal dispositions for signals, potentially improving robustness in subshell contexts.

- **Documentation**
	- Refined documentation throughout the codebase to reflect updated terminology and enhance clarity regarding signal management processes.

- **Tests**
	- Revised test cases to align with the new signal disposition terminology, ensuring checks remain valid and comprehensive.

- **Refactor**
	- Renamed various functions and types to standardize the terminology used for signal management across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->