### PR TITLE
Release yash-syntax-0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -24,7 +24,7 @@ yash-env = { path = "../yash-env", version = "0.4.0" }
 yash-executor = { path = "../yash-executor", version = "1.0.0" }
 yash-prompt = { path = "../yash-prompt", version = "0.2.0" }
 yash-semantics = { path = "../yash-semantics", version = "0.4.0" }
-yash-syntax = { path = "../yash-syntax", version = "0.12.0" }
+yash-syntax = { path = "../yash-syntax", version = "0.12.1" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.1] - Unreleased
+## [0.12.1] - 2024-11-10
 
 ### Changed
 
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token as a pattern after an opening parenthesis, as required by POSIX.1-2024.
   The previous version of POSIX did not allow `esac` as the first pattern, so
   the method was returning `SyntaxError::EsacAsPattern` in that case.
+- External dependency versions:
+    - Rust 1.79.0 → 1.82.0
 - Internal dependency versions:
     - futures-util 0.3.28 → 0.3.31
 

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "yash-syntax"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.82.0"
 description = "POSIX-compatible shell script syntax parser"
 # documentation = "https://yash.osdn.jp/doc/"
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the `yash-syntax` package to version 0.12.1, enhancing error handling and method functionality to align with POSIX.1-2024 standards.
  
- **Bug Fixes**
  - Deprecated the `SyntaxError::EsacAsPattern` variant, improving overall syntax parsing.

- **Chores**
  - Updated external dependencies, including Rust and futures-util versions, to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->