### PR TITLE
Implement ignore-eof shell option

### DIFF
--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive shells now report updates to job status before showing the prompt.
 - Interactive shells no longer exit on shell errors such as syntax errors.
 - Interactive shells now ignore the `noexec` option.
+- Interactive shells now support the `ignoreeof` option.
 - Interactive shells now allow modifying the trap for signals that were ignored
   on the shell startup.
 

--- a/yash-cli/CHANGELOG-lib.md
+++ b/yash-cli/CHANGELOG-lib.md
@@ -31,9 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `!`.
 - The signature of the `startup::input::prepare_input` function has been revised
   with more lifetime parameters for more flexible usage.
-- The `startup::input::prepare_input` function now applies the
-  `yash_env::input::Reporter` decorator to the returned source input if the shell
-  is interactive.
+- The `startup::input::prepare_input` function now additionally applies the
+  following decorators to the returned source input:
+    - `yash_env::input::Reporter` to report the job status if the shell is
+      interactive.
+    - `yash_env::input::IgnoreEof` to ignore the EOF character if the shell is
+      interactive and the input is associated with a file descriptor.
+    - `yash_prompt::Prompter` to show the prompt before reading the input if the
+      shell is interactive and the input is associated with a file descriptor.
+      (Previously, the `Prompter` was applied only to the standard input. It is
+      now also applied to the input from any file.)
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
     - yash-env 0.2.0 → 0.3.0

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -164,7 +164,7 @@ fn prepare_fd_input<'i>(fd: Fd, ref_env: &'i RefCell<&mut Env>) -> Box<dyn Input
         let prompter = Prompter::new(basic_input, ref_env);
         let reporter = Reporter::new(prompter, ref_env);
         let message =
-            "Type `exit` to leave the shell when the ignore-eof option is on.".to_string();
+            "# Type `exit` to leave the shell when the ignore-eof option is on.\n".to_string();
         Box::new(IgnoreEof::new(reporter, fd, ref_env, message))
     }
 }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This is a utility for formatting status reports of multiple jobs.
 - `input::Reporter`
     - This `Input` decorator reports job status changes to the user.
+- `input::IgnoreEof`
+    - This `Input` decorator implements the behavior of the `ignoreeof` shell option.
 
 ### Removed
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - Unreleased
+## [0.4.0] - Unreleased
 
 ### Added
 
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This `Input` decorator reports job status changes to the user.
 - `input::IgnoreEof`
     - This `Input` decorator implements the behavior of the `ignoreeof` shell option.
+- `system::virtual::FileBody::Terminal`
+    - This is a new variant of `FileBody` that represents a terminal device.
+
+### Changed
+
+- `system::virtual::FileBody` is now `non_exhaustive`.
+- `system::virtual::VirtualSystem::isatty` now returns true for a file
+  descriptor associated with `FileBody::Terminal`.
 
 ### Removed
 
