### PR TITLE
Remove nix dependency from yash-env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "bitflags",
  "either",
  "enumset",
+ "errno",
  "futures-executor",
  "futures-util",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -579,6 +579,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "itertools",
+ "libc",
  "nix",
  "slab",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,6 @@ dependencies = [
  "futures-util",
  "itertools",
  "libc",
- "nix",
  "slab",
  "strum",
  "tempfile",

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `builtin::Builtin` struct now has the `is_declaration_utility` field.
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.
+- The `system::errno::Errno` struct now can be converted to and from the `Errno`
+  type from the `errno` crate.
 - Internal dependencies:
+    - errno 0.3.10
     - libc 0.2.169
 
 ### Changed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External dependency versions:
     - yash-syntax 0.13.0 → 0.14.0
 
+### Removed
+
+- The implementation of `From` for converting `errno::Errno` to and from
+  `nix::errno::Errno`.
+- Internal dependencies:
+    - nix 0.29.0
+
 ## [0.5.0] - 2024-12-14
 
 ### Changed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `System::getpwnam_dir` now takes a `&CStr` parameter instead of a `&str`.
 - The `builtin::Builtin` struct is now `non_exhaustive`.
 - External dependency versions:
     - yash-syntax 0.13.0 → 0.14.0

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `builtin::Builtin` struct now has the `is_declaration_utility` field.
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.
+- Internal dependencies:
+    - libc 0.2.169
 
 ### Changed
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -33,6 +33,7 @@ yash-syntax = { path = "../yash-syntax", version = "0.14.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
+libc = { version = "0.2.169", default-features = false }
 nix = { version = "0.29.0", features = ["fs", "signal", "user"] }
 yash-executor = { path = "../yash-executor", version = "1.0.0" }
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -19,6 +19,7 @@ annotate-snippets = "0.11.4"
 bitflags = "2.6.0"
 either = "1.9.0"
 enumset = "1.1.2"
+errno = { version = "0.3.10", default-features = false }
 futures-util = "0.3.31"
 itertools = "0.13.0"
 slab = "0.4.9"

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -35,7 +35,6 @@ yash-syntax = { path = "../yash-syntax", version = "0.14.0", features = [
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.169", default-features = false }
-nix = { version = "0.29.0", features = ["fs", "signal", "user"] }
 yash-executor = { path = "../yash-executor", version = "1.0.0" }
 
 [dev-dependencies]

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -50,7 +50,7 @@ use std::ops::Deref;
 use thiserror::Error;
 
 #[cfg(unix)]
-type RawPidDef = nix::libc::pid_t;
+type RawPidDef = libc::pid_t;
 #[cfg(not(unix))]
 type RawPidDef = i32;
 
@@ -63,8 +63,6 @@ type RawPidDef = i32;
 ///
 /// Process IDs are usually wrapped in the [`Pid`] type for better type safety,
 /// so this type is not used directly in most cases.
-///
-/// [`libc`]: nix::libc
 pub type RawPid = RawPidDef;
 
 /// Process ID
@@ -82,7 +80,6 @@ pub type RawPid = RawPidDef;
 ///
 /// This type may also be used to represent process group IDs, session IDs, etc.
 ///
-/// [`libc`]: nix::libc
 /// [`kill`]: crate::system::System::kill
 /// [`wait`]: crate::system::System::wait
 /// [`setpgid`]: crate::system::System::setpgid

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -434,7 +434,7 @@ pub trait System: Debug {
     /// Returns the home directory path of the given user.
     ///
     /// Returns `Ok(None)` if the user is not found.
-    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>>;
+    fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>>;
 
     /// Returns the standard `$PATH` value where all standard utilities are
     /// expected to be found.

--- a/yash-env/src/system/errno.rs
+++ b/yash-env/src/system/errno.rs
@@ -410,28 +410,6 @@ impl From<errno::Errno> for Errno {
     }
 }
 
-/// Converts [`Errno`] to [`nix::Error`].
-///
-/// This conversion is only available on Unix-like systems.
-#[cfg(unix)]
-impl From<Errno> for nix::Error {
-    #[inline]
-    fn from(errno: Errno) -> Self {
-        Self::from_raw(errno.0)
-    }
-}
-
-/// Converts [`nix::Error`] to [`Errno`].
-///
-/// This conversion is only available on Unix-like systems.
-#[cfg(unix)]
-impl From<nix::Error> for Errno {
-    #[inline]
-    fn from(error: nix::Error) -> Self {
-        Self(error as RawErrno)
-    }
-}
-
 impl From<Errno> for std::io::Error {
     #[inline]
     fn from(errno: Errno) -> Self {

--- a/yash-env/src/system/errno.rs
+++ b/yash-env/src/system/errno.rs
@@ -50,167 +50,167 @@ impl Errno {
 #[cfg(unix)]
 impl Errno {
     /// Argument list too long
-    pub const E2BIG: Self = Self(nix::libc::E2BIG as _);
+    pub const E2BIG: Self = Self(libc::E2BIG as _);
     /// Permission denied
-    pub const EACCES: Self = Self(nix::libc::EACCES as _);
+    pub const EACCES: Self = Self(libc::EACCES as _);
     /// Address in use.
-    pub const EADDRINUSE: Self = Self(nix::libc::EADDRINUSE as _);
+    pub const EADDRINUSE: Self = Self(libc::EADDRINUSE as _);
     /// Address not available
-    pub const EADDRNOTAVAIL: Self = Self(nix::libc::EADDRNOTAVAIL as _);
+    pub const EADDRNOTAVAIL: Self = Self(libc::EADDRNOTAVAIL as _);
     /// Address family not supported
-    pub const EAFNOSUPPORT: Self = Self(nix::libc::EAFNOSUPPORT as _);
+    pub const EAFNOSUPPORT: Self = Self(libc::EAFNOSUPPORT as _);
     /// Resource unavailable, try again (may be the same value as [`EWOULDBLOCK`](Self::EWOULDBLOCK))
-    pub const EAGAIN: Self = Self(nix::libc::EAGAIN as _);
+    pub const EAGAIN: Self = Self(libc::EAGAIN as _);
     /// Connection already in progress
-    pub const EALREADY: Self = Self(nix::libc::EALREADY as _);
+    pub const EALREADY: Self = Self(libc::EALREADY as _);
     /// Bad file descriptor
-    pub const EBADF: Self = Self(nix::libc::EBADF as _);
+    pub const EBADF: Self = Self(libc::EBADF as _);
     /// Bad message
-    pub const EBADMSG: Self = Self(nix::libc::EBADMSG as _);
+    pub const EBADMSG: Self = Self(libc::EBADMSG as _);
     /// Device or resource busy
-    pub const EBUSY: Self = Self(nix::libc::EBUSY as _);
+    pub const EBUSY: Self = Self(libc::EBUSY as _);
     /// Operation canceled
-    pub const ECANCELED: Self = Self(nix::libc::ECANCELED as _);
+    pub const ECANCELED: Self = Self(libc::ECANCELED as _);
     /// No child processes
-    pub const ECHILD: Self = Self(nix::libc::ECHILD as _);
+    pub const ECHILD: Self = Self(libc::ECHILD as _);
     /// Connection aborted
-    pub const ECONNABORTED: Self = Self(nix::libc::ECONNABORTED as _);
+    pub const ECONNABORTED: Self = Self(libc::ECONNABORTED as _);
     /// Connection refused
-    pub const ECONNREFUSED: Self = Self(nix::libc::ECONNREFUSED as _);
+    pub const ECONNREFUSED: Self = Self(libc::ECONNREFUSED as _);
     /// Connection reset
-    pub const ECONNRESET: Self = Self(nix::libc::ECONNRESET as _);
+    pub const ECONNRESET: Self = Self(libc::ECONNRESET as _);
     /// Resource deadlock would occur
-    pub const EDEADLK: Self = Self(nix::libc::EDEADLK as _);
+    pub const EDEADLK: Self = Self(libc::EDEADLK as _);
     /// Destination address required
-    pub const EDESTADDRREQ: Self = Self(nix::libc::EDESTADDRREQ as _);
+    pub const EDESTADDRREQ: Self = Self(libc::EDESTADDRREQ as _);
     /// Mathematics argument out of domain of function
-    pub const EDOM: Self = Self(nix::libc::EDOM as _);
+    pub const EDOM: Self = Self(libc::EDOM as _);
     /// Reserved
-    pub const EDQUOT: Self = Self(nix::libc::EDQUOT as _);
+    pub const EDQUOT: Self = Self(libc::EDQUOT as _);
     /// File exists
-    pub const EEXIST: Self = Self(nix::libc::EEXIST as _);
+    pub const EEXIST: Self = Self(libc::EEXIST as _);
     /// Bad address
-    pub const EFAULT: Self = Self(nix::libc::EFAULT as _);
+    pub const EFAULT: Self = Self(libc::EFAULT as _);
     /// File too large
-    pub const EFBIG: Self = Self(nix::libc::EFBIG as _);
+    pub const EFBIG: Self = Self(libc::EFBIG as _);
     /// Host is unreachable
-    pub const EHOSTUNREACH: Self = Self(nix::libc::EHOSTUNREACH as _);
+    pub const EHOSTUNREACH: Self = Self(libc::EHOSTUNREACH as _);
     /// Identifier removed
-    pub const EIDRM: Self = Self(nix::libc::EIDRM as _);
+    pub const EIDRM: Self = Self(libc::EIDRM as _);
     /// Illegal byte sequence
-    pub const EILSEQ: Self = Self(nix::libc::EILSEQ as _);
+    pub const EILSEQ: Self = Self(libc::EILSEQ as _);
     /// Operation in progress
-    pub const EINPROGRESS: Self = Self(nix::libc::EINPROGRESS as _);
+    pub const EINPROGRESS: Self = Self(libc::EINPROGRESS as _);
     /// Interrupted function
-    pub const EINTR: Self = Self(nix::libc::EINTR as _);
+    pub const EINTR: Self = Self(libc::EINTR as _);
     /// Invalid argument
-    pub const EINVAL: Self = Self(nix::libc::EINVAL as _);
+    pub const EINVAL: Self = Self(libc::EINVAL as _);
     /// I/O error
-    pub const EIO: Self = Self(nix::libc::EIO as _);
+    pub const EIO: Self = Self(libc::EIO as _);
     /// Socket is connected
-    pub const EISCONN: Self = Self(nix::libc::EISCONN as _);
+    pub const EISCONN: Self = Self(libc::EISCONN as _);
     /// Is a directory
-    pub const EISDIR: Self = Self(nix::libc::EISDIR as _);
+    pub const EISDIR: Self = Self(libc::EISDIR as _);
     /// Too many levels of symbolic links
-    pub const ELOOP: Self = Self(nix::libc::ELOOP as _);
+    pub const ELOOP: Self = Self(libc::ELOOP as _);
     /// File descriptor value too large
-    pub const EMFILE: Self = Self(nix::libc::EMFILE as _);
+    pub const EMFILE: Self = Self(libc::EMFILE as _);
     /// Too many links
-    pub const EMLINK: Self = Self(nix::libc::EMLINK as _);
+    pub const EMLINK: Self = Self(libc::EMLINK as _);
     /// Message too large
-    pub const EMSGSIZE: Self = Self(nix::libc::EMSGSIZE as _);
+    pub const EMSGSIZE: Self = Self(libc::EMSGSIZE as _);
     // Not supported on every platform /// Reserved
-    // pub const EMULTIHOP: Self = Self(nix::libc::EMULTIHOP as _);
+    // pub const EMULTIHOP: Self = Self(libc::EMULTIHOP as _);
     /// Filename too long
-    pub const ENAMETOOLONG: Self = Self(nix::libc::ENAMETOOLONG as _);
+    pub const ENAMETOOLONG: Self = Self(libc::ENAMETOOLONG as _);
     /// Network is down
-    pub const ENETDOWN: Self = Self(nix::libc::ENETDOWN as _);
+    pub const ENETDOWN: Self = Self(libc::ENETDOWN as _);
     /// Connection aborted by network
-    pub const ENETRESET: Self = Self(nix::libc::ENETRESET as _);
+    pub const ENETRESET: Self = Self(libc::ENETRESET as _);
     /// Network unreachable
-    pub const ENETUNREACH: Self = Self(nix::libc::ENETUNREACH as _);
+    pub const ENETUNREACH: Self = Self(libc::ENETUNREACH as _);
     /// Too many files open in system
-    pub const ENFILE: Self = Self(nix::libc::ENFILE as _);
+    pub const ENFILE: Self = Self(libc::ENFILE as _);
     /// No buffer space available
-    pub const ENOBUFS: Self = Self(nix::libc::ENOBUFS as _);
+    pub const ENOBUFS: Self = Self(libc::ENOBUFS as _);
     // Not supported on every platform /// No message is available on the STREAM head read queue
-    // pub const ENODATA: Self = Self(nix::libc::ENODATA as _);
+    // pub const ENODATA: Self = Self(libc::ENODATA as _);
     /// No such device
-    pub const ENODEV: Self = Self(nix::libc::ENODEV as _);
+    pub const ENODEV: Self = Self(libc::ENODEV as _);
     /// No such file or directory
-    pub const ENOENT: Self = Self(nix::libc::ENOENT as _);
+    pub const ENOENT: Self = Self(libc::ENOENT as _);
     /// Executable file format error
-    pub const ENOEXEC: Self = Self(nix::libc::ENOEXEC as _);
+    pub const ENOEXEC: Self = Self(libc::ENOEXEC as _);
     /// No locks available
-    pub const ENOLCK: Self = Self(nix::libc::ENOLCK as _);
+    pub const ENOLCK: Self = Self(libc::ENOLCK as _);
     // Not supported on every platform /// Reserved
-    // pub const ENOLINK: Self = Self(nix::libc::ENOLINK as _);
+    // pub const ENOLINK: Self = Self(libc::ENOLINK as _);
     /// Not enough space
-    pub const ENOMEM: Self = Self(nix::libc::ENOMEM as _);
+    pub const ENOMEM: Self = Self(libc::ENOMEM as _);
     /// No message of the desired type
-    pub const ENOMSG: Self = Self(nix::libc::ENOMSG as _);
+    pub const ENOMSG: Self = Self(libc::ENOMSG as _);
     /// Protocol not available
-    pub const ENOPROTOOPT: Self = Self(nix::libc::ENOPROTOOPT as _);
+    pub const ENOPROTOOPT: Self = Self(libc::ENOPROTOOPT as _);
     /// No space left on device
-    pub const ENOSPC: Self = Self(nix::libc::ENOSPC as _);
+    pub const ENOSPC: Self = Self(libc::ENOSPC as _);
     // Obsolete: Not supported /// No STREAM resources
-    // pub const ENOSR: Self = Self(nix::libc::ENOSR as _);
+    // pub const ENOSR: Self = Self(libc::ENOSR as _);
     // Obsolete: Not supported /// Not a STREAM
-    // pub const ENOSTR: Self = Self(nix::libc::ENOSTR as _);
+    // pub const ENOSTR: Self = Self(libc::ENOSTR as _);
     /// Functionality not supported
-    pub const ENOSYS: Self = Self(nix::libc::ENOSYS as _);
+    pub const ENOSYS: Self = Self(libc::ENOSYS as _);
     /// The socket is not connected
-    pub const ENOTCONN: Self = Self(nix::libc::ENOTCONN as _);
+    pub const ENOTCONN: Self = Self(libc::ENOTCONN as _);
     /// Not a directory or a symbolic link to a directory
-    pub const ENOTDIR: Self = Self(nix::libc::ENOTDIR as _);
+    pub const ENOTDIR: Self = Self(libc::ENOTDIR as _);
     /// Directory not empty
-    pub const ENOTEMPTY: Self = Self(nix::libc::ENOTEMPTY as _);
+    pub const ENOTEMPTY: Self = Self(libc::ENOTEMPTY as _);
     // Not supported on every platform /// State not recoverable
-    // pub const ENOTRECOVERABLE: Self = Self(nix::libc::ENOTRECOVERABLE as _);
+    // pub const ENOTRECOVERABLE: Self = Self(libc::ENOTRECOVERABLE as _);
     /// Not a socket
-    pub const ENOTSOCK: Self = Self(nix::libc::ENOTSOCK as _);
+    pub const ENOTSOCK: Self = Self(libc::ENOTSOCK as _);
     /// Not supported (may be the same value as [`EOPNOTSUPP`](Self::EOPNOTSUPP))
-    pub const ENOTSUP: Self = Self(nix::libc::ENOTSUP as _);
+    pub const ENOTSUP: Self = Self(libc::ENOTSUP as _);
     /// Inappropriate I/O control operation
-    pub const ENOTTY: Self = Self(nix::libc::ENOTTY as _);
+    pub const ENOTTY: Self = Self(libc::ENOTTY as _);
     /// No such device or address
-    pub const ENXIO: Self = Self(nix::libc::ENXIO as _);
+    pub const ENXIO: Self = Self(libc::ENXIO as _);
     /// Operation not supported on socket (may be the same value as [`ENOTSUP`](Self::ENOTSUP))
-    pub const EOPNOTSUPP: Self = Self(nix::libc::EOPNOTSUPP as _);
+    pub const EOPNOTSUPP: Self = Self(libc::EOPNOTSUPP as _);
     /// Value too large to be stored in data type
-    pub const EOVERFLOW: Self = Self(nix::libc::EOVERFLOW as _);
+    pub const EOVERFLOW: Self = Self(libc::EOVERFLOW as _);
     // Not supported on every platform /// Previous owner died
-    // pub const EOWNERDEAD: Self = Self(nix::libc::EOWNERDEAD as _);
+    // pub const EOWNERDEAD: Self = Self(libc::EOWNERDEAD as _);
     /// Operation not permitted
-    pub const EPERM: Self = Self(nix::libc::EPERM as _);
+    pub const EPERM: Self = Self(libc::EPERM as _);
     /// Broken pipe
-    pub const EPIPE: Self = Self(nix::libc::EPIPE as _);
+    pub const EPIPE: Self = Self(libc::EPIPE as _);
     /// Protocol error
-    pub const EPROTO: Self = Self(nix::libc::EPROTO as _);
+    pub const EPROTO: Self = Self(libc::EPROTO as _);
     /// Protocol not supported
-    pub const EPROTONOSUPPORT: Self = Self(nix::libc::EPROTONOSUPPORT as _);
+    pub const EPROTONOSUPPORT: Self = Self(libc::EPROTONOSUPPORT as _);
     /// Protocol wrong type for socket
-    pub const EPROTOTYPE: Self = Self(nix::libc::EPROTOTYPE as _);
+    pub const EPROTOTYPE: Self = Self(libc::EPROTOTYPE as _);
     /// Result too large
-    pub const ERANGE: Self = Self(nix::libc::ERANGE as _);
+    pub const ERANGE: Self = Self(libc::ERANGE as _);
     /// Read-only file system
-    pub const EROFS: Self = Self(nix::libc::EROFS as _);
+    pub const EROFS: Self = Self(libc::EROFS as _);
     /// Invalid seek
-    pub const ESPIPE: Self = Self(nix::libc::ESPIPE as _);
+    pub const ESPIPE: Self = Self(libc::ESPIPE as _);
     /// No such process
-    pub const ESRCH: Self = Self(nix::libc::ESRCH as _);
+    pub const ESRCH: Self = Self(libc::ESRCH as _);
     /// Reserved
-    pub const ESTALE: Self = Self(nix::libc::ESTALE as _);
+    pub const ESTALE: Self = Self(libc::ESTALE as _);
     // Obsolete: Not supported /// Stream ioctl() timeout
-    // pub const ETIME: Self = Self(nix::libc::ETIME as _);
+    // pub const ETIME: Self = Self(libc::ETIME as _);
     /// Connection timed out
-    pub const ETIMEDOUT: Self = Self(nix::libc::ETIMEDOUT as _);
+    pub const ETIMEDOUT: Self = Self(libc::ETIMEDOUT as _);
     /// Text file busy
-    pub const ETXTBSY: Self = Self(nix::libc::ETXTBSY as _);
+    pub const ETXTBSY: Self = Self(libc::ETXTBSY as _);
     /// Operation would block (may be the same value as [`EAGAIN`](Self::EAGAIN))
-    pub const EWOULDBLOCK: Self = Self(nix::libc::EWOULDBLOCK as _);
+    pub const EWOULDBLOCK: Self = Self(libc::EWOULDBLOCK as _);
     /// Cross-device link
-    pub const EXDEV: Self = Self(nix::libc::EXDEV as _);
+    pub const EXDEV: Self = Self(libc::EXDEV as _);
 }
 
 #[doc = include_str!("errno.md")]

--- a/yash-env/src/system/errno.rs
+++ b/yash-env/src/system/errno.rs
@@ -394,6 +394,22 @@ impl From<RawErrno> for Errno {
     }
 }
 
+/// Converts [`Errno`] to [`errno::Errno`].
+impl From<Errno> for errno::Errno {
+    #[inline]
+    fn from(errno: Errno) -> Self {
+        Self(errno.0)
+    }
+}
+
+/// Converts [`errno::Errno`] to [`Errno`].
+impl From<errno::Errno> for Errno {
+    #[inline]
+    fn from(errno: errno::Errno) -> Self {
+        Self(errno.into())
+    }
+}
+
 /// Converts [`Errno`] to [`nix::Error`].
 ///
 /// This conversion is only available on Unix-like systems.

--- a/yash-env/src/system/file_system.rs
+++ b/yash-env/src/system/file_system.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 use yash_syntax::syntax::Fd;
 
 #[cfg(unix)]
-const RAW_AT_FDCWD: i32 = nix::libc::AT_FDCWD;
+const RAW_AT_FDCWD: i32 = libc::AT_FDCWD;
 #[cfg(not(unix))]
 const RAW_AT_FDCWD: i32 = -100;
 
@@ -54,7 +54,7 @@ pub trait Dir: Debug {
 }
 
 #[cfg(unix)]
-type RawModeDef = nix::libc::mode_t;
+type RawModeDef = libc::mode_t;
 #[cfg(not(unix))]
 type RawModeDef = u32;
 
@@ -67,8 +67,6 @@ type RawModeDef = u32;
 ///
 /// File permission bits are usually wrapped in the [`Mode`] type for better type
 /// safety, so this type is not used directly in most cases.
-///
-/// [`libc`]: nix::libc
 pub type RawMode = RawModeDef;
 
 /// File permission bits

--- a/yash-env/src/system/id.rs
+++ b/yash-env/src/system/id.rs
@@ -17,7 +17,7 @@
 //! Definitions of ID types
 
 #[cfg(unix)]
-type RawUidDef = nix::libc::uid_t;
+type RawUidDef = libc::uid_t;
 #[cfg(not(unix))]
 type RawUidDef = u32;
 
@@ -30,8 +30,6 @@ type RawUidDef = u32;
 ///
 /// User IDs are usually wrapped in the [`Uid`] type for better type safety, so
 /// this type is not used directly in most cases.
-///
-/// [`libc`]: nix::libc
 pub type RawUid = RawUidDef;
 
 /// User ID
@@ -39,14 +37,12 @@ pub type RawUid = RawUidDef;
 /// This type implements the new type pattern for the raw user ID type
 /// [`RawUid`]. The advantage of using this type is that it is more type-safe
 /// than using the raw integer value directly.
-///
-/// [`libc`]: nix::libc
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Uid(pub RawUid);
 
 #[cfg(unix)]
-type RawGidDef = nix::libc::gid_t;
+type RawGidDef = libc::gid_t;
 #[cfg(not(unix))]
 type RawGidDef = u32;
 
@@ -59,8 +55,6 @@ type RawGidDef = u32;
 ///
 /// Group IDs are usually wrapped in the [`Gid`] type for better type safety, so
 /// this type is not used directly in most cases.
-///
-/// [`libc`]: nix::libc
 pub type RawGid = RawGidDef;
 
 /// Group ID

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -394,13 +394,13 @@ impl System for RealSystem {
 
     fn fdopendir(&mut self, fd: Fd) -> Result<Box<dyn Dir>> {
         let dir = unsafe { libc::fdopendir(fd.0) };
-        let dir = NonNull::new(dir).ok_or_else(NixErrno::last)?;
+        let dir = NonNull::new(dir).ok_or_else(Errno::last)?;
         Ok(Box::new(RealDir(dir)))
     }
 
     fn opendir(&mut self, path: &CStr) -> Result<Box<dyn Dir>> {
         let dir = unsafe { libc::opendir(path.as_ptr()) };
-        let dir = NonNull::new(dir).ok_or_else(NixErrno::last)?;
+        let dir = NonNull::new(dir).ok_or_else(Errno::last)?;
         Ok(Box::new(RealDir(dir)))
     }
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -204,7 +204,8 @@ impl System for RealSystem {
     fn fstat(&self, fd: Fd) -> Result<Stat> {
         let mut stat = MaybeUninit::<libc::stat>::uninit();
         unsafe { libc::fstat(fd.0, stat.as_mut_ptr()) }.errno_if_m1()?;
-        Ok(Stat::from_raw(&stat))
+        let stat = unsafe { Stat::from_raw(&stat) };
+        Ok(stat)
     }
 
     fn fstatat(&self, dir_fd: Fd, path: &CStr, follow_symlinks: bool) -> Result<Stat> {
@@ -217,7 +218,8 @@ impl System for RealSystem {
         let mut stat = MaybeUninit::<libc::stat>::uninit();
         unsafe { libc::fstatat(dir_fd.0, path.as_ptr(), stat.as_mut_ptr(), flags) }
             .errno_if_m1()?;
-        Ok(Stat::from_raw(&stat))
+        let stat = unsafe { Stat::from_raw(&stat) };
+        Ok(stat)
     }
 
     fn is_executable_file(&self, path: &CStr) -> bool {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -720,9 +720,30 @@ impl System for RealSystem {
     }
 
     fn getcwd(&self) -> Result<PathBuf> {
-        let path = nix::unistd::getcwd()?;
-        let raw = path.into_os_string().into_vec();
-        Ok(PathBuf::from(UnixString::from_vec(raw)))
+        // Some getcwd implementations allocate a buffer for the path if the
+        // first argument is null, but we cannot use that feature because Vec's
+        // allocator may not be compatible with the system's allocator.
+
+        // Since there is no way to know the required buffer size, we try
+        // several buffer sizes.
+        let mut buffer = Vec::<u8>::new();
+        for capacity in [1 << 10, 1 << 12, 1 << 14, 1 << 16] {
+            buffer.reserve_exact(capacity);
+
+            let result = unsafe { libc::getcwd(buffer.as_mut_ptr().cast(), capacity) };
+            if !result.is_null() {
+                // len does not include the null terminator
+                let len = unsafe { CStr::from_ptr(buffer.as_ptr().cast()) }.count_bytes();
+                unsafe { buffer.set_len(len) }
+                buffer.shrink_to_fit();
+                return Ok(PathBuf::from(UnixString::from_vec(buffer)));
+            }
+            let errno = Errno::last();
+            if errno != Errno::ERANGE {
+                return Err(errno);
+            }
+        }
+        Err(Errno::ERANGE)
     }
 
     fn chdir(&mut self, path: &CStr) -> Result<()> {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -747,8 +747,8 @@ impl System for RealSystem {
     }
 
     fn chdir(&mut self, path: &CStr) -> Result<()> {
-        nix::unistd::chdir(path)?;
-        Ok(())
+        let result = unsafe { libc::chdir(path.as_ptr()) };
+        result.errno_if_m1().map(drop)
     }
 
     fn getuid(&self) -> Uid {

--- a/yash-env/src/system/real/errno.rs
+++ b/yash-env/src/system/real/errno.rs
@@ -29,21 +29,21 @@ impl Errno {
     #[inline]
     #[must_use]
     pub(super) fn last() -> Self {
-        Self(nix::Error::last() as _)
+        errno::errno().into()
     }
 
-    // TODO Need nix 0.28.0
-    // /// Sets the current `errno` value.
-    // ///
-    // /// This function sets the current `errno` value to the specified value.
-    // /// The next call to [`last`](Self::last) will return the specified value
-    // /// unless another system call changes the `errno` value. This function is
-    // /// useful when you want to simulate an error condition in a system call.
-    // ///
-    // /// Use [`clear`](Self::clear) to reset the `errno` value.
-    // pub(super) fn set_last(errno: Self) {
-    //     nix::Error::set_raw(errno.0)
-    // }
+    /// Sets the current `errno` value.
+    ///
+    /// This function sets the current `errno` value to the specified value.
+    /// The next call to [`last`](Self::last) will return the specified value
+    /// unless another system call changes the `errno` value. This function is
+    /// useful when you want to simulate an error condition in a system call.
+    ///
+    /// Use [`clear`](Self::clear) to reset the `errno` value.
+    #[inline]
+    pub(super) fn set_last(errno: Self) {
+        errno::set_errno(errno.into())
+    }
 
     /// Clears the current `errno` value.
     ///
@@ -53,12 +53,11 @@ impl Errno {
     /// and check the `errno` value after calling the function to see if an
     /// error occurred. This function resets the current `errno` value to
     /// [`NO_ERROR`](Self::NO_ERROR).
-    // ///
-    // /// Use [`set_last`](Self::set_last) to set the `errno` value to an
-    // /// arbitrary value.
+    ///
+    /// Use [`set_last`](Self::set_last) to set the `errno` value to an
+    /// arbitrary value.
     #[inline]
     pub(super) fn clear() {
-        // Self::set_last(Self::NO_ERROR)
-        nix::Error::clear()
+        Self::set_last(Self::NO_ERROR)
     }
 }

--- a/yash-env/src/system/real/file_system.rs
+++ b/yash-env/src/system/real/file_system.rs
@@ -22,14 +22,14 @@ use std::mem::MaybeUninit;
 impl FileType {
     #[must_use]
     pub(super) const fn from_raw(mode: RawMode) -> Self {
-        match mode & nix::libc::S_IFMT {
-            nix::libc::S_IFREG => Self::Regular,
-            nix::libc::S_IFDIR => Self::Directory,
-            nix::libc::S_IFLNK => Self::Symlink,
-            nix::libc::S_IFIFO => Self::Fifo,
-            nix::libc::S_IFBLK => Self::BlockDevice,
-            nix::libc::S_IFCHR => Self::CharacterDevice,
-            nix::libc::S_IFSOCK => Self::Socket,
+        match mode & libc::S_IFMT {
+            libc::S_IFREG => Self::Regular,
+            libc::S_IFDIR => Self::Directory,
+            libc::S_IFLNK => Self::Symlink,
+            libc::S_IFIFO => Self::Fifo,
+            libc::S_IFBLK => Self::BlockDevice,
+            libc::S_IFCHR => Self::CharacterDevice,
+            libc::S_IFSOCK => Self::Socket,
             _ => Self::Other,
         }
     }
@@ -42,7 +42,7 @@ impl Stat {
     /// passed as `MaybeUninit` because of possible padding or extension fields
     /// in the structure which may not be initialized by the `stat` system call.
     #[must_use]
-    pub(super) const fn from_raw(stat: &MaybeUninit<nix::libc::stat>) -> Self {
+    pub(super) const fn from_raw(stat: &MaybeUninit<libc::stat>) -> Self {
         let ptr = stat.as_ptr();
         let raw_mode = unsafe { (&raw const (*ptr).st_mode).read() };
         Self {

--- a/yash-env/src/system/real/file_system.rs
+++ b/yash-env/src/system/real/file_system.rs
@@ -44,16 +44,16 @@ impl Stat {
     #[must_use]
     pub(super) const fn from_raw(stat: &MaybeUninit<libc::stat>) -> Self {
         let ptr = stat.as_ptr();
-        let raw_mode = unsafe { (&raw const (*ptr).st_mode).read() };
+        let raw_mode = unsafe { (*ptr).st_mode };
         Self {
-            dev: unsafe { (&raw const (*ptr).st_dev).read() } as _,
-            ino: unsafe { (&raw const (*ptr).st_ino).read() } as _,
+            dev: unsafe { (*ptr).st_dev } as _,
+            ino: unsafe { (*ptr).st_ino } as _,
             mode: Mode::from_bits_truncate(raw_mode),
             r#type: FileType::from_raw(raw_mode),
-            nlink: unsafe { (&raw const (*ptr).st_nlink).read() } as _,
-            uid: Uid(unsafe { (&raw const (*ptr).st_uid).read() }),
-            gid: Gid(unsafe { (&raw const (*ptr).st_gid).read() }),
-            size: unsafe { (&raw const (*ptr).st_size).read() } as _,
+            nlink: unsafe { (*ptr).st_nlink } as _,
+            uid: Uid(unsafe { (*ptr).st_uid }),
+            gid: Gid(unsafe { (*ptr).st_gid }),
+            size: unsafe { (*ptr).st_size } as _,
         }
     }
 }

--- a/yash-env/src/system/real/file_system.rs
+++ b/yash-env/src/system/real/file_system.rs
@@ -38,11 +38,12 @@ impl FileType {
 impl Stat {
     /// Converts a raw `stat` structure to a `Stat` object.
     ///
-    /// This function requires the `stat` structure to be initialized, but it is
-    /// passed as `MaybeUninit` because of possible padding or extension fields
-    /// in the structure which may not be initialized by the `stat` system call.
+    /// This function assumes the `stat` structure to be initialized by the
+    /// `stat` system call, but it is passed as `MaybeUninit` because of
+    /// possible padding or extension fields in the structure which may not be
+    /// initialized by the system call.
     #[must_use]
-    pub(super) const fn from_raw(stat: &MaybeUninit<libc::stat>) -> Self {
+    pub(super) const unsafe fn from_raw(stat: &MaybeUninit<libc::stat>) -> Self {
         let ptr = stat.as_ptr();
         let raw_mode = unsafe { (*ptr).st_mode };
         Self {

--- a/yash-env/src/system/real/open_flag.rs
+++ b/yash-env/src/system/real/open_flag.rs
@@ -23,9 +23,9 @@ impl OfdAccess {
     #[must_use]
     pub(super) fn to_real_flags(self) -> Option<c_int> {
         match self {
-            Self::ReadOnly => Some(nix::libc::O_RDONLY),
-            Self::WriteOnly => Some(nix::libc::O_WRONLY),
-            Self::ReadWrite => Some(nix::libc::O_RDWR),
+            Self::ReadOnly => Some(libc::O_RDONLY),
+            Self::WriteOnly => Some(libc::O_WRONLY),
+            Self::ReadWrite => Some(libc::O_RDWR),
             // TODO Support O_EXEC, O_PATH and O_SEARCH
             Self::Exec | Self::Search => None,
         }
@@ -33,10 +33,10 @@ impl OfdAccess {
 
     #[must_use]
     pub(super) fn from_real_flags(flags: c_int) -> Self {
-        match flags & nix::libc::O_ACCMODE {
-            nix::libc::O_RDONLY => Self::ReadOnly,
-            nix::libc::O_WRONLY => Self::WriteOnly,
-            nix::libc::O_RDWR => Self::ReadWrite,
+        match flags & libc::O_ACCMODE {
+            libc::O_RDONLY => Self::ReadOnly,
+            libc::O_WRONLY => Self::WriteOnly,
+            libc::O_RDWR => Self::ReadWrite,
             _ => Self::Exec, // TODO Support O_PATH and O_SEARCH
         }
     }
@@ -46,22 +46,22 @@ impl OpenFlag {
     #[must_use]
     pub(super) fn to_real_flags(self) -> Option<c_int> {
         match self {
-            Self::Append => Some(nix::libc::O_APPEND),
-            Self::CloseOnExec => Some(nix::libc::O_CLOEXEC),
-            Self::Create => Some(nix::libc::O_CREAT),
-            Self::Directory => Some(nix::libc::O_DIRECTORY),
-            Self::Exclusive => Some(nix::libc::O_EXCL),
+            Self::Append => Some(libc::O_APPEND),
+            Self::CloseOnExec => Some(libc::O_CLOEXEC),
+            Self::Create => Some(libc::O_CREAT),
+            Self::Directory => Some(libc::O_DIRECTORY),
+            Self::Exclusive => Some(libc::O_EXCL),
             #[cfg(not(any(target_env = "newlib", target_os = "redox")))]
-            Self::NoCtty => Some(nix::libc::O_NOCTTY),
+            Self::NoCtty => Some(libc::O_NOCTTY),
             #[cfg(any(target_env = "newlib", target_os = "redox"))]
             Self::NoCtty => None,
-            Self::NoFollow => Some(nix::libc::O_NOFOLLOW),
-            Self::NonBlock => Some(nix::libc::O_NONBLOCK),
+            Self::NoFollow => Some(libc::O_NOFOLLOW),
+            Self::NonBlock => Some(libc::O_NONBLOCK),
             #[cfg(not(target_os = "redox"))]
-            Self::Sync => Some(nix::libc::O_SYNC),
+            Self::Sync => Some(libc::O_SYNC),
             #[cfg(target_os = "redox")]
             Self::Sync => None,
-            Self::Truncate => Some(nix::libc::O_TRUNC),
+            Self::Truncate => Some(libc::O_TRUNC),
         }
     }
 }

--- a/yash-env/src/system/real/resource.rs
+++ b/yash-env/src/system/real/resource.rs
@@ -27,15 +27,15 @@ impl Resource {
     pub(super) const fn as_raw_type(&self) -> Option<std::ffi::c_int> {
         match *self {
             #[cfg(not(any(target_env = "newlib", target_os = "redox")))]
-            Self::AS => Some(nix::libc::RLIMIT_AS as _),
-            Self::CORE => Some(nix::libc::RLIMIT_CORE as _),
-            Self::CPU => Some(nix::libc::RLIMIT_CPU as _),
-            Self::DATA => Some(nix::libc::RLIMIT_DATA as _),
-            Self::FSIZE => Some(nix::libc::RLIMIT_FSIZE as _),
+            Self::AS => Some(libc::RLIMIT_AS as _),
+            Self::CORE => Some(libc::RLIMIT_CORE as _),
+            Self::CPU => Some(libc::RLIMIT_CPU as _),
+            Self::DATA => Some(libc::RLIMIT_DATA as _),
+            Self::FSIZE => Some(libc::RLIMIT_FSIZE as _),
             #[cfg(target_os = "freebsd")]
-            Self::KQUEUES => Some(nix::libc::RLIMIT_KQUEUES as _),
+            Self::KQUEUES => Some(libc::RLIMIT_KQUEUES as _),
             #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::LOCKS => Some(nix::libc::RLIMIT_LOCKS as _),
+            Self::LOCKS => Some(libc::RLIMIT_LOCKS as _),
             #[cfg(any(
                 target_os = "macos",
                 target_os = "ios",
@@ -50,12 +50,12 @@ impl Resource {
                 target_os = "emscripten",
                 target_os = "nto"
             ))]
-            Self::MEMLOCK => Some(nix::libc::RLIMIT_MEMLOCK as _),
+            Self::MEMLOCK => Some(libc::RLIMIT_MEMLOCK as _),
             #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::MSGQUEUE => Some(nix::libc::RLIMIT_MSGQUEUE as _),
+            Self::MSGQUEUE => Some(libc::RLIMIT_MSGQUEUE as _),
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            Self::NICE => Some(nix::libc::RLIMIT_NICE as _),
-            Self::NOFILE => Some(nix::libc::RLIMIT_NOFILE as _),
+            Self::NICE => Some(libc::RLIMIT_NICE as _),
+            Self::NOFILE => Some(libc::RLIMIT_NOFILE as _),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "macos",
@@ -71,7 +71,7 @@ impl Resource {
                 target_os = "emscripten",
                 target_os = "nto"
             ))]
-            Self::NPROC => Some(nix::libc::RLIMIT_NPROC as _),
+            Self::NPROC => Some(libc::RLIMIT_NPROC as _),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "macos",
@@ -87,18 +87,18 @@ impl Resource {
                 target_os = "emscripten",
                 target_os = "nto"
             ))]
-            Self::RSS => Some(nix::libc::RLIMIT_RSS as _),
+            Self::RSS => Some(libc::RLIMIT_RSS as _),
             #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::RTPRIO => Some(nix::libc::RLIMIT_RTPRIO as _),
+            Self::RTPRIO => Some(libc::RLIMIT_RTPRIO as _),
             #[cfg(target_os = "linux")]
-            Self::RTTIME => Some(nix::libc::RLIMIT_RTTIME as _),
+            Self::RTTIME => Some(libc::RLIMIT_RTTIME as _),
             #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
-            Self::SBSIZE => Some(nix::libc::RLIMIT_SBSIZE as _),
+            Self::SBSIZE => Some(libc::RLIMIT_SBSIZE as _),
             #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-            Self::SIGPENDING => Some(nix::libc::RLIMIT_SIGPENDING as _),
-            Self::STACK => Some(nix::libc::RLIMIT_STACK as _),
+            Self::SIGPENDING => Some(libc::RLIMIT_SIGPENDING as _),
+            Self::STACK => Some(libc::RLIMIT_STACK as _),
             #[cfg(target_os = "freebsd")]
-            Self::SWAP => Some(nix::libc::RLIMIT_SWAP as _),
+            Self::SWAP => Some(libc::RLIMIT_SWAP as _),
             _ => None,
         }
     }

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -436,8 +436,8 @@ impl Disposition {
         let mut sa = MaybeUninit::<libc::sigaction>::uninit();
         let sa_ptr = sa.as_mut_ptr();
         unsafe {
-            (&raw mut (*sa_ptr).sa_flags).write(0);
-            libc::sigemptyset(&raw mut ((*sa_ptr).sa_mask));
+            (*sa_ptr).sa_flags = 0;
+            libc::sigemptyset(&raw mut (*sa_ptr).sa_mask);
 
             #[cfg(not(target_os = "aix"))]
             #[allow(clippy::useless_transmute)] // See from_sigaction below
@@ -453,10 +453,10 @@ impl Disposition {
     /// Converts the `sigaction` to the signal disposition for the real system.
     pub(super) unsafe fn from_sigaction(sa: &MaybeUninit<libc::sigaction>) -> Self {
         #[cfg(not(target_os = "aix"))]
-        let handler = (&raw const (*sa.as_ptr()).sa_sigaction).read();
+        let handler = (*sa.as_ptr()).sa_sigaction;
 
         #[cfg(target_os = "aix")]
-        let handler = (&raw const (*sa.as_ptr()).sa_union.__su_sigaction).read();
+        let handler = (*sa.as_ptr()).sa_union.__su_sigaction;
 
         // It is platform-specific whether we really need to transmute the handler.
         #[allow(clippy::useless_transmute)]

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -30,7 +30,7 @@ use std::ops::RangeInclusive;
 #[must_use]
 fn rt_range() -> RangeInclusive<RawNumber> {
     #[cfg(target_os = "aix")]
-    return nix::libc::SIGRTMIN..=nix::libc::SIGRTMAX;
+    return libc::SIGRTMIN..=libc::SIGRTMAX;
 
     #[cfg(any(
         target_os = "android",
@@ -38,7 +38,7 @@ fn rt_range() -> RangeInclusive<RawNumber> {
         target_os = "l4re",
         target_os = "linux",
     ))]
-    return nix::libc::SIGRTMIN()..=nix::libc::SIGRTMAX();
+    return libc::SIGRTMIN()..=libc::SIGRTMAX();
 
     #[allow(unreachable_code)]
     {
@@ -56,17 +56,17 @@ impl Name {
         }
 
         match self {
-            Self::Abrt => wrap(nix::libc::SIGABRT),
-            Self::Alrm => wrap(nix::libc::SIGALRM),
-            Self::Bus => wrap(nix::libc::SIGBUS),
-            Self::Chld => wrap(nix::libc::SIGCHLD),
+            Self::Abrt => wrap(libc::SIGABRT),
+            Self::Alrm => wrap(libc::SIGALRM),
+            Self::Bus => wrap(libc::SIGBUS),
+            Self::Chld => wrap(libc::SIGCHLD),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "horizon",
                 target_os = "illumos",
                 target_os = "solaris",
             ))]
-            Self::Cld => wrap(nix::libc::SIGCLD),
+            Self::Cld => wrap(libc::SIGCLD),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "horizon",
@@ -74,7 +74,7 @@ impl Name {
                 target_os = "solaris",
             )))]
             Self::Cld => None,
-            Self::Cont => wrap(nix::libc::SIGCONT),
+            Self::Cont => wrap(libc::SIGCONT),
             #[cfg(not(any(
                 target_os = "android",
                 target_os = "emscripten",
@@ -83,7 +83,7 @@ impl Name {
                 target_os = "linux",
                 target_os = "redox",
             )))]
-            Self::Emt => wrap(nix::libc::SIGEMT),
+            Self::Emt => wrap(libc::SIGEMT),
             #[cfg(any(
                 target_os = "android",
                 target_os = "emscripten",
@@ -93,9 +93,9 @@ impl Name {
                 target_os = "redox",
             ))]
             Self::Emt => None,
-            Self::Fpe => wrap(nix::libc::SIGFPE),
-            Self::Hup => wrap(nix::libc::SIGHUP),
-            Self::Ill => wrap(nix::libc::SIGILL),
+            Self::Fpe => wrap(libc::SIGFPE),
+            Self::Hup => wrap(libc::SIGHUP),
+            Self::Ill => wrap(libc::SIGILL),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "android",
@@ -105,7 +105,7 @@ impl Name {
                 target_os = "linux",
                 target_os = "redox",
             )))]
-            Self::Info => wrap(nix::libc::SIGINFO),
+            Self::Info => wrap(libc::SIGINFO),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -116,7 +116,7 @@ impl Name {
                 target_os = "redox",
             ))]
             Self::Info => None,
-            Self::Int => wrap(nix::libc::SIGINT),
+            Self::Int => wrap(libc::SIGINT),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -128,7 +128,7 @@ impl Name {
                 target_os = "nto",
                 target_os = "solaris",
             ))]
-            Self::Io => wrap(nix::libc::SIGIO),
+            Self::Io => wrap(libc::SIGIO),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "android",
@@ -141,13 +141,13 @@ impl Name {
                 target_os = "solaris",
             )))]
             Self::Io => None,
-            Self::Iot => wrap(nix::libc::SIGIOT),
-            Self::Kill => wrap(nix::libc::SIGKILL),
+            Self::Iot => wrap(libc::SIGIOT),
+            Self::Kill => wrap(libc::SIGKILL),
             #[cfg(target_os = "horizon")]
-            Self::Lost => wrap(nix::libc::SIGLOST),
+            Self::Lost => wrap(libc::SIGLOST),
             #[cfg(not(target_os = "horizon"))]
             Self::Lost => None,
-            Self::Pipe => wrap(nix::libc::SIGPIPE),
+            Self::Pipe => wrap(libc::SIGPIPE),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -160,7 +160,7 @@ impl Name {
                 target_os = "nto",
                 target_os = "solaris",
             ))]
-            Self::Poll => wrap(nix::libc::SIGPOLL),
+            Self::Poll => wrap(libc::SIGPOLL),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "android",
@@ -174,7 +174,7 @@ impl Name {
                 target_os = "solaris",
             )))]
             Self::Poll => None,
-            Self::Prof => wrap(nix::libc::SIGPROF),
+            Self::Prof => wrap(libc::SIGPROF),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -186,7 +186,7 @@ impl Name {
                 target_os = "redox",
                 target_os = "solaris",
             ))]
