### PR TITLE
Release yash-0.1.0 and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "0.1.0-beta.2"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env-test-helper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "futures-executor",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -636,7 +636,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_matches",
  "enumset",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.4.0] - 2024-09-29
 
 ### Added
 
@@ -38,8 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a function that returns an error of type `Errno` instead of `std::io::Error`.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
-    - yash-env 0.2.0 → 0.3.0
-    - yash-syntax 0.10.0 → 0.11.0
+    - yash-env 0.2.0 → 0.4.0
+    - yash-semantics 0.3.0 → 0.4.0 (optional)
+    - yash-syntax 0.10.0 → 0.12.0
+- Internal dependency versions:
+    - yash-prompt 0.1.0 → 0.2.0 (optional)
 
 ## [0.3.0] - 2024-07-13
 

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -24,15 +24,15 @@ either = "1.9.0"
 enumset = { version = "1.1.2", optional = true }
 itertools = "0.13.0"
 thiserror = "1.0.47"
-yash-env = { path = "../yash-env", version = "0.3.0" }
-yash-prompt = { path = "../yash-prompt", version = "0.1.0", optional = true }
+yash-env = { path = "../yash-env", version = "0.4.0" }
+yash-prompt = { path = "../yash-prompt", version = "0.2.0", optional = true }
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
-yash-semantics = { path = "../yash-semantics", version = "0.3.0", optional = true }
-yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
+yash-semantics = { path = "../yash-semantics", version = "0.4.0", optional = true }
+yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 futures-executor = "0.3.28"
 futures-util = { version = "0.3.28", features = ["channel"] }
-yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.1.0" }
-yash-semantics = { path = "../yash-semantics", version = "0.3.0" }
+yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.2.0" }
+yash-semantics = { path = "../yash-semantics", version = "0.4.0" }

