### PR TITLE
Declaration utility

### DIFF
--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -162,7 +162,9 @@ use yash_syntax::syntax::Assign;
 /// detail semantics may differ in other shell implementations.
 impl Command for syntax::SimpleCommand {
     async fn execute(&self, env: &mut Env) -> Result {
-        let (fields, exit_status) = match expand_words(env, &self.words).await {
+        // TODO Honor the expansion behavior
+        let words = self.words.iter().map(|(word, _)| word);
+        let (fields, exit_status) = match expand_words(env, words).await {
             Ok(result) => result,
             Err(error) => return error.handle(env).await,
         };

--- a/yash-syntax/src/parser/compound_command.rs
+++ b/yash-syntax/src/parser/compound_command.rs
@@ -100,6 +100,7 @@ mod tests {
     use crate::source::Location;
     use crate::source::Source;
     use crate::syntax::Command;
+    use crate::syntax::ExpansionBehavior;
     use crate::syntax::SimpleCommand;
     use assert_matches::assert_matches;
     use futures_util::FutureExt;
@@ -253,7 +254,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["foo".parse().unwrap()],
+            words: vec![("foo".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -193,7 +193,7 @@ impl FromStr for Assign {
                 if let Some(word) = c.words.pop() {
                     Err(Some(Error {
                         cause: ErrorCause::Syntax(SyntaxError::RedundantToken),
-                        location: word.location,
+                        location: word.0.location,
                     }))
                 } else if let Some(redir) = c.redirs.first() {
                     Err(Some(Error {

--- a/yash-syntax/src/parser/function.rs
+++ b/yash-syntax/src/parser/function.rs
@@ -54,7 +54,7 @@ impl Parser<'_, '_> {
             });
         }
 
-        let name = intro.words.pop().unwrap();
+        let name = intro.words.pop().unwrap().0;
         debug_assert!(intro.is_empty());
         // TODO reject invalid name if POSIXly-correct
 
@@ -95,6 +95,7 @@ mod tests {
     use crate::alias::{AliasSet, EmptyGlossary, HashEntry};
     use crate::source::Location;
     use crate::source::Source;
+    use crate::syntax::ExpansionBehavior;
     use assert_matches::assert_matches;
     use futures_util::FutureExt;
 
@@ -124,7 +125,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["foo".parse().unwrap()],
+            words: vec![("foo".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 
@@ -141,7 +142,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["foo".parse().unwrap()],
+            words: vec![("foo".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 
@@ -163,7 +164,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["foo".parse().unwrap()],
+            words: vec![("foo".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 
@@ -185,7 +186,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &EmptyGlossary);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["foo".parse().unwrap()],
+            words: vec![("foo".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 
@@ -304,7 +305,7 @@ mod tests {
         let mut parser = Parser::new(&mut lexer, &aliases);
         let c = SimpleCommand {
             assigns: vec![],
-            words: vec!["f".parse().unwrap()],
+            words: vec![("f".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec![].into(),
         };
 

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -25,6 +25,7 @@ use super::lex::Operator::{CloseParen, Newline, OpenParen};
 use super::lex::TokenId::{Operator, Token};
 use crate::syntax::Array;
 use crate::syntax::Assign;
+use crate::syntax::ExpansionBehavior;
 use crate::syntax::Redir;
 use crate::syntax::Scalar;
 use crate::syntax::SimpleCommand;
@@ -34,7 +35,7 @@ use crate::syntax::Word;
 #[derive(Default)]
 struct Builder {
     assigns: Vec<Assign>,
-    words: Vec<Word>,
+    words: Vec<(Word, ExpansionBehavior)>,
     redirs: Vec<Redir>,
 }
 
@@ -123,13 +124,14 @@ impl Parser<'_, '_> {
 
             // Tell assignment from word
             if !result.words.is_empty() {
-                result.words.push(token.word);
+                // TODO Provide the correct expansion behavior
+                result.words.push((token.word, ExpansionBehavior::Regular));
                 continue;
             }
             let mut assign = match Assign::try_from(token.word) {
                 Ok(assign) => assign,
                 Err(word) => {
-                    result.words.push(word);
+                    result.words.push((word, ExpansionBehavior::Regular));
                     continue;
                 }
             };
@@ -336,7 +338,8 @@ mod tests {
         assert_eq!(sc.assigns, []);
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.words.len(), 1);
-        assert_eq!(sc.words[0].to_string(), "word");
+        assert_eq!(sc.words[0].0.to_string(), "word");
+        assert_eq!(sc.words[0].1, ExpansionBehavior::Regular);
     }
 
     #[test]
@@ -349,9 +352,12 @@ mod tests {
         assert_eq!(sc.assigns, []);
         assert_eq!(*sc.redirs, []);
         assert_eq!(sc.words.len(), 3);
-        assert_eq!(sc.words[0].to_string(), ":");
-        assert_eq!(sc.words[1].to_string(), "if");
-        assert_eq!(sc.words[2].to_string(), "then");
+        assert_eq!(sc.words[0].0.to_string(), ":");
+        assert_eq!(sc.words[0].1, ExpansionBehavior::Regular);
+        assert_eq!(sc.words[1].0.to_string(), "if");
+        assert_eq!(sc.words[1].1, ExpansionBehavior::Regular);
+        assert_eq!(sc.words[2].0.to_string(), "then");
+        assert_eq!(sc.words[2].1, ExpansionBehavior::Regular);
     }
 
     #[test]
@@ -416,7 +422,8 @@ mod tests {
         assert_eq!(sc.words.len(), 1);
         assert_eq!(sc.assigns[0].name, "if");
         assert_eq!(sc.assigns[0].value.to_string(), "then");
-        assert_eq!(sc.words[0].to_string(), "else");
+        assert_eq!(sc.words[0].0.to_string(), "else");
+        assert_eq!(sc.words[0].1, ExpansionBehavior::Regular);
     }
 
     #[test]
@@ -429,7 +436,8 @@ mod tests {
         assert_eq!(sc.assigns, []);
         assert_eq!(sc.words.len(), 1);
         assert_eq!(sc.redirs.len(), 1);
-        assert_eq!(sc.words[0].to_string(), "word");
+        assert_eq!(sc.words[0].0.to_string(), "word");
+        assert_eq!(sc.words[0].1, ExpansionBehavior::Regular);
         assert_eq!(sc.redirs[0].fd, None);
         assert_matches!(sc.redirs[0].body, RedirBody::Normal { ref operator, ref operand } => {
             assert_eq!(operator, &RedirOp::FileIn);
@@ -468,7 +476,8 @@ mod tests {
         assert_eq!(sc.redirs.len(), 1);
         assert_eq!(sc.assigns[0].name, "if");
         assert_eq!(sc.assigns[0].value.to_string(), "then");
-        assert_eq!(sc.words[0].to_string(), "else");
+        assert_eq!(sc.words[0].0.to_string(), "else");
+        assert_eq!(sc.words[0].1, ExpansionBehavior::Regular);
         assert_eq!(sc.redirs[0].fd, None);
         assert_matches!(sc.redirs[0].body, RedirBody::Normal { ref operator, ref operand } => {
             assert_eq!(operator, &RedirOp::FileIn);

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -641,9 +641,8 @@ pub enum ExpansionBehavior {
 pub struct SimpleCommand {
     /// Assignments
     pub assigns: Vec<Assign>,
-    // TODO Change to Vec<(Word, ExpansionBehavior)>
     /// Command name and arguments
-    pub words: Vec<Word>,
+    pub words: Vec<(Word, ExpansionBehavior)>,
     /// Redirections
     pub redirs: Rc<Vec<Redir>>,
 }
@@ -663,7 +662,7 @@ impl SimpleCommand {
     /// Tests whether the first word of the simple command is a keyword.
     #[must_use]
     fn first_word_is_keyword(&self) -> bool {
-        let Some(word) = self.words.first() else {
+        let Some((word, _)) = self.words.first() else {
             return false;
         };
         let Some(literal) = word.to_string_if_literal() else {

--- a/yash-syntax/src/syntax/impl_display.rs
+++ b/yash-syntax/src/syntax/impl_display.rs
@@ -237,7 +237,7 @@ impl fmt::Display for Redir {
 impl fmt::Display for SimpleCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let i1 = self.assigns.iter().map(|x| x as &dyn fmt::Display);
-        let i2 = self.words.iter().map(|x| x as &dyn fmt::Display);
+        let i2 = self.words.iter().map(|x| &x.0 as &dyn fmt::Display);
         let i3 = self.redirs.iter().map(|x| x as &dyn fmt::Display);
 
         if !self.assigns.is_empty() || !self.first_word_is_keyword() {
@@ -742,10 +742,14 @@ mod tests {
             .push(Assign::from_str("hello=world").unwrap());
         assert_eq!(command.to_string(), "name=value hello=world");
 
-        command.words.push(Word::from_str("echo").unwrap());
+        command
+            .words
+            .push((Word::from_str("echo").unwrap(), ExpansionBehavior::Regular));
         assert_eq!(command.to_string(), "name=value hello=world echo");
 
-        command.words.push(Word::from_str("foo").unwrap());
+        command
+            .words
+            .push((Word::from_str("foo").unwrap(), ExpansionBehavior::Assign));
         assert_eq!(command.to_string(), "name=value hello=world echo foo");
 
         Rc::make_mut(&mut command.redirs).push(Redir {
@@ -782,7 +786,7 @@ mod tests {
     fn simple_command_display_with_keyword() {
         let command = SimpleCommand {
             assigns: vec![],
-            words: vec!["if".parse().unwrap()],
+            words: vec![("if".parse().unwrap(), ExpansionBehavior::Regular)],
             redirs: vec!["<foo".parse().unwrap()].into(),
         };
         assert_eq!(command.to_string(), "<foo if");


### PR DESCRIPTION
- Syntax
  - [x] Define `ExpansionBehavior`
  - [x] Redefine `SimpleCommand::words` using `ExpansionBehavior`
- Semantics
  - [ ] Implement `expand_simple_command_word`
  - [ ] Implement `expand_simple_command_words`
  - [ ] Use the new expansion functions in the simple command execution
  - [ ] Deprecate `expand_words`
  - [ ] Revise the module-level documentation for `yash_semantics::expansion`
- Parser
  - [ ] Refactor the parser builder API to allow more options
  - [ ] Add a parser option to tell whether a command is a declaration utility
  - [ ] Parse assignment words in declaration utilities
- [ ] Implement scripted tests
- [ ] Update CHANGELOG
- [ ] Resolve any remaining TODOs