### PR TITLE
Support the `-e` option in the `cd` built-in

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+The `cd` built-in now supports the `-e` (`--ensure-pwd`) option, which ensures
+that the `$PWD` variable is set to the actual current working directory after
+changing the working directory. The following items have been added to implement
+this feature:
+
 - `common::report`, `common::report_simple`
     - These functions are generalizations of the existing `report_failure`,
       `report_error`, `report_simple_failure`, and `report_simple_error`
@@ -18,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cd::EXIT_STATUS_SYNTAX_ERROR`
     - These constants represent exit statuses that can be returned by the `cd`
       built-in.
+- `cd::Command::ensure_pwd`
+    - This field represents the new `-e` option of the `cd` built-in.
+- `cd::syntax::Error::EnsurePwdNotPhysical`
+    - This error variant represents a syntax error that occurs when the `-e`
+      option is specified without the `-P` option.
 
 ### Changed
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - Unreleased
 
+### Added
+
+- `common::report`, `common::report_simple`
+    - These functions are generalizations of the existing `report_failure`,
+      `report_error`, `report_simple_failure`, and `report_simple_error`
+      functions that allow returning a custom exit status.
+
 ### Changed
 
 - External dependency versions:

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,9 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - These functions are generalizations of the existing `report_failure`,
       `report_error`, `report_simple_failure`, and `report_simple_error`
       functions that allow returning a custom exit status.
+- `cd::EXIT_STATUS_SUCCESS`, `cd::EXIT_STATUS_STALE_PWD`,
+  `cd::EXIT_STATUS_CHDIR_ERROR`, `cd::EXIT_STATUS_UNSET_VARIABLE`, and
+  `cd::EXIT_STATUS_SYNTAX_ERROR`
+    - These constants represent exit statuses that can be returned by the `cd`
+      built-in.
 
 ### Changed
 
+- The `cd::chdir::report_failure` function now returns a result with
+  `EXIT_STATUS_CHDIR_ERROR`.
 - External dependency versions:
     - yash-env 0.5.0 → 0.6.0
     - yash-semantics 0.5.0 → 0.6.0 (optional)

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -33,6 +33,8 @@ this feature:
 
 - The `cd::chdir::report_failure` function now returns a result with
   `EXIT_STATUS_CHDIR_ERROR`.
+- The `cd::assign::new_pwd` function now returns `Result<PathBuf, Errno>` instead
+  of `PathBuf`. Previously, it returned an empty `PathBuf` on failure.
 - External dependency versions:
     - yash-env 0.5.0 → 0.6.0
     - yash-semantics 0.5.0 → 0.6.0 (optional)

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -174,7 +174,7 @@
 //! the above conditions are not met. The current implementation does it if and
 //! only if the final operand starts with `$PWD`.
 
-use crate::common::report_error;
+use crate::common::report;
 use crate::common::report_failure;
 use crate::Result;
 use yash_env::path::Path;
@@ -240,7 +240,7 @@ fn get_pwd(env: &Env) -> String {
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,
-        Err(e) => return report_error(env, &e).await,
+        Err(e) => return report(env, &e, EXIT_STATUS_SYNTAX_ERROR).await,
     };
 
     let pwd = get_pwd(env);

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -214,7 +214,15 @@ pub enum Mode {
 #[non_exhaustive]
 pub struct Command {
     /// Treatments of symbolic links in the pathname
+    ///
+    /// The `-L` and `-P` options are translated to this field.
     pub mode: Mode,
+
+    /// Whether to ensure the new `$PWD` value
+    ///
+    /// The `-e` option is translated to this field.
+    /// This option must be used together with the `-P` option.
+    pub ensure_pwd: bool,
 
     /// The operand that specifies the directory to change to
     pub operand: Option<Field>,

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -178,9 +178,25 @@ use crate::common::report_error;
 use crate::common::report_failure;
 use crate::Result;
 use yash_env::path::Path;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::variable::PWD;
 use yash_env::Env;
+
+/// Exit status when the built-in succeeds
+pub const EXIT_STATUS_SUCCESS: ExitStatus = ExitStatus(0);
+
+/// Exit status when the new `$PWD` value cannot be determined
+pub const EXIT_STATUS_STALE_PWD: ExitStatus = ExitStatus(1);
+
+/// Exit status for an error in the underlying `chdir` system call
+pub const EXIT_STATUS_CHDIR_ERROR: ExitStatus = ExitStatus(2);
+
+/// Exit status for an unset or empty `$HOME` or `$OLDPWD`
+pub const EXIT_STATUS_UNSET_VARIABLE: ExitStatus = ExitStatus(3);
+
+/// Exit status for invalid command arguments
+pub const EXIT_STATUS_SYNTAX_ERROR: ExitStatus = ExitStatus(4);
 
 /// Treatments of symbolic links in the pathname
 #[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -247,5 +263,5 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
     assign::set_oldpwd(env, pwd).await;
     assign::set_pwd(env, new_pwd).await;
 
-    Result::default()
+    Result::from(EXIT_STATUS_SUCCESS)
 }

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -175,7 +175,6 @@
 //! only if the final operand starts with `$PWD`.
 
 use crate::common::report;
-use crate::common::report_failure;
 use crate::Result;
 use yash_env::path::Path;
 use yash_env::semantics::ExitStatus;
@@ -247,7 +246,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
 
     let (path, origin) = match target::target(env, &command, &pwd) {
         Ok(target) => target,
-        Err(e) => return report_failure(env, &e).await,
+        Err(e) => return report(env, &e, EXIT_STATUS_UNSET_VARIABLE).await,
     };
 
     let short_path = shorten::shorten(&path, Path::new(&pwd), command.mode);

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -22,7 +22,6 @@ use std::ffi::CString;
 use std::ffi::NulError;
 use thiserror::Error;
 use yash_env::path::Path;
-use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 #[cfg(doc)]
 use yash_env::stack::Stack;
@@ -101,5 +100,5 @@ pub async fn report_failure(
 ) -> crate::Result {
     let (message, divert) = failure_message(env, operand, path, error);
     env.system.print_error(&message).await;
-    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
+    crate::Result::with_exit_status_and_divert(super::EXIT_STATUS_CHDIR_ERROR, divert)
 }

--- a/yash-builtin/src/cd/target.rs
+++ b/yash-builtin/src/cd/target.rs
@@ -254,6 +254,7 @@ mod tests {
         let mut env = Env::new_virtual();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: None,
         };
         env.get_or_create_variable(HOME, Scope::Global)
@@ -269,6 +270,7 @@ mod tests {
         let mut env = Env::new_virtual();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: None,
         };
         let arg0 = Field::dummy("cd");
@@ -287,6 +289,7 @@ mod tests {
         let mut env = Env::new_virtual();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: None,
         };
         let arg0 = Field::dummy("cd");
@@ -308,6 +311,7 @@ mod tests {
         let mut env = Env::new_virtual();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: Some(Field::dummy("-")),
         };
         env.get_or_create_variable(OLDPWD, Scope::Global)
@@ -325,6 +329,7 @@ mod tests {
         let location = operand.origin.clone();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: Some(operand),
         };
 
@@ -339,6 +344,7 @@ mod tests {
         let location = operand.origin.clone();
         let command = Command {
             mode: Mode::default(),
+            ensure_pwd: false,
             operand: Some(operand),
         };
         env.get_or_create_variable(OLDPWD, Scope::Global)
@@ -357,6 +363,7 @@ mod tests {
             &env,
             &Command {
                 mode: Mode::Physical,
+                ensure_pwd: false,
                 operand: Some(Field::dummy("foo")),
             },
             "/ignored",
@@ -368,6 +375,7 @@ mod tests {
             &env,
             &Command {
                 mode: Mode::Physical,
+                ensure_pwd: false,
                 operand: Some(Field::dummy("foo/bar")),
             },
             "/ignored",
@@ -384,6 +392,7 @@ mod tests {
             &env,
             &Command {
                 mode: Mode::Logical,
+                ensure_pwd: false,
                 operand: Some(Field::dummy("/foo")),
             },
             "/ignored",
@@ -395,6 +404,7 @@ mod tests {
             &env,
             &Command {
                 mode: Mode::Logical,
+                ensure_pwd: false,
                 operand: Some(Field::dummy("/foo/bar")),
             },
             "/ignored",
@@ -409,6 +419,7 @@ mod tests {
         let env = Env::new_virtual();
         let command = Command {
             mode: Mode::Logical,
+            ensure_pwd: false,
             operand: Some(Field::dummy("foo/bar")),
         };
 

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -67,7 +67,7 @@ pub fn arrange_message_and_divert<'e: 'm, 'm>(
         // Add an annotation indicating the built-in name
         message.annotations.push(Annotation::new(
             AnnotationType::Info,
-            format!("error occurred in the {} built-in", builtin.name.value).into(),
+            format!("executing the {} built-in", builtin.name.value).into(),
             &builtin.name.origin,
         ));
         let source = &builtin.name.origin.code.source;

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -87,24 +87,26 @@ pub fn arrange_message_and_divert<'e: 'm, 'm>(
     (message, divert)
 }
 
-async fn report(
-    env: &mut Env,
-    message: Message<'_>,
-    exit_status: ExitStatus,
-) -> yash_env::builtin::Result {
-    let (message, divert) = arrange_message_and_divert(env, message);
-    env.system.print_error(&message).await;
-    yash_env::builtin::Result::with_exit_status_and_divert(exit_status, divert)
-}
-
-/// Prints a failure message.
+/// Reports a message with the given exit status.
 ///
-/// This function is only usable when the `message` argument does not contain
-/// any references borrowed from the environment. Otherwise, inline the body of
-/// this function into the caller:
+/// This is a convenience function for reporting a message with a specific exit
+/// status. The message is converted to a string and [`Divert`] using
+/// [`arrange_message_and_divert`], and then printed to the standard error.
+/// The returned result contains the given exit status and the divert value.
+///
+/// When the exit status is [`ExitStatus::FAILURE`] or [`ExitStatus::ERROR`],
+/// you can use [`report_failure`] or [`report_error`] instead of this function,
+/// respectively.
+///
+/// This function requires a mutable borrow of the environment to print the
+/// message, so it is only usable when the `message` argument does not contain
+/// any borrows from the environment. Otherwise, directly call
+/// [`arrange_message_and_divert`], which only requires an immutable borrow of
+/// the environment, to construct the message and divert value, and then print
+/// the message yourself.
 ///
 /// ```