-            Self::Pwr => wrap(nix::libc::SIGPWR),
+            Self::Pwr => wrap(libc::SIGPWR),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "android",
@@ -199,8 +199,8 @@ impl Name {
                 target_os = "solaris",
             )))]
             Self::Pwr => None,
-            Self::Quit => wrap(nix::libc::SIGQUIT),
-            Self::Segv => wrap(nix::libc::SIGSEGV),
+            Self::Quit => wrap(libc::SIGQUIT),
+            Self::Segv => wrap(libc::SIGSEGV),
             #[cfg(all(
                 any(
                     target_os = "android",
@@ -210,7 +210,7 @@ impl Name {
                 ),
                 not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
             ))]
-            Self::Stkflt => wrap(nix::libc::SIGSTKFLT),
+            Self::Stkflt => wrap(libc::SIGSTKFLT),
             #[cfg(not(all(
                 any(
                     target_os = "android",
@@ -221,24 +221,24 @@ impl Name {
                 not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
             )))]
             Self::Stkflt => None,
-            Self::Stop => wrap(nix::libc::SIGSTOP),
-            Self::Sys => wrap(nix::libc::SIGSYS),
-            Self::Term => wrap(nix::libc::SIGTERM),
+            Self::Stop => wrap(libc::SIGSTOP),
+            Self::Sys => wrap(libc::SIGSYS),
+            Self::Term => wrap(libc::SIGTERM),
             #[cfg(target_os = "freebsd")]
