### PR TITLE
`;&`, `;|`, `;;&` in case command

### DIFF
--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - Unreleased
 
+### Added
+
+- A case branch now can be terminated with `;&` or `;|` instead of `;;` to fall
+  through to the next branch or to resume pattern matching from the next branch,
+  respectively. `;&` is a POSIX.1-2024 feature, and `;|` is an extension. For
+  compatibility with other shells, `;;&` is also accepted as an alias for `;|`.
+
 ### Changed
 
 - The shell's syntax now allows `esac` as the first pattern of a case branch

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -151,6 +151,11 @@ fn case_command() {
 }
 
 #[test]
+fn case_command_ex() {
+    run("case-y.sh");
+}
+
+#[test]
 fn cd_builtin() {
     run("cd-p.sh")
 }

--- a/yash-cli/tests/scripted_test/case-p.sh
+++ b/yash-cli/tests/scripted_test/case-p.sh
@@ -189,7 +189,7 @@ case $(false) in
 esac
 __IN__
 
-# The behavior is POSIXly-unspecified for this case. See case-y.tst.
+# The behavior is POSIXly-unspecified for this case. See case-y.sh.
 #test_OE -e 0 'exit status of case command (matched, empty)'
 
 test_OE -e 17 'exit status of case command (matched, non-empty)'
@@ -199,6 +199,27 @@ case $(echo 2; exit 2) in
     3) true; (exit 19);;
 esac
 __IN__
+
+test_oE -e 42 'executing item after ;&'
+case 1 in
+    0) echo not reached 0;;
+    1) echo matched 1;&
+    2) echo matched 2; (exit 42);&
+esac
+__IN__
+matched 1
+matched 2
+__OUT__
+
+test_oE 'exit status after empty ;& in case command'
+(exit 1)
+case i in
+    i) ;&
+    j) echo $?
+esac
+__IN__
+1
+__OUT__
 
 test_oE 'patterns can be preceded by ('
 case a in