@@ -280,7 +288,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env` crate
 
-[0.3.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.3.1
+[0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.3.0
 [0.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.2.1
 [0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.2.0

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -29,5 +29,8 @@ pub use fd_reader::FdReader;
 mod echo;
 pub use echo::Echo;
 
+mod ignore_eof;
+pub use ignore_eof::IgnoreEof;
+
 mod reporter;
 pub use reporter::Reporter;

--- a/yash-env/src/input/ignore_eof.rs
+++ b/yash-env/src/input/ignore_eof.rs
@@ -1,0 +1,295 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines the [`IgnoreEof`] input decorator.
+
+use super::{Context, Input, Result};
+use crate::io::Fd;
+use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off};
+use crate::Env;
+use async_trait::async_trait;
+use std::cell::RefCell;
+
+/// `Input` decorator that ignores EOF on a terminal
+///
+/// This is a decorator of [`Input`] that adds the behavior of the
+/// [`ignore-eof` shell option](crate::option::IgnoreEof).
+///
+/// The decorator is effective only when all of the following conditions are
+/// met:
+///
+/// - The shell is interactive, that is, the [`Interactive`] option is enabled.
+/// - The `ignore-eof` option is enabled.
+/// - The input is a terminal.
+///
+/// The decorator reads from the inner input and usually returns the result
+/// as is. However, if the result is an empty string and the above conditions
+/// are met, the decorator will re-read the input until a non-empty string
+/// is obtained, an error occurs, or this process is repeated 20 times.
+///
+/// [`Interactive`]: crate::option::Interactive
+#[derive(Clone, Debug)]
+pub struct IgnoreEof<'a, 'b, T> {
+    /// Inner input to read from
+    inner: T,
+    /// File descriptor to be checked if it is a terminal
+    fd: Fd,
+    /// Environment to check the shell options and interact with the system
+    env: &'a RefCell<&'b mut Env>,
+    /// Text to be displayed when EOF is ignored
+    message: String,
+}
+
+impl<'a, 'b, T> IgnoreEof<'a, 'b, T> {
+    /// Creates a new `IgnoreEof` decorator.
+    ///
+    /// The first argument is the inner `Input` that performs the actual input
+    /// operation. The second argument is the file descriptor to be checked if
+    /// it is a terminal. The third argument is the shell environment that
+    /// contains the shell option state and the system interface to interact
+    /// with the system.  It is wrapped in a `RefCell` so that it can be shared
+    /// with other decorators and the parser. The fourth argument is the text to
+    /// be displayed when EOF is ignored.
+    ///
+    /// The second argument `fd` should match the file descriptor that the inner
+    /// input reads from. If the inner input reads from a different file
+    /// descriptor, the `IgnoreEof` decorator may not detect the terminal
+    /// correctly.
+    pub fn new(inner: T, fd: Fd, env: &'a RefCell<&'b mut Env>, message: String) -> Self {
+        Self {
+            inner,
+            fd,
+            env,
+            message,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl<'a, 'b, T> Input for IgnoreEof<'a, 'b, T>
+where
+    T: Input,
+{
+    #[allow(clippy::await_holding_refcell_ref)]
+    async fn next_line(&mut self, context: &Context) -> Result {
+        let mut remaining_tries = 50;
+
+        loop {
+            let line = self.inner.next_line(context).await?;
+
+            let env = self.env.borrow();
+
+            let should_break = !line.is_empty()
+                || env.options.get(Interactive) == Off
+                || env.options.get(IgnoreEofOption) == Off
+                || remaining_tries == 0;
+            if should_break {
+                return Ok(line);
+            }
+
+            env.system.print_error(&self.message).await;
+            remaining_tries -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::option::On;
+    use crate::system::r#virtual::VirtualSystem;
+    use crate::tests::assert_stderr;
+    use futures_util::FutureExt as _;
+    use yash_syntax::input::Memory;
+
+    /// `Input` decorator that returns EOF for the first `count` calls
+    /// and then reads from the inner input.
+    struct EofStub<T> {
+        inner: T,
+        count: usize,
+    }
+
+    #[async_trait(?Send)]
+    impl<T> Input for EofStub<T>
+    where
+        T: Input,
+    {
+        async fn next_line(&mut self, context: &Context) -> Result {
+            if let Some(remaining) = self.count.checked_sub(1) {
+                self.count = remaining;
+                Ok("".to_string())
+            } else {
+                self.inner.next_line(context).await
+            }
+        }
+    }
+
+    #[test]
+    fn decorator_reads_from_inner_input() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            Memory::new("echo foo\n"),
+            Fd::STDIN,
+            &ref_env,
+            "unused".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+    }
+
+    #[test]
+    fn decorator_reads_input_again_on_eof() {
+        let system = Box::new(VirtualSystem::new());
+        let state = system.state.clone();
+        let mut env = Env::with_system(system);
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+            "EOF ignored\n".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "EOF ignored\n"));
+    }
+
+    #[test]
+    fn decorator_reads_input_up_to_50_times() {
+        let system = Box::new(VirtualSystem::new());
+        let state = system.state.clone();
+        let mut env = Env::with_system(system);
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 50,
+            },
+            Fd::STDIN,
+            &ref_env,
+            "EOF ignored\n".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "EOF ignored\n".repeat(50))
+        });
+    }
+
+    #[test]
+    fn decorator_returns_empty_line_after_reading_51_times() {
+        let system = Box::new(VirtualSystem::new());
+        let state = system.state.clone();
+        let mut env = Env::with_system(system);
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 51,
+            },
+            Fd::STDIN,
+            &ref_env,
+            "EOF ignored\n".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "EOF ignored\n".repeat(50))
+        });
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_not_interactive() {
+        let system = Box::new(VirtualSystem::new());
+        let state = system.state.clone();
+        let mut env = Env::with_system(system);
+        env.options.set(Interactive, Off);
+        env.options.set(IgnoreEofOption, On);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+            "EOF ignored\n".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_not_ignore_eof() {
+        let system = Box::new(VirtualSystem::new());
+        let state = system.state.clone();
+        let mut env = Env::with_system(system);
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, Off);
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = IgnoreEof::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+            "EOF ignored\n".to_string(),
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    // TODO decorator_returns_immediately_if_not_terminal
+}

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -537,8 +537,11 @@ impl System for VirtualSystem {
         Ok(())
     }
 
-    fn isatty(&self, _fd: Fd) -> bool {
-        false
+    fn isatty(&self, fd: Fd) -> bool {
+        self.with_open_file_description(fd, |ofd| {
+            Ok(matches!(&ofd.file.borrow().body, FileBody::Terminal { .. }))
+        })
+        .unwrap_or(false)
     }
 
     fn read(&mut self, fd: Fd, buffer: &mut [u8]) -> Result<usize> {

--- a/yash-env/src/system/virtual/file_system.rs
+++ b/yash-env/src/system/virtual/file_system.rs
@@ -212,6 +212,7 @@ impl Inode {
 
 /// Filetype-specific content of a file
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum FileBody {
     /// Regular file
     Regular {
@@ -244,6 +245,13 @@ pub enum FileBody {
         /// Path to the file referenced by this symlink
         target: PathBuf,
     },
+    /// Terminal device
+    ///
+    /// This is a dummy device that works like a regular file.
+    Terminal {
+        /// Virtual file content
+        content: Vec<u8>,
+    },
     // TODO Other filetypes
 }
 
@@ -274,6 +282,7 @@ impl FileBody {
             Self::Directory { .. } => FileType::Directory,
             Self::Fifo { .. } => FileType::Fifo,
             Self::Symlink { .. } => FileType::Symlink,
+            Self::Terminal { .. } => FileType::CharacterDevice,
         }
     }
 
@@ -285,6 +294,7 @@ impl FileBody {
             Self::Directory { files } => files.len(),
             Self::Fifo { content, .. } => content.len(),
             Self::Symlink { target } => target.as_unix_str().len(),
+            Self::Terminal { .. } => 0,
         }
     }
 }

--- a/yash-env/src/system/virtual/io.rs
+++ b/yash-env/src/system/virtual/io.rs
@@ -38,19 +38,22 @@ pub const PIPE_BUF: usize = 512;
 /// The real system may have a different configuration.
 pub const PIPE_SIZE: usize = PIPE_BUF * 2;
 
-/// State of a file opened for reading and/or writing.
+/// State of a file opened for reading and/or writing
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct OpenFileDescription {
-    /// The file.
-    pub(super) file: Rc<RefCell<Inode>>,
-    /// Position in bytes to perform next I/O operation at.
-    pub(super) offset: usize,
-    /// Whether this file is opened for reading.
-    pub(super) is_readable: bool,
-    /// Whether this file is opened for writing.
-    pub(super) is_writable: bool,
-    /// Whether this file is opened for appending.
-    pub(super) is_appending: bool,
+    /// File content and metadata
+    pub(crate) file: Rc<RefCell<Inode>>,
+    /// Position in bytes to perform next I/O operation at
+    pub(crate) offset: usize,
+    /// Whether this file is opened for reading
+    pub(crate) is_readable: bool,
+    /// Whether this file is opened for writing
+    pub(crate) is_writable: bool,
+    /// Whether this file is opened for appending
+    pub(crate) is_appending: bool,
+    // TODO is_nonblocking
+    // TODO consider making these fields public
 }
 
 impl Drop for OpenFileDescription {

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -119,7 +119,7 @@ pub async fn read_eval_loop(env: &RefCell<&mut Env>, lexer: &mut Lexer<'_>) -> R
 ///
 /// - Prompting the user for input (see the `yash-prompt` crate)
 /// - Reporting job status changes before the prompt (see [`Reporter`])
-/// - Applying the [`IgnoreEof`] option
+/// - Applying the `ignore-eof` option (see [`IgnoreEof`])
 ///
 /// This function is intended to be used as the top-level read-eval loop in an
 /// interactive shell. It is not suitable for non-interactive command execution
@@ -127,7 +127,7 @@ pub async fn read_eval_loop(env: &RefCell<&mut Env>, lexer: &mut Lexer<'_>) -> R
 ///
 /// [`Interrupt`]: crate::Divert::Interrupt
 /// [`Reporter`]: yash_env::input::Reporter
-/// [`IgnoreEof`]: yash_env::option::IgnoreEof
+/// [`IgnoreEof`]: yash_env::input::IgnoreEof
 pub async fn interactive_read_eval_loop(env: &RefCell<&mut Env>, lexer: &mut Lexer<'_>) -> Result {
     read_eval_loop_impl(env, lexer, /* is_interactive */ true).await
 }


### PR DESCRIPTION
Closes #408

- [x] Support terminal file type in the virtual system
- [x] `IgnoreEof` decorator
    - [x] Don't ignore EOF if the input is not a terminal
- [x] Use the decorator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced interactive shell functionality with job status updates before prompts.
	- Introduced `ignoreeof` option to prevent accidental shell exits on EOF.
	- Added support for terminal file types in file handling.
	- Improved input preparation process with clearer decorator application logic.

- **Bug Fixes**
	- Improved robustness by preventing shell exits on syntax errors.

- **Documentation**
	- Updated documentation for clarity on `ignore-eof` option and related functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->