### PR TITLE
Dollar-single-quotes

### DIFF
--- a/yash-cli/CHANGELOG-bin.md
+++ b/yash-cli/CHANGELOG-bin.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through to the next branch or to resume pattern matching from the next branch,
   respectively. `;&` is a POSIX.1-2024 feature, and `;|` is an extension. For
   compatibility with other shells, `;;&` is also accepted as an alias for `;|`.
+- Dollar-single-quotes are now supported as a form of quoting where backslash
+  escapes are recognized.
+    - Currently, octal and hexadecimal escapes that expand to a value greater
+      than 127 are translated to a UTF-8 sequence for the corresponding Unicode
+      scalar value. This behavior does not conform to POSIX.1-2024 and is
+      subject to change.
+    - As an extension to POSIX.1-2024, the shell also recognizes the `\u` and
+      `\U` escapes for Unicode scalar values, and the `\E` escape as a synonym
+      for `\e`.
 
 ### Changed
 

--- a/yash-cli/tests/scripted_test/quote-p.sh
+++ b/yash-cli/tests/scripted_test/quote-p.sh
@@ -399,6 +399,17 @@ b][a
 b]
 __OUT__
 
+test_oE 'dollar-single-quotes'
+bracket $'' $'a' $'a
+b' -$'\"\'\'"\\\a\b\e\f\n\r\t\v\x20\1000'-
+bracket $'\cA\c^\c\\\c?'
+__IN__
+[][a][a
+b][-"''"\
+	 @0-]
+[]
+__OUT__
+
 test_oE 'double quotes'
 bracket "abc" "'a'"
 bracket "a

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `<yash_syntax::syntax::CompoundCommand as command::Command>::execute` now
   honors the `CaseContinuation` specified for the executed case item.
+- `<yash_syntax::syntax::WordUnit as expansion::Expand>::expand` now supports
+  expanding dollar-single-quotes.
 - External dependency versions:
     - Rust 1.79.0 → 1.82.0
 

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -22,25 +22,48 @@ use super::super::Error;
 use super::Env;
 use super::Expand;
 use super::Phrase;
+use yash_syntax::syntax::Unquote as _;
 use yash_syntax::syntax::Word;
 use yash_syntax::syntax::WordUnit::{self, *};
 
+const SINGLE_QUOTE: AttrChar = AttrChar {
+    value: '\'',
+    origin: Origin::Literal,
+    is_quoted: false,
+    is_quoting: true,
+};
+
 fn expand_single_quote(value: &str) -> Phrase {
-    const QUOTE: AttrChar = AttrChar {
-        value: '\'',
-        origin: Origin::Literal,
-        is_quoted: false,
-        is_quoting: true,
-    };
     let mut field = Vec::with_capacity(value.chars().count() + 2);
-    field.push(QUOTE);
+    field.push(SINGLE_QUOTE);
     field.extend(value.chars().map(|c| AttrChar {
         value: c,
         origin: Origin::Literal,
         is_quoted: true,
         is_quoting: false,
     }));
-    field.push(QUOTE);
+    field.push(SINGLE_QUOTE);
+    Phrase::Field(field)
+}
+
+/// Adds dollar-single-quotes around the string.
+fn dollar_single_quote(s: &str) -> Phrase {
+    const DOLLAR: AttrChar = AttrChar {
+        value: '$',
+        origin: Origin::Literal,
+        is_quoted: false,
+        is_quoting: true,
+    };
+    let mut field = Vec::with_capacity(s.chars().count() + 3);
+    field.push(DOLLAR);
+    field.push(SINGLE_QUOTE);
+    field.extend(s.chars().map(|c| AttrChar {
+        value: c,
+        origin: Origin::Literal,
+        is_quoted: true,
+        is_quoting: false,
+    }));
+    field.push(SINGLE_QUOTE);
     Phrase::Field(field)
 }
 
@@ -90,6 +113,11 @@ fn double_quote(phrase: &mut Phrase) {
 /// A double-quoted text expands to a phrase in a non-splitting context and
 /// surrounds each field in the phrase with `"`.
 ///
+/// # Dollar-single-quote
+///
+/// `DollarSingleQuote(string)` expands to
+/// `dollar_single_quote(&string.unquote().0)` surrounded by `$'` and `'`.
+///
 /// # Tilde
 ///
 /// `Tilde("")` expands to the value of the `HOME` scalar variable.
@@ -111,7 +139,7 @@ impl Expand for WordUnit {
                 double_quote(&mut phrase);
                 Ok(phrase)
             }
-            DollarSingleQuote(_) => todo!(),
+            DollarSingleQuote(string) => Ok(dollar_single_quote(&string.unquote().0)),
             Tilde(name) => Ok(super::tilde::expand(name, env.inner).into()),
         }
     }
@@ -268,6 +296,45 @@ mod tests {
         };
         let o = AttrChar { value: 'o', ..d };
         assert_eq!(result, Phrase::Field(vec![q, d, o, q]));
