### PR TITLE
Allow `esac` as the first pattern of a case branch

### DIFF
--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The shell's syntax now allows `esac` as the first pattern of a case branch
+  as in `case esac in (esac|case) echo ok; esac`. Previously, it was a syntax
+  error, but POSIX.1-2024 allows it.
 - The `bg` built-in now updates the `!` special parameter to the process ID of
   the background job, as required by POSIX.1-2024.
 - The `exec` built-in no longer exits the shell when the specified command is

--- a/yash-cli/tests/scripted_test/case-p.sh
+++ b/yash-cli/tests/scripted_test/case-p.sh
@@ -333,7 +333,13 @@ test_reserved_word_as_pattern "$LINENO" then
 test_reserved_word_as_pattern "$LINENO" until
 test_reserved_word_as_pattern "$LINENO" while
 
-test_oE 'reserved word esac as (non-first) pattern'
+test_oE 'esac as first pattern'
+case esac in (esac) echo matched;; esac
+__IN__
+matched
+__OUT__
+
+test_oE 'esac as non-first pattern'
 case esac in -|esac) echo matched;; esac
 __IN__
 matched

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,8 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- In the `parser::Parser::case_item` method, the parser now accepts an `esac`
+  token as a pattern after an opening parenthesis, as required by POSIX.1-2024.
+  The previous version of POSIX did not allow `esac` as the first pattern, so
+  the method was returning `SyntaxError::EsacAsPattern` in that case.
 - Internal dependency versions:
     - futures-util 0.3.28 → 0.3.31
+
+### Deprecated
+
+- `parser::SyntaxError::EsacAsPattern`
+    - This variant is deprecated because this error condition is no longer
+      possible as described above.
 
 ## [0.12.0] - 2024-09-29
 

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -135,6 +135,7 @@ pub enum SyntaxError {
     /// The pattern is not a valid word token.
     InvalidPattern,
     /// The first pattern of a case item is `esac`.
+    #[deprecated = "this error no longer occurs"]
     EsacAsPattern,
     /// An `esac` or `;;` appears outside a case command.
     UnopenedCase,
@@ -219,6 +220,7 @@ impl SyntaxError {
             UnclosedPatternList => "The pattern list is not properly closed by a `)`",
             MissingPattern => "A pattern is missing in the `case` command",
             InvalidPattern => "The pattern is not a valid word token",
+            #[allow(deprecated)]
             EsacAsPattern => "`esac` cannot be the first of a pattern list",
             UnclosedCase { .. } => "The `case` command is missing its closing `esac`",
             UnmatchedParenthesis => "`)` is missing after `(`",
@@ -290,6 +292,7 @@ impl SyntaxError {
             UnopenedIf => "not in an `if` command",
             UnclosedIf { .. } => "expected `fi`",
             MissingIn { .. } => "expected `in`",
+            #[allow(deprecated)]
             EsacAsPattern => "needs quoting",
             UnopenedCase => "not in a `case` command",
             UnclosedCase { .. } => "expected `esac`",


### PR DESCRIPTION
POSIX has been changed to allow `esac` as the first pattern of a case
branch. This commit implements this change in the parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 0.1.1

- **New Features**
  - The shell now accepts `esac` as the first pattern in a case branch, aligning with POSIX.1-2024 standards.
  - Enhanced `bg` built-in to correctly reflect the process ID of background jobs.
  - Modified `exec` built-in to prevent shell exit on command not found in interactive mode.

- **Bug Fixes**
  - Improved error handling for parameter expansions and syntax errors.
  - Updated exit statuses for scripts that cannot be opened, now compliant with POSIX.

- **Tests**
  - Added new test cases for the `case` command to ensure compliance with various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->