-            Self::Thr => wrap(nix::libc::SIGTHR),
+            Self::Thr => wrap(libc::SIGTHR),
             #[cfg(not(target_os = "freebsd"))]
             Self::Thr => None,
-            Self::Trap => wrap(nix::libc::SIGTRAP),
-            Self::Tstp => wrap(nix::libc::SIGTSTP),
-            Self::Ttin => wrap(nix::libc::SIGTTIN),
-            Self::Ttou => wrap(nix::libc::SIGTTOU),
-            Self::Urg => wrap(nix::libc::SIGURG),
-            Self::Usr1 => wrap(nix::libc::SIGUSR1),
-            Self::Usr2 => wrap(nix::libc::SIGUSR2),
-            Self::Vtalrm => wrap(nix::libc::SIGVTALRM),
-            Self::Winch => wrap(nix::libc::SIGWINCH),
-            Self::Xcpu => wrap(nix::libc::SIGXCPU),
-            Self::Xfsz => wrap(nix::libc::SIGXFSZ),
+            Self::Trap => wrap(libc::SIGTRAP),
+            Self::Tstp => wrap(libc::SIGTSTP),
+            Self::Ttin => wrap(libc::SIGTTIN),
+            Self::Ttou => wrap(libc::SIGTTOU),
+            Self::Urg => wrap(libc::SIGURG),
+            Self::Usr1 => wrap(libc::SIGUSR1),
+            Self::Usr2 => wrap(libc::SIGUSR2),
+            Self::Vtalrm => wrap(libc::SIGVTALRM),
+            Self::Winch => wrap(libc::SIGWINCH),
+            Self::Xcpu => wrap(libc::SIGXCPU),
+            Self::Xfsz => wrap(libc::SIGXFSZ),
 
             Self::Rtmin(n) => {
                 let range = rt_range();
@@ -270,26 +270,26 @@ impl Name {
         #[allow(unreachable_patterns)]
         match number {
             // Standard signals
-            nix::libc::SIGABRT => Some(Self::Abrt),
-            nix::libc::SIGALRM => Some(Self::Alrm),
-            nix::libc::SIGBUS => Some(Self::Bus),
-            nix::libc::SIGCHLD => Some(Self::Chld),
-            nix::libc::SIGCONT => Some(Self::Cont),
-            nix::libc::SIGFPE => Some(Self::Fpe),
-            nix::libc::SIGHUP => Some(Self::Hup),
-            nix::libc::SIGILL => Some(Self::Ill),
-            nix::libc::SIGINT => Some(Self::Int),
-            nix::libc::SIGKILL => Some(Self::Kill),
-            nix::libc::SIGPIPE => Some(Self::Pipe),
-            nix::libc::SIGQUIT => Some(Self::Quit),
-            nix::libc::SIGSEGV => Some(Self::Segv),
-            nix::libc::SIGSTOP => Some(Self::Stop),
-            nix::libc::SIGTERM => Some(Self::Term),
-            nix::libc::SIGTSTP => Some(Self::Tstp),
-            nix::libc::SIGTTIN => Some(Self::Ttin),
-            nix::libc::SIGTTOU => Some(Self::Ttou),
-            nix::libc::SIGUSR1 => Some(Self::Usr1),
-            nix::libc::SIGUSR2 => Some(Self::Usr2),
+            libc::SIGABRT => Some(Self::Abrt),
+            libc::SIGALRM => Some(Self::Alrm),
+            libc::SIGBUS => Some(Self::Bus),
+            libc::SIGCHLD => Some(Self::Chld),
+            libc::SIGCONT => Some(Self::Cont),
+            libc::SIGFPE => Some(Self::Fpe),
+            libc::SIGHUP => Some(Self::Hup),
+            libc::SIGILL => Some(Self::Ill),
+            libc::SIGINT => Some(Self::Int),
+            libc::SIGKILL => Some(Self::Kill),
+            libc::SIGPIPE => Some(Self::Pipe),
+            libc::SIGQUIT => Some(Self::Quit),
+            libc::SIGSEGV => Some(Self::Segv),
+            libc::SIGSTOP => Some(Self::Stop),
+            libc::SIGTERM => Some(Self::Term),
+            libc::SIGTSTP => Some(Self::Tstp),
+            libc::SIGTTIN => Some(Self::Ttin),
+            libc::SIGTTOU => Some(Self::Ttou),
+            libc::SIGUSR1 => Some(Self::Usr1),
+            libc::SIGUSR2 => Some(Self::Usr2),
 
             // Non-standard but common signals
             #[cfg(any(
@@ -304,15 +304,15 @@ impl Name {
                 target_os = "nto",
                 target_os = "solaris",
             ))]
-            nix::libc::SIGPOLL => Some(Self::Poll),
-            nix::libc::SIGPROF => Some(Self::Prof),
-            nix::libc::SIGSYS => Some(Self::Sys),
-            nix::libc::SIGTRAP => Some(Self::Trap),
-            nix::libc::SIGURG => Some(Self::Urg),
-            nix::libc::SIGVTALRM => Some(Self::Vtalrm),
-            nix::libc::SIGWINCH => Some(Self::Winch),
-            nix::libc::SIGXCPU => Some(Self::Xcpu),
-            nix::libc::SIGXFSZ => Some(Self::Xfsz),
+            libc::SIGPOLL => Some(Self::Poll),
+            libc::SIGPROF => Some(Self::Prof),
+            libc::SIGSYS => Some(Self::Sys),
+            libc::SIGTRAP => Some(Self::Trap),
+            libc::SIGURG => Some(Self::Urg),
+            libc::SIGVTALRM => Some(Self::Vtalrm),
+            libc::SIGWINCH => Some(Self::Winch),
+            libc::SIGXCPU => Some(Self::Xcpu),
+            libc::SIGXFSZ => Some(Self::Xfsz),
 
             // other signals
             #[cfg(not(any(
@@ -323,7 +323,7 @@ impl Name {
                 target_os = "linux",
                 target_os = "redox",
             )))]