+    }
+
+    #[test]
+    fn expand_dollar_single_quote() {
+        let mut env = yash_env::Env::new_virtual();
+        let mut env = Env::new(&mut env);
+        let unit = DollarSingleQuote(r"\\\n".parse().unwrap());
+        let result = unit.expand(&mut env).now_or_never().unwrap();
+
+        let dollar = AttrChar {
+            value: '$',
+            origin: Origin::Literal,
+            is_quoted: false,
+            is_quoting: true,
+        };
+        let quote = AttrChar {
+            value: '\'',
+            origin: Origin::Literal,
+            is_quoted: false,
+            is_quoting: true,
+        };
+        let backslash = AttrChar {
+            value: '\\',
+            origin: Origin::Literal,
+            is_quoted: true,
+            is_quoting: false,
+        };
+        let newline = AttrChar {
+            value: '\n',
+            origin: Origin::Literal,
+            is_quoted: true,
+            is_quoting: false,
+        };
+        assert_eq!(
+            result,
+            Ok(Phrase::Field(vec![
+                dollar, quote, backslash, newline, quote
+            ]))
+        );
     }
 
     #[test]

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -33,7 +33,8 @@ const SINGLE_QUOTE: AttrChar = AttrChar {
     is_quoting: true,
 };
 
-fn expand_single_quote(value: &str) -> Phrase {
+/// Adds single quotes around the string.
+fn single_quote(value: &str) -> Phrase {
     let mut field = Vec::with_capacity(value.chars().count() + 2);
     field.push(SINGLE_QUOTE);
     field.extend(value.chars().map(|c| AttrChar {
@@ -129,7 +130,7 @@ impl Expand for WordUnit {
     async fn expand(&self, env: &mut Env<'_>) -> Result<Phrase, Error> {
         match self {
             Unquoted(text_unit) => text_unit.expand(env).await,
-            SingleQuote(value) => Ok(expand_single_quote(value)),
+            SingleQuote(value) => Ok(single_quote(value)),
             DoubleQuote(text) => {
                 let would_split = std::mem::replace(&mut env.will_split, false);
                 let result = text.expand(env).await;
@@ -269,7 +270,7 @@ mod tests {
 
     #[test]
     fn empty_single_quote() {
-        let result = expand_single_quote("");
+        let result = single_quote("");
         let q = AttrChar {
             value: '\'',
             origin: Origin::Literal,
@@ -281,7 +282,7 @@ mod tests {
 
     #[test]
     fn non_empty_single_quote() {
-        let result = expand_single_quote("do");
+        let result = single_quote("do");
         let q = AttrChar {
             value: '\'',
             origin: Origin::Literal,

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -111,6 +111,7 @@ impl Expand for WordUnit {
                 double_quote(&mut phrase);
                 Ok(phrase)
             }
+            DollarSingleQuote(_) => todo!(),
             Tilde(name) => Ok(super::tilde::expand(name, env.inner).into()),
         }
     }

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `parser::Parser::case_item` and `syntax::CaseItem::from_str` methods
       now consume a trailing terminator token, if any. The terminator can be
       not only `;;`, but also `;&`, `;|`, or `;;&`.
+- Dollar-single-quotes are now supported.
+    - The `DollarSingleQuote` variant is added to the `syntax::WordUnit` enum.
+    - The `EscapeUnit` enum and `EscapedString` struct are added to the
+      `syntax` module.
 - In the `syntax::MaybeLiteral` trait, the `extend_if_literal` method is
   replaced with the `extend_literal` method, which now takes a mutable reference
   to an `Extend<char>` object, instead of an ownership of it. The method may

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The `DollarSingleQuote` variant is added to the `syntax::WordUnit` enum.
     - The `EscapeUnit` enum and `EscapedString` struct are added to the
       `syntax` module.
+    - The `escape_unit` and `escaped_string` methods are added to the
+      `parser::lex::Lexer` struct.
+    - The following error variants are added to `parser::SyntaxError`:
+        - `IncompleteControlBackslashEscape`
+        - `IncompleteControlEscape`
+        - `IncompleteEscape`
+        - `IncompleteHexEscape`
+        - `IncompleteLongUnicodeEscape`
+        - `IncompleteShortUnicodeEscape`
+        - `InvalidControlEscape`
+        - `InvalidEscape`
+        - `UnclosedDollarSingleQuote`
+        - `UnicodeEscapeOutOfRange`
 - In the `syntax::MaybeLiteral` trait, the `extend_if_literal` method is
   replaced with the `extend_literal` method, which now takes a mutable reference
   to an `Extend<char>` object, instead of an ownership of it. The method may

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -92,12 +92,21 @@ impl FromStr for TextUnit {
     }
 }
 
-// Parses a text by `lexer.text(|_| false, |_| true)`.
+/// Parses a text by `lexer.text(|_| false, |_| true)`.
 impl FromStr for Text {
     type Err = Error;
     fn from_str(s: &str) -> Result<Text, Error> {
         let mut lexer = Lexer::from_memory(s, Source::Unknown);
         unwrap_ready(lexer.text(|_| false, |_| true))
+    }
+}
+
+/// Parses an escaped string by `lexer.escaped_string(|_| false)`.
+impl FromStr for EscapedString {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut lexer = Lexer::from_memory(s, Source::Unknown);
+        unwrap_ready(lexer.escaped_string(|_| false))
     }
 }
 

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -101,6 +101,19 @@ impl FromStr for Text {
     }
 }
 
+impl FromStr for EscapeUnit {
+    /// Optional error value
+    ///
+    /// The error is `None` if the input is empty.
+    /// A proper error is returned in `Some(_)` in case of a syntax error.
+    type Err = Option<Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut lexer = Lexer::from_memory(s, Source::Unknown);
+        unwrap_ready(lexer.escape_unit()).shift()
+    }
+}
+
 /// Parses an escaped string by `lexer.escaped_string(|_| false)`.
 impl FromStr for EscapedString {
     type Err = Error;
@@ -464,6 +477,23 @@ mod tests {
             assert_matches!(&parse.0[2], CommandSubst { content, .. } => {
                 assert_eq!(&**content, "c");
             });
+        })
+    }
+
+    #[test]
+    fn escape_unit_from_str() {
+        block_on(async {
+            let parse: EscapeUnit = r"\n".parse().unwrap();
+            assert_eq!(parse, EscapeUnit::Newline);
+        })
+    }
+
+    #[test]
+    fn escaped_string_from_str() {
+        block_on(async {
+            let parse: EscapedString = r"a\nb".parse().unwrap();
+            use EscapeUnit::*;
+            assert_eq!(parse.0, [Literal('a'), Newline, Literal('b')]);
         })
     }
 

--- a/yash-syntax/src/parser/lex.rs
+++ b/yash-syntax/src/parser/lex.rs
@@ -26,7 +26,7 @@ mod backquote;
 mod braced_param;
 mod command_subst;
 mod dollar;
-mod dollar_single;
+mod escape;
 mod heredoc;
 mod keyword;
 mod misc;

--- a/yash-syntax/src/parser/lex.rs
+++ b/yash-syntax/src/parser/lex.rs
@@ -26,6 +26,7 @@ mod backquote;
 mod braced_param;
 mod command_subst;
 mod dollar;
+mod dollar_single;
 mod heredoc;
 mod keyword;
 mod misc;

--- a/yash-syntax/src/parser/lex/dollar.rs
+++ b/yash-syntax/src/parser/lex/dollar.rs
@@ -29,6 +29,9 @@ impl WordLexer<'_, '_> {
     /// If the next character is `$`, a parameter expansion, command
     /// substitution, or arithmetic expansion is parsed. Otherwise, no
     /// characters are consumed and the return value is `Ok(None)`.
+    ///
+    /// This function does not parse dollar-single-quotes. They are handled in
+    /// [`word_unit`](Self::word_unit).
     pub async fn dollar_unit(&mut self) -> Result<Option<TextUnit>> {
         let start_index = self.index();
         if !self.skip_if(|c| c == '$').await? {
@@ -48,7 +51,6 @@ impl WordLexer<'_, '_> {
             return Ok(Some(result));
         }
 
-        // TODO maybe reject unrecognized dollar unit?
         self.rewind(start_index);
         Ok(None)
     }

--- a/yash-syntax/src/parser/lex/dollar_single.rs
+++ b/yash-syntax/src/parser/lex/dollar_single.rs
@@ -1,0 +1,228 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2024 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Parsing dollar-single-quoted strings
+
+use super::core::Lexer;
+use crate::parser::core::Result;
+use crate::syntax::EscapeUnit;
+use crate::syntax::EscapedString;
+use crate::syntax::WordUnit::{self, DollarSingleQuote};
+
+impl Lexer<'_> {
+    /// Parses a dollar-single-quoted string.
+    ///
+    /// The initial `$` must have been consumed before calling this function.
+    /// The enclosing `'`s are consumed in this function.
+    ///
+    /// If the next character is not `'`, this function returns `None`.
+    pub(super) async fn dollar_single_quote(&mut self) -> Result<Option<WordUnit>> {
+        if self.consume_char_if(|c| c == '\'').await?.is_none() {
+            return Ok(None);
+        }
+
+        let mut units = Vec::new();
+        // Loop until the closing `'` is found
+        loop {
+            let Some(c) = self.peek_char().await? else {
+                todo!("return error");
+            };
+            self.consume_char();
+
+            use EscapeUnit::*;
+            match c {
+                '\'' => break,
+
+                '\\' => {
+                    let Some(c2) = self.peek_char().await? else {
+                        todo!("return error");
+                    };
+                    self.consume_char();
+                    match c2 {
+                        '"' => units.push(DoubleQuote),
+                        '\'' => units.push(SingleQuote),
+                        '\\' => units.push(Backslash),
+                        '?' => units.push(Question),
+                        'a' => units.push(Alert),
+                        'b' => units.push(Backspace),
+                        'e' | 'E' => units.push(Escape),
+                        'f' => units.push(FormFeed),
+                        'n' => units.push(Newline),
+                        'r' => units.push(CarriageReturn),
+                        't' => units.push(Tab),
+                        'v' => units.push(VerticalTab),
+
+                        'c' => {
+                            let Some(c3) = self.peek_char().await? else {
+                                todo!("return error");
+                            };
+                            self.consume_char();
+                            match c3.to_ascii_uppercase() {
+                                '\\' => {
+                                    let Some('\\') = self.peek_char().await? else {
+                                        todo!("return error");
+                                    };
+                                    self.consume_char();
+                                    units.push(Control(0x1C));
+                                }
+
+                                c3 @ ('\u{3F}'..'\u{60}') => units.push(Control(c3 as u8 ^ 0x40)),
+
+                                _ => todo!("return error: unknown control character {c3:?}"),
+                            }
+                        }
+
+                        _ => todo!("return error: unknown escape character {c2:?}"),
+                    }
+                }
+
+                c => units.push(Literal(c)),
+            }
+        }
+        Ok(Some(DollarSingleQuote(EscapedString(units))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::Source;
+    use assert_matches::assert_matches;
+    use futures_util::FutureExt;
+
+    #[test]
+    fn lexer_word_unit_dollar_single_quote_empty() {
+        let mut lexer = Lexer::from_memory("''", Source::Unknown);
+        let result = lexer.dollar_single_quote().now_or_never().unwrap().unwrap();
+        assert_matches!(result, Some(DollarSingleQuote(EscapedString(content))) => {
+            assert_eq!(content, []);
+        });
+    }
+
+    #[test]
+    fn lexer_word_unit_dollar_single_quote_literals() {
+        let mut lexer = Lexer::from_memory("'foo'", Source::Unknown);
+        let result = lexer.dollar_single_quote().now_or_never().unwrap().unwrap();
+        assert_matches!(result, Some(DollarSingleQuote(EscapedString(content))) => {
+            assert_eq!(
+                content,
+                [
+                    EscapeUnit::Literal('f'),
+                    EscapeUnit::Literal('o'),
+                    EscapeUnit::Literal('o'),
+                ]
+            );
+        });
+
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(None));
+    }
+
+    #[test]
+    fn lexer_word_unit_dollar_single_quote_named_escapes() {
+        let mut lexer = Lexer::from_memory(r#"'\""\'\\\?\a\b\e\E\f\n\r\t\v'x"#, Source::Unknown);
+        let result = lexer.dollar_single_quote().now_or_never().unwrap().unwrap();
+        assert_matches!(result, Some(DollarSingleQuote(EscapedString(content))) => {
+            assert_eq!(
+                content,
+                [
+                    EscapeUnit::DoubleQuote,
+                    EscapeUnit::Literal('"'),
+                    EscapeUnit::SingleQuote,
+                    EscapeUnit::Backslash,
+                    EscapeUnit::Question,
+                    EscapeUnit::Alert,
+                    EscapeUnit::Backspace,
+                    EscapeUnit::Escape,
+                    EscapeUnit::Escape,
+                    EscapeUnit::FormFeed,
+                    EscapeUnit::Newline,
+                    EscapeUnit::CarriageReturn,
+                    EscapeUnit::Tab,
+                    EscapeUnit::VerticalTab,
+                ]
+            );
+        });
+
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(Some('x')));
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_incomplete_escapes() {
+        todo!()
+    }
+
+    #[test]
+    fn lexer_word_unit_dollar_single_quote_control_escapes() {
+        let mut lexer = Lexer::from_memory(r"'\cA\cz\c^\c?\c\\'", Source::Unknown);
+        let result = lexer.dollar_single_quote().now_or_never().unwrap().unwrap();
+        assert_matches!(result, Some(DollarSingleQuote(EscapedString(content))) => {
+            assert_eq!(
+                content,
+                [
+                    EscapeUnit::Control(0x01),
+                    EscapeUnit::Control(0x1A),
+                    EscapeUnit::Control(0x1E),
+                    EscapeUnit::Control(0x7F),
+                    EscapeUnit::Control(0x1C),
+                ]
+            );
+        });
+
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(None));
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_incomplete_control_escapes() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_octal_escapes() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_hex_escapes() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_incomplete_hex_escape() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_unicode_escapes() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not implemented"]
+    fn lexer_word_unit_dollar_single_quote_incomplete_unicode_escapes() {
+        todo!()
+    }
+
+    // TODO Reject non-portable escapes in POSIX mode
+
+    // TODO lexer_word_unit_dollar_single_quote_unclosed
+    // TODO lexer_word_unit_dollar_single_quote_not_quote_in_text_context
+}

--- a/yash-syntax/src/parser/lex/dollar_single.rs
+++ b/yash-syntax/src/parser/lex/dollar_single.rs
@@ -18,10 +18,108 @@
 
 use super::core::Lexer;
 use crate::parser::core::Result;
+#[cfg(doc)]
 use crate::syntax::EscapeUnit;
+use crate::syntax::EscapeUnit::*;
 use crate::syntax::EscapedString;
 
 impl Lexer<'_> {
+    /// Parses an escaped string.
+    ///
+    /// The `is_delimiter` function is called with each character in the string
+    /// to determine if it is a delimiter. If `is_delimiter` returns `true`, the
+    /// character is not consumed and the function returns the string up to that
+    /// point. Otherwise, the character is consumed and the function continues.
+    ///
+    /// The string may contain escape sequences as defined in [`EscapeUnit`].
+    ///
+    /// Escaped strings typically appear as the content of
+    /// [dollar-single-quotes], so `is_delimiter` is usually `|c| c == '\''`.
+    ///
+    /// [dollar-single-quotes]: crate::syntax::WordUnit::DollarSingleQuote
+    pub async fn escaped_string<F>(&mut self, mut is_delimiter: F) -> Result<EscapedString>
+    where
+        F: FnMut(char) -> bool,
+    {
+        self.escaped_string_dyn(&mut is_delimiter).await
+    }
+
+    /// Dynamic version of [`Self::escaped_string`]
+    async fn escaped_string_dyn(
+        &mut self,
+        is_delimiter: &mut dyn FnMut(char) -> bool,
+    ) -> Result<EscapedString> {
+        let mut units = Vec::new();
+
+        while let Some(c) = self.consume_char_if(|c| !is_delimiter(c)).await? {
+            let c = c.value;
+            if c == '\\' {
+                // TODO Consider extracting this to a separate function
+                let Some(c2) = self.peek_char().await? else {
+                    todo!("return error");
+                };
+                self.consume_char();
+                match c2 {
+                    '"' => units.push(DoubleQuote),
+                    '\'' => units.push(SingleQuote),
+                    '\\' => units.push(Backslash),
+                    '?' => units.push(Question),
+                    'a' => units.push(Alert),
+                    'b' => units.push(Backspace),
+                    'e' | 'E' => units.push(Escape),
+                    'f' => units.push(FormFeed),
+                    'n' => units.push(Newline),
+                    'r' => units.push(CarriageReturn),
+                    't' => units.push(Tab),
+                    'v' => units.push(VerticalTab),
+
+                    'c' => {
+                        let Some(c3) = self.peek_char().await? else {
+                            todo!("return error");
+                        };
+                        self.consume_char();
+                        match c3.to_ascii_uppercase() {
+                            '\\' => {
+                                let Some('\\') = self.peek_char().await? else {
+                                    todo!("return error");
+                                };
+                                self.consume_char();
+                                units.push(Control(0x1C));
+                            }
+
+                            c3 @ ('\u{3F}'..'\u{60}') => units.push(Control(c3 as u8 ^ 0x40)),
+
+                            _ => todo!("return error: unknown control character {c3:?}"),
+                        }
+                    }
+
+                    _ => {
+                        // Consume at most 3 octal digits (including c2)
+                        let Some(mut value) = c2.to_digit(8) else {
+                            todo!("return error: unknown escape character {c2:?}");
+                        };
+                        for _ in 0..2 {
+                            let Some(digit) = self.peek_char().await? else {
+                                todo!("return error: missing closing quote");
+                            };
+                            if let Some(digit) = digit.to_digit(8) {
+                                value = value * 8 + digit;
+                                self.consume_char();
+                            } else {
+                                break;
+                            }
+                        }
+                        units.push(Octal(value as u8));
+                    }
+                }
+            } else {
+                units.push(Literal(c));
+            }
+        }
+
+        Ok(EscapedString(units))
+    }
+
     /// Parses an escaped string enclosed in single quotes.
     ///
     /// This function is meant to be used for parsing dollar-single-quoted
@@ -33,87 +131,23 @@ impl Lexer<'_> {
     /// closing `'` is not found or an invalid escape sequence is found, this
     /// function returns an error.
     pub(super) async fn single_quoted_escaped_string(&mut self) -> Result<Option<EscapedString>> {
-        if self.consume_char_if(|c| c == '\'').await?.is_none() {
+        let is_single_quote = |c| c == '\'';
+
+        // Consume the opening single quote
+        if self.consume_char_if(is_single_quote).await?.is_none() {
             return Ok(None);
         }
 
-        let mut units = Vec::new();
-        // Loop until the closing `'` is found
-        loop {
-            let Some(c) = self.peek_char().await? else {
-                todo!("return error");
-            };
+        let content = self.escaped_string(is_single_quote).await?;
+
+        // Consume the closing single quote
+        if let Some(quote) = self.peek_char().await? {
+            debug_assert_eq!(quote, '\'');
             self.consume_char();
-
-            use EscapeUnit::*;
-            match c {
-                '\'' => break,
-
-                // TODO Consider extracting this to a separate function
-                '\\' => {
-                    let Some(c2) = self.peek_char().await? else {
-                        todo!("return error");
-                    };
-                    self.consume_char();
-                    match c2 {
-                        '"' => units.push(DoubleQuote),
-                        '\'' => units.push(SingleQuote),
-                        '\\' => units.push(Backslash),
-                        '?' => units.push(Question),
-                        'a' => units.push(Alert),
-                        'b' => units.push(Backspace),
-                        'e' | 'E' => units.push(Escape),
-                        'f' => units.push(FormFeed),
-                        'n' => units.push(Newline),
-                        'r' => units.push(CarriageReturn),
-                        't' => units.push(Tab),
-                        'v' => units.push(VerticalTab),
-
-                        'c' => {
-                            let Some(c3) = self.peek_char().await? else {
-                                todo!("return error");
-                            };
-                            self.consume_char();
-                            match c3.to_ascii_uppercase() {
-                                '\\' => {
-                                    let Some('\\') = self.peek_char().await? else {
-                                        todo!("return error");
-                                    };
-                                    self.consume_char();
-                                    units.push(Control(0x1C));
-                                }
-
-                                c3 @ ('\u{3F}'..'\u{60}') => units.push(Control(c3 as u8 ^ 0x40)),
-
-                                _ => todo!("return error: unknown control character {c3:?}"),
-                            }
-                        }
-
-                        _ => {
-                            // Consume at most 3 octal digits (including c2)
-                            let Some(mut value) = c2.to_digit(8) else {
-                                todo!("return error: unknown escape character {c2:?}");
-                            };
-                            for _ in 0..2 {
-                                let Some(digit) = self.peek_char().await? else {
-                                    todo!("return error: missing closing quote");
-                                };
-                                if let Some(digit) = digit.to_digit(8) {
-                                    value = value * 8 + digit;
-                                    self.consume_char();
-                                } else {
-                                    break;
-                                }
-                            }
-                            units.push(Octal(value as u8));
-                        }
-                    }
-                }
-
-                c => units.push(Literal(c)),
-            }
+            Ok(Some(content))
+        } else {
+            todo!("return error: missing closing quote");
         }
-        Ok(Some(EscapedString(units)))
     }
 }
 
@@ -125,100 +159,70 @@ mod tests {
     use futures_util::FutureExt;
 
     #[test]
-    fn single_quoted_escaped_string_empty() {
-        let mut lexer = Lexer::from_memory("''", Source::Unknown);
-        let result = lexer
-            .single_quoted_escaped_string()
+    fn escaped_string_literals() {
+        let mut lexer = Lexer::from_memory("foo", Source::Unknown);
+        let EscapedString(content) = lexer
+            .escaped_string(|_| false)
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_matches!(result, Some(EscapedString(content)) => {
-            assert_eq!(content, []);
-        });
+        assert_eq!(content, [Literal('f'), Literal('o'), Literal('o')]);
     }
 
     #[test]
-    fn single_quoted_escaped_string_literals() {
-        let mut lexer = Lexer::from_memory("'foo'", Source::Unknown);
-        let result = lexer
-            .single_quoted_escaped_string()
+    fn escaped_string_named_escapes() {
+        let mut lexer = Lexer::from_memory(r#"\""\'\\\?\a\b\e\E\f\n\r\t\v"#, Source::Unknown);
+        let EscapedString(content) = lexer
+            .escaped_string(|_| false)
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_matches!(result, Some(EscapedString(content)) => {
-            assert_eq!(
-                content,
-                [
-                    EscapeUnit::Literal('f'),
-                    EscapeUnit::Literal('o'),
-                    EscapeUnit::Literal('o'),
-                ]
-            );
-        });
-
+        assert_eq!(
+            content,
+            [
+                DoubleQuote,
+                Literal('"'),
+                SingleQuote,
+                Backslash,
+                Question,
+                Alert,
+                Backspace,
+                Escape,
+                Escape,
+                FormFeed,
+                Newline,
+                CarriageReturn,
+                Tab,
+                VerticalTab,
+            ]
+        );
         assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(None));
     }
 
     #[test]
-    fn single_quoted_escaped_string_named_escapes() {
-        let mut lexer = Lexer::from_memory(r#"'\""\'\\\?\a\b\e\E\f\n\r\t\v'x"#, Source::Unknown);
-        let result = lexer
-            .single_quoted_escaped_string()
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        assert_matches!(result, Some(EscapedString(content)) => {
-            assert_eq!(
-                content,
-                [
-                    EscapeUnit::DoubleQuote,
-                    EscapeUnit::Literal('"'),
-                    EscapeUnit::SingleQuote,
-                    EscapeUnit::Backslash,
-                    EscapeUnit::Question,
-                    EscapeUnit::Alert,
-                    EscapeUnit::Backspace,
-                    EscapeUnit::Escape,
-                    EscapeUnit::Escape,
-                    EscapeUnit::FormFeed,
-                    EscapeUnit::Newline,
-                    EscapeUnit::CarriageReturn,
-                    EscapeUnit::Tab,
-                    EscapeUnit::VerticalTab,
-                ]
-            );
-        });
-
-        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(Some('x')));
-    }
-
-    #[test]
     #[ignore = "not implemented"]
-    fn single_quoted_escaped_string_incomplete_escapes() {
+    fn escaped_string_incomplete_escapes() {
         todo!()
     }
 
     #[test]
-    fn single_quoted_escaped_string_control_escapes() {
-        let mut lexer = Lexer::from_memory(r"'\cA\cz\c^\c?\c\\'", Source::Unknown);
-        let result = lexer
-            .single_quoted_escaped_string()
+    fn escaped_string_control_escapes() {
+        let mut lexer = Lexer::from_memory(r"\cA\cz\c^\c?\c\\", Source::Unknown);
+        let EscapedString(content) = lexer
+            .escaped_string(|_| false)
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_matches!(result, Some(EscapedString(content)) => {
-            assert_eq!(
-                content,
-                [
-                    EscapeUnit::Control(0x01),
-                    EscapeUnit::Control(0x1A),
-                    EscapeUnit::Control(0x1E),
-                    EscapeUnit::Control(0x7F),
-                    EscapeUnit::Control(0x1C),
-                ]
-            );
-        });
-
+        assert_eq!(
+            content,
+            [
+                Control(0x01),
+                Control(0x1A),
+                Control(0x1E),
+                Control(0x7F),
+                Control(0x1C),
+            ]
+        );
         assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(None));
     }
 
@@ -230,24 +234,23 @@ mod tests {
 
     #[test]
     fn single_quoted_escaped_string_octal_escapes() {
-        let mut lexer = Lexer::from_memory(r"'\0\07\177\0123'", Source::Unknown);
-        let result = lexer
-            .single_quoted_escaped_string()
+        let mut lexer = Lexer::from_memory(r"\0\07\177\0123", Source::Unknown);
+        let EscapedString(content) = lexer
+            .escaped_string(|_| false)
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_matches!(result, Some(EscapedString(content)) => {
-            assert_eq!(
-                content,
-                [
-                    EscapeUnit::Octal(0o0),
-                    EscapeUnit::Octal(0o7),
-                    EscapeUnit::Octal(0o177),
-                    EscapeUnit::Octal(0o12),
-                    EscapeUnit::Literal('3'),
-                ]
-            );
-        });
+        assert_eq!(
+            content,
+            [
+                Octal(0o0),
+                Octal(0o7),
+                Octal(0o177),
+                Octal(0o12),
+                Literal('3'),
+            ]
+        );
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(None));
     }
 
     #[test]
@@ -255,7 +258,7 @@ mod tests {
     fn single_quoted_escaped_string_non_byte_octal_escape() {
         let mut lexer = Lexer::from_memory(r"'\700'", Source::Unknown);
         let result = lexer
-            .single_quoted_escaped_string()
+            .escaped_string(|_| false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -288,6 +291,38 @@ mod tests {
 
     // TODO Reject non-portable escapes in POSIX mode
 
+    #[test]
+    fn single_quoted_escaped_string_empty() {
+        let mut lexer = Lexer::from_memory("''", Source::Unknown);
+        let result = lexer
+            .single_quoted_escaped_string()
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, Some(EscapedString(vec![])));
+    }
+
+    #[test]
+    fn single_quoted_escaped_string_nonempty() {
+        let mut lexer = Lexer::from_memory(r"'foo\e'x", Source::Unknown);
+        let result = lexer
+            .single_quoted_escaped_string()
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_matches!(result, Some(EscapedString(content)) => {
+            assert_eq!(
+                content,
+                [
+                    Literal('f'),
+                    Literal('o'),
+                    Literal('o'),
+                    Escape,
+                ]
+            );
+        });
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(Some('x')));
+    }
+
     // TODO single_quoted_escaped_string_unclosed
-    // TODO single_quoted_escaped_string_not_quote_in_text_context
 }

--- a/yash-syntax/src/parser/lex/escape.rs
+++ b/yash-syntax/src/parser/lex/escape.rs
@@ -16,8 +16,6 @@
 
 //! Parsing escape units and escaped strings
 
-// TODO Rename this module to `escape`
-
 use super::core::Lexer;
 use crate::parser::core::Result;
 use crate::syntax::EscapeUnit::{self, *};

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -26,7 +26,7 @@ use crate::source::Location;
 use crate::source::SourceChar;
 use crate::syntax::TextUnit;
 use crate::syntax::Word;
-use crate::syntax::WordUnit::{self, DoubleQuote, SingleQuote, Unquoted};
+use crate::syntax::WordUnit::{self, DollarSingleQuote, DoubleQuote, SingleQuote, Unquoted};
 
 impl Lexer<'_> {
     /// Parses a single-quoted string.
@@ -132,8 +132,8 @@ impl WordLexer<'_, '_> {
             _ => {
                 let unit = self.text_unit(is_delimiter, is_escapable).await?;
                 if allow_single_quote && unit == Some(TextUnit::Literal('$')) {
-                    if let Some(result) = self.dollar_single_quote().await? {
-                        return Ok(Some(result));
+                    if let Some(result) = self.single_quoted_escaped_string().await? {
+                        return Ok(Some(DollarSingleQuote(result)));
                     }
                     // TODO Maybe reject any other characters after `$`?
                 }

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -341,6 +341,65 @@ pub use TextUnit::*;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Text(pub Vec<TextUnit>);
 
+/// Element of an [`EscapedString`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscapeUnit {
+    /// Literal single character
+    Literal(char),
+    /// Backslash-escaped double-quote character (`\"`)
+    DoubleQuote,
+    /// Backslash-escaped single-quote character (`\'`)
+    SingleQuote,
+    /// Backslash-escaped backslash character (`\\`)
+    Backslash,
+    /// Backslash-escaped question mark character (`\?`)
+    Question,
+    /// Backslash notation for the bell character (`\a`, ASCII 7)
+    Alert,
+    /// Backslash notation for the backspace character (`\b`, ASCII 8)
+    Backspace,
+    /// Backslash notation for the escape character (`\e`, ASCII 27)
+    Escape,
+    /// Backslash notation for the form feed character (`\f`, ASCII 12)
+    FormFeed,
+    /// Backslash notation for the newline character (`\n`, ASCII 10)
+    Newline,
+    /// Backslash notation for the carriage return character (`\r`, ASCII 13)
+    CarriageReturn,
+    /// Backslash notation for the horizontal tab character (`\t`, ASCII 9)
+    Tab,
+    /// Backslash notation for the vertical tab character (`\v`, ASCII 11)
+    VerticalTab,
+    /// Control character notation (`\c...`)
+    ///
+    /// The associated value is the control character represented by the
+    /// following character in the input.
+    Control(u8),
+    /// Single-byte octal notation (`\OOO`)
+    ///
+    /// The associated value is the byte represented by the three octal digits
+    /// following the backslash.
+    Octal(u8),
+    /// Single-byte hexadecimal notation (`\xHH`)
+    ///
+    /// The associated value is the byte represented by the two hexadecimal
+    /// digits following the `x`.
+    Hex(u8),
+    /// Unicode notation (`\uHHHH` or `\UHHHHHHHH`)
+    ///
+    /// The associated value is the Unicode scalar value represented by the four
+    /// or eight hexadecimal digits following the `u` or `U`.
+    Unicode(char),
+}
+
+/// String that may contain some escapes
+///
+/// An escaped string is a sequence of [escape unit](EscapeUnit)s, which may
+/// contain some kinds of escapes. This type is used for the value of a
+/// [dollar-single-quoted string](WordUnit::DollarSingleQuote).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EscapedString(pub Vec<EscapeUnit>);
+
 /// Element of a [Word], i.e., text with quotes and tilde expansion
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WordUnit {
@@ -350,6 +409,8 @@ pub enum WordUnit {
     SingleQuote(String),
     /// Text surrounded with a pair of double quotations
     DoubleQuote(Text),
+    /// String surrounded with a pair of single quotations and preceded by a dollar sign
+    DollarSingleQuote(EscapedString),
     /// Tilde expansion
     ///
     /// The `String` value does not contain the initial tilde.

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -439,7 +439,7 @@ impl Unquote for WordUnit {
                 Ok(true)
             }
             DoubleQuote(inner) => inner.write_unquoted(w),
-            DollarSingleQuote(_) => todo!(),
+            DollarSingleQuote(inner) => inner.write_unquoted(w),
             Tilde(s) => {
                 write!(w, "~{s}")?;
                 Ok(false)

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -419,6 +419,17 @@ impl Unquote for EscapeUnit {
     }
 }
 
+impl MaybeLiteral for EscapeUnit {
+    fn extend_literal<T: Extend<char>>(&self, result: &mut T) -> Result<(), NotLiteral> {
+        if let Self::Literal(c) = self {
+            result.extend(std::iter::once(*c));
+            Ok(())
+        } else {
+            Err(NotLiteral)
+        }
+    }
+}
+
 /// Converts an escaped string into the string represented by the escape
 /// sequences.
 ///
@@ -427,6 +438,12 @@ impl Unquote for EscapeUnit {
 impl Unquote for EscapedString {
     fn write_unquoted<W: fmt::Write>(&self, w: &mut W) -> UnquoteResult {
         self.0.write_unquoted(w)
+    }
+}
+
+impl MaybeLiteral for EscapedString {
+    fn extend_literal<T: Extend<char>>(&self, result: &mut T) -> Result<(), NotLiteral> {
+        self.0.extend_literal(result)
     }
 }
 

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -354,6 +354,7 @@ impl Unquote for WordUnit {
                 Ok(true)
             }
             DoubleQuote(inner) => inner.write_unquoted(w),
+            DollarSingleQuote(_) => todo!(),
             Tilde(s) => {
                 write!(w, "~{s}")?;
                 Ok(false)

--- a/yash-syntax/src/syntax/impl_display.rs
+++ b/yash-syntax/src/syntax/impl_display.rs
@@ -133,6 +133,7 @@ impl fmt::Display for WordUnit {
             Unquoted(dq) => dq.fmt(f),
             SingleQuote(s) => write!(f, "'{s}'"),
             DoubleQuote(content) => write!(f, "\"{content}\""),
+            DollarSingleQuote(_) => todo!(),
             Tilde(s) => write!(f, "~{s}"),
         }
     }


### PR DESCRIPTION
- Syntax definition
    - [x] Define `EscapeUnit` and `EscapedString`
    - [x] Implement `Unquote` for `EscapeUnit` and `EscapedString`
    - [x] Implement `MaybeLiteral` for `EscapeUnit` and `EscapedString`
    - [x] Implement `Display` for `EscapeUnit` and `EscapedString`
- Parsing
    - [x] Implement the parser
    - [x] Implement `FromStr` for `EscapeUnit` and `EscapedString`
- Semantics
    - [x] `impl Expand for WordUnit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for new case branch termination options: `;&`, `;|`, and `;;&`.
	- Added dollar-single-quotes for quoting, allowing for backslash escapes and UTF-8 sequences.
	- Enhanced error handling and reporting for syntax errors related to escape sequences.

- **Bug Fixes**
	- Improved handling of background job process IDs.
	- Fixed issues with `exec` built-in command behavior in interactive mode.

- **Tests**
	- Expanded test coverage for quoting behavior, particularly with dollar-single quotes and line continuation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->