### PR TITLE
Update stable toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       RUSTDOCFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Run basic tests
       run: ./check.sh -v
@@ -25,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - uses: giraffate/clippy-action@v1
       with:
@@ -35,6 +37,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Run extra tests
       run: |
@@ -58,6 +61,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Test yash-arith
       run: cargo test --all-features --package yash-arith


### PR DESCRIPTION
GitHub Actions images are updated regularly, but sometimes the
preinstalled Rust toolchain is not the latest stable release. This
commit updates the stable toolchain to the latest version in the CI
workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow configuration to use stable Rust toolchain across multiple jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->