### PR TITLE
Use Ubuntu 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
@@ -22,7 +22,7 @@ jobs:
     - name: Run basic tests
       run: ./check.sh -v
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -30,7 +30,7 @@ jobs:
       with:
         reporter: github-pr-review
   extra:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
     steps:
@@ -43,7 +43,7 @@ jobs:
   msrv:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -80,7 +80,7 @@ jobs:
     - name: Test yash-builtin
       run: cargo test --all-features --package yash-builtin
   summarize:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [check, clippy, extra, msrv, windows]
     if: ${{ always() }}
     steps:


### PR DESCRIPTION
Prepare for the upcoming update to GitHub Actions where the default Ubuntu image will be Ubuntu 24.

See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to utilize the latest Ubuntu version (ubuntu-24.04) for improved build and test processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->