--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -8,7 +8,7 @@ implementing library crate are in [CHANGELOG-lib.md](CHANGELOG-lib.md).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0-beta.3] - Unreleased
+## [0.1.0] - 2024-09-29
 
 ### Added
 
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
-[0.1.0-beta.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.3
+[0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0
 [0.1.0-beta.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.1
 [0.1.0-alpha.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-alpha.1

--- a/yash-cli/CHANGELOG-lib.md
+++ b/yash-cli/CHANGELOG-lib.md
@@ -9,7 +9,7 @@ For changes to the shell binary as a whole, see [CHANGELOG-bin.md](CHANGELOG-bin
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0-beta.3] - Unreleased
+## [0.1.0] - 2024-09-29
 
 ### Added
 
@@ -45,8 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       now also applied to the input from any file.)
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
-    - yash-env 0.2.0 → 0.3.0
-    - yash-syntax 0.10.0 → 0.11.0
+    - yash-env 0.2.0 → 0.4.0
+    - yash-syntax 0.10.0 → 0.12.0
+- Internal dependency versions:
+    - yash-builtin 0.3.0 → 0.4.0
+    - yash-prompt 0.1.0 → 0.2.0
+    - yash-semantics 0.3.0 → 0.4.0
 
 ### Fixed
 
@@ -117,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-cli` crate
 
-[0.1.0-beta.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.3
+[0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0
 [0.1.0-beta.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-beta.1
 [0.1.0-alpha.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.1.0-alpha.1

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "0.1.0-beta.2"
+version = "0.1.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -19,12 +19,12 @@ path = "src/main.rs"
 
 [dependencies]
 thiserror = "1.0.47"
-yash-builtin = { path = "../yash-builtin", version = "0.3.0" }
-yash-env = { path = "../yash-env", version = "0.3.0" }
+yash-builtin = { path = "../yash-builtin", version = "0.4.0" }
+yash-env = { path = "../yash-env", version = "0.4.0" }
 yash-executor = { path = "../yash-executor", version = "1.0.0" }
-yash-prompt = { path = "../yash-prompt", version = "0.1.0" }
-yash-semantics = { path = "../yash-semantics", version = "0.3.0" }
-yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
+yash-prompt = { path = "../yash-prompt", version = "0.2.0" }
+yash-semantics = { path = "../yash-semantics", version = "0.4.0" }
+yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/yash-env-test-helper/CHANGELOG.md
+++ b/yash-env-test-helper/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to `yash-env-test-helper` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - Unreleased
+## [0.2.0] - 2024-09-29
 
 ### Changed
 
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
-    - yash-env 0.2.0 → 0.3.0
+    - yash-env 0.2.0 → 0.4.0
 
 ## [0.1.0] - 2024-07-12
 
@@ -19,5 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env-test-helper` crate
 
-[0.1.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.1.1
+[0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.2.0
 [0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.1.0

--- a/yash-env-test-helper/Cargo.toml
+++ b/yash-env-test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env-test-helper"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -17,4 +17,4 @@ categories = ["command-line-utilities"]
 assert_matches = "1.5.0"
 futures-executor = "0.3.28"
 futures-util = { version = "0.3.28", features = ["channel"] }
-yash-env = { path = "../yash-env", version = "0.3.0" }
+yash-env = { path = "../yash-env", version = "0.4.0" }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.4.0] - 2024-09-29
 
 ### Added
 
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl yash_syntax::input::Input` for `input::FdReader`, `input::Echo`,
   `input::IgnoreEof`, and `input::Reporter` now conforms to the new definition
   of the `next_line` method.
+- External dependency versions:
+    - yash-syntax 0.11.0 → 0.12.0
 
 ### Removed
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -27,7 +27,7 @@ thiserror = "1.0.47"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
-yash-syntax = { path = "../yash-syntax", version = "0.11.0", features = ["annotate-snippets"] }
+yash-syntax = { path = "../yash-syntax", version = "0.12.0", features = ["annotate-snippets"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["fs", "signal", "user"] }

--- a/yash-executor/CHANGELOG.md
+++ b/yash-executor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-executor` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - Unreleased
+## [1.0.0] - 2024-09-29
 
 This is the initial release.
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2024-09-29
 
 ### Changed
 
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   definition of the `next_line` method.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
-    - yash-env 0.2.0 → 0.3.0
-    - yash-syntax 0.10.0 → 0.11.0
+    - yash-env 0.2.0 → 0.4.0
+    - yash-syntax 0.10.0 → 0.12.0
+- Internal dependency versions:
+    - yash-semantics 0.3.0 → 0.4.0
 
 ### Removed
 

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 futures-util = "0.3.28"
-yash-env = { path = "../yash-env", version = "0.3.0" }
-yash-semantics = { path = "../yash-semantics", version = "0.3.0" }
-yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
+yash-env = { path = "../yash-env", version = "0.4.0" }
+yash-semantics = { path = "../yash-semantics", version = "0.4.0" }
+yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
-yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.1.0" }
+yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.2.0" }

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.4.0] - 2024-09-29
 
 ### Added
 
@@ -44,8 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       the `Exec` and `Interactive` shell options are both off.
 - External dependency versions:
     - Rust 1.77.0 → 1.79.0
-    - yash-env 0.2.0 → 0.3.0
-    - yash-syntax 0.10.0 → 0.11.0
+    - yash-env 0.2.0 → 0.4.0
+    - yash-syntax 0.10.0 → 0.12.0
 
 ## [0.3.0] - 2024-07-13
 

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -19,12 +19,12 @@ enumset = "1.1.2"
 itertools = "0.13.0"
 thiserror = "1.0.47"
 yash-arith = { path = "../yash-arith", version = "0.2.1" }
-yash-env = { path = "../yash-env", version = "0.3.0" }
+yash-env = { path = "../yash-env", version = "0.4.0" }
 yash-fnmatch = { path = "../yash-fnmatch", version = "1.1.1" }
 yash-quote = { path = "../yash-quote", version = "1.1.1" }
-yash-syntax = { path = "../yash-syntax", version = "0.11.0" }
+yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
 futures-executor = "0.3.28"
 futures-util = { version = "0.3.28", features = ["channel"] }
-yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.1.0" }
+yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.2.0" }

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.0] - Unreleased
+## [0.12.0] - 2024-09-29
 
 ### Added
 

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
 rust-version = "1.79.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `yash-cli` crate and implemented the `yash_syntax::input::Input` trait for various input types in `yash-env`.
  
- **Dependency Updates**
  - Upgraded Rust version from 1.77.0 to 1.79.0 across multiple packages.
  - Updated several dependencies including `yash-env`, `yash-syntax`, and `yash-semantics` to their latest versions.

- **Version Updates**
  - Released `yash-builtin` (0.4.0), `yash-cli` (0.1.0), `yash-env` (0.4.0), `yash-prompt` (0.2.0), `yash-semantics` (0.4.0), and `yash-syntax` (0.12.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->