### PR TITLE
Use yash-executor in child processes of RealSystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "thiserror",
  "unix_path",
  "unix_str",
+ "yash-executor",
  "yash-quote",
  "yash-syntax",
 ]

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The child process created by `system::real::RealSystem::new_child_process`
   now uses a new executor instead of reusing the executor inherited from the
   parent process.
+- `system::ChildProcessStarter` has been redefined as
+  `Box<dyn FnOnce(&mut Env, ChildProcessTask) -> Pid>`. The function now
+  directly returns the PID of the child process instead of a future that
+  resolves to the PID.
 - `system::virtual::FileBody` is now `non_exhaustive`.
 - `system::virtual::VirtualSystem::isatty` now returns true for a file
   descriptor associated with `FileBody::Terminal`.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This `Input` decorator implements the behavior of the `ignoreeof` shell option.
 - `system::virtual::FileBody::Terminal`
     - This is a new variant of `FileBody` that represents a terminal device.
+- Internal dependencies:
+    - yash-executor 1.0.0
 
 ### Changed
 
+- The child process created by `system::real::RealSystem::new_child_process`
+  now uses a new executor instead of reusing the executor inherited from the
+  parent process.
 - `system::virtual::FileBody` is now `non_exhaustive`.
 - `system::virtual::VirtualSystem::isatty` now returns true for a file
   descriptor associated with `FileBody::Terminal`.

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -31,6 +31,7 @@ yash-syntax = { path = "../yash-syntax", version = "0.11.0", features = ["annota
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["fs", "signal", "user"] }
+yash-executor = { path = "../yash-executor", version = "1.0.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -199,7 +199,7 @@ where
 
         // Start the child
         let child = mask_guard.env.system.new_child_process()?;
-        let child_pid = child(mask_guard.env, task).await;
+        let child_pid = child(mask_guard.env, task);
 
         // The finishing
         if job_control.is_some() {

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -543,9 +543,7 @@ pub type ChildProcessTask =
 /// This function only starts the child, which continues to run asynchronously
 /// after the function returns its PID. To wait for the child to finish and
 /// obtain its exit status, use [`System::wait`].
-pub type ChildProcessStarter = Box<
-    dyn for<'a> FnOnce(&'a mut Env, ChildProcessTask) -> Pin<Box<dyn Future<Output = Pid> + 'a>>,
->;
+pub type ChildProcessStarter = Box<dyn FnOnce(&mut Env, ChildProcessTask) -> Pid>;
 
 /// Extension for [`System`]
 ///

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -671,35 +671,31 @@ impl System for RealSystem {
     /// process ID. In the child, the starter runs the task and exits the
     /// process.
     fn new_child_process(&mut self) -> Result<ChildProcessStarter> {
-        use nix::unistd::ForkResult::*;
-        // SAFETY: As stated on RealSystem::new, the caller is responsible for
-        // making only one instance of RealSystem in the process.
-        match unsafe { nix::unistd::fork()? } {
-            Parent { child } => Ok(Box::new(move |_env, _task| {
-                Box::pin(std::future::ready(Pid::from_nix(child)))
-            })),
-
-            Child => Ok(Box::new(|env, task| {
-                Box::pin(async move {
-                    let system = env.system.clone();
-                    // Here we create a new executor to run the task. This makes sure that any
-                    // other concurrent tasks in the parent process do not interfere with the
-                    // child process.
-                    let executor = Executor::new();
-                    let task = Box::pin(async move {
-                        task(env).await;
-                        std::process::exit(env.exit_status.0)
-                    });
-                    // SAFETY: We never create new threads in the whole process, so wakers are
-                    // never shared between threads.
-                    unsafe { executor.spawn_pinned(task) }
-                    loop {
-                        executor.run_until_stalled();
-                        system.select(false).ok();
-                    }
-                })
-            })),
+        let raw_pid = unsafe { nix::libc::fork() }.errno_if_m1()?;
+        if raw_pid != 0 {
+            // Parent process
+            return Ok(Box::new(move |_env, _task| Pid(raw_pid)));
         }
+
+        // Child process
+        Ok(Box::new(|env, task| {
+            let system = env.system.clone();
+            // Here we create a new executor to run the task. This makes sure that any
+            // other concurrent tasks in the parent process do not interfere with the
+            // child process.
+            let executor = Executor::new();
+            let task = Box::pin(async move {
+                task(env).await;
+                std::process::exit(env.exit_status.0)
+            });
+            // SAFETY: We never create new threads in the whole process, so wakers are
+            // never shared between threads.
+            unsafe { executor.spawn_pinned(task) }
+            loop {
+                executor.run_until_stalled();
+                system.select(false).ok();
+            }
+        }))
     }
 
     fn wait(&mut self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -84,6 +84,7 @@ use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
+use yash_executor::Executor;
 
 trait ErrnoIfM1: PartialEq + Sized {
     const MINUS_1: Self;
@@ -677,10 +678,25 @@ impl System for RealSystem {
             Parent { child } => Ok(Box::new(move |_env, _task| {
                 Box::pin(std::future::ready(Pid::from_nix(child)))
             })),
+
             Child => Ok(Box::new(|env, task| {
                 Box::pin(async move {
-                    task(env).await;
-                    std::process::exit(env.exit_status.0)
+                    let system = env.system.clone();
+                    // Here we create a new executor to run the task. This makes sure that any
+                    // other concurrent tasks in the parent process do not interfere with the
+                    // child process.
+                    let executor = Executor::new();
+                    let task = Box::pin(async move {
+                        task(env).await;
+                        std::process::exit(env.exit_status.0)
+                    });
+                    // SAFETY: We never create new threads in the whole process, so wakers are
+                    // never shared between threads.
+                    unsafe { executor.spawn_pinned(task) }
+                    loop {
+                        executor.run_until_stalled();
+                        system.select(false).ok();
+                    }
                 })
             })),
         }

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -839,7 +839,7 @@ impl System for VirtualSystem {
     /// the same process.
     ///
     /// To run the concurrent task, this function needs an executor that has
-    /// been set in the system state. If the system state does not have an
+    /// been set in the [`SystemState`]. If the system state does not have an
     /// executor, this function fails with `Errno::ENOSYS`.
     ///
     /// The process ID of the child will be the maximum of existing process IDs

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -859,43 +859,41 @@ impl System for VirtualSystem {
 
         let state = Rc::clone(&self.state);
         Ok(Box::new(move |parent_env, task| {
-            Box::pin(async move {
-                let mut system = VirtualSystem { state, process_id };
-                let mut child_env = parent_env.clone_with_system(Box::new(system.clone()));
+            let mut system = VirtualSystem { state, process_id };
+            let mut child_env = parent_env.clone_with_system(Box::new(system.clone()));
 
+            {
+                let mut process = system.current_process_mut();
+                process.selector = Rc::downgrade(&child_env.system.0);
+            }
+
+            let run_task_and_set_exit_status = Box::pin(async move {
+                let mut runner = ProcessRunner {
+                    task: task(&mut child_env),
+                    system,
+                    waker: Rc::new(Cell::new(None)),
+                };
+                (&mut runner).await;
+
+                let ProcessRunner { system, .. } = { runner };
+                let mut state = system.state.borrow_mut();
+                let process = state
+                    .processes
+                    .get_mut(&process_id)
+                    .expect("missing child process");
+                if process.state == ProcessState::Running
+                    && process.set_state(ProcessState::exited(child_env.exit_status))
                 {
-                    let mut process = system.current_process_mut();
-                    process.selector = Rc::downgrade(&child_env.system.0);
+                    let ppid = process.ppid;
+                    raise_sigchld(&mut state, ppid);
                 }
+            });
 
-                let run_task_and_set_exit_status = Box::pin(async move {
-                    let mut runner = ProcessRunner {
-                        task: task(&mut child_env),
-                        system,
-                        waker: Rc::new(Cell::new(None)),
-                    };
-                    (&mut runner).await;
+            executor
+                .spawn(run_task_and_set_exit_status)
+                .expect("the executor failed to start the child process task");
 
-                    let ProcessRunner { system, .. } = { runner };
-                    let mut state = system.state.borrow_mut();
-                    let process = state
-                        .processes
-                        .get_mut(&process_id)
-                        .expect("missing child process");
-                    if process.state == ProcessState::Running
-                        && process.set_state(ProcessState::exited(child_env.exit_status))
-                    {
-                        let ppid = process.ppid;
-                        raise_sigchld(&mut state, ppid);
-                    }
-                });
-
-                executor
-                    .spawn(run_task_and_set_exit_status)
-                    .expect("the executor failed to start the child process task");
-
-                process_id
-            })
+            process_id
         }))
     }
 
@@ -2120,13 +2118,11 @@ mod tests {
 
     #[test]
     fn setpgid_creating_new_group_from_parent() {
-        let (system, mut executor) = virtual_system_with_executor();
+        let (system, _executor) = virtual_system_with_executor();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child = env.system.new_child_process().unwrap();
-        let future = child(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid = executor.run_until(future);
-        executor.run_until_stalled();
+        let pid = child(&mut env, Box::new(|_env| Box::pin(pending())));
 
         let result = env.system.setpgid(pid, pid);
         assert_eq!(result, Ok(()));
@@ -2141,7 +2137,7 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child = env.system.new_child_process().unwrap();
-        let future = child(
+        let pid = child(
             &mut env,
             Box::new(|child_env| {
                 Box::pin(async move {
@@ -2150,7 +2146,6 @@ mod tests {
                 })
             }),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let pgid = state.borrow().processes[&pid].pgid();
@@ -2159,17 +2154,14 @@ mod tests {
 
     #[test]
     fn setpgid_extending_existing_group_from_parent() {
-        let (system, mut executor) = virtual_system_with_executor();
+        let (system, _executor) = virtual_system_with_executor();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child_1 = env.system.new_child_process().unwrap();
-        let future = child_1(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid_1 = executor.run_until(future);
+        let pid_1 = child_1(&mut env, Box::new(|_env| Box::pin(pending())));
         env.system.setpgid(pid_1, pid_1).unwrap();
         let child_2 = env.system.new_child_process().unwrap();
-        let future = child_2(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid_2 = executor.run_until(future);
-        executor.run_until_stalled();
+        let pid_2 = child_2(&mut env, Box::new(|_env| Box::pin(pending())));
 
         let result = env.system.setpgid(pid_2, pid_1);
         assert_eq!(result, Ok(()));
@@ -2180,13 +2172,11 @@ mod tests {
 
     #[test]
     fn setpgid_with_nonexisting_pid() {
-        let (system, mut executor) = virtual_system_with_executor();
+        let (system, _executor) = virtual_system_with_executor();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child = env.system.new_child_process().unwrap();
-        let future = child(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid = executor.run_until(future);
-        executor.run_until_stalled();
+        let pid = child(&mut env, Box::new(|_env| Box::pin(pending())));
 
         let dummy_pid = Pid(123);
         let result = env.system.setpgid(dummy_pid, dummy_pid);
@@ -2203,7 +2193,7 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child = env.system.new_child_process().unwrap();
-        let future = child(
+        let _pid = child(
             &mut env,
             Box::new(move |child_env| {
                 Box::pin(async move {
@@ -2212,7 +2202,6 @@ mod tests {
                 })
             }),
         );
-        let _pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let pgid = state.borrow().processes[&parent_pid].pgid();
@@ -2234,7 +2223,7 @@ mod tests {
         state.borrow_mut().file_system.save(path, content).unwrap();
         let mut env = Env::with_system(Box::new(system));
         let child = env.system.new_child_process().unwrap();
-        let future = child(
+        let pid = child(
             &mut env,
             Box::new(move |child_env| {
                 Box::pin(async move {
@@ -2243,7 +2232,6 @@ mod tests {
                 })
             }),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let result = env.system.setpgid(pid, pid);
@@ -2259,12 +2247,10 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Box::new(system));
         let child_1 = env.system.new_child_process().unwrap();
-        let future = child_1(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid_1 = executor.run_until(future);
+        let pid_1 = child_1(&mut env, Box::new(|_env| Box::pin(pending())));
         // env.system.setpgid(pid_1, pid_1).unwrap();
         let child_2 = env.system.new_child_process().unwrap();
-        let future = child_2(&mut env, Box::new(|_env| Box::pin(pending())));
-        let pid_2 = executor.run_until(future);
+        let pid_2 = child_2(&mut env, Box::new(|_env| Box::pin(pending())));
         executor.run_until_stalled();
 
         let result = env.system.setpgid(pid_2, pid_1);
@@ -2318,7 +2304,7 @@ mod tests {
 
     #[test]
     fn new_child_process_with_executor() {
-        let (mut system, mut executor) = virtual_system_with_executor();
+        let (mut system, _executor) = virtual_system_with_executor();
 
         let result = system.new_child_process();
 
@@ -2328,21 +2314,19 @@ mod tests {
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = result.unwrap();
-        let future = child_process(&mut env, Box::new(|_env| Box::pin(async {})));
-        let pid = executor.run_until(future);
+        let pid = child_process(&mut env, Box::new(|_env| Box::pin(async {})));
         assert_eq!(pid, Pid(3));
     }
 
     #[test]
     fn wait_for_running_child() {
-        let (mut system, mut executor) = virtual_system_with_executor();
+        let (mut system, _executor) = virtual_system_with_executor();
 
         let child_process = system.new_child_process();
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = child_process.unwrap();
-        let future = child_process(&mut env, Box::new(|_env| Box::pin(async move {})));
-        let pid = executor.run_until(future);
+        let pid = child_process(&mut env, Box::new(|_env| Box::pin(async move {})));
 
         let result = env.system.wait(pid);
         assert_eq!(result, Ok(None))
@@ -2356,15 +2340,10 @@ mod tests {
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = child_process.unwrap();
-        let future = child_process(
+        let pid = child_process(
             &mut env,
-            Box::new(|env| {
-                Box::pin(async move {
-                    env.exit_status = ExitStatus(5);
-                })
-            }),
+            Box::new(|env| Box::pin(async move { env.exit_status = ExitStatus(5) })),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
@@ -2379,7 +2358,7 @@ mod tests {
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = child_process.unwrap();
-        let future = child_process(
+        let pid = child_process(
             &mut env,
             Box::new(|env| {
                 Box::pin(async move {
@@ -2389,7 +2368,6 @@ mod tests {
                 })
             }),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
@@ -2413,7 +2391,7 @@ mod tests {
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = child_process.unwrap();
-        let future = child_process(
+        let pid = child_process(
             &mut env,
             Box::new(|env| {
                 Box::pin(async move {
@@ -2423,7 +2401,6 @@ mod tests {
                 })
             }),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         let result = env.system.wait(pid);
@@ -2438,7 +2415,7 @@ mod tests {
 
         let mut env = Env::with_system(Box::new(system));
         let child_process = child_process.unwrap();
-        let future = child_process(
+        let pid = child_process(
             &mut env,
             Box::new(|env| {
                 Box::pin(async move {
@@ -2449,7 +2426,6 @@ mod tests {
                 })
             }),
         );
-        let pid = executor.run_until(future);
         executor.run_until_stalled();
 
         env.system
@@ -2492,8 +2468,7 @@ mod tests {
         let child_process = system.new_child_process().unwrap();
 
         let mut env = Env::with_system(Box::new(system));
-        let future = child_process(&mut env, Box::new(|_env| Box::pin(async {})));
-        executor.run_until(future);
+        let _pid = child_process(&mut env, Box::new(|_env| Box::pin(async {})));
         executor.run_until_stalled();
 
         assert_eq!(env.system.caught_signals(), [SIGCHLD]);


### PR DESCRIPTION
- Makes `RealSystem::new_child_process` safer with possible existence of other concurrent tasks
- Simplifies the definition of `ChildProcessStarter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency, `yash-executor` version 1.0.0, enhancing child process management.
	- Updated child process initiation to allow for synchronous execution, improving control flow.

- **Documentation**
	- Clarified API documentation regarding child process management and the usage of `new_child_process` and `ChildProcessStarter`.

- **Bug Fixes**
	- Streamlined logic in the `VirtualSystem` implementation for better readability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->