-/// # use futures_util::future::FutureExt;
+/// # use futures_util::future::FutureExt as _;
 /// # use yash_builtin::common::arrange_message_and_divert;
 /// # use yash_env::builtin::Result;
 /// # use yash_env::semantics::ExitStatus;
@@ -119,70 +121,83 @@ async fn report(
 /// # }.now_or_never().unwrap();
 /// ```
 #[inline]
+pub async fn report<'a, M>(
+    env: &mut Env,
+    message: M,
+    exit_status: ExitStatus,
+) -> yash_env::builtin::Result
+where
+    M: Into<Message<'a>> + 'a,
+{
+    async fn inner(
+        env: &mut Env,
+        message: Message<'_>,
+        exit_status: ExitStatus,
+    ) -> yash_env::builtin::Result {
+        let (message, divert) = arrange_message_and_divert(env, message);
+        env.system.print_error(&message).await;
+        yash_env::builtin::Result::with_exit_status_and_divert(exit_status, divert)
+    }
+    inner(env, message.into(), exit_status).await
+}
+
+/// Prints a failure message.
+///
+/// This is a simple shortcut for calling [`report`] with [`ExitStatus::FAILURE`].
+#[inline]
 pub async fn report_failure<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
 where
     M: Into<Message<'a>> + 'a,
 {
-    report(env, message.into(), ExitStatus::FAILURE).await
-}
-
-/// Prints a simple failure message.
-///
-/// This function constructs a [`Message`] with the given title and prints it
-/// using [`report_failure`]. The message has no annotations except for the
-/// built-in name which is added by [`arrange_message_and_divert`].
-pub async fn report_simple_failure(env: &mut Env, title: &str) -> yash_env::builtin::Result {
-    let message = Message {
-        r#type: AnnotationType::Error,
-        title: title.into(),
-        annotations: vec![],
-        footers: vec![],
-    };
-    report_failure(env, message).await
+    report(env, message, ExitStatus::FAILURE).await
 }
 
 /// Prints an error message.
 ///
