### PR TITLE
Remove async-trait dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,17 +34,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-trait"
-version = "0.1.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,7 +573,6 @@ version = "0.3.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
- "async-trait",
  "bitflags",
  "either",
  "enumset",
@@ -626,7 +614,6 @@ dependencies = [
 name = "yash-prompt"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "futures-util",
  "yash-env",
  "yash-env-test-helper",
@@ -643,7 +630,6 @@ name = "yash-semantics"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
- "async-trait",
  "enumset",
  "futures-executor",
  "futures-util",
@@ -663,7 +649,6 @@ version = "0.11.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
- "async-trait",
  "futures-executor",
  "futures-util",
  "itertools",

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -42,14 +42,14 @@ use yash_env::system::SystemEx as _;
 use yash_env::Env;
 use yash_env::System;
 use yash_prompt::Prompter;
-use yash_syntax::input::InputEx;
+use yash_syntax::input::InputObject;
 use yash_syntax::input::Memory;
 use yash_syntax::source::Source as SyntaxSource;
 
 /// Result of [`prepare_input`].
 pub struct SourceInput<'a> {
     /// Input to be passed to the lexer
-    pub input: Box<dyn InputEx + 'a>,
+    pub input: Box<dyn InputObject + 'a>,
     /// Description of the source
     pub source: SyntaxSource,
 }
@@ -133,7 +133,7 @@ pub fn prepare_input<'s: 'i + 'e, 'i, 'e>(
             let basic_input = Memory::new(command);
 
             let is_interactive = env.borrow().options.get(Interactive) == On;
-            let input: Box<dyn InputEx> = if is_interactive {
+            let input: Box<dyn InputObject> = if is_interactive {
                 Box::new(Reporter::new(basic_input, env))
             } else {
                 Box::new(basic_input)
@@ -150,7 +150,7 @@ pub fn prepare_input<'s: 'i + 'e, 'i, 'e>(
 /// and wraps it with the [`Echo`] decorator. If the [`Interactive`] option is
 /// enabled, the [`Prompter`], [`Reporter`], and [`IgnoreEof`] decorators are
 /// applied to the input object.
-fn prepare_fd_input<'i>(fd: Fd, ref_env: &'i RefCell<&mut Env>) -> Box<dyn InputEx + 'i> {
+fn prepare_fd_input<'i>(fd: Fd, ref_env: &'i RefCell<&mut Env>) -> Box<dyn InputObject + 'i> {
     let env = ref_env.borrow();
     let system = env.system.clone();
 

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -42,14 +42,14 @@ use yash_env::system::SystemEx as _;
 use yash_env::Env;
 use yash_env::System;
 use yash_prompt::Prompter;
-use yash_syntax::input::Input;
+use yash_syntax::input::InputEx;
 use yash_syntax::input::Memory;
 use yash_syntax::source::Source as SyntaxSource;
 
 /// Result of [`prepare_input`].
 pub struct SourceInput<'a> {
     /// Input to be passed to the lexer
-    pub input: Box<dyn Input + 'a>,
+    pub input: Box<dyn InputEx + 'a>,
     /// Description of the source
     pub source: SyntaxSource,
 }
@@ -133,7 +133,7 @@ pub fn prepare_input<'s: 'i + 'e, 'i, 'e>(
             let basic_input = Memory::new(command);
 
             let is_interactive = env.borrow().options.get(Interactive) == On;
-            let input: Box<dyn Input> = if is_interactive {
+            let input: Box<dyn InputEx> = if is_interactive {
                 Box::new(Reporter::new(basic_input, env))
             } else {
                 Box::new(basic_input)
@@ -150,7 +150,7 @@ pub fn prepare_input<'s: 'i + 'e, 'i, 'e>(
 /// and wraps it with the [`Echo`] decorator. If the [`Interactive`] option is
 /// enabled, the [`Prompter`], [`Reporter`], and [`IgnoreEof`] decorators are
 /// applied to the input object.
-fn prepare_fd_input<'i>(fd: Fd, ref_env: &'i RefCell<&mut Env>) -> Box<dyn Input + 'i> {
+fn prepare_fd_input<'i>(fd: Fd, ref_env: &'i RefCell<&mut Env>) -> Box<dyn InputEx + 'i> {
     let env = ref_env.borrow();
     let system = env.system.clone();
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `system::virtual::FileBody` is now `non_exhaustive`.
 - `system::virtual::VirtualSystem::isatty` now returns true for a file
   descriptor associated with `FileBody::Terminal`.