-            nix::libc::SIGEMT => Some(Self::Emt),
+            libc::SIGEMT => Some(Self::Emt),
             #[cfg(not(any(
                 target_os = "aix",
                 target_os = "android",
@@ -333,7 +333,7 @@ impl Name {
                 target_os = "linux",
                 target_os = "redox",
             )))]
-            nix::libc::SIGINFO => Some(Self::Info),
+            libc::SIGINFO => Some(Self::Info),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -345,9 +345,9 @@ impl Name {
                 target_os = "nto",
                 target_os = "solaris",
             ))]
-            nix::libc::SIGIO => Some(Self::Io),
+            libc::SIGIO => Some(Self::Io),
             #[cfg(target_os = "horizon")]
-            nix::libc::SIGLOST => Some(Self::Lost),
+            libc::SIGLOST => Some(Self::Lost),
             #[cfg(any(
                 target_os = "aix",
                 target_os = "android",
@@ -359,7 +359,7 @@ impl Name {
                 target_os = "redox",
                 target_os = "solaris",
             ))]
-            nix::libc::SIGPWR => Some(Self::Pwr),
+            libc::SIGPWR => Some(Self::Pwr),
             #[cfg(all(
                 any(
                     target_os = "android",
@@ -369,9 +369,9 @@ impl Name {
                 ),
                 not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
             ))]