-/// This function is only usable when the `message` argument does not contain
-/// any references borrowed from the environment. Otherwise, inline the body of
-/// this function into the caller:
-///
-/// ```
-/// # use futures_util::future::FutureExt;
-/// # use yash_builtin::common::arrange_message_and_divert;
-/// # use yash_env::builtin::Result;
-/// # use yash_env::semantics::ExitStatus;
-/// # use yash_syntax::source::pretty::{Annotation, AnnotationType, Message};
-/// # use yash_syntax::syntax::Fd;
-/// # async {
-/// # let mut env = yash_env::Env::new_virtual();
-/// # let message = Message { r#type: AnnotationType::Error, title: "".into(), annotations: vec![], footers: vec![] };
-/// let (message, divert) = arrange_message_and_divert(&env, message);
-/// env.system.print_error(&message).await;
-/// Result::with_exit_status_and_divert(ExitStatus::ERROR, divert)
-/// # }.now_or_never().unwrap();
-/// ```
+/// This is a simple shortcut for calling [`report`] with [`ExitStatus::ERROR`].
 #[inline]
 pub async fn report_error<'a, M>(env: &mut Env, message: M) -> yash_env::builtin::Result
 where
     M: Into<Message<'a>> + 'a,
 {
-    report(env, message.into(), ExitStatus::ERROR).await
+    report(env, message, ExitStatus::ERROR).await
 }
 
