### PR TITLE
Update futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,24 +142,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -179,15 +179,15 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -32,7 +32,7 @@ yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures-executor = "0.3.28"
-futures-util = { version = "0.3.28", features = ["channel"] }
+futures-executor = "0.3.31"
+futures-util = { version = "0.3.31", features = ["channel"] }
 yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.2.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.4.0" }

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -28,7 +28,7 @@ yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures-util = { version = "0.3.28", features = ["channel"] }
+futures-util = { version = "0.3.31", features = ["channel"] }
 fuzed-iterator = "1.0.0"
 nix = { version = "0.29.0", features = ["fs", "process", "term"] }
 tempfile = "3.8.0"

--- a/yash-env-test-helper/CHANGELOG.md
+++ b/yash-env-test-helper/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-env-test-helper` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - Unreleased
+
+### Changed
+
+- Internal dependency versions:
+    - futures-executor 0.3.28 → 0.3.31
+    - futures-util 0.3.28 → 0.3.31
+
 ## [0.2.0] - 2024-09-29
 
 ### Changed
@@ -19,5 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env-test-helper` crate
 
+[0.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.2.1
 [0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.2.0
 [0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.1.0

--- a/yash-env-test-helper/Cargo.toml
+++ b/yash-env-test-helper/Cargo.toml
@@ -15,6 +15,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 assert_matches = "1.5.0"
-futures-executor = "0.3.28"
-futures-util = { version = "0.3.28", features = ["channel"] }
+futures-executor = "0.3.31"
+futures-util = { version = "0.3.31", features = ["channel"] }
 yash-env = { path = "../yash-env", version = "0.4.0" }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - Unreleased
+
+### Changed
+
+- Internal dependency versions:
+    - futures-util 0.3.28 → 0.3.31
+
 ## [0.4.0] - 2024-09-29
 
 ### Added
@@ -304,6 +311,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env` crate
 
+[0.4.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.4.1
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.3.0
 [0.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.2.1

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -18,7 +18,7 @@ annotate-snippets = "0.11.4"
 bitflags = "2.6.0"
 either = "1.9.0"
 enumset = "1.1.2"
-futures-util = "0.3.28"
+futures-util = "0.3.31"
 itertools = "0.13.0"
 slab = "0.4.9"
 strum = { version = "0.26.2", features = ["derive"] }
@@ -35,5 +35,5 @@ yash-executor = { path = "../yash-executor", version = "1.0.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures-executor = "0.3.28"
-futures-util = { version = "0.3.28", features = ["channel"] }
+futures-executor = "0.3.31"
+futures-util = { version = "0.3.31", features = ["channel"] }

--- a/yash-executor/Cargo.toml
+++ b/yash-executor/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["concurrency", "executor", "single-threaded"]
 categories = ["asynchronous", "concurrency", "no-std"]
 
 [dev-dependencies]
-futures-task = "0.3.30"
+futures-task = "0.3.31"
 pin-utils = "0.1.0"

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - Unreleased
+
+### Changed
+
+- Internal dependency versions:
+    - futures-util 0.3.28 → 0.3.31
+
 ## [0.2.0] - 2024-09-29
 
 ### Changed
@@ -33,5 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.2.1
 [0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.2.0
 [0.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.1.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-futures-util = "0.3.28"
+futures-util = "0.3.31"
 yash-env = { path = "../yash-env", version = "0.4.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.4.0" }
 yash-syntax = { path = "../yash-syntax", version = "0.12.0" }

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -25,6 +25,6 @@ yash-quote = { path = "../yash-quote", version = "1.1.1" }
 yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
 
 [dev-dependencies]
-futures-executor = "0.3.28"
-futures-util = { version = "0.3.28", features = ["channel"] }
+futures-executor = "0.3.31"
+futures-util = { version = "0.3.31", features = ["channel"] }
 yash-env-test-helper = { path = "../yash-env-test-helper", version = "0.2.0" }

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - Unreleased
+
+### Changed
+
+- Internal dependency versions:
+    - futures-util 0.3.28 → 0.3.31
+
 ## [0.12.0] - 2024-09-29
 
 ### Added
@@ -334,6 +341,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.12.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.1
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.11.0
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.10.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["command-line-utilities", "parser-implementations"]
 
 [dependencies]
 annotate-snippets = { version = "0.11.4", optional = true }
-futures-util = "0.3.28"
+futures-util = "0.3.31"
 itertools = "0.13.0"
 thiserror = "1.0.47"
 
 [dev-dependencies]
 annotate-snippets = "0.11.4"
 assert_matches = "1.5.0"
-futures-executor = "0.3.28"
+futures-executor = "0.3.31"


### PR DESCRIPTION
All futures-util versions prior to 0.3.31 have been yanked because of a
soundness bug [1]. This commit updates the futures family of crates to
0.3.31.

[1]: https://github.com/rust-lang/futures-rs/issues/2795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated internal dependencies across multiple packages to improve performance and stability.
  
- **Chores**
	- Incremented versions of `futures-executor` and `futures-util` from `0.3.28` to `0.3.31` in various packages.
	- Updated changelogs to reflect new unreleased versions and document changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->