-            nix::libc::SIGSTKFLT => Some(Self::Stkflt),
+            libc::SIGSTKFLT => Some(Self::Stkflt),
             #[cfg(target_os = "freebsd")]
-            nix::libc::SIGTHR => Some(Self::Thr),
+            libc::SIGTHR => Some(Self::Thr),
 
             // Real-time signals
             _ => {
@@ -414,9 +414,9 @@ fn all_signals() -> impl Iterator<Item = Number> {
 /// Converts the signal set to a vector of signal numbers.
 ///
 /// This function adds the signal numbers in the set to the vector.
-pub(super) fn sigset_to_vec(set: *const nix::libc::sigset_t, vec: &mut Vec<Number>) {
+pub(super) fn sigset_to_vec(set: *const libc::sigset_t, vec: &mut Vec<Number>) {
     vec.extend(
-        all_signals().filter(|number| unsafe { nix::libc::sigismember(set, number.as_raw()) == 1 }),
+        all_signals().filter(|number| unsafe { libc::sigismember(set, number.as_raw()) == 1 }),
     );
 }
 
@@ -426,18 +426,18 @@ impl Disposition {
     /// This function returns the `sigaction` in an `MaybeUninit` because the
     /// `sigaction` structure may contain platform-dependent extra fields that
     /// are not initialized by this function.
-    pub(super) fn to_sigaction(self) -> MaybeUninit<nix::libc::sigaction> {
+    pub(super) fn to_sigaction(self) -> MaybeUninit<libc::sigaction> {
         let handler = match self {
-            Disposition::Default => nix::libc::SIG_DFL,
-            Disposition::Ignore => nix::libc::SIG_IGN,
+            Disposition::Default => libc::SIG_DFL,
+            Disposition::Ignore => libc::SIG_IGN,
             Disposition::Catch => super::catch_signal as *const extern "C" fn(c_int) as _,
         };
 
-        let mut sa = MaybeUninit::<nix::libc::sigaction>::uninit();
+        let mut sa = MaybeUninit::<libc::sigaction>::uninit();
         let sa_ptr = sa.as_mut_ptr();
         unsafe {
             (&raw mut (*sa_ptr).sa_flags).write(0);
-            nix::libc::sigemptyset(&raw mut ((*sa_ptr).sa_mask));
+            libc::sigemptyset(&raw mut ((*sa_ptr).sa_mask));
 
             #[cfg(not(target_os = "aix"))]
             #[allow(clippy::useless_transmute)] // See from_sigaction below
@@ -451,7 +451,7 @@ impl Disposition {
     }
 
     /// Converts the `sigaction` to the signal disposition for the real system.
-    pub(super) unsafe fn from_sigaction(sa: &MaybeUninit<nix::libc::sigaction>) -> Self {
+    pub(super) unsafe fn from_sigaction(sa: &MaybeUninit<libc::sigaction>) -> Self {
         #[cfg(not(target_os = "aix"))]
         let handler = (&raw const (*sa.as_ptr()).sa_sigaction).read();
 
@@ -461,8 +461,8 @@ impl Disposition {
         // It is platform-specific whether we really need to transmute the handler.
         #[allow(clippy::useless_transmute)]
         match std::mem::transmute(handler) {
-            nix::libc::SIG_DFL => Self::Default,
-            nix::libc::SIG_IGN => Self::Ignore,
+            libc::SIG_DFL => Self::Default,
+            libc::SIG_IGN => Self::Ignore,
             _ => Self::Catch,
         }
     }

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -23,7 +23,7 @@
 //! [`setrlimit`]: super::System::setrlimit
 
 #[cfg(unix)]
-type RawLimit = nix::libc::rlim_t;
+type RawLimit = libc::rlim_t;
 #[cfg(not(unix))]
 type RawLimit = u64;
 
@@ -33,7 +33,7 @@ type RawLimit = u64;
 pub type Limit = RawLimit;
 
 #[cfg(unix)]
-const RLIM_INFINITY: Limit = nix::libc::RLIM_INFINITY;
+const RLIM_INFINITY: Limit = libc::RLIM_INFINITY;
 #[cfg(not(unix))]
 const RLIM_INFINITY: Limit = Limit::MAX;
 

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -455,7 +455,7 @@ impl System for &SharedSystem {
     fn getegid(&self) -> Gid {
         self.0.borrow().getegid()
     }
-    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
+    fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>> {
         self.0.borrow().getpwnam_dir(name)
     }
     fn confstr_path(&self) -> Result<UnixString> {
@@ -677,7 +677,7 @@ impl System for SharedSystem {
         (&self).getegid()
     }
     #[inline]
-    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
+    fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>> {
         (&self).getpwnam_dir(name)
     }
     #[inline]

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -982,8 +982,12 @@ impl System for VirtualSystem {
         self.current_process().egid()
     }
 
-    fn getpwnam_dir(&self, name: &str) -> Result<Option<PathBuf>> {
+    fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>> {
         let state = self.state.borrow();
+        let name = match name.to_str() {
+            Ok(name) => name,
+            Err(_utf8_error) => return Ok(None),
+        };
         Ok(state.home_dirs.get(name).cloned())
     }
 

--- a/yash-semantics/src/expansion/initial/tilde.rs
+++ b/yash-semantics/src/expansion/initial/tilde.rs
@@ -18,6 +18,7 @@
 
 use crate::expansion::attr::AttrChar;
 use crate::expansion::attr::Origin;
+use std::ffi::CString;
 use yash_env::variable::HOME;
 use yash_env::Env;
 use yash_env::System;
@@ -42,9 +43,11 @@ pub fn expand(name: &str, env: &Env) -> Vec<AttrChar> {
         let result = env.variables.get_scalar(HOME).unwrap_or("~");
         into_attr_chars(result.chars())
     } else {
-        if let Ok(Some(path)) = env.system.getpwnam_dir(name) {
-            if let Ok(path) = path.into_unix_string().into_string() {
-                return into_attr_chars(path.chars());
+        if let Ok(name) = CString::new(name) {
+            if let Ok(Some(path)) = env.system.getpwnam_dir(&name) {
+                if let Ok(path) = path.into_unix_string().into_string() {
+                    return into_attr_chars(path.chars());
+                }
             }
         }
         into_attr_chars(std::iter::once('~').chain(name.chars()))


### PR DESCRIPTION
I want to completely remove the `nix` crate dependency from the `yash-env` crate. I find `nix` unreliable because of its careless use of `MaybeUninit::assume_init` (and similar functions) and the drastic changes sometimes made to the API. `Nix` has been transitioning to use `AsFd` instead of `RawFd` for functions that require a valid FD, which is incompatible with our use of raw FDs for `RealSystem`.

- All around yash-env
  - [x] Use libc directly instead of by nix::libc
- system::real::errno::Errno
  - [x] Migrate from nix::error::Errno to errno::Errno
- RealSystem
  - [x] nix::errno::Errno
  - [x] nix::fcntl::AtFlags
  - [x] nix::sys::stat::stat
  - [x] nix::unistd::AccessFlags
  - [x] nix::unistd::Pid
    - [x] RealSystem::wait
  - [x] nix::unistd::faccessat
  - [x] nix::sys::wait::waitpid
  - [x] nix::unistd::execve
  - [x] nix::unistd::getcwd
  - [x] nix::unistd::chdir
  - [x] nix::unistd::User::from_name
- system::errno::Errno
  - [x] Remove conversion to and from nix::Errno

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes for version 0.6.0 of yash-env:

- **New Features**
	- Enhanced system error handling with improved error conversion support
	- Added support for converting between different error types
	- Improved interoperability with system-level libraries

- **Breaking Changes**
	- Updated method signatures requiring C-style string inputs
	- Removed dependency on `nix` crate
	- Modified error handling mechanisms

- **Dependency Updates**
	- Replaced `nix` dependency with direct `libc` and `errno` crate usage
	- Updated internal library references for system calls and data structures

- **Performance**
	- Streamlined system interaction code
	- Simplified library dependencies

- **Compatibility**
	- Improved cross-platform support through standardized library usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->