### PR TITLE
New executor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Test yash-arith
       run: cargo test --all-features --package yash-arith
+    - name: Test yash-executor
+      run: cargo test --all-features --package yash-executor
     - name: Test yash-fnmatch
       run: cargo test --all-features --package yash-fnmatch
     - name: Test yash-quote

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,6 @@ dependencies = [
 [[package]]
 name = "yash-executor"
 version = "0.1.0"
-dependencies = [
- "futures-task",
-]
 
 [[package]]
 name = "yash-fnmatch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,6 @@ name = "yash-cli"
 version = "0.1.0-beta.2"
 dependencies = [
  "assert_matches",
- "futures-executor",
  "futures-util",
  "fuzed-iterator",
  "nix",
@@ -562,6 +561,7 @@ dependencies = [
  "thiserror",
  "yash-builtin",
  "yash-env",
+ "yash-executor",
  "yash-prompt",
  "yash-semantics",
  "yash-syntax",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "yash-executor"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "futures-task",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,9 @@ dependencies = [
 [[package]]
 name = "yash-executor"
 version = "0.1.0"
+dependencies = [
+ "futures-task",
+]
 
 [[package]]
 name = "yash-fnmatch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "yash-executor"
+version = "0.1.0"
+
+[[package]]
 name = "yash-fnmatch"
 version = "1.1.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ name = "yash-executor"
 version = "1.0.0"
 dependencies = [
  "futures-task",
+ "pin-utils",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ TBD
 
 Yash is distributed under [GPLv3](yash-cli/LICENSE-GPL).
 
-Exceptionally, you can reuse the `yash-fnmatch` and `yash-quote` crate in your
-software under the [MIT License](yash-quote/LICENSE-MIT) or [Apache License
-2.0](yash-quote/LICENSE-Apache), whichever at your option.
+Exceptionally, you can reuse the `yash-executor`, `yash-fnmatch` and
+`yash-quote` crates in your software under the
+[MIT License](yash-quote/LICENSE-MIT) or
+[Apache License 2.0](yash-quote/LICENSE-Apache), whichever at your option.

--- a/check-extra.sh
+++ b/check-extra.sh
@@ -10,6 +10,7 @@ cargo tomlfmt --dryrun --path yash-builtin/Cargo.toml
 cargo tomlfmt --dryrun --path yash-cli/Cargo.toml
 cargo tomlfmt --dryrun --path yash-env/Cargo.toml
 cargo tomlfmt --dryrun --path yash-env-test-helper/Cargo.toml
+cargo tomlfmt --dryrun --path yash-executor/Cargo.toml
 cargo tomlfmt --dryrun --path yash-fnmatch/Cargo.toml
 cargo tomlfmt --dryrun --path yash-prompt/Cargo.toml
 cargo tomlfmt --dryrun --path yash-quote/Cargo.toml
@@ -30,6 +31,7 @@ cargo build --package 'yash-builtin' --all-targets --no-default-features --featu
 cargo build --package 'yash-cli' --all-targets
 cargo build --package 'yash-env' --all-targets
 cargo build --package 'yash-env-test-helper' --all-targets
+cargo build --package 'yash-executor' --all-targets
 cargo build --package 'yash-fnmatch' --all-targets
 cargo build --package 'yash-prompt' --all-targets
 cargo build --package 'yash-quote' --all-targets

--- a/check-msrv.sh
+++ b/check-msrv.sh
@@ -36,6 +36,10 @@ update_workspace_member yash-env-test-helper
 cargo +nightly update -Z direct-minimal-versions
 cargo +1.79.0 test --package yash-env-test-helper -- $quiet
 
+update_workspace_member yash-executor
+cargo +nightly update -Z direct-minimal-versions
+cargo +1.65.0 test --package yash-executor -- $quiet
+
 update_workspace_member yash-fnmatch
 cargo +nightly update -Z direct-minimal-versions
 cargo +1.65.0 test --package yash-fnmatch -- $quiet

--- a/yash-cli/CHANGELOG-lib.md
+++ b/yash-cli/CHANGELOG-lib.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `default_rcfile_path`
     - `resolve_rcfile_path`
     - `DefaultFilePathError`
+- Internal dependencies:
+    - yash-executor 1.0.0
 
 ### Changed
 
@@ -51,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When the shell cannot open a script specified by the command-line argument,
   it now returns the exit status of 126 or 127 as required by POSIX. Previously,
   it returned the exit status of 2.
+
+### Removed
+
+- Internal dependencies:
+    - futures-executor 0.3.28
+    - futures-util 0.3.28
 
 ## [0.1.0-beta.2] - 2024-07-13
 

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -18,17 +18,17 @@ name = "yash3"
 path = "src/main.rs"
 
 [dependencies]
-futures-executor = "0.3.28"
-futures-util = { version = "0.3.28", features = ["channel"] }
 thiserror = "1.0.47"
 yash-builtin = { path = "../yash-builtin", version = "0.3.0" }
 yash-env = { path = "../yash-env", version = "0.3.0" }
+yash-executor = { path = "../yash-executor", version = "1.0.0" }
 yash-prompt = { path = "../yash-prompt", version = "0.1.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.3.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+futures-util = { version = "0.3.28", features = ["channel"] }
 fuzed-iterator = "1.0.0"
 nix = { version = "0.29.0", features = ["fs", "process", "term"] }
 tempfile = "3.8.0"

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -141,6 +141,8 @@ pub fn main() -> ! {
         let exit_status = parse_and_print(env).await;
         std::process::exit(exit_status.0);
     });
+    // SAFETY: We never create new threads in the whole process, so wakers are
+    // never shared between threads.
     unsafe { executor.spawn_pinned(task) }
     loop {
         executor.run_until_stalled();

--- a/yash-executor/CHANGELOG.md
+++ b/yash-executor/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to `yash-executor` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+This is the initial release.
+
+[0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-executor-0.1.0

--- a/yash-executor/CHANGELOG.md
+++ b/yash-executor/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to `yash-executor` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [1.0.0] - Unreleased
 
 This is the initial release.
 
-[0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-executor-0.1.0
+[1.0.0]: https://github.com/magicant/yash-rs/releases/tag/yash-executor-1.0.0

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "yash-executor"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/magicant/yash-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["concurrency", "executor", "single-threaded"]
 categories = ["asynchronous", "concurrency", "no-std"]
+
+[dependencies]
+futures-task = "0.3.30" # TODO Remove this dependency

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/magicant/yash-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["concurrency", "executor", "single-threaded"]
 categories = ["asynchronous", "concurrency", "no-std"]
+
+[dev-dependencies]
+futures-task = "0.3.30"

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -12,6 +12,3 @@ repository = "https://github.com/magicant/yash-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["concurrency", "executor", "single-threaded"]
 categories = ["asynchronous", "concurrency", "no-std"]
-
-[dependencies]
-futures-task = "0.3.30" # TODO Remove this dependency

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "yash-executor"
 version = "0.1.0"
+authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
-
-[dependencies]
+rust-version = "1.65.0"
+description = "single-threaded concurrent task executor"
+# documentation = "https://yash.osdn.jp/doc/"
+readme = "README.md"
+# homepage = "https://yash.osdn.jp/"
+repository = "https://github.com/magicant/yash-rs"
+license = "MIT OR Apache-2.0"
+keywords = ["concurrency", "executor", "single-threaded"]
+categories = ["asynchronous", "concurrency", "no-std"]

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-executor"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -15,3 +15,4 @@ categories = ["asynchronous", "concurrency", "no-std"]
 
 [dev-dependencies]
 futures-task = "0.3.30"
+pin-utils = "0.1.0"

--- a/yash-executor/LICENSE-Apache
+++ b/yash-executor/LICENSE-Apache
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/yash-executor/LICENSE-MIT
+++ b/yash-executor/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright 2024 WATANABE Yuki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/yash-executor/README.md
+++ b/yash-executor/README.md
@@ -1,0 +1,37 @@
+# Yash-executor
+
+`yash-executor` is a Rust library that provides a simple executor for running
+futures. It is designed to be used in single-threaded applications where you
+want to run futures concurrently, but you don't need to run them on multiple
+threads.
+
+[![yash-executor at crates.io](https://img.shields.io/crates/v/yash-executor.svg)](https://crates.io/crates/yash-executor)
+[![yash-executor at docs.rs](https://docs.rs/yash-executor/badge.svg)](https://docs.rs/yash-executor)
+[![Build status](https://github.com/magicant/yash-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/magicant/yash-rs/actions/workflows/rust.yml)
+
+- [Changelog](CHANGELOG.md)
+
+## License
+
+[MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-Apache), at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+## Similar crates
+
+The [`futures-executor`] crate's `LocalPool` is similar but rejects reentrant
+calls to `run`, etc. The `yash-executor` crate allows reentrant calls and is
+simpler in design.
+
+The [`async-executor`] crate provides `LocalExecutor` which is a wrapper around
+the thread-safe `Executor` and depends on locks for synchronization.
+The `yash-executor` crate is lock-free at the cost of unsafe spawning.
+
+The [`simple-async-local-executor`] crate is similar to `yash-executor` but
+also provides event signaling.
+
+[`futures-executor`]: https://crates.io/crates/futures-executor
+[`async-executor`]: https://crates.io/crates/async-executor
+[`simple-async-local-executor`]: https://crates.io/crates/simple-async-local-executor

--- a/yash-executor/README.md
+++ b/yash-executor/README.md
@@ -5,6 +5,10 @@ futures. It is designed to be used in single-threaded applications where you
 want to run futures concurrently, but you don't need to run them on multiple
 threads.
 
+This crate is free of locks and atomic operations at the cost of unsafe
+spawning. Wakers used in this crate are thread-unsafe and not guarded by locks
+or atomics, so you must ensure that wakers are not shared between threads.
+
 [![yash-executor at crates.io](https://img.shields.io/crates/v/yash-executor.svg)](https://crates.io/crates/yash-executor)
 [![yash-executor at docs.rs](https://docs.rs/yash-executor/badge.svg)](https://docs.rs/yash-executor)
 [![Build status](https://github.com/magicant/yash-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/magicant/yash-rs/actions/workflows/rust.yml)
@@ -22,15 +26,18 @@ dual licensed as above, without any additional terms or conditions.
 ## Similar crates
 
 The [`futures-executor`] crate's `LocalPool` is similar but rejects reentrant
-calls to `run`, etc. The `yash-executor` crate allows reentrant calls and is
-simpler in design.
+calls to `run`, etc. as it depends on thread-local states. The `yash-executor`
+crate allows creating and running multiple executors that work independently, so
+users can have more fine-grained control over how concurrent tasks are run.
 
 The [`async-executor`] crate provides `LocalExecutor` which is a wrapper around
 the thread-safe `Executor` and depends on locks for synchronization.
 The `yash-executor` crate is lock-free at the cost of unsafe spawning.
 
 The [`simple-async-local-executor`] crate is similar to `yash-executor` but
-also provides event signaling.
+also provides event signaling. Its implementation is free of locks and atomics
+but still safe because the `Waker` is a dummy and the `Executor` polls all
+futures even if not awakened.
 
 [`futures-executor`]: https://crates.io/crates/futures-executor
 [`async-executor`]: https://crates.io/crates/async-executor

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -61,6 +61,12 @@ impl<'a> Executor<'a> {
     ///
     /// This method panics if a task is polled recursively.
     pub fn run_until_stalled(&self) -> usize {
-        0 // TODO
+        let mut completed = 0;
+        while let Some(is_complete) = self.step() {
+            if is_complete {
+                completed += 1;
+            }
+        }
+        completed
     }
 }

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -1,0 +1,43 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+//! Implementation of `Executor`
+
+use crate::Executor;
+
+impl Executor {
+    /// Creates a new `Executor` with an empty task queue.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // TODO wake_count
+
+    // TODO spawn_pinned method
+    // TODO spawn method that takes a non-pinned future
+
+    /// Runs a task that has been woken up.
+    ///
+    /// This method removes a single task from the task queue and polls it.
+    /// Returns:
+    /// - `Some(true)` if the task is complete
+    /// - `Some(false)` if the task is not complete
+    /// - `None` if there are no tasks to run
+    ///
+    /// This method panics if the task is polled recursively.
+    pub fn step(&self) -> Option<bool> {
+        todo!()
+    }
+
+    /// Runs tasks until there are no more tasks to run.
+    ///
+    /// This method repeatedly calls `step` until it returns `None`, that is,
+    /// there are no more tasks that have been woken up. Returns the number of
+    /// completed tasks.
+    ///
+    /// This method panics if a task is polled recursively.
+    pub fn run_until_stalled(&self) -> usize {
+        todo!()
+    }
+}

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -5,7 +5,7 @@
 
 use crate::Executor;
 
-impl Executor {
+impl<'a> Executor<'a> {
     /// Creates a new `Executor` with an empty task queue.
     #[must_use]
     pub fn new() -> Self {
@@ -15,7 +15,7 @@ impl Executor {
     // TODO wake_count
 
     // TODO spawn_pinned method
-    // TODO spawn method that takes a non-pinned future
+    // TODO spawn method that takes a non-pinned future that may return a non-unit output
 
     /// Runs a task that has been woken up.
     ///

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -28,8 +28,15 @@ impl<'a> Executor<'a> {
     /// The added task is not polled immediately. It will be polled when the
     /// executor runs tasks.
     ///
-    /// TODO: This method should be unsafe
-    pub fn spawn_pinned(&self, future: Pin<Box<dyn Future<Output = ()> + 'a>>) {
+    /// # Safety
+    ///
+    /// It may be surprising that this method is unsafe. The reason is that the
+    /// `Waker` available in the `Context` passed to the future's `poll` method
+    /// is thread-unsafe despite `Waker` being `Send` and `Sync`. The `Waker` is
+    /// not protected by a lock or atomic operation, and it is your sole
+    /// responsibility to ensure that the `Waker` is not passed to or accessed
+    /// from other threads.
+    pub unsafe fn spawn_pinned(&self, future: Pin<Box<dyn Future<Output = ()> + 'a>>) {
         let task = Task {
             executor: Rc::downgrade(&self.state),
             future: RefCell::new(Some(future)),

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -27,6 +27,8 @@ impl<'a> Executor<'a> {
     ///
     /// The added task is not polled immediately. It will be polled when the
     /// executor runs tasks.
+    ///
+    /// TODO: This method should be unsafe
     pub fn spawn_pinned(&self, future: Pin<Box<dyn Future<Output = ()> + 'a>>) {
         let task = Task {
             executor: Rc::downgrade(&self.state),
@@ -47,7 +49,8 @@ impl<'a> Executor<'a> {
     ///
     /// This method panics if the task is polled recursively.
     pub fn step(&self) -> Option<bool> {
-        Some(self.state.borrow_mut().wake_queue.pop_front()?.poll())
+        let task = self.state.borrow_mut().wake_queue.pop_front()?;
+        Some(task.poll())
     }
 
     /// Runs tasks until there are no more tasks to run.

--- a/yash-executor/src/executor.rs
+++ b/yash-executor/src/executor.rs
@@ -3,7 +3,7 @@
 
 //! Implementation of `Executor`
 
-use crate::forwarder::{forwarder, Receiver, SendError};
+use crate::forwarder::{forwarder, Receiver};
 use crate::{Executor, ExecutorState, Spawner, Task};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -123,8 +123,7 @@ impl<'a> ExecutorState<'a> {
         let task = Task {
             executor: Rc::downgrade(this),
             future: RefCell::new(Some(Box::pin(async move {
-                let send_result = sender.send(future.await);
-                debug_assert!(!matches!(send_result, Err((_, SendError::AlreadySent))));
+                sender.send(future.await).unwrap_or_default()
             }))),
         };
         this.borrow_mut().wake_queue.push_back(Rc::new(task));

--- a/yash-executor/src/forwarder.rs
+++ b/yash-executor/src/forwarder.rs
@@ -96,7 +96,7 @@ pub enum TryReceiveError {
 impl<T> Sender<T> {
     /// Sends a value to the receiver.
     ///
-    /// The value is sent to the receiver. If the the receiver has been dropped,
+    /// The value is sent to the receiver. If the receiver has been dropped,
     /// the value is returned back to the caller.
     ///
     /// This method consumes the sender, ensuring that the value is sent at most

--- a/yash-executor/src/forwarder.rs
+++ b/yash-executor/src/forwarder.rs
@@ -10,6 +10,7 @@
 
 use alloc::rc::{Rc, Weak};
 use core::cell::RefCell;
+use core::fmt::Display;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
@@ -159,3 +160,24 @@ impl<T> Future for Receiver<T> {
         }
     }
 }
+
+impl Display for SendError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SendError::ReceiverDropped => "receiver already dropped".fmt(f),
+            SendError::AlreadySent => "result already sent".fmt(f),
+        }
+    }
+}
+
+impl Display for TryReceiveError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TryReceiveError::SenderDropped => "sender already dropped".fmt(f),
+            TryReceiveError::NotSent => "result not sent yet".fmt(f),
+            TryReceiveError::AlreadyReceived => "result already received".fmt(f),
+        }
+    }
+}
+
+// TODO Bump MSRV to 1.81.0 to impl core::error::Error for SendError and TryReceiveError

--- a/yash-executor/src/forwarder.rs
+++ b/yash-executor/src/forwarder.rs
@@ -118,7 +118,6 @@ impl<T> Receiver<T> {
                     Err(TryReceiveError::NotSent)
                 }
             }
-            Relay::Done => Err(TryReceiveError::AlreadyReceived),
 
             Relay::Computed(_) => {
                 let Relay::Computed(value) = core::mem::replace(relay, Relay::Done) else {
@@ -126,6 +125,8 @@ impl<T> Receiver<T> {
                 };
                 Ok(value)
             }
+
+            Relay::Done => Err(TryReceiveError::AlreadyReceived),
         }
     }
 }

--- a/yash-executor/src/forwarder.rs
+++ b/yash-executor/src/forwarder.rs
@@ -1,0 +1,159 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+//! Utilities for forwarding the result of a future to another future
+//!
+//! The [`forwarder`] function creates a pair of [`Sender`] and [`Receiver`] that
+//! can be used to forward the result of a future to another future. The sender
+//! half is used to send the result, and the receiver half is used to receive the
+//! result.
+
+use alloc::rc::{Rc, Weak};
+use core::cell::RefCell;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+
+/// State shared between the sender and receiver
+#[derive(Debug)]
+enum Relay<T> {
+    /// The result has not been computed yet, and the receiver has not been polled.
+    Pending,
+    /// The result has not been computed yet, and the receiver has been polled.
+    Polled(Waker),
+    /// The result has been computed, but the receiver has not received it yet.
+    Computed(T),
+    /// The receiver has received the result.
+    Done,
+}
+
+/// Sender half of the forwarder
+#[derive(Debug)]
+pub struct Sender<T> {
+    relay: Weak<RefCell<Relay<T>>>,
+}
+
+/// Receiver half of the forwarder
+#[derive(Debug)]
+pub struct Receiver<T> {
+    relay: Rc<RefCell<Relay<T>>>,
+}
+
+/// Creates a new forwarder.
+#[must_use]
+pub fn forwarder<T>() -> (Sender<T>, Receiver<T>) {
+    let relay = Rc::new(RefCell::new(Relay::Pending));
+    let sender = Sender {
+        relay: Rc::downgrade(&relay),
+    };
+    let receiver = Receiver { relay };
+    (sender, receiver)
+}
+
+/// Error returned when sending a value fails
+///
+/// This error may be returned from the [`Sender::send`] method.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SendError {
+    /// The receiver has been dropped.
+    ReceiverDropped,
+    /// The value has already been sent.
+    AlreadySent,
+}
+
+/// Error returned when receiving a value fails
+///
+/// This error may be returned from the [`Receiver::try_receive`] method.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TryReceiveError {
+    /// The sender has been dropped.
+    SenderDropped,
+    /// The value has not been sent yet.
+    NotSent,
+    /// The value has already been received.
+    AlreadyReceived,
+}
+
+impl<T> Sender<T> {
+    /// Sends a value to the receiver.
+    pub fn send(&self, value: T) -> Result<(), (T, SendError)> {
+        let Some(relay) = self.relay.upgrade() else {
+            return Err((value, SendError::ReceiverDropped));
+        };
+
+        let relay = &mut *relay.borrow_mut();
+        match relay {
+            Relay::Pending => {
+                *relay = Relay::Computed(value);
+                Ok(())
+            }
+
+            Relay::Polled(_) => {
+                let Relay::Polled(waker) = core::mem::replace(relay, Relay::Computed(value)) else {
+                    unreachable!()
+                };
+                waker.wake();
+                Ok(())
+            }
+
+            Relay::Computed(_) | Relay::Done => Err((value, SendError::AlreadySent)),
+        }
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Receives a value from the sender.
+    ///
+    /// This method is similar to [`poll()`](Self::poll), but it does not
+    /// require a `Context` argument. If the value has not been sent yet, this
+    /// method returns `Err(TryReceiveError::NotSent)`.
+    pub fn try_receive(&self) -> Result<T, TryReceiveError> {
+        if Rc::weak_count(&self.relay) == 0 {
+            return Err(TryReceiveError::SenderDropped);
+        }
+
+        let relay = &mut *self.relay.borrow_mut();
+        match relay {
+            Relay::Pending | Relay::Polled(_) => Err(TryReceiveError::NotSent),
+            Relay::Done => Err(TryReceiveError::AlreadyReceived),
+
+            Relay::Computed(_) => {
+                let Relay::Computed(value) = core::mem::replace(relay, Relay::Done) else {
+                    unreachable!()
+                };
+                Ok(value)
+            }
+        }
+    }
+}
+
+impl<T> Future for Receiver<T> {
+    type Output = T;
+
+    /// Polls the receiver to receive the value.
+    ///
+    /// This method is similar to [`try_receive()`](Self::try_receive), but it
+    /// requires a `Context` argument. If the value has not been sent yet, this
+    /// method returns `Poll::Pending` and stores the `Waker` from the `Context`
+    /// for waking up the task when the value is sent.
+    ///
+    /// This method should not be called after the value has been received.
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<T> {
+        let relay = &mut *self.relay.borrow_mut();
+        match relay {
+            Relay::Pending | Relay::Polled(_) => {
+                *relay = Relay::Polled(context.waker().clone());
+                Poll::Pending
+            }
+
+            Relay::Computed(_) => {
+                let Relay::Computed(value) = core::mem::replace(relay, Relay::Done) else {
+                    unreachable!()
+                };
+                Poll::Ready(value)
+            }
+
+            Relay::Done => panic!("Receiver polled after receiving the value"),
+        }
+    }
+}

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -1,3 +1,9 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+#![no_std]
+extern crate alloc;
+
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -30,7 +30,7 @@ use core::pin::Pin;
 ///
 /// `Executor` implements `Clone` but all clones share the same set of tasks.
 /// Separately created `Executor` instances do not share tasks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Executor {
     state: Rc<RefCell<ExecutorState>>,
 }
@@ -44,12 +44,17 @@ pub struct Executor {
 /// `Spawner`s maintain a weak reference to the executor state, so they do not
 /// prevent the executor from being deallocated. If the executor is deallocated,
 /// the `Spawner` will not be able to spawn any more tasks.
-#[derive(Clone, Debug)]
+///
+/// To obtain a `Spawner` from an `Executor`, use the [`Executor::spawner`]
+/// method. The [`dead()`](Self::dead) and `default()` functions return a
+/// `Spawner` that cannot spawn tasks.
+#[derive(Clone, Debug, Default)]
 pub struct Spawner {
     state: Weak<RefCell<ExecutorState>>,
 }
 
 /// Internal state of the executor
+#[derive(Default)]
 struct ExecutorState {
     /// Queue of woken tasks to be executed
     ///
@@ -86,3 +91,8 @@ struct Task {
     /// it again.
     future: RefCell<Option<Pin<Box<dyn Future<Output = ()>>>>>,
 }
+
+mod executor;
+mod spawner;
+mod task;
+mod waker;

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -98,3 +98,5 @@ mod executor;
 mod spawner;
 mod task;
 mod waker;
+
+pub use spawner::SpawnError;

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -42,8 +42,8 @@ pub struct Executor {
 ///
 /// `Spawner` instances can be cloned and share the same executor state.
 /// `Spawner`s maintain a weak reference to the executor state, so they do not
-/// prevent the executor from being deallocated. If the executor is deallocated,
-/// the `Spawner` will not be able to spawn any more tasks.
+/// prevent the executor from being dropped. If the executor is dropped, the
+/// `Spawner` will not be able to spawn any more tasks.
 ///
 /// To obtain a `Spawner` from an `Executor`, use the [`Executor::spawner`]
 /// method. The [`dead()`](Self::dead) and `default()` functions return a

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -36,7 +36,8 @@
 //!
 //! [`Spawner`]s provide a subset of the functionality of [`Executor`] to allow
 //! spawning tasks without access to the full executor. It is useful for adding
-//! tasks from within another task without creating cyclic
+//! tasks from within another task without creating cyclic dependencies, which
+//! can cause memory leaks.
 //!
 //! The [`forwarder`] module provides utilities for forwarding the result of a
 //! future to another future. The [`forwarder`](forwarder::forwarder) function

--- a/yash-executor/src/lib.rs
+++ b/yash-executor/src/lib.rs
@@ -92,6 +92,8 @@ struct Task<'a> {
     future: RefCell<Option<Pin<Box<dyn Future<Output = ()> + 'a>>>>,
 }
 
+pub mod forwarder;
+
 mod executor;
 mod spawner;
 mod task;

--- a/yash-executor/src/spawner.rs
+++ b/yash-executor/src/spawner.rs
@@ -10,7 +10,7 @@ use core::cell::RefCell;
 use core::future::Future;
 use core::pin::Pin;
 
-impl Spawner {
+impl<'a> Spawner<'a> {
     /// Creates a dummy `Spawner` that is not associated with any executor and
     /// thus cannot spawn tasks.
     #[must_use]
@@ -22,7 +22,7 @@ impl Spawner {
 
     /// Creates a new `Spawner` that will add tasks to the given executor state.
     #[must_use]
-    pub(crate) fn with_executor_state(state: Weak<RefCell<ExecutorState>>) -> Self {
+    pub(crate) fn with_executor_state(state: Weak<RefCell<ExecutorState<'a>>>) -> Self {
         Self { state }
     }
 
@@ -36,12 +36,12 @@ impl Spawner {
     pub unsafe fn spawn_pinned(
         &self,
         future: Pin<Box<dyn Future<Output = ()>>>,
-    ) -> Result<(), Pin<Box<dyn Future<Output = ()>>>> {
+    ) -> Result<(), Pin<Box<dyn Future<Output = ()> + 'a>>> {
         // if let Some(state) = self.state.upgrade() {
         //     state.borrow_mut().spawn(future);
         // }
         todo!()
     }
 
-    // TODO spawn method that takes a non-pinned future
+    // TODO spawn method that takes a non-pinned future that may return a non-unit output
 }

--- a/yash-executor/src/spawner.rs
+++ b/yash-executor/src/spawner.rs
@@ -32,7 +32,14 @@ impl<'a> Spawner<'a> {
     /// If the executor has been dropped, this method will return the future
     /// back to the caller.
     ///
-    /// This method is unsafe because TODO
+    /// # Safety
+    ///
+    /// It may be surprising that this method is unsafe. The reason is that the
+    /// `Waker` available in the `Context` passed to the future's `poll` method
+    /// is thread-unsafe despite `Waker` being `Send` and `Sync`. The `Waker` is
+    /// not protected by a lock or atomic operation, and it is your sole
+    /// responsibility to ensure that the `Waker` is not passed to or accessed
+    /// from other threads.
     pub unsafe fn spawn_pinned(
         &self,
         future: Pin<Box<dyn Future<Output = ()>>>,

--- a/yash-executor/src/spawner.rs
+++ b/yash-executor/src/spawner.rs
@@ -29,9 +29,9 @@ impl Spawner {
     /// Adds the given future to the executor's task queue so that it will be
     /// polled when the executor is run.
     ///
-    /// If the executor has been deallocated, this method will return the future
+    /// If the executor has been dropped, this method will return the future
     /// back to the caller.
-    /// 
+    ///
     /// This method is unsafe because TODO
     pub unsafe fn spawn_pinned(
         &self,

--- a/yash-executor/src/spawner.rs
+++ b/yash-executor/src/spawner.rs
@@ -1,0 +1,47 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+//! Implementation of `Spawner`
+
+use crate::{ExecutorState, Spawner};
+use alloc::boxed::Box;
+use alloc::rc::Weak;
+use core::cell::RefCell;
+use core::future::Future;
+use core::pin::Pin;
+
+impl Spawner {
+    /// Creates a dummy `Spawner` that is not associated with any executor and
+    /// thus cannot spawn tasks.
+    #[must_use]
+    pub fn dead() -> Self {
+        Self {
+            state: Default::default(),
+        }
+    }
+
+    /// Creates a new `Spawner` that will add tasks to the given executor state.
+    #[must_use]
+    pub(crate) fn with_executor_state(state: Weak<RefCell<ExecutorState>>) -> Self {
+        Self { state }
+    }
+
+    /// Adds the given future to the executor's task queue so that it will be
+    /// polled when the executor is run.
+    ///
+    /// If the executor has been deallocated, this method will return the future
+    /// back to the caller.
+    /// 
+    /// This method is unsafe because TODO
+    pub unsafe fn spawn_pinned(
+        &self,
+        future: Pin<Box<dyn Future<Output = ()>>>,
+    ) -> Result<(), Pin<Box<dyn Future<Output = ()>>>> {
+        // if let Some(state) = self.state.upgrade() {
+        //     state.borrow_mut().spawn(future);
+        // }
+        todo!()
+    }
+
+    // TODO spawn method that takes a non-pinned future
+}

--- a/yash-executor/src/spawner.rs
+++ b/yash-executor/src/spawner.rs
@@ -56,6 +56,7 @@ impl<'a> Spawner<'a> {
     /// not protected by a lock or atomic operation, and it is your sole
     /// responsibility to ensure that the `Waker` is not passed to or accessed
     /// from other threads.
+    #[allow(clippy::type_complexity)]
     pub unsafe fn spawn_pinned(
         &self,
         future: Pin<Box<dyn Future<Output = ()> + 'a>>,

--- a/yash-executor/src/task.rs
+++ b/yash-executor/src/task.rs
@@ -7,7 +7,7 @@ use crate::Task;
 use alloc::rc::Rc;
 use core::task::{Context, Waker};
 
-impl Task {
+impl Task<'_> {
     /// Wakes the task so that it will be polled again by the executor.
     pub fn wake(self: Rc<Self>) {
         todo!()
@@ -29,9 +29,9 @@ impl Task {
                 if self.executor.strong_count() == 0 {
                     todo!("executor has been dropped");
                 }
-                // let waker = futures_task::noop_waker();
-                // let mut context = Context::from_waker(&waker);
-                // let poll = future.as_mut().poll(&mut context);
+                let waker = futures_task::noop_waker();
+                let mut context = Context::from_waker(&waker);
+                let poll = future.as_mut().poll(&mut context);
                 true // TODO false if poll is not ready
             }
         }
@@ -59,15 +59,13 @@ mod tests {
 
     #[test]
     fn polling_ready_future() {
-        let executor = Rc::default();
         let polled = Rc::new(Cell::new(false));
+        let executor = Rc::default();
         let task = Rc::new(Task {
             executor: Rc::downgrade(&executor),
-            future: RefCell::new(Some(Box::pin(async {
-                // TODO polled.set(true);
-            }))),
+            future: RefCell::new(Some(Box::pin(async { polled.set(true) }))),
         });
         assert!(task.poll());
-        // TODO assert!(polled.get());
+        assert!(polled.get());
     }
 }

--- a/yash-executor/src/task.rs
+++ b/yash-executor/src/task.rs
@@ -34,9 +34,7 @@ impl Task<'_> {
     /// If `self.executor` has been dropped or the task is polled recursively,
     /// this method panics.
     pub fn poll(self: &Rc<Self>) -> bool {
-        if self.executor.strong_count() == 0 {
-            panic!("executor has been dropped");
-        }
+        assert_ne!(self.executor.strong_count(), 0, "executor has been dropped");
 
         let mut future_or_none = self
             .future

--- a/yash-executor/src/task.rs
+++ b/yash-executor/src/task.rs
@@ -22,21 +22,24 @@ impl Task<'_> {
     /// If `self.executor` has been dropped or the task is polled recursively,
     /// this method panics.
     pub fn poll(self: &Rc<Self>) -> bool {
-        let mut future = self.future.borrow_mut();
-        match future.as_mut() {
-            None => todo!(),
-            Some(future) => {
-                if self.executor.strong_count() == 0 {
-                    todo!("executor has been dropped");
-                }
-                let waker = futures_task::noop_waker();
-                let mut context = Context::from_waker(&waker);
-                let poll = future.as_mut().poll(&mut context);
-                true // TODO false if poll is not ready
-            }
+        let mut future_or_none = self
+            .future
+            .try_borrow_mut()
+            .expect("future polled recursively");
+        let Some(future) = future_or_none.as_mut() else {
+            return true;
+        };
+        if self.executor.strong_count() == 0 {
+            todo!("executor has been dropped");
         }
-
-        // TODO Change self.future to None if the future is complete
+        let waker = futures_task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        let poll = future.as_mut().poll(&mut context);
+        let is_ready = poll.is_ready();
+        if is_ready {
+            *future_or_none = None;
+        }
+        is_ready
     }
 }
 
@@ -46,10 +49,11 @@ mod tests {
     use alloc::boxed::Box;
     use alloc::rc::Weak;
     use core::cell::{Cell, RefCell};
+    use core::future::pending;
 
     #[test]
     #[should_panic = "executor has been dropped"]
-    fn polling_without_executor() {
+    fn polling_without_executor_panics() {
         let task = Rc::new(Task {
             executor: Weak::new(),
             future: RefCell::new(Some(Box::pin(async { unreachable!() }))),
@@ -67,5 +71,46 @@ mod tests {
         });
         assert!(task.poll());
         assert!(polled.get());
+    }
+
+    #[test]
+    fn polling_pending_future() {
+        let executor = Rc::default();
+        let task = Rc::new(Task {
+            executor: Rc::downgrade(&executor),
+            future: RefCell::new(Some(Box::pin(pending()))),
+        });
+        assert!(!task.poll());
+    }
+
+    #[test]
+    fn polling_pending_future_again_should_do_nothing() {
+        let poll_count = Rc::new(Cell::new(0));
+        let executor = Rc::default();
+        let task = Rc::new(Task {
+            executor: Rc::downgrade(&executor),
+            future: RefCell::new(Some(Box::pin(async {
+                poll_count.set(poll_count.get() + 1)
+            }))),
+        });
+        assert!(task.poll());
+        assert_eq!(poll_count.get(), 1);
+        assert!(task.poll());
+        assert_eq!(poll_count.get(), 1);
+    }
+
+    #[test]
+    #[should_panic = "future polled recursively"]
+    fn recursive_poll_panics() {
+        let executor = Rc::default();
+        let task = Rc::new(Task {
+            executor: Rc::downgrade(&executor),
+            future: RefCell::new(None),
+        });
+        let task2 = Rc::clone(&task);
+        *task.future.borrow_mut() = Some(Box::pin(async move {
+            task2.poll();
+        }));
+        task.poll();
     }
 }

--- a/yash-executor/src/task.rs
+++ b/yash-executor/src/task.rs
@@ -1,0 +1,24 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+//! Implementation of `Task`
+
+use crate::Task;
+use alloc::boxed::Box;
+
+impl Task {
+    /// Wakes the task so that it will be polled again by the executor.
+    pub fn wake(self: Box<Self>) {
+        todo!()
+    }
+
+    /// Polls the future contained in the task.
+    ///
+    /// If the future completes, this method returns `true` and will do
+    /// nothing on subsequent calls. If the future is not complete, this
+    /// method returns `false`.
+    pub fn poll(self) -> bool {
+        todo!()
+        // TODO Change self.future to None if the future is complete
+    }
+}

--- a/yash-executor/src/waker.rs
+++ b/yash-executor/src/waker.rs
@@ -36,7 +36,7 @@ const VTABLE: &RawWakerVTable = &RawWakerVTable::new(clone, wake, wake_by_ref, d
 /// When the returned `Waker` is woken, the task will be enqueued to be polled
 /// by the executor.
 #[must_use]
-pub fn into_waker(task: Rc<Task>) -> Waker {
+pub(crate) fn into_waker(task: Rc<Task>) -> Waker {
     let data = Rc::into_raw(task).cast();
     let raw_waker = RawWaker::new(data, VTABLE);
     unsafe { Waker::from_raw(raw_waker) }

--- a/yash-executor/src/waker.rs
+++ b/yash-executor/src/waker.rs
@@ -1,0 +1,4 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+//! Implementation of `Waker`

--- a/yash-executor/src/waker.rs
+++ b/yash-executor/src/waker.rs
@@ -2,3 +2,42 @@
 // Copyright (C) 2024 WATANABE Yuki
 
 //! Implementation of `Waker`
+//!
+//! This module provides a function to convert a `Task` into a `Waker`. The
+//! `RawWaker`'s data pointer is a `Rc<Task>`, and the `RawWakerVTable` contains
+//! functions to clone, wake, wake by reference, and drop the `Rc<Task>`.
+
+use crate::Task;
+use alloc::rc::Rc;
+use core::task::{RawWaker, RawWakerVTable, Waker};
+
+unsafe fn clone(data: *const ()) -> RawWaker {
+    Rc::<Task>::increment_strong_count(data.cast());
+    RawWaker::new(data, VTABLE)
+}
+
+unsafe fn wake(data: *const ()) {
+    Rc::<Task>::from_raw(data.cast()).wake();
+}
+
+unsafe fn wake_by_ref(data: *const ()) {
+    Rc::<Task>::increment_strong_count(data.cast());
+    Rc::<Task>::from_raw(data.cast()).wake();
+}
+
+unsafe fn drop(data: *const ()) {
+    Rc::<Task>::decrement_strong_count(data.cast());
+}
+
+const VTABLE: &RawWakerVTable = &RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+
+/// Converts a `Task` into a `Waker`.
+///
+/// When the returned `Waker` is woken, the task will be enqueued to be polled
+/// by the executor.
+#[must_use]
+pub fn into_waker(task: Rc<Task>) -> Waker {
+    let data = Rc::into_raw(task).cast();
+    let raw_waker = RawWaker::new(data, VTABLE);
+    unsafe { Waker::from_raw(raw_waker) }
+}

--- a/yash-executor/tests/executor.rs
+++ b/yash-executor/tests/executor.rs
@@ -1,0 +1,97 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+use yash_executor::Executor;
+
+mod spawn_pinned {
+    use super::*;
+
+    #[test]
+    fn increases_wake_count() {
+        let executor = Executor::new();
+        assert_eq!(executor.wake_count(), 0);
+
+        executor.spawn_pinned(Box::pin(async {}));
+        assert_eq!(executor.wake_count(), 1);
+    }
+
+    #[test]
+    fn does_not_poll_added_future() {
+        let executor = Executor::new();
+        executor.spawn_pinned(Box::pin(async { unreachable!() }));
+    }
+}
+
+mod step {
+    use super::*;
+    use std::cell::Cell;
+    use std::future::{pending, poll_fn};
+    use std::task::Poll;
+
+    #[test]
+    fn returns_none_when_no_tasks() {
+        let executor = Executor::new();
+        assert_eq!(executor.step(), None);
+    }
+
+    #[test]
+    fn returns_false_when_task_not_complete() {
+        let executor = Executor::new();
+        executor.spawn_pinned(Box::pin(pending()));
+        assert_eq!(executor.step(), Some(false));
+    }
+
+    #[test]
+    fn returns_true_when_task_complete() {
+        let executor = Executor::new();
+        executor.spawn_pinned(Box::pin(async {}));
+        assert_eq!(executor.step(), Some(true));
+    }
+
+    #[test]
+    fn removes_task_from_wake_queue() {
+        let executor = Executor::new();
+        executor.spawn_pinned(Box::pin(async {}));
+        executor.step();
+        assert_eq!(executor.wake_count(), 0);
+    }
+
+    #[test]
+    #[ignore = "TODO: task needs to poll with valid waker"]
+    fn supports_yielding_future() {
+        let poll_count = Cell::new(0);
+        let executor = Executor::new();
+        executor.spawn_pinned(Box::pin(poll_fn(|cx| match poll_count.get() {
+            0 => {
+                poll_count.set(1);
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            1 => {
+                poll_count.set(2);
+                Poll::Ready(())
+            }
+            _ => unreachable!(),
+        })));
+
+        executor.step();
+        assert_eq!(poll_count.get(), 1);
+
+        executor.step();
+        assert_eq!(poll_count.get(), 2);
+    }
+
+    // TODO supports spawning tasks within tasks
+}
+
+mod run_until_stalled {
+    use super::*;
+
+    #[test]
+    fn returns_zero_when_no_tasks() {
+        let executor = Executor::new();
+        assert_eq!(executor.run_until_stalled(), 0);
+    }
+
+    // TODO
+}

--- a/yash-executor/tests/executor.rs
+++ b/yash-executor/tests/executor.rs
@@ -41,7 +41,7 @@ mod spawn {
     #[test]
     fn does_not_poll_added_future() {
         let executor = Executor::new();
-        let _: Receiver<()> = unsafe { executor.spawn(async { unreachable!() }) };
+        let _receiver: Receiver<()> = unsafe { executor.spawn(async { unreachable!() }) };
     }
 
     #[test]

--- a/yash-executor/tests/executor.rs
+++ b/yash-executor/tests/executor.rs
@@ -57,7 +57,6 @@ mod step {
     }
 
     #[test]
-    #[ignore = "TODO: task needs to poll with valid waker"]
     fn supports_yielding_future() {
         let poll_count = Cell::new(0);
         let executor = Executor::new();

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -31,26 +31,26 @@ fn sender_can_be_dropped_before_receiving() {
 
 #[test]
 fn send_to_dropped_receiver() {
-    let (sender, _) = forwarder::<()>();
-    let send_result = sender.send(());
-    assert_eq!(send_result, Err(((), SendError::ReceiverDropped)));
+    let (sender, _) = forwarder::<u32>();
+    let send_result = sender.send(42);
+    assert_eq!(send_result, Err((42, SendError::ReceiverDropped)));
 }
 
 #[test]
 fn send_after_send() {
-    let (sender, _receiver) = forwarder::<()>();
-    sender.send(()).unwrap();
-    let send_result = sender.send(());
-    assert_eq!(send_result, Err(((), SendError::AlreadySent)));
+    let (sender, _receiver) = forwarder::<u32>();
+    sender.send(1).unwrap();
+    let send_result = sender.send(2);
+    assert_eq!(send_result, Err((2, SendError::AlreadySent)));
 }
 
 #[test]
 fn send_after_received() {
-    let (sender, receiver) = forwarder::<()>();
-    sender.send(()).unwrap();
+    let (sender, receiver) = forwarder::<u32>();
+    sender.send(1).unwrap();
     receiver.try_receive().unwrap();
-    let send_result = sender.send(());
-    assert_eq!(send_result, Err(((), SendError::AlreadySent)));
+    let send_result = sender.send(2);
+    assert_eq!(send_result, Err((2, SendError::AlreadySent)));
 }
 
 #[test]

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -20,6 +20,16 @@ fn send_and_try_receive() {
 }
 
 #[test]
+fn sender_can_be_dropped_before_receiving() {
+    let (sender, receiver) = forwarder::<u32>();
+    let send_result = sender.send(42);
+    drop(sender);
+    assert_eq!(send_result, Ok(()));
+    let receive_result = receiver.try_receive();
+    assert_eq!(receive_result, Ok(42));
+}
+
+#[test]
 fn send_to_dropped_receiver() {
     let (sender, _) = forwarder::<()>();
     let send_result = sender.send(());

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -20,37 +20,10 @@ fn send_and_try_receive() {
 }
 
 #[test]
-fn sender_can_be_dropped_before_receiving() {
-    let (sender, receiver) = forwarder::<u32>();
-    let send_result = sender.send(42);
-    drop(sender);
-    assert_eq!(send_result, Ok(()));
-    let receive_result = receiver.try_receive();
-    assert_eq!(receive_result, Ok(42));
-}
-
-#[test]
 fn send_to_dropped_receiver() {
     let (sender, _) = forwarder::<u32>();
     let send_result = sender.send(42);
     assert_eq!(send_result, Err(42));
-}
-
-#[test]
-fn send_after_send() {
-    let (sender, _receiver) = forwarder::<u32>();
-    sender.send(1).unwrap();
-    let send_result = sender.send(2);
-    assert_eq!(send_result, Err(2));
-}
-
-#[test]
-fn send_after_received() {
-    let (sender, receiver) = forwarder::<u32>();
-    sender.send(1).unwrap();
-    receiver.try_receive().unwrap();
-    let send_result = sender.send(2);
-    assert_eq!(send_result, Err(2));
 }
 
 #[test]

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -2,10 +2,10 @@
 // Copyright (C) 2024 WATANABE Yuki
 
 use futures_task::noop_waker_ref;
+use pin_utils::pin_mut;
 use std::cell::Cell;
 use std::future::poll_fn;
 use std::future::Future as _;
-use std::pin::pin;
 use std::task::{Context, Poll};
 use yash_executor::forwarder::*;
 use yash_executor::Executor;
@@ -53,7 +53,7 @@ fn try_receive_after_received() {
 fn try_receive_does_not_modify_waker() {
     let received = Cell::new(false);
     let (sender, receiver) = forwarder::<()>();
-    let mut receiver = pin!(receiver);
+    pin_mut!(receiver); // TODO std::pin::pin requires Rust 1.68.0
     let executor = Executor::new();
     unsafe {
         executor.spawn_pinned(Box::pin(poll_fn(|context| {
@@ -122,7 +122,7 @@ fn second_poll_overwrites_waker() {
 
     let received = Cell::new(false);
     let (sender, receiver) = forwarder::<()>();
-    let mut receiver = pin!(receiver);
+    pin_mut!(receiver); // TODO std::pin::pin requires Rust 1.68.0
     let executor = Executor::new();
     unsafe {
         executor.spawn_pinned(Box::pin(poll_fn(|context| {

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -1,0 +1,184 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+use futures_task::noop_waker_ref;
+use std::cell::Cell;
+use std::future::poll_fn;
+use std::future::Future as _;
+use std::pin::pin;
+use std::task::{Context, Poll};
+use yash_executor::forwarder::*;
+use yash_executor::Executor;
+
+#[test]
+fn send_and_try_receive() {
+    let (sender, receiver) = forwarder::<u32>();
+    let send_result = sender.send(42);
+    assert_eq!(send_result, Ok(()));
+    let receive_result = receiver.try_receive();
+    assert_eq!(receive_result, Ok(42));
+}
+
+#[test]
+fn send_to_dropped_receiver() {
+    let (sender, _) = forwarder::<()>();
+    let send_result = sender.send(());
+    assert_eq!(send_result, Err(((), SendError::ReceiverDropped)));
+}
+
+#[test]
+fn send_after_send() {
+    let (sender, _receiver) = forwarder::<()>();
+    sender.send(()).unwrap();
+    let send_result = sender.send(());
+    assert_eq!(send_result, Err(((), SendError::AlreadySent)));
+}
+
+#[test]
+fn send_after_received() {
+    let (sender, receiver) = forwarder::<()>();
+    sender.send(()).unwrap();
+    receiver.try_receive().unwrap();
+    let send_result = sender.send(());
+    assert_eq!(send_result, Err(((), SendError::AlreadySent)));
+}
+
+#[test]
+fn try_receive_without_send() {
+    let (_sender, receiver) = forwarder::<()>();
+    let result = receiver.try_receive();
+    assert_eq!(result, Err(TryReceiveError::NotSent));
+}
+
+#[test]
+fn try_receive_from_dropped_sender() {
+    let (_, receiver) = forwarder::<()>();
+    let result = receiver.try_receive();
+    assert_eq!(result, Err(TryReceiveError::SenderDropped));
+}
+
+#[test]
+fn try_receive_after_received() {
+    let (sender, receiver) = forwarder::<()>();
+    sender.send(()).unwrap();
+    receiver.try_receive().unwrap();
+    let result = receiver.try_receive();
+    assert_eq!(result, Err(TryReceiveError::AlreadyReceived));
+}
+
+#[test]
+fn try_receive_does_not_modify_waker() {
+    let received = Cell::new(false);
+    let (sender, receiver) = forwarder::<()>();
+    let mut receiver = pin!(receiver);
+    let executor = Executor::new();
+    unsafe {
+        executor.spawn_pinned(Box::pin(poll_fn(|context| {
+            let poll = receiver.as_mut().poll(context);
+            if poll.is_pending() {
+                assert_eq!(receiver.try_receive(), Err(TryReceiveError::NotSent));
+            } else {
+                received.set(true);
+            }
+            poll
+        })));
+    }
+
+    // This polls the above task for the first time, in which the receiver is
+    // not ready. The `try_receive` method is called but should not modify the
+    // waker set in the `poll` call.
+    executor.run_until_stalled();
+
+    sender.send(()).unwrap();
+
+    // This polls the above task for the second time, in which the receiver is
+    // ready. The `received` flag should be set.
+    executor.run_until_stalled();
+    assert!(received.get());
+}
+
+#[test]
+fn send_and_poll() {
+    let received = Cell::new(false);
+    let (sender, receiver) = forwarder::<u32>();
+    sender.send(42).unwrap();
+    let executor = Executor::new();
+    unsafe {
+        executor.spawn_pinned(Box::pin(async {
+            let result = receiver.await;
+            assert_eq!(result, 42);
+            received.set(true);
+        }));
+    }
+    executor.run_until_stalled();
+    assert!(received.get());
+}
+
+#[test]
+fn poll_and_send() {
+    let received = Cell::new(false);
+    let (sender, receiver) = forwarder::<u32>();
+    let executor = Executor::new();
+    unsafe {
+        executor.spawn_pinned(Box::pin(async {
+            let result = receiver.await;
+            assert_eq!(result, 42);
+            received.set(true);
+        }));
+    }
+    executor.run_until_stalled();
+    sender.send(42).unwrap();
+    executor.run_until_stalled();
+    assert!(received.get());
+}
+
+#[test]
+fn second_poll_overwrites_waker() {
+    // It is important that the relay keeps the waker from the last poll so that
+    // it can wake the correct task.
+
+    let received = Cell::new(false);
+    let (sender, receiver) = forwarder::<()>();
+    let mut receiver = pin!(receiver);
+    let executor = Executor::new();
+    unsafe {
+        executor.spawn_pinned(Box::pin(poll_fn(|context| {
+            let mut null_context = Context::from_waker(noop_waker_ref());
+            match receiver.as_mut().poll(&mut null_context) {
+                Poll::Pending => receiver.as_mut().poll(context),
+                Poll::Ready(()) => {
+                    received.set(true);
+                    Poll::Ready(())
+                }
+            }
+        })));
+    }
+
+    // This polls the above task for the first time, in which the receiver is
+    // not ready. This involves two calls to `poll` on the receiver, and the
+    // context from the second call is stored in the relay.
+    executor.run_until_stalled();
+
+    sender.send(()).unwrap();
+
+    // This polls the above task for the second time, in which the receiver is
+    // ready. The first call to `poll` on the receiver should return `Ready`,
+    // so the `received` flag should be set.
+    executor.run_until_stalled();
+    assert!(received.get());
+}
+
+#[test]
+#[should_panic = "polled after receiving"]
+fn poll_after_received() {
+    let (sender, mut receiver) = forwarder::<()>();
+    sender.send(()).unwrap();
+    let executor = Executor::new();
+    unsafe {
+        executor.spawn_pinned(Box::pin(async {
+            (&mut receiver).await;
+            receiver.await;
+        }));
+    }
+    executor.run_until_stalled();
+}

--- a/yash-executor/tests/forwarder.rs
+++ b/yash-executor/tests/forwarder.rs
@@ -33,7 +33,7 @@ fn sender_can_be_dropped_before_receiving() {
 fn send_to_dropped_receiver() {
     let (sender, _) = forwarder::<u32>();
     let send_result = sender.send(42);
-    assert_eq!(send_result, Err((42, SendError::ReceiverDropped)));
+    assert_eq!(send_result, Err(42));
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn send_after_send() {
     let (sender, _receiver) = forwarder::<u32>();
     sender.send(1).unwrap();
     let send_result = sender.send(2);
-    assert_eq!(send_result, Err((2, SendError::AlreadySent)));
+    assert_eq!(send_result, Err(2));
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn send_after_received() {
     sender.send(1).unwrap();
     receiver.try_receive().unwrap();
     let send_result = sender.send(2);
-    assert_eq!(send_result, Err((2, SendError::AlreadySent)));
+    assert_eq!(send_result, Err(2));
 }
 
 #[test]

--- a/yash-executor/tests/spawner.rs
+++ b/yash-executor/tests/spawner.rs
@@ -1,0 +1,71 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+
+use futures_task::noop_waker_ref;
+use std::cell::Cell;
+use std::task::Context;
+use yash_executor::{Executor, Spawner};
+
+#[test]
+fn dead_spawner_does_nothing() {
+    let run = Cell::new(false);
+    let spawner = Spawner::dead();
+
+    let result = unsafe { spawner.spawn_pinned(Box::pin(async { run.set(true) })) };
+    assert!(!run.get());
+
+    // Make sure the returned future is the same as the one passed in
+    let mut future = result.unwrap_err();
+    let mut context = Context::from_waker(noop_waker_ref());
+    let poll = future.as_mut().poll(&mut context);
+    assert!(poll.is_ready());
+    assert!(run.get());
+}
+
+#[test]
+fn spawner_does_nothing_after_executor_was_dropped() {
+    let run = Cell::new(false);
+    let spawner = Executor::new().spawner();
+
+    let result = unsafe { spawner.spawn_pinned(Box::pin(async { run.set(true) })) };
+    assert!(!run.get());
+
+    // Make sure the returned future is the same as the one passed in
+    let mut future = result.unwrap_err();
+    let mut context = Context::from_waker(noop_waker_ref());
+    let poll = future.as_mut().poll(&mut context);
+    assert!(poll.is_ready());
+    assert!(run.get());
+}
+
+#[test]
+fn spawning_task_outside_task() {
+    let run = Cell::new(false);
+    let executor = Executor::new();
+    let spawner = executor.spawner();
+
+    let result = unsafe { spawner.spawn_pinned(Box::pin(async { run.set(true) })) };
+    assert!(result.is_ok());
+    assert!(!run.get());
+    assert_eq!(executor.wake_count(), 1);
+
+    executor.step();
+    assert!(run.get());
+}
+
+#[test]
+fn spawning_task_inside_task() {
+    let executor = Executor::new();
+    let spawner = executor.spawner();
+    unsafe {
+        executor.spawn_pinned(Box::pin(async move {
+            let result = spawner.spawn_pinned(Box::pin(async {}));
+            assert!(result.is_ok());
+        }));
+    }
+
+    executor.step();
+    assert_eq!(executor.wake_count(), 1);
+    executor.step();
+    assert_eq!(executor.wake_count(), 0);
+}

--- a/yash-executor/tests/spawner.rs
+++ b/yash-executor/tests/spawner.rs
@@ -2,9 +2,9 @@
 // Copyright (C) 2024 WATANABE Yuki
 
 use futures_task::noop_waker_ref;
+use pin_utils::pin_mut;
 use std::cell::Cell;
 use std::future::Future as _;
-use std::pin::pin;
 use std::task::Context;
 use yash_executor::forwarder::TryReceiveError;
 use yash_executor::{Executor, Spawner};
@@ -86,7 +86,8 @@ mod spawn {
         assert!(!run.get());
 
         // Make sure the returned future is the same as the one passed in
-        let mut future = pin!(result.unwrap_err().0);
+        let future = result.unwrap_err().0;
+        pin_mut!(future); // TODO std::pin::pin requires Rust 1.68.0
         let mut context = Context::from_waker(noop_waker_ref());
         let poll = future.as_mut().poll(&mut context);
         assert!(poll.is_ready());
@@ -102,7 +103,8 @@ mod spawn {
         assert!(!run.get());
 
         // Make sure the returned future is the same as the one passed in
-        let mut future = pin!(result.unwrap_err().0);
+        let future = result.unwrap_err().0;
+        pin_mut!(future); // TODO std::pin::pin requires Rust 1.68.0
         let mut context = Context::from_waker(noop_waker_ref());
         let poll = future.as_mut().poll(&mut context);
         assert!(poll.is_ready());

--- a/yash-fnmatch/README.md
+++ b/yash-fnmatch/README.md
@@ -28,6 +28,10 @@ assert_eq!(p.find("string"), Some(2..6));
 
 [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-Apache), at your option
 
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
 ## Similar crates
 
 `yash-fnmatch` is very similar to the

--- a/yash-quote/README.md
+++ b/yash-quote/README.md
@@ -26,6 +26,10 @@ assert_eq!(quote("'$foo'"), Owned::<str>(r#""'\$foo'""#.to_owned()));
 
 [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-Apache), at your option
 
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
 ## Similar crates
 
 - [`r-shquote`](https://crates.io/crates/r-shquote) provides a function that always quotes using single quotes.


### PR DESCRIPTION
This pull request introduces a custom executor for running concurrent tasks. This is in preparation for a refactoring of the `System::new_child_process` API, in which we will need an executor implementation that allows multiple instances of itself to work independently. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced the `yash-executor` library for managing asynchronous tasks in a single-threaded environment.
  - Added a new job in the GitHub Actions workflow for testing the `yash-executor` package.
  - Updated licensing information to include the `yash-executor` crate under MIT and Apache licenses.

- **Bug Fixes**
  - Improved exit status handling to adhere to POSIX standards.

- **Documentation**
  - Added `CHANGELOG.md` and updated `README.md` files for the `yash-executor` package, detailing its functionality and usage.

- **Tests**
  - Implemented comprehensive unit tests for the `Executor`, `Spawner`, and `forwarder` functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->