-/// Prints a simple error message.
+/// Reports a simple message with the given exit status.
 ///
 /// This function constructs a [`Message`] with the given title and prints it
-/// using [`report_error`]. The message has no annotations except for the
-/// built-in name which is added by [`arrange_message_and_divert`].
-pub async fn report_simple_error(env: &mut Env, title: &str) -> yash_env::builtin::Result {
+/// using [`report`]. The message has no annotations except for the built-in
+/// name which is added by [`arrange_message_and_divert`].
+///
+/// When the exit status is [`ExitStatus::FAILURE`] or [`ExitStatus::ERROR`],
+/// you can use [`report_simple_failure`] or [`report_simple_error`] instead of
+/// this function, respectively.
+pub async fn report_simple(
+    env: &mut Env,
+    title: &str,
+    exit_status: ExitStatus,
+) -> yash_env::builtin::Result {
     let message = Message {
         r#type: AnnotationType::Error,
         title: title.into(),
         annotations: vec![],
         footers: vec![],
     };
-    report_error(env, message).await
+    report(env, message, exit_status).await
+}
+
+/// Prints a simple failure message.
+///
+/// This is a simple shortcut for calling [`report_simple`] with [`ExitStatus::FAILURE`].
+pub async fn report_simple_failure(env: &mut Env, title: &str) -> yash_env::builtin::Result {
+    report_simple(env, title, ExitStatus::FAILURE).await
+}
+
+/// Prints a simple error message.
+///
+/// This is a simple shortcut for calling [`report_simple`] with [`ExitStatus::ERROR`].
+pub async fn report_simple_error(env: &mut Env, title: &str) -> yash_env::builtin::Result {
+    report_simple(env, title, ExitStatus::ERROR).await
 }
 
 /// Prints a simple error message for a command syntax error.

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -161,6 +161,11 @@ fn cd_builtin() {
 }
 
 #[test]
+fn cd_builtin_ex() {
+    run("cd-y.sh");
+}
+
+#[test]
 fn command_builtin() {
     run("command-p.sh")
 }

--- a/yash-cli/tests/scripted_test/cd-y.sh
+++ b/yash-cli/tests/scripted_test/cd-y.sh
@@ -4,12 +4,12 @@ cd -P .
 export ORIGPWD="$PWD"
 mkdir dir -
 
-test_O -d -e 1 'unset HOME'
+test_O -d -e 3 'unset HOME'
 unset HOME
 cd
 __IN__
 
-test_O -d -e 1 'empty HOME'
+test_O -d -e 3 'empty HOME'
 HOME=
 cd
 __IN__
@@ -28,7 +28,7 @@ OLDPWD=
 $ORIGPWD/dir
 __OUT__
 
-test_O -d -e 1 'unset OLDPWD'
+test_O -d -e 3 'unset OLDPWD'
 unset OLDPWD
 cd -
 __IN__

--- a/yash-cli/tests/scripted_test/cd-y.sh
+++ b/yash-cli/tests/scripted_test/cd-y.sh
@@ -1,0 +1,165 @@
+# cd-y.sh: yash-specific test of the cd built-in
+
+cd -P .
+export ORIGPWD="$PWD"
+mkdir dir -
+
+test_O -d -e 1 'unset HOME'
+unset HOME
+cd
+__IN__
+
+test_O -d -e 1 'empty HOME'
+HOME=
+cd
+__IN__
+
+testcase "$LINENO" 'unset PWD' \
+    3<<\__IN__ 5</dev/null 4<<__OUT__
+unset CDPATH PWD
+cd dir
+echo ---
+printf 'PWD=%s\nOLDPWD=%s\n' "$PWD" "$OLDPWD"
+pwd
+__IN__
+---
+PWD=dir
+OLDPWD=
+$ORIGPWD/dir
+__OUT__
+
+test_O -d -e 1 'unset OLDPWD'
+unset OLDPWD
+cd -
+__IN__
+
+# It is POSIXly unclear what the exit status of cd should be in this case.
+testcase "$LINENO" -d 'read-only PWD' 3<<\__IN__ 4<<__OUT__
+unset CDPATH
+readonly PWD
+cd dir
+echo --- $?
+printf 'PWD=%s\n' "$PWD"
+pwd
+__IN__
+--- 0
+PWD=$ORIGPWD
+$ORIGPWD/dir
+__OUT__
+
+# It is POSIXly unclear what the exit status of cd should be in this case.
+test_o -d 'unset OLDPWD'
+unset CDPATH
+readonly OLDPWD=/
+cd dir
+echo --- $?
+printf 'OLDPWD=%s\n' "$OLDPWD"
+__IN__
+--- 0
+OLDPWD=/
+__OUT__
+
+: TODO not implemented yet <<\__OUT__
+test_oE -e 0 'YASH_AFTER_CD is iteratively executed after changing directory'
+YASH_AFTER_CD=(
+'printf "PWD=%s\n" "$PWD"'
+'printf "status=%d\n" "$?"'
+'(exit 1); break -i'
+'echo not reached')
+(exit 11)
+cd /
+__IN__
+PWD=/
+status=11
+__OUT__
+
+(
+posix="true"
+
+test_OE -e 0 'YASH_AFTER_CD is ignored (-o POSIX)'
+YASH_AFTER_CD='echo not reached'
+cd /
+__IN__
+
+)
+
+(
+if ! [ / -ef /.. ]; then
+    skip="true"
+fi
+
+: TODO not implemented yet <<\__OUT__
+test_oE '/.. is canonicalized to / (+o POSIX)'
+cd /..//../dev
+printf '%s\n' "$PWD"
+cd /../..
+printf '%s\n' "$PWD"
+__IN__
+/dev
+/
+__OUT__
+
+(
+posix="true"
+
+test_oE '/.. is kept intact (-o POSIX)'
+cd /../../dev
+printf '%s\n' "$PWD"
+__IN__
+/../../dev
+__OUT__
+
+)
+
+)
+
+testcase "$LINENO" 'redundant slashes are removed' \
+    3<<\__IN__ 5</dev/null 4<<__OUT__
+cd .//dir///
+pwd
+__IN__
+$ORIGPWD/dir
+__OUT__
+
+: TODO not implemented yet <<\__OUT__
+test_oE 'default directory option with operand'
+HOME=/tmp cd --default-directory=/ /dev
+echo --- $?
+pwd
+__IN__
+--- 0
+/dev
+__OUT__
+
+: TODO not implemented yet <<\__OUT__
+test_oE 'default directory option without operand'
+HOME=/tmp cd --default-directory=/
+echo --- $?
+pwd
+__IN__
+--- 0
+/
+__OUT__
+
+: TODO not implemented yet <<\__OUT__
+testcase "$LINENO" 'hyphen is literal in default directory option' \
+    3<<\__IN__ 5</dev/null 4<<__OUT__
+OLDPWD=/ cd --default-directory=-
+pwd
+__IN__
+$ORIGPWD/-
+__OUT__
+
+test_O -d -e 2 'too many operands'
+cd . .
+__IN__
+
+test_O -d -e 2 'invalid option'
+cd --no-such-option
+__IN__
+
+test_O -e 0 'printing to closed stream'
+OLDPWD=/ cd - >&-
+__IN__
+
+# vim: set ft=sh ts=8 sts=4 sw=4 et:

--- a/yash-cli/tests/scripted_test/cd-y.sh
+++ b/yash-cli/tests/scripted_test/cd-y.sh
@@ -150,11 +150,11 @@ __IN__
 $ORIGPWD/-
 __OUT__
 
-test_O -d -e 2 'too many operands'
+test_O -d -e 4 'too many operands'
 cd . .
 __IN__
 
-test_O -d -e 2 'invalid option'
+test_O -d -e 4 'invalid option'
 cd --no-such-option
 __IN__
 

--- a/yash-cli/tests/scripted_test/cd-y.sh
+++ b/yash-cli/tests/scripted_test/cd-y.sh
@@ -4,6 +4,10 @@ cd -P .
 export ORIGPWD="$PWD"
 mkdir dir -
 
+test_O -d -e 2 'directory not changeable'
+cd _no_such_directory_
+__IN__
+
 test_O -d -e 3 'unset HOME'
 unset HOME
 cd

--- a/yash-cli/tests/scripted_test/error-y.sh
+++ b/yash-cli/tests/scripted_test/error-y.sh
@@ -191,9 +191,9 @@ test_nonspecial_builtin_syntax() (
 # -l and -n are mutually exclusive for the kill built-in.
 # Four arguments are too many for the test built-in.
 $2 -l -n --no-such-option-- -
-echo \$?
+test \$? -ne 0 && echo reached
 __IN__
-2
+reached
 __OUT__
 )
 


### PR DESCRIPTION
This pull request introduces a new feature to the `cd` built-in command, adding support for the `-e` (`--ensure-pwd`) option. This option ensures that the `$PWD` variable is set to the actual current working directory after changing the directory. The changes include updates to the documentation, new constants for exit statuses, and modifications to the `cd` implementation to handle the new option.

### New Feature:
* Added support for the `-e` (`--ensure-pwd`) option in the `cd` built-in command. This option ensures that `$PWD` is set correctly after changing directories. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R37) [[2]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L24-R24) [[3]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6R79-R84) [[4]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L91-R115) [[5]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L106-R136) [[6]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L117-R151) [[7]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6R162-R164) [[8]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L147-R206) [[9]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6R225-R234) [[10]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6R252-R287) [[11]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L214-R351)

