### PR TITLE
Update `$!` when resuming a background job

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `bg` built-in now updates the `!` special parameter (which is backed by
+  `yash_env::job::JobList::last_async_pid`) to the process ID of the background
+  job, as required by POSIX.1-2024.
 - The `exec` built-in no longer exits the shell when the specified command is
   not found in an interactive shell, as required by POSIX.1-2024.
 - External dependency versions:

--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `bg` built-in now updates the `!` special parameter to the process ID of
+  the background job, as required by POSIX.1-2024.
 - The `exec` built-in no longer exits the shell when the specified command is
   not found in an interactive shell, as required by POSIX.1-2024.
 

--- a/yash-cli/tests/scripted_test/bg-p.sh
+++ b/yash-cli/tests/scripted_test/bg-p.sh
@@ -84,6 +84,12 @@ bg >bg.out
 grep -qx '\[[[:digit:]][[:digit:]]*][[:blank:]]*sleep 1' bg.out
 __IN__
 
+test_O -e 17 'bg updates $!' -m
+sh -c 'kill -s STOP $$; exit 17'
+bg >/dev/null
+wait $!
+__IN__
+
 test_O -e 0 'exit status of bg' -m
 sh -c 'kill -s STOP $$; exit 17'
 bg >/dev/null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - The `bg` command now resumes suspended jobs and updates the `!` special parameter with the last resumed job's process ID.
  - The `exec` command behavior has been adjusted to prevent shell exit when a command is not found in interactive mode.

- **Bug Fixes**
  - Enhanced error handling for invalid job IDs and job control status in the `bg` command.

- **Tests**
  - Added a new test case to verify the correct updating of the `$!` variable in the `bg` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->