### PR TITLE
check-msrv: Autodetect expected MSRV

### DIFF
--- a/check-msrv.sh
+++ b/check-msrv.sh
@@ -16,43 +16,33 @@ resolver = "2"
 EOF
 }
 
-prepare() {
-    update_workspace_member "$1"
+# $1 = package name
+# $2, $3, ... = additional options to `cargo test`
+check() {
+    package="$1"
+    shift
+    if [ "$#" -eq 0 ]; then
+        set ''
+    fi
+
+    update_workspace_member "$package"
     cargo +nightly update -Z direct-minimal-versions
     msrv=$(cargo metadata --format-version=1 |
-        jq -r ".packages[] | select(.name == \"$1\") | .rust_version")
+        jq -r ".packages[] | select(.name == \"$package\") | .rust_version")
+
+    for options do
+        cargo +$msrv test --package "$package" $options -- $quiet
+    done
 }
 
-prepare yash-arith
-cargo +$msrv test --package yash-arith -- $quiet
-
-prepare yash-builtin
-cargo +$msrv test --package yash-builtin -- $quiet
-
-prepare yash-cli
-cargo +$msrv test --package yash-cli -- $quiet
-
-prepare yash-env
-cargo +$msrv test --package yash-env -- $quiet
-
-prepare yash-env-test-helper
-cargo +$msrv test --package yash-env-test-helper -- $quiet
-
-prepare yash-executor
-cargo +$msrv test --package yash-executor -- $quiet
-
-prepare yash-fnmatch
-cargo +$msrv test --package yash-fnmatch -- $quiet
-
-prepare yash-prompt
-cargo +$msrv test --package yash-prompt -- $quiet
-
-prepare yash-quote
-cargo +$msrv test --package yash-quote -- $quiet
-
-prepare yash-semantics
-cargo +$msrv test --package yash-semantics -- $quiet
-
-prepare yash-syntax
-cargo +$msrv test --package yash-syntax -- $quiet
-cargo +$msrv test --package yash-syntax --features annotate-snippets -- $quiet
+check yash-arith
+check yash-builtin
+check yash-cli
+check yash-env
+check yash-env-test-helper
+check yash-executor
+check yash-fnmatch
+check yash-prompt
+check yash-quote
+check yash-semantics
+check yash-syntax '' '--features annotate-snippets'

--- a/check-msrv.sh
+++ b/check-msrv.sh
@@ -16,47 +16,43 @@ resolver = "2"
 EOF
 }
 
-update_workspace_member yash-arith
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.65.0 test --package yash-arith -- $quiet
+prepare() {
+    update_workspace_member "$1"
+    cargo +nightly update -Z direct-minimal-versions
+    msrv=$(cargo metadata --format-version=1 |
+        jq -r ".packages[] | select(.name == \"$1\") | .rust_version")
+}
 
-update_workspace_member yash-builtin
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-builtin -- $quiet
+prepare yash-arith
+cargo +$msrv test --package yash-arith -- $quiet
 
-update_workspace_member yash-cli
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-cli -- $quiet
+prepare yash-builtin
+cargo +$msrv test --package yash-builtin -- $quiet
 
-update_workspace_member yash-env
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-env -- $quiet
+prepare yash-cli
+cargo +$msrv test --package yash-cli -- $quiet
 
-update_workspace_member yash-env-test-helper
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-env-test-helper -- $quiet
+prepare yash-env
+cargo +$msrv test --package yash-env -- $quiet
 
-update_workspace_member yash-executor
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.65.0 test --package yash-executor -- $quiet
+prepare yash-env-test-helper
+cargo +$msrv test --package yash-env-test-helper -- $quiet
 
-update_workspace_member yash-fnmatch
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.65.0 test --package yash-fnmatch -- $quiet
+prepare yash-executor
+cargo +$msrv test --package yash-executor -- $quiet
 
-update_workspace_member yash-prompt
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-prompt -- $quiet
+prepare yash-fnmatch
+cargo +$msrv test --package yash-fnmatch -- $quiet
 
-update_workspace_member yash-quote
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.65.0 test --package yash-quote -- $quiet
+prepare yash-prompt
+cargo +$msrv test --package yash-prompt -- $quiet
 
-update_workspace_member yash-semantics
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-semantics -- $quiet
+prepare yash-quote
+cargo +$msrv test --package yash-quote -- $quiet
 
-update_workspace_member yash-syntax
-cargo +nightly update -Z direct-minimal-versions
-cargo +1.82.0 test --package yash-syntax -- $quiet
-cargo +1.82.0 test --package yash-syntax --features annotate-snippets -- $quiet
+prepare yash-semantics
+cargo +$msrv test --package yash-semantics -- $quiet
+
+prepare yash-syntax
+cargo +$msrv test --package yash-syntax -- $quiet
+cargo +$msrv test --package yash-syntax --features annotate-snippets -- $quiet


### PR DESCRIPTION
This commit updates the `check-msrv` script to autodetect the expected
minimum supported Rust version (MSRV) for each crate. This is done by
querying the `rust_version` field of the package metadata using `jq`.
This ensures that the script always tests the correct MSRV for each
crate, even if the MSRV is updated in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `check` function to streamline workspace member updates and dynamically retrieve the minimum supported Rust version (MSRV) for packages.

- **Improvements**
	- Enhanced control flow and maintainability by consolidating repeated logic within the `check` function.
	- Updated testing commands to utilize dynamically retrieved MSRV values instead of hardcoded versions.

- **Bug Fixes**
	- Improved quiet mode functionality for better control of output based on user input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->