+- `impl yash_syntax::input::Input` for `input::FdReader`, `input::Echo`,
+  `input::IgnoreEof`, and `input::Reporter` now conforms to the new definition
+  of the `next_line` method.
 
 ### Removed
 
@@ -31,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The redundant lifetime constraint `T: 'a` is removed from the implementations
   of `yash_syntax::input::Input` for `input::Echo<'a, 'b, T>` and
   `input::Reporter<'a, 'b, T>`.
+- Internal dependencies:
+    - async-trait 0.1.73
 
 ## [0.3.0] - 2024-08-22
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 annotate-snippets = "0.11.4"
-async-trait = "0.1.73"
 bitflags = "2.6.0"
 either = "1.9.0"
 enumset = "1.1.2"

--- a/yash-env/src/input/echo.rs
+++ b/yash-env/src/input/echo.rs
@@ -19,7 +19,6 @@
 use crate::option::Option::Verbose;
 use crate::option::State::On;
 use crate::Env;
-use async_trait::async_trait;
 use std::cell::RefCell;
 use yash_syntax::input::{Context, Input, Result};
 
@@ -50,7 +49,6 @@ impl<'a, 'b, T> Echo<'a, 'b, T> {
     }
 }
 
-#[async_trait(?Send)]
 impl<'a, 'b, T> Input for Echo<'a, 'b, T>
 where
     T: Input,

--- a/yash-env/src/input/fd_reader.rs
+++ b/yash-env/src/input/fd_reader.rs
@@ -19,7 +19,6 @@
 use crate::io::Fd;
 use crate::option::State;
 use crate::system::SharedSystem;
-use async_trait::async_trait;
 use std::cell::Cell;
 use std::rc::Rc;
 use std::slice::from_mut;
@@ -82,7 +81,6 @@ impl FdReader {
     }
 }
 
-#[async_trait(?Send)]
 impl Input for FdReader {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable

--- a/yash-env/src/input/ignore_eof.rs
+++ b/yash-env/src/input/ignore_eof.rs
@@ -21,7 +21,6 @@ use crate::io::Fd;
 use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off};
 use crate::system::System as _;
 use crate::Env;
-use async_trait::async_trait;
 use std::cell::RefCell;
 
 /// `Input` decorator that ignores EOF on a terminal
@@ -79,7 +78,6 @@ impl<'a, 'b, T> IgnoreEof<'a, 'b, T> {
     }
 }
 
-#[async_trait(?Send)]
 impl<'a, 'b, T> Input for IgnoreEof<'a, 'b, T>
 where
     T: Input,
@@ -127,7 +125,6 @@ mod tests {
         count: usize,
     }
 
-    #[async_trait(?Send)]
     impl<T> Input for EofStub<T>
     where
         T: Input,

--- a/yash-env/src/input/reporter.rs
+++ b/yash-env/src/input/reporter.rs
@@ -17,7 +17,6 @@
 use crate::job::fmt::Accumulator;
 use crate::option::{Interactive, Monitor, Off};
 use crate::Env;
-use async_trait::async_trait;
 use std::cell::RefCell;
 use yash_syntax::input::{Context, Input, Result};
 use yash_syntax::syntax::Fd;
@@ -46,7 +45,6 @@ impl<'a, 'b, T> Reporter<'a, 'b, T> {
     }
 }
 
-#[async_trait(?Send)]
 impl<'a, 'b, T> Input for Reporter<'a, 'b, T>
 where
     T: Input,