### Documentation Updates:
* Updated the synopsis and description of the `cd` command to include the `-e` option. [[1]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L24-R24) [[2]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6R79-R84)
* Expanded the error and exit status sections to describe the behavior when the `-e` option is used. [[1]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L91-R115) [[2]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L106-R136)

### Code Changes:
* Introduced new constants for various exit statuses in `yash-builtin/src/cd.rs`.
* Modified the `Command` struct to include a new `ensure_pwd` field representing the `-e` option.
* Updated the `new_pwd` function to return a `Result<PathBuf, Errno>` instead of just `PathBuf`.
* Added a new `report_pwd_error` function to handle errors related to determining the new `$PWD` value.
* Updated the `main` function to handle the new `ensure_pwd` option and use the new exit statuses.

### Test Additions:
* Added tests to verify the behavior of the `report_pwd_error` function with and without the `ensure_pwd` option.

### Syntax Parsing:
* Updated the syntax parsing logic to handle the new `-e` option and ensure it is used correctly with the `-P` option. [[1]](diffhunk://#diff-ca54a36049b426d55ddff374595c8d122f7151438172af6c8fb1ab1dad8cfb25R41-R51) [[2]](diffhunk://#diff-ca54a36049b426d55ddff374595c8d122f7151438172af6c8fb1ab1dad8cfb25R81-R115) [[3]](diffhunk://#diff-ca54a36049b426d55ddff374595c8d122f7151438172af6c8fb1ab1dad8cfb25R133)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for the `-e` (`--ensure-pwd`) option in the `cd` built-in command.
	- Enhanced error handling and exit status reporting for directory changes.

- **Bug Fixes**
	- Improved handling of working directory changes and `$PWD` variable updates.
	- Added more precise error reporting for `cd` command scenarios.

- **Documentation**
	- Updated changelog to reflect new functionality and changes in version 0.6.0.

- **Tests**
	- Added new test scripts to validate `cd` command behavior and error handling.
	- Expanded test coverage with additional scenarios related to the `cd` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