--- a/yash-cli/tests/scripted_test/case-y.sh
+++ b/yash-cli/tests/scripted_test/case-y.sh
@@ -1,0 +1,166 @@
+# case-y.sh: yash-specific test of case command
+
+test_oe 'patterns separated by | are expanded and matched in order'
+case 1 in
+    $(echo expanded 0 >&2; echo 0) |\
+    $(echo expanded 1 >&2; echo 1) |\
+    $(echo expanded 2 >&2; echo 2)) echo matched;;
+esac
+__IN__
+matched
+__OUT__
+expanded 0
+expanded 1
+__ERR__
+
+# The behavior is unspecified in POSIX, but many existing shells seem to behave
+# this way (with the notable exception of ksh).
+test_OE -e 0 'exit status of case command (matched, empty)'
+case $(echo 2; exit 2) in
+    1) ;;
+    2) ;;
+    3) ;;
+esac
+__IN__
+
+# The behavior is unspecified in POSIX, but many existing shells seem to behave
+# this way (with the notable exception of ksh).
+test_OE -e 0 'exit status of case command with ;& followed by empty item'
+case i in
+    i) (exit 1);&
+    j) ;;
+esac
+__IN__
+
+test_oE -e 42 'pattern matching after ;|'
+case 1 in
+    0) echo not reached 0;;
+    1) echo matched 1; (exit 12);|
+    2) echo not reached 2;;
+    1) echo matched 2 $?; (exit 42);|
+    2) echo not reached 3;;
+esac
+__IN__
+matched 1
+matched 2 12
+__OUT__
+
+test_oE -e 42 'pattern matching after ;;&'
+case 1 in
+    0) echo not reached 0;;
+    1) echo matched 1; (exit 12);;&
+    2) echo not reached 2;;
+    1) echo matched 2 $?; (exit 42);;&
+    2) echo not reached 3;;
+esac
+__IN__
+matched 1
+matched 2 12
+__OUT__
+
+# Existing shells disagree on the behavior of this case.
+test_oE 'exit status in case command with subject containing command substitution'
+case $(echo 1; exit 42) in
+    1) echo $?
+esac
+__IN__
+0
+__OUT__
+
+# Many existing shells behave this way (with the notable exception of ksh).
+test_OE -e 0 'exit status of case command with subject containing command substitution'
+case $(echo 1; exit 42) in esac
+__IN__
+
+test_O -d -e 2 'in without case'
+in
+__IN__
+
+test_O -d -e 2 ';; outside case (at beginning of line)'
+;;
+__IN__
+
+test_O -d -e 2 ';; outside case (after simple command)'
+echo foo;;
+__IN__
+
+test_O -d -e 2 'esac without case'
+esac
+__IN__
+
+test_O -d -e 2 'case followed by EOF'
+case
+__IN__
+
+test_O -d -e 2 'case followed by symbol'
+case </dev/null
+__IN__
+
+test_O -d -e 2 'case followed by newline'
+case
+    1 in 1) echo not reached;; esac
+__IN__
+
+test_O -d -e 2 'word followed by EOF'
+case 1
+__IN__
+
+test_O -d -e 2 'word followed by symbol'
+case 1 </dev/null
+__IN__
+
+test_O -d -e 2 'in followed by EOF'
+case 1 in
+__IN__
+
+test_O -d -e 2 'in followed by invalid symbol'
+case 1 in </dev.null
+__IN__
+
+test_O -d -e 2 '( followed by EOF'
+case 1 in (
+__IN__
+
+test_O -d -e 2 'invalid symbol in pattern'
+case 1 in a</dev.null
+__IN__
+
+test_O -d -e 2 'missing pattern (separated by |)'
+case 1 in |foo) esac
+__IN__
+
+test_O -d -e 2 'missing pattern (separated by parenthesis)'
+case 1 in ) esac
+__IN__
+
+test_O -d -e 2 'separator followed by EOF'
+case 1 in (1|
+__IN__
+
+test_O -d -e 2 'pattern followed by EOF'
+case 1 in 1
+__IN__
+
+test_O -d -e 2 'pattern followed by esac (after one pattern)'
+case 1 in 1 esac
+__IN__
+
+test_O -d -e 2 'pattern followed by esac (after two patterns)'
+case 1 in 1|2 esac
+__IN__
+
+test_O -d -e 2 ') followed by EOF'
+case 1 in 1)
+__IN__
+
+test_O -d -e 2 'inner command followed by EOF'
+case 1 in 1) echo not reached
+__IN__
+
+test_O -d -e 2 'missing in-esac (in grouping)'
+{ case 1 }
+__IN__
+
+test_O -d -e 2 'missing esac (in grouping)'
+{ case 1 in *) }
+__IN__

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `<yash_syntax::syntax::CompoundCommand as command::Command>::execute` now
+  honors the `CaseContinuation` specified for the executed case item.
 - External dependency versions:
     - Rust 1.79.0 → 1.82.0
 

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -124,6 +124,9 @@ impl Command for syntax::FullCompoundCommand {
 ///
 /// POSIX does not specify the order in which the shell tests multiple patterns
 /// in an item. This implementation tries them in the order of appearance.
+///
+/// After executing the body of the matching item, the case command may process
+/// the next item depending on the continuation.
 impl Command for syntax::CompoundCommand {
     async fn execute(&self, env: &mut Env) -> Result {
         use syntax::CompoundCommand::*;

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - Unreleased
+
+### Added
+
+- Extended the case item syntax to allow `;&`, `;|`, and `;;&` as terminators.
+    - The `SemicolonAnd`, `SemicolonSemicolonAnd`, and `SemicolonBar` variants
+      are added to the `parser::lex::Operator` enum.
+
 ## [0.12.1] - 2024-11-10
 
 ### Changed
@@ -353,6 +361,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.13.0
 [0.12.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.1
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.11.0

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `SemicolonAnd`, `SemicolonSemicolonAnd`, and `SemicolonBar` variants
       are added to the `parser::lex::Operator` enum.
     - The `parser::Parser::case_item` and `syntax::CaseItem::from_str` methods
-      now consume a trailing terminator token, if any.
+      now consume a trailing terminator token, if any. The terminator can be
+      not only `;;`, but also `;&`, `;|`, or `;;&`.
 
 ## [0.12.1] - 2024-11-10
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended the case item syntax to allow `;&`, `;|`, and `;;&` as terminators.
     - The `SemicolonAnd`, `SemicolonSemicolonAnd`, and `SemicolonBar` variants
       are added to the `parser::lex::Operator` enum.
+    - The `parser::Parser::case_item` and `syntax::CaseItem::from_str` methods
+      now consume a trailing terminator token, if any.
 
 ## [0.12.1] - 2024-11-10
 

--- a/yash-syntax/src/parser/case.rs
+++ b/yash-syntax/src/parser/case.rs
@@ -24,6 +24,7 @@ use super::error::SyntaxError;
 use super::lex::Keyword::{Case, Esac, In};
 use super::lex::Operator::{Bar, CloseParen, Newline, OpenParen, SemicolonSemicolon};
 use super::lex::TokenId::{self, EndOfInput, Operator, Token};
+use crate::syntax::CaseContinuation;
 use crate::syntax::CaseItem;
 use crate::syntax::CompoundCommand;
 
@@ -102,8 +103,13 @@ impl Parser<'_, '_> {
         }
 
         let body = self.maybe_compound_list_boxed().await?;
+        let continuation = CaseContinuation::default();
 
-        Ok(Some(CaseItem { patterns, body }))
+        Ok(Some(CaseItem {
+            patterns,
+            body,
+            continuation,
+        }))
     }
 
     /// Parses a case conditional construct.

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -269,7 +269,7 @@ impl FromStr for CaseItem {
         let mut lexer = Lexer::from_memory(s, Source::Unknown);
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         unwrap_ready(async {
-            let item = parser.case_item().await?;
+            let item = parser.case_item().await?.map(|(item, _)| item);
             if item.is_some() {
                 if parser.peek_token().await?.id == TokenId::Operator(Operator::SemicolonSemicolon)
                 {

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -236,9 +236,28 @@ const AND: Trie = Trie(&[Edge {
 }]);
 
 /// Trie of the operators that start with `;`.
-const SEMICOLON: Trie = Trie(&[Edge {
-    key: ';',
-    value: Some(Operator::SemicolonSemicolon),
+const SEMICOLON: Trie = Trie(&[
+    Edge {
+        key: '&',
+        value: Some(Operator::SemicolonAnd),
+        next: NONE,
+    },
+    Edge {
+        key: ';',
+        value: Some(Operator::SemicolonSemicolon),
+        next: SEMICOLON_SEMICOLON,
+    },
+    Edge {
+        key: '|',
+        value: Some(Operator::SemicolonBar),
+        next: NONE,
+    },
+]);
+
+/// Trie of the operators that start with `;;`.
+const SEMICOLON_SEMICOLON: Trie = Trie(&[Edge {
+    key: '&',
+    value: Some(Operator::SemicolonSemicolonAnd),
     next: NONE,
 }]);
 

--- a/yash-syntax/src/parser/lex/op.rs
+++ b/yash-syntax/src/parser/lex/op.rs
@@ -43,8 +43,14 @@ pub enum Operator {
     CloseParen,
     /// `;`
     Semicolon,
+    /// `;&`
+    SemicolonAnd,
     /// `;;`
     SemicolonSemicolon,
+    /// `;;&`
+    SemicolonSemicolonAnd,
+    /// `;|`
+    SemicolonBar,
     /// `<`
     Less,
     /// `<&`
@@ -89,7 +95,10 @@ impl Operator {
             OpenParen => "(",
             CloseParen => ")",
             Semicolon => ";",
+            SemicolonAnd => ";&",
             SemicolonSemicolon => ";;",
+            SemicolonSemicolonAnd => ";;&",
+            SemicolonBar => ";|",
             Less => "<",
             LessAnd => "<&",
             LessOpenParen => "<(",
@@ -110,13 +119,23 @@ impl Operator {
 
     /// Determines if this token can be a delimiter of a clause.
     ///
-    /// This function returns `true` for `CloseParen` and `SemicolonSemicolon`,
-    /// and `false` for others.
+    /// This function returns `true` for the following operators:
+    ///
+    /// - `CloseParen` (`)`)
+    /// - `SemicolonAnd` (`;&`)
+    /// - `SemicolonSemicolon` (`;;`)
+    /// - `SemicolonSemicolonAnd` (`;;&`)
+    /// - `SemicolonBar` (`;|`)
     #[must_use]
     pub const fn is_clause_delimiter(self) -> bool {
         use Operator::*;
         match self {
-            CloseParen | SemicolonSemicolon => true,
+            CloseParen
+            | SemicolonAnd
+            | SemicolonSemicolon
+            | SemicolonSemicolonAnd
+            | SemicolonBar => true,
+
             Newline | And | AndAnd | OpenParen | Semicolon | Less | LessAnd | LessOpenParen
             | LessLess | LessLessDash | LessLessLess | LessGreater | Greater | GreaterAnd
             | GreaterOpenParen | GreaterGreater | GreaterGreaterBar | GreaterBar | Bar | BarBar => {

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -51,7 +51,9 @@ fn error_type_for_trailing_token_in_command_line(token_id: TokenId) -> Option<Sy
             And | AndAnd | Semicolon | Bar | BarBar => Some(InvalidCommandToken),
             OpenParen => Some(MissingSeparator),
             CloseParen => Some(UnopenedSubshell),
-            SemicolonSemicolon => Some(UnopenedCase),
+            SemicolonAnd | SemicolonSemicolon | SemicolonSemicolonAnd | SemicolonBar => {
+                Some(UnopenedCase)
+            }
             Newline | Less | LessAnd | LessOpenParen | LessLess | LessLessDash | LessLessLess
             | LessGreater | Greater | GreaterAnd | GreaterOpenParen | GreaterGreater
             | GreaterGreaterBar | GreaterBar => unreachable!(),


### PR DESCRIPTION
- [x] Data structure
- [x] Lexer
- [x] Parser
- [x] Semantics
- [x] Add comments about disabling `;|` in the POSIX mode
- [x] Scripted tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new case branch terminators: `;&`, `;|`, and `;;&` for enhanced control flow.
	- Added `CaseContinuation` enum to define termination behavior of case branches.
	- Enhanced error handling for the `case` command and improved exit status reporting.

- **Bug Fixes**
	- Corrected exit statuses for script opening failures to comply with POSIX standards.

- **Tests**
	- Expanded test suite to cover new case command features and edge cases, including fall-through behavior.

- **Documentation**
	- Updated changelogs and comments for better clarity on new features and compliance with POSIX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->