@@ -122,7 +120,6 @@ mod tests {
         env.options.set(Monitor, On);
 
         struct InputMock(Rc<RefCell<SystemState>>);
-        #[async_trait::async_trait(?Send)]
         impl Input for InputMock {
             async fn next_line(&mut self, _: &Context) -> Result {
                 // The Report is expected to have shown the report before

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `impl yash_syntax::input::Input for Prompter` now conforms to the new
+  definition of the `next_line` method.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
     - yash-env 0.2.0 → 0.3.0
@@ -20,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Prompter<'a, 'b, T>`.
 - The redundant lifetime constraint `T: 'a` is removed from the implementation
   of `yash_syntax::input::Input` for `Prompter<'a, 'b, T>`.
+- Internal dependencies:
+    - async-trait 0.1.73
 
 ## [0.1.0] - 2024-07-13
 

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-async-trait = "0.1.73"
 futures-util = "0.3.28"
 yash-env = { path = "../yash-env", version = "0.3.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.3.0" }

--- a/yash-prompt/src/prompter.rs
+++ b/yash-prompt/src/prompter.rs
@@ -16,7 +16,6 @@
 
 //! Defines the `Prompter` decorator.
 
-use async_trait::async_trait;
 use std::cell::RefCell;
 use yash_env::input::{Context, Input, Result};
 use yash_env::variable::{VariableSet, PS1, PS2};
@@ -46,7 +45,6 @@ impl<'a, 'b, T> Prompter<'a, 'b, T> {
     }
 }
 
-#[async_trait(?Send)]
 impl<'a, 'b, T> Input for Prompter<'a, 'b, T>
 where
     T: Input,
@@ -126,7 +124,6 @@ mod tests {
         define_variable(&mut env, PS1, PS1_INITIAL_VALUE_NON_ROOT);
 
         struct InputMock(Rc<RefCell<SystemState>>);
-        #[async_trait::async_trait(?Send)]
         impl Input for InputMock {
             async fn next_line(&mut self, _: &Context) -> Result {
                 // The Prompter is expected to have shown the prompt before

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -25,7 +25,6 @@ yash-quote = { path = "../yash-quote", version = "1.1.1" }
 yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
 
 [dev-dependencies]
-async-trait = "0.1.73"
 futures-executor = "0.3.28"
 futures-util = { version = "0.3.28", features = ["channel"] }
 yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.1.0" }

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -199,7 +199,6 @@ mod tests {
     use super::*;
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
-    use async_trait::async_trait;
     use futures_util::FutureExt;
     use std::num::NonZeroU64;
     use std::rc::Rc;
@@ -397,7 +396,6 @@ mod tests {
     #[test]
     fn input_error_aborts_loop() {
         struct BrokenInput;
-        #[async_trait(?Send)]
         impl yash_syntax::input::Input for BrokenInput {
             async fn next_line(&mut self, _context: &Context) -> std::io::Result<String> {
                 Err(std::io::Error::new(std::io::ErrorKind::Other, "broken"))

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.1] - Unreleased
 
+### Added
+
+- `input::InputEx` trait
+    - This new trait is an object-safe version of `input::Input`.
+
 ### Changed
 
 - The `input::Input` trait is now `#[must_use]`.

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.1] - Unreleased
+## [0.12.0] - Unreleased
 
 ### Added
 
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `input::Input` trait is now `#[must_use]`.
+- The `input::Input::next_line` method now returns
+  `impl Future<Output = input::Result>`. This change reduces the number of
+  allocations when reading input lines.
+
+### Removed
+
+- Internal dependencies:
+    - async-trait 0.1.73
 
 ## [0.11.0] - 2024-08-22
 
@@ -326,7 +334,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
-[0.11.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.11.1
+[0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.11.0
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.9.0

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `input::InputEx` trait
+- `input::InputObject` trait
     - This new trait is an object-safe version of `input::Input`.
 
 ### Changed

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities", "parser-implementations"]
 
 [dependencies]
 annotate-snippets = { version = "0.11.4", optional = true }
-async-trait = "0.1.73"
 futures-util = "0.3.28"
 itertools = "0.13.0"
 thiserror = "1.0.47"

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -106,6 +106,29 @@ where
     }
 }
 
+/// Object-safe adapter for the [`Input`] trait
+///
+/// `InputEx` is an object-safe version of the [`Input`] trait. It allows the
+/// trait to be used as a trait object, which is necessary for dynamic dispatch.
+///
+/// The umbrella implementation is provided for all types that implement the
+/// [`Input`] trait.
+pub trait InputEx {
+    fn next_line<'a>(
+        &'a mut self,
+        context: &'a Context,
+    ) -> Pin<Box<dyn Future<Output = Result> + 'a>>;
+}
+
+impl<T: Input> InputEx for T {
+    fn next_line<'a>(
+        &'a mut self,
+        context: &'a Context,
+    ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
+        Box::pin(Input::next_line(self, context))
+    }
+}
+
 /// Input function that reads from a string in memory.
 pub struct Memory<'a> {
     lines: std::str::SplitInclusive<'a, char>,
@@ -128,7 +151,7 @@ impl Input for Memory<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Context, Input, Memory};
     use futures_util::FutureExt;
 
     #[test]

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -125,7 +125,7 @@ impl<T: Input> InputEx for T {
         &'a mut self,
         context: &'a Context,
     ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
-        Box::pin(Input::next_line(self, context))
+        Input::next_line(self, context)
     }
 }
 

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -16,7 +16,6 @@
 
 //! Methods about passing [source](crate::source) code to the [parser](crate::parser).
 
-use async_trait::async_trait;
 use std::future::Future;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -63,10 +62,11 @@ pub type Error = std::io::Error;
 /// Result of the [Input] function.
 pub type Result = std::result::Result<String, Error>;
 
-/// Line-oriented source code reader.
+/// Line-oriented source code reader
 ///
 /// An `Input` object provides the parser with source code by reading from underlying source.
-#[async_trait(?Send)]
+///
+/// [`InputEx`] is an object-safe version of this trait.
 #[must_use = "Input instances should be used by a parser"]
 pub trait Input {
     /// Reads a next line of the source code.
@@ -78,30 +78,15 @@ pub trait Input {
     ///
     /// Errors returned from this function are considered unrecoverable. Once an error is returned,
     /// this function should not be called any more.
-    ///
-    /// For object safety, this async method is declared to return the future in a pinning box.
-    async fn next_line(&mut self, context: &Context) -> Result;
+    fn next_line(&mut self, context: &Context) -> impl Future<Output = Result>;
 }
 
-// #[async_trait(?Send)]
 impl<T> Input for T
 where
     T: DerefMut,
     T::Target: Input,
 {
-    // Avoid a Box allocation by forwarding the call without using async_trait.
-    // async fn next_line(&mut self, context: &Context) -> Result {
-    //     self.deref_mut().next_line(context).await
-    // }
-    fn next_line<'s, 'c, 'f>(
-        &'s mut self,
-        context: &'c Context,
-    ) -> Pin<Box<dyn Future<Output = Result> + 'f>>
-    where
-        's: 'f,
-        'c: 'f,
-        Self: 'f,
-    {
+    fn next_line(&mut self, context: &Context) -> impl Future<Output = Result> {
         self.deref_mut().next_line(context)
     }
 }
@@ -125,7 +110,7 @@ impl<T: Input> InputEx for T {
         &'a mut self,
         context: &'a Context,
     ) -> Pin<Box<dyn Future<Output = Result> + 'a>> {
-        Input::next_line(self, context)
+        Box::pin(Input::next_line(self, context))
     }
 }
 
@@ -142,7 +127,6 @@ impl Memory<'_> {
     }
 }
 
-#[async_trait(?Send)]
 impl Input for Memory<'_> {
     async fn next_line(&mut self, _context: &Context) -> Result {
         Ok(self.lines.next().unwrap_or("").to_owned())

--- a/yash-syntax/src/input.rs
+++ b/yash-syntax/src/input.rs
@@ -64,9 +64,9 @@ pub type Result = std::result::Result<String, Error>;
 
 /// Line-oriented source code reader
 ///
-/// An `Input` object provides the parser with source code by reading from underlying source.
+/// An `Input` implementor provides the parser with source code by reading from underlying source.
 ///
-/// [`InputEx`] is an object-safe version of this trait.
+/// [`InputObject`] is an object-safe version of this trait.
 #[must_use = "Input instances should be used by a parser"]
 pub trait Input {
     /// Reads a next line of the source code.
@@ -93,19 +93,20 @@ where
 
 /// Object-safe adapter for the [`Input`] trait
 ///
-/// `InputEx` is an object-safe version of the [`Input`] trait. It allows the
-/// trait to be used as a trait object, which is necessary for dynamic dispatch.
+/// `InputObject` is an object-safe version of the [`Input`] trait. It allows
+/// the trait to be used as a trait object, which is necessary for dynamic
+/// dispatch.
 ///
 /// The umbrella implementation is provided for all types that implement the
 /// [`Input`] trait.
-pub trait InputEx {
+pub trait InputObject {
     fn next_line<'a>(
         &'a mut self,
         context: &'a Context,
     ) -> Pin<Box<dyn Future<Output = Result> + 'a>>;
 }
 
-impl<T: Input> InputEx for T {
+impl<T: Input> InputObject for T {
     fn next_line<'a>(
         &'a mut self,
         context: &'a Context,

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -21,7 +21,7 @@ use super::op::Operator;
 use crate::alias::Alias;
 use crate::alias::EmptyGlossary;
 use crate::input::Context;
-use crate::input::Input;
+use crate::input::InputEx;
 use crate::input::Memory;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
@@ -154,7 +154,7 @@ fn ex<I: IntoIterator<Item = SourceChar>>(i: I) -> impl Iterator<Item = SourceCh
 
 /// Core part of the lexical analyzer.
 struct LexerCore<'a> {
-    input: Box<dyn Input + 'a>,
+    input: Box<dyn InputEx + 'a>,
     state: InputState,
     raw_code: Rc<Code>,
     source: Vec<SourceCharEx>,
@@ -165,7 +165,7 @@ impl<'a> LexerCore<'a> {
     /// Creates a new lexer core that reads using the given input function.
     #[must_use]
     fn new(
-        input: Box<dyn Input + 'a>,
+        input: Box<dyn InputEx + 'a>,
         start_line_number: NonZeroU64,
         source: Rc<Source>,
     ) -> LexerCore<'a> {
@@ -454,7 +454,7 @@ impl<'a> Lexer<'a> {
     /// Creates a new lexer that reads using the given input function.
     #[must_use]
     pub fn new(
-        input: Box<dyn Input + 'a>,
+        input: Box<dyn InputEx + 'a>,
         start_line_number: NonZeroU64,
         source: Rc<Source>,
     ) -> Lexer<'a> {
@@ -838,6 +838,7 @@ impl<'a, 'b> DerefMut for WordLexer<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::Input;
     use crate::parser::error::ErrorCause;
     use crate::parser::error::SyntaxError;
     use assert_matches::assert_matches;

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -868,7 +868,6 @@ mod tests {
             }
         }
         impl std::error::Error for Failing {}
-        #[async_trait::async_trait(?Send)]
         impl Input for Failing {
             async fn next_line(&mut self, _: &Context) -> crate::input::Result {
                 Err(std::io::Error::new(std::io::ErrorKind::Other, Failing))
@@ -893,7 +892,6 @@ mod tests {
         struct InputMock {
             first: bool,
         }
-        #[async_trait::async_trait(?Send)]
         impl Input for InputMock {
             async fn next_line(&mut self, context: &Context) -> crate::input::Result {
                 assert_eq!(context.is_first_line(), self.first);

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -21,7 +21,7 @@ use super::op::Operator;
 use crate::alias::Alias;
 use crate::alias::EmptyGlossary;
 use crate::input::Context;
-use crate::input::InputEx;
+use crate::input::InputObject;
 use crate::input::Memory;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
@@ -154,7 +154,7 @@ fn ex<I: IntoIterator<Item = SourceChar>>(i: I) -> impl Iterator<Item = SourceCh
 
 /// Core part of the lexical analyzer.
 struct LexerCore<'a> {
-    input: Box<dyn InputEx + 'a>,
+    input: Box<dyn InputObject + 'a>,
     state: InputState,
     raw_code: Rc<Code>,
     source: Vec<SourceCharEx>,
@@ -165,7 +165,7 @@ impl<'a> LexerCore<'a> {
     /// Creates a new lexer core that reads using the given input function.
     #[must_use]
     fn new(
-        input: Box<dyn InputEx + 'a>,
+        input: Box<dyn InputObject + 'a>,
         start_line_number: NonZeroU64,
         source: Rc<Source>,
     ) -> LexerCore<'a> {
@@ -454,7 +454,7 @@ impl<'a> Lexer<'a> {
     /// Creates a new lexer that reads using the given input function.
     #[must_use]
     pub fn new(
-        input: Box<dyn InputEx + 'a>,
+        input: Box<dyn InputObject + 'a>,
         start_line_number: NonZeroU64,
         source: Rc<Source>,
     ) -> Lexer<'a> {

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -511,7 +511,6 @@ mod tests {
     #[test]
     fn lexer_operator_should_not_peek_beyond_newline() {
         struct OneLineInput(Option<String>);
-        #[async_trait::async_trait(?Send)]
         impl Input for OneLineInput {
             async fn next_line(&mut self, _: &Context) -> crate::input::Result {
                 if let Some(line) = self.0.take() {


### PR DESCRIPTION
This pull request splits the `Input` trait into two traits: `Input` and `InputObject`. The `Input` trait is no longer object-safe, but the `InputObject` trait is. This reduces the number of allocations made in the `next_line` method calls, especially when many `Input` decorators are nested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `InputObject` trait for improved input handling flexibility.
	- Updated the `next_line` method to return an `impl Future<Output = Result>`, optimizing performance.
  
- **Bug Fixes**
	- Removed asynchronous traits from several input implementations, streamlining their usage and improving compatibility.

- **Chores**
	- Removed the `async-trait` dependency from multiple projects, simplifying the codebase.

- **Documentation**
	- Updated changelogs to reflect changes and new features in the `yash-env` and `yash-syntax` projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->