### PR TITLE
Include initially ignored traps in `trap` built-in output

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -43,6 +43,8 @@ The `cd` built-in now errors out when a given operand is an empty string.
   `EXIT_STATUS_CHDIR_ERROR`.
 - The `cd::assign::new_pwd` function now returns `Result<PathBuf, Errno>` instead
   of `PathBuf`. Previously, it returned an empty `PathBuf` on failure.
+- The output of the `trap` built-in now includes not only user-defined traps but
+  also signal dispositions that are not explicitly set by the user.
 - External dependency versions:
     - yash-env 0.5.0 → 0.6.0
     - yash-semantics 0.5.0 → 0.6.0 (optional)

--- a/yash-builtin/src/kill/print.rs
+++ b/yash-builtin/src/kill/print.rs
@@ -37,6 +37,9 @@ use yash_syntax::source::pretty::{Annotation, AnnotationType, MessageBase};
 /// Returns an iterator over all supported signals.
 ///
 /// The iterator yields non-real-time signals first, followed by real-time signals.
+// TODO Most part of this function is duplicated in yash_env::trap::Condition::iter.
+// Consider refactoring to avoid duplication. Note that the two functions require
+// different trait bounds.
 fn all_signals<S: System>(system: &S) -> impl Iterator<Item = (Name, Number)> + '_ {
     let non_real_time = Name::iter()
         .filter(|name| !matches!(name, Name::Rtmin(_) | Name::Rtmax(_)))

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -186,11 +186,7 @@ pub mod syntax;
 pub fn display_traps<S: SignalSystem>(traps: &TrapSet, system: &S) -> String {
     let mut output = String::new();
     for (cond, current, parent) in traps {
-        let trap = match (current, parent) {
-            (_, Some(trap)) => trap,
-            (Some(trap), None) => trap,
-            (None, None) => continue,
-        };
+        let trap = parent.unwrap_or(current);
         let command = match &trap.action {
             Action::Default => continue,
             Action::Ignore => "",

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -21,36 +21,49 @@
 //! # Synopsis
 //!
 //! ```sh
-//! trap
+//! trap [action] condition…
 //! ```
 //!
 //! ```sh
-//! trap [action] condition…
+//! trap [-p [condition…]]
 //! ```
 //!
 //! # Description
 //!
+//! The `trap` built-in can be used to either set or print traps.
+//! To set traps, pass an *action* and one or more *condition*s as operands.
+//! To print the currently configured traps, invoke the built-in with no
+//! operands or with the `-p` option.
+//!
+//! ## Setting traps
+//!
+//! When setting traps, the built-in sets the *action* for each *condition* in
+//! the current shell environment. To set different actions for multiple
+//! conditions, use multiple invocations of the built-in.
+//!
+//! ## Printing traps
+//!
 //! When the built-in is invoked with no operands, it prints the currently
 //! configured traps in the format `trap -- action condition` where *action* and
 //! *condition* are properly quoted so that the output can be read by the shell
-//! to restore the traps.
+//! to restore the traps. By default, the built-in prints traps that have
+//! non-default actions. To print all traps, use the `-p` option with no
+//! operands.
+//!
+//! When the `-p` option is used with one or more *condition*s, the built-in
+//! prints the traps for the specified *condition*s.
 //!
 //! When a [subshell](yash_env::subshell) is entered, traps other than
 //! `Action::Ignore` are reset to the default action. This behavior would make
 //! it impossible to save the current traps by using a command substitution as
-//! in `traps=$(trap)`. To avoid this, when the built-in is invoked in a
+//! in `traps=$(trap)`. To make this work, when the built-in is invoked in a
 //! subshell and no traps have been modified in the subshell, it prints the
 //! traps that were configured in the parent shell.
 //!
-//! When operands are given, the built-in sets the trap specified by *action*
-//! and *condition*. When there are more than one *condition*, the built-in sets
-//! the same *action* for all of them.
-//!
 //! # Options
 //!
-//! None.
-//!
-//! (TODO: `-p` option)
+//! The **`-p`** (**`--print`**) option prints the traps configured in the shell
+//! environment.
 //!
 //! # Operands
 //!
@@ -111,6 +124,9 @@
 //! configured in the parent shell. The check may be done by a simple literal
 //! comparison, so you should not expect the shell to recognize complex
 //! expressions such as `cmd=trap; traps=$($cmd)`.
+//!
+//! In other shells, the `EXIT` condition may be triggered when the shell is
+//! terminated by a signal.
 //!
 //! # Implementation notes
 //!

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -187,8 +187,8 @@ pub fn display_traps<S: SignalSystem>(traps: &TrapSet, system: &S) -> String {
     let mut output = String::new();
     for (cond, current, parent) in traps {
         let trap = match (current, parent) {
-            (Some(trap), _) => trap,
-            (None, Some(trap)) => trap,
+            (_, Some(trap)) => trap,
+            (Some(trap), None) => trap,
             (None, None) => continue,
         };
         let command = match &trap.action {

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `cd` built-in now errors out when a given operand is an empty string.
 - The `cd` built-in now returns different exit statuses for different errors.
+- The output of the `trap` built-in now includes not only user-defined traps but
+  also signal dispositions that are not explicitly set by the user.
 
 ## [0.2.0] - 2024-12-14
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `builtin::Builtin` struct now has the `is_declaration_utility` field.
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.
+- The `trap::SignalSystem` trait now has the `get_disposition` method.
 - The `system::errno::Errno` struct now can be converted to and from the `Errno`
   type from the `errno` crate.
 - Internal dependencies:

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `builtin::Builtin` struct now has the `is_declaration_utility` field.
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.
+- The `trap::Condition` enum now has the `iter` associated function.
+    - Given a `SignalSystem` implementation, this function returns an iterator
+      that yields all the conditions available in the system.
 - The `trap::SignalSystem` trait now has the `get_disposition` method.
 - The `Origin` enum has been added to the `trap` module.
     - This enum represents the origin of a configured trap.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `System::getpwnam_dir` now takes a `&CStr` parameter instead of a `&str`.
 - The `builtin::Builtin` struct is now `non_exhaustive`.
 - The `origin` field of the `trap::TrapState` struct is now `trap::Origin`.
+- The `TrapSet::get_state` method now returns a `TrapState` reference even if
+  the current action was not set by the user.
 - External dependency versions:
     - yash-syntax 0.13.0 → 0.14.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Env` struct now contains the `any` field of type `DataSet`.
     - The `DataSet` struct is defined in the newly added `any` module.
       It can be used to store arbitrary data.
+- The `System` trait now has the `get_sigaction` method.
+    - This method returns the current signal handling configuration for a signal.
+      This method does not modify anything, so it can be used with an immutable
+      reference to the system.
 - The `builtin::Builtin` struct now has the `is_declaration_utility` field.
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `origin` field of the `trap::TrapState` struct is now `trap::Origin`.
 - The `TrapSet::get_state` method now returns a `TrapState` reference even if
   the current action was not set by the user.
+- The `trap::Iter` iterator now yields
+  `(&'a Condition, &'a TrapState, Option<&'a TrapState>)` instead of
+  `(&'a Condition, Option<&'a TrapState>, Option<&'a TrapState>)`.
+  It now yields the current state even if the current action was not set by the
+  user.
 - External dependency versions:
     - yash-syntax 0.13.0 → 0.14.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `builtin::Builtin` struct now can be constructed with the associated
   function `new`.
 - The `trap::SignalSystem` trait now has the `get_disposition` method.
+- The `Origin` enum has been added to the `trap` module.
+    - This enum represents the origin of a configured trap.
+- The `trap::TrapSet` struct now implements `Default`.
 - The `system::errno::Errno` struct now can be converted to and from the `Errno`
   type from the `errno` crate.
 - Internal dependencies:
@@ -31,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `System::getpwnam_dir` now takes a `&CStr` parameter instead of a `&str`.
 - The `builtin::Builtin` struct is now `non_exhaustive`.
+- The `origin` field of the `trap::TrapState` struct is now `trap::Origin`.
 - External dependency versions:
     - yash-syntax 0.13.0 → 0.14.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Origin` enum has been added to the `trap` module.
     - This enum represents the origin of a configured trap.
 - The `trap::TrapSet` struct now implements `Default`.
+- The `trap::TrapSet` struct now has the `peek_state` method.
+    - This method can be used to get the current state of a trap by accessing
+      the underlying system if necessary. It reports the trap state that should
+      be used in the output of the `trap` built-in.
 - The `system::errno::Errno` struct now can be converted to and from the `Errno`
   type from the `errno` crate.
 - Internal dependencies:

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -407,12 +407,10 @@ mod tests {
                 .unwrap();
             let subshell = Subshell::new(|env, _job_control| {
                 Box::pin(async {
-                    let trap_state = assert_matches!(
-                        env.traps.get_state(SIGCHLD),
-                        (None, Some(trap_state)) => trap_state
-                    );
+                    let (current, parent) = env.traps.get_state(SIGCHLD);
+                    assert_eq!(current.unwrap().action, Action::Default);
                     assert_matches!(
-                        &trap_state.action,
+                        &parent.unwrap().action,
                         Action::Command(body) => assert_eq!(&**body, "echo foo")
                     );
                 })

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -259,6 +259,12 @@ pub trait System: Debug {
 
     /// Gets the disposition for a signal.
     ///
+    /// This is a low-level function used internally by
+    /// [`SharedSystem::get_disposition`]. You should not call this function
+    /// directly, or you will leave the `SharedSystem` instance in an
+    /// inconsistent state. The description below applies if you want to do
+    /// everything yourself without depending on `SharedSystem`.
+    ///
     /// This is an abstract wrapper around the `sigaction` system call. This
     /// function returns the current disposition if successful.
     ///
@@ -269,9 +275,9 @@ pub trait System: Debug {
     ///
     /// This is a low-level function used internally by
     /// [`SharedSystem::set_disposition`]. You should not call this function
-    /// directly, or you will disrupt the behavior of `SharedSystem`. The
-    /// description below applies if you want to do everything yourself without
-    /// depending on `SharedSystem`.
+    /// directly, or you will leave the `SharedSystem` instance in an
+    /// inconsistent state. The description below applies if you want to do
+    /// everything yourself without depending on `SharedSystem`.
     ///
     /// This is an abstract wrapper around the `sigaction` system call. This
     /// function returns the previous disposition if successful.

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -257,6 +257,14 @@ pub trait System: Debug {
         old_mask: Option<&mut Vec<signal::Number>>,
     ) -> Result<()>;
 
+    /// Gets the disposition for a signal.
+    ///
+    /// This is an abstract wrapper around the `sigaction` system call. This
+    /// function returns the current disposition if successful.
+    ///
+    /// To change the disposition, use [`sigaction`](Self::sigaction).
+    fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition>;
+
     /// Gets and sets the disposition for a signal.
     ///
     /// This is a low-level function used internally by
@@ -271,6 +279,9 @@ pub trait System: Debug {
     /// When you set the disposition to `Disposition::Catch`, signals sent to
     /// this process are accumulated in the `System` instance and made available
     /// from [`caught_signals`](Self::caught_signals).
+    ///
+    /// To get the current disposition without changing it, use
+    /// [`get_sigaction`](Self::get_sigaction).
     fn sigaction(&mut self, signal: signal::Number, action: Disposition) -> Result<Disposition>;
 
     /// Returns signals this process has caught, if any.

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -107,6 +107,14 @@ impl SelectSystem {
         Ok(())
     }
 
+    /// Implements signal disposition query.
+    ///
+    /// See [`SharedSystem::get_disposition`].
+    #[inline]
+    pub fn get_disposition(&self, signal: signal::Number) -> Result<Disposition> {
+        self.system.get_sigaction(signal)
+    }
+
     /// Implements signal disposition update.
     ///
     /// See [`SharedSystem::set_disposition`].

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -716,6 +716,10 @@ impl SignalSystem for &SharedSystem {
         System::signal_number_from_name(*self, name)
     }
 
+    fn get_disposition(&self, signal: signal::Number) -> Result<Disposition> {
+        self.0.borrow().get_disposition(signal)
+    }
+
     fn set_disposition(
         &mut self,
         signal: signal::Number,
@@ -734,6 +738,11 @@ impl SignalSystem for SharedSystem {
     #[inline]
     fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
         System::signal_number_from_name(self, name)
+    }
+
+    #[inline]
+    fn get_disposition(&self, signal: signal::Number) -> Result<Disposition> {
+        self.0.borrow().get_disposition(signal)
     }
 
     #[inline]

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -388,6 +388,9 @@ impl System for &SharedSystem {
     ) -> Result<()> {
         (**self.0.borrow_mut()).sigmask(op, old_mask)
     }
+    fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition> {
+        self.0.borrow().get_sigaction(signal)
+    }
     fn sigaction(&mut self, signal: signal::Number, action: Disposition) -> Result<Disposition> {
         self.0.borrow_mut().sigaction(signal, action)
     }
@@ -589,6 +592,10 @@ impl System for SharedSystem {
         old_mask: Option<&mut Vec<signal::Number>>,
     ) -> Result<()> {
         (&mut &*self).sigmask(op, old_mask)
+    }
+    #[inline]
+    fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition> {
+        (&self).get_sigaction(signal)
     }
     #[inline]
     fn sigaction(&mut self, signal: signal::Number, action: Disposition) -> Result<Disposition> {

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -632,6 +632,11 @@ impl System for VirtualSystem {
         Ok(())
     }
 
+    fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition> {
+        let process = self.current_process();
+        Ok(process.disposition(signal))
+    }
+
     fn sigaction(
         &mut self,
         signal: signal::Number,

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -123,14 +123,17 @@ pub struct TrapSet {
 }
 
 impl TrapSet {
-    /// Returns the current state for a condition.
+    /// Returns the current and parent states for a condition.
     ///
     /// This function returns a pair of optional trap states. The first is the
     /// currently configured trap action, and the second is the action set
     /// before [`enter_subshell`](Self::enter_subshell) was called.
     ///
-    /// This function does not reflect the initial signal actions the shell
-    /// inherited on startup.
+    /// The current state (the first return value) is `None` if no trap action
+    /// has been set for the condition and the signal disposition is not yet
+    /// known. The parent state (the second return value) is `None` if the
+    /// shell environment has not entered a subshell or a trap action has been
+    /// modified after entering a subshell.
     pub fn get_state<C: Into<Condition>>(
         &self,
         cond: C,

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -507,7 +507,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin: origin_1,
+                    origin: Some(origin_1),
                     pending: false
                 }),
                 None
@@ -518,7 +518,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: command,
-                    origin: origin_2,
+                    origin: Some(origin_2),
                     pending: false
                 }),
                 None
@@ -580,12 +580,12 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR1));
         assert_eq!(first.1.unwrap().action, Action::Ignore);
-        assert_eq!(first.1.unwrap().origin, origin_1);
+        assert_eq!(first.1.unwrap().origin, Some(origin_1));
         assert_eq!(first.2, None);
         let second = i.next().unwrap();
         assert_eq!(second.0, &Condition::Signal(SIGUSR2));
         assert_eq!(second.1.unwrap().action, command);
-        assert_eq!(second.1.unwrap().origin, origin_2);
+        assert_eq!(second.1.unwrap().origin, Some(origin_2));
         assert_eq!(first.2, None);
         assert_eq!(i.next(), None);
     }
@@ -621,13 +621,13 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR1));
         assert_eq!(first.1.unwrap().action, Action::Ignore);
-        assert_eq!(first.1.unwrap().origin, origin_1);
+        assert_eq!(first.1.unwrap().origin, Some(origin_1));
         assert_eq!(first.2, None);
         let second = i.next().unwrap();
         assert_eq!(second.0, &Condition::Signal(SIGUSR2));
         assert_eq!(second.1, None);
         assert_eq!(second.2.unwrap().action, command);
-        assert_eq!(second.2.unwrap().origin, origin_2);
+        assert_eq!(second.2.unwrap().origin, Some(origin_2));
         assert_eq!(i.next(), None);
     }
 
@@ -657,7 +657,7 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR2));
         assert_eq!(first.1.unwrap().action, command);
-        assert_eq!(first.1.unwrap().origin, origin_2);
+        assert_eq!(first.1.unwrap().origin, Some(origin_2));
         assert_eq!(first.2, None);
         assert_eq!(i.next(), None);
     }
@@ -679,7 +679,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -702,7 +702,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -731,7 +731,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -759,7 +759,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -787,7 +787,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -815,7 +815,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -843,7 +843,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -871,7 +871,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -899,7 +899,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 })
             )
@@ -940,7 +940,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: command,
-                    origin: origin_3,
+                    origin: Some(origin_3),
                     pending: false
                 }),
                 None
@@ -1426,7 +1426,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin,
+                        origin: Some(origin),
                         pending: false
                     }),
                     None
@@ -1444,7 +1444,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin,
+                        origin: Some(origin),
                         pending: false
                     }),
                     None
@@ -1480,7 +1480,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin: origin.clone(),
+                        origin: Some(origin.clone()),
                         pending: false
                     }),
                     None

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -625,7 +625,8 @@ mod tests {
         assert_eq!(first.2, None);
         let second = i.next().unwrap();
         assert_eq!(second.0, &Condition::Signal(SIGUSR2));
-        assert_eq!(second.1, None);
+        assert_eq!(second.1.unwrap().action, Action::Default);
+        assert_eq!(second.1.unwrap().origin, Origin::Subshell);
         assert_eq!(second.2.unwrap().action, command);
         assert_eq!(second.2.unwrap().origin, Origin::User(origin_2));
         assert_eq!(i.next(), None);
@@ -655,10 +656,15 @@ mod tests {
 
         let mut i = trap_set.iter();
         let first = i.next().unwrap();
-        assert_eq!(first.0, &Condition::Signal(SIGUSR2));
-        assert_eq!(first.1.unwrap().action, command);
-        assert_eq!(first.1.unwrap().origin, Origin::User(origin_2));
+        assert_eq!(first.0, &Condition::Signal(SIGUSR1));
+        assert_eq!(first.1.unwrap().action, Action::Default);
+        assert_eq!(first.1.unwrap().origin, Origin::Subshell);
         assert_eq!(first.2, None);
+        let second = i.next().unwrap();
+        assert_eq!(second.0, &Condition::Signal(SIGUSR2));
+        assert_eq!(second.1.unwrap().action, command);
+        assert_eq!(second.1.unwrap().origin, Origin::User(origin_2));
+        assert_eq!(second.2, None);
         assert_eq!(i.next(), None);
     }
 
@@ -676,7 +682,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGCHLD),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -728,7 +738,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGCHLD),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -756,7 +770,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGINT),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -784,7 +802,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGTERM),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -812,7 +834,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGQUIT),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -840,7 +866,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGTSTP),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -868,7 +898,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGTTIN),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -896,7 +930,11 @@ mod tests {
         assert_eq!(
             trap_set.get_state(SIGTTOU),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -946,7 +984,17 @@ mod tests {
                 None
             )
         );
-        assert_eq!(trap_set.get_state(SIGUSR2), (None, None));
+        assert_eq!(
+            trap_set.get_state(SIGUSR2),
+            (
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
+                None
+            )
+        );
         assert_eq!(system.0[&SIGUSR1], Disposition::Catch);
         assert_eq!(system.0[&SIGUSR2], Disposition::Default);
     }
@@ -968,8 +1016,28 @@ mod tests {
         trap_set.enter_subshell(&mut system, false, false);
         trap_set.enter_subshell(&mut system, false, false);
 
-        assert_eq!(trap_set.get_state(SIGUSR1), (None, None));
-        assert_eq!(trap_set.get_state(SIGUSR2), (None, None));
+        assert_eq!(
+            trap_set.get_state(SIGUSR1),
+            (
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
+                None
+            )
+        );
+        assert_eq!(
+            trap_set.get_state(SIGUSR2),
+            (
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
+                None
+            )
+        );
         assert_eq!(system.0[&SIGUSR1], Disposition::Default);
         assert_eq!(system.0[&SIGUSR2], Disposition::Default);
     }

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -190,15 +190,15 @@ impl TrapSet {
             }
         }
 
-        self.clear_parent_settings();
+        self.clear_parent_states();
 
         let entry = self.traps.entry(cond);
         GrandState::set_action(system, entry, action, origin, override_ignore)
     }
 
-    fn clear_parent_settings(&mut self) {
+    fn clear_parent_states(&mut self) {
         for state in self.traps.values_mut() {
-            state.clear_parent_setting();
+            state.clear_parent_state();
         }
     }
 
@@ -254,7 +254,7 @@ impl TrapSet {
         ignore_sigint_sigquit: bool,
         keep_internal_dispositions_for_stoppers: bool,
     ) {
-        self.clear_parent_settings();
+        self.clear_parent_states();
 
         for (&cond, state) in &mut self.traps {
             let option = match cond {

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -37,7 +37,7 @@ mod cond;
 mod state;
 
 pub use self::cond::Condition;
-pub use self::state::{Action, SetActionError, TrapState};
+pub use self::state::{Action, Origin, SetActionError, TrapState};
 use self::state::{EnterSubshellOption, GrandState};
 use crate::signal;
 use crate::system::{Disposition, Errno};
@@ -507,7 +507,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin: Some(origin_1),
+                    origin: Origin::User(origin_1),
                     pending: false
                 }),
                 None
@@ -518,7 +518,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: command,
-                    origin: Some(origin_2),
+                    origin: Origin::User(origin_2),
                     pending: false
                 }),
                 None
@@ -580,12 +580,12 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR1));
         assert_eq!(first.1.unwrap().action, Action::Ignore);
-        assert_eq!(first.1.unwrap().origin, Some(origin_1));
+        assert_eq!(first.1.unwrap().origin, Origin::User(origin_1));
         assert_eq!(first.2, None);
         let second = i.next().unwrap();
         assert_eq!(second.0, &Condition::Signal(SIGUSR2));
         assert_eq!(second.1.unwrap().action, command);
-        assert_eq!(second.1.unwrap().origin, Some(origin_2));
+        assert_eq!(second.1.unwrap().origin, Origin::User(origin_2));
         assert_eq!(first.2, None);
         assert_eq!(i.next(), None);
     }
@@ -621,13 +621,13 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR1));
         assert_eq!(first.1.unwrap().action, Action::Ignore);
-        assert_eq!(first.1.unwrap().origin, Some(origin_1));
+        assert_eq!(first.1.unwrap().origin, Origin::User(origin_1));
         assert_eq!(first.2, None);
         let second = i.next().unwrap();
         assert_eq!(second.0, &Condition::Signal(SIGUSR2));
         assert_eq!(second.1, None);
         assert_eq!(second.2.unwrap().action, command);
-        assert_eq!(second.2.unwrap().origin, Some(origin_2));
+        assert_eq!(second.2.unwrap().origin, Origin::User(origin_2));
         assert_eq!(i.next(), None);
     }
 
@@ -657,7 +657,7 @@ mod tests {
         let first = i.next().unwrap();
         assert_eq!(first.0, &Condition::Signal(SIGUSR2));
         assert_eq!(first.1.unwrap().action, command);
-        assert_eq!(first.1.unwrap().origin, Some(origin_2));
+        assert_eq!(first.1.unwrap().origin, Origin::User(origin_2));
         assert_eq!(first.2, None);
         assert_eq!(i.next(), None);
     }
@@ -679,7 +679,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -702,7 +702,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 }),
                 None
@@ -731,7 +731,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -759,7 +759,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -787,7 +787,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -815,7 +815,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -843,7 +843,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -871,7 +871,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -899,7 +899,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin: Some(origin),
+                    origin: Origin::User(origin),
                     pending: false
                 })
             )
@@ -940,7 +940,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: command,
-                    origin: Some(origin_3),
+                    origin: Origin::User(origin_3),
                     pending: false
                 }),
                 None
@@ -1426,7 +1426,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin: Some(origin),
+                        origin: Origin::User(origin),
                         pending: false
                     }),
                     None
@@ -1444,7 +1444,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin: Some(origin),
+                        origin: Origin::User(origin),
                         pending: false
                     }),
                     None
@@ -1480,7 +1480,7 @@ mod tests {
                 (
                     Some(&TrapState {
                         action: Action::Ignore,
-                        origin: Some(origin.clone()),
+                        origin: Origin::User(origin.clone()),
                         pending: false
                     }),
                     None

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -74,6 +74,13 @@ pub trait SignalSystem {
     #[must_use]
     fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number>;
 
+    /// Returns the current disposition for a signal.
+    ///
+    /// This function returns the current disposition for the specified signal like
+    /// [`set_disposition`](Self::set_disposition) does, but does not change the
+    /// disposition.
+    fn get_disposition(&self, signal: signal::Number) -> Result<Disposition, Errno>;
+
     /// Sets how a signal is handled.
     ///
     /// This function updates the signal blocking mask and the disposition for
@@ -451,15 +458,16 @@ mod tests {
             VirtualSystem::new().signal_number_from_name(name)
         }
 
+        fn get_disposition(&self, signal: signal::Number) -> Result<Disposition, Errno> {
+            Ok(self.0.get(&signal).copied().unwrap_or_default())
+        }
+
         fn set_disposition(
             &mut self,
             signal: signal::Number,
             disposition: Disposition,
         ) -> Result<Disposition, Errno> {
-            Ok(self
-                .0
-                .insert(signal, disposition)
-                .unwrap_or(Disposition::Default))
+            Ok(self.0.insert(signal, disposition).unwrap_or_default())
         }
     }
 

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Items that manage the state of a single signal.
+//! Items that manage the state of a single signal
 
 #[cfg(doc)]
 use super::TrapSet;
@@ -52,7 +52,7 @@ impl From<&Action> for Disposition {
     }
 }
 
-/// Error that may happen in [`TrapSet::set_action`].
+/// Error that may happen in [`TrapSet::set_action`]
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum SetActionError {
     /// Attempt to set a trap that has been ignored since the shell startup.
@@ -72,31 +72,31 @@ pub enum SetActionError {
     SystemError(#[from] Errno),
 }
 
-/// State of the trap action for a condition.
+/// State of the trap action for a condition
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TrapState {
-    /// Action taken when the condition is met.
+    /// Action taken when the condition is met
     pub action: Action,
     /// Location of the simple command that invoked the trap built-in that set
-    /// the current action.
+    /// the current action
     pub origin: Location,
     /// True iff a signal specified by the condition has been caught and the
     /// action command has not yet executed.
     pub pending: bool,
 }
 
-/// User-visible trap setting.
+/// User-visible trap setting
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Setting {
     /// The user has not yet set a trap for the signal specified by the
     /// condition, and the signal disposition the shell has inherited from the
-    /// pre-exec process is `SIG_DFL`.
+    /// pre-exec process is [`Disposition::Default`].
     InitiallyDefaulted,
     /// The user has not yet set a trap for the signal specified by the
     /// condition, and the signal disposition the shell has inherited from the
-    /// pre-exec process is `SIG_IGN`.
+    /// pre-exec process is [`Disposition::Ignore`].
     InitiallyIgnored,
-    /// User-defined trap.
+    /// User-defined trap
     UserSpecified(TrapState),
 }
 

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -113,7 +113,11 @@ impl TrapState {
         let action = match disposition {
             Disposition::Default => Action::Default,
             Disposition::Ignore => Action::Ignore,
-            Disposition::Catch => panic!("initial disposition cannot be `Catch`"),
+            // The Rust runtime installs a handler for SIGSEGV and SIGBUS before
+            // the shell is initialized. We should treat these signals as if
+            // they have the default disposition.
+            // Disposition::Catch => panic!("initial disposition cannot be `Catch`"),
+            Disposition::Catch => Action::Default,
         };
         TrapState {
             action,
@@ -400,7 +404,12 @@ impl GrandState {
         let origin = match initial_disposition {
             Disposition::Default => Origin::Subshell,
             Disposition::Ignore => Origin::Inherited,
-            Disposition::Catch => panic!("initial disposition cannot be `Catch`"),
+            // The Rust runtime installs a handler for SIGSEGV and SIGBUS before
+            // the shell is initialized. We should treat these signals as if
+            // they have the default disposition (though the ignore function is
+            // normally not called for these signals).
+            // Disposition::Catch => panic!("initial disposition cannot be `Catch`"),
+            Disposition::Catch => Origin::Subshell,
         };
         vacant.insert(GrandState {
             current_state: TrapState {

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -77,14 +77,20 @@ pub enum SetActionError {
 pub struct TrapState {
     /// Action taken when the condition is met
     pub action: Action,
+
     /// Location of the simple command that invoked the trap built-in that set
     /// the current action
-    pub origin: Location,
+    ///
+    /// If this value is `None`, the action was inherited from the previous
+    /// process that `exec`ed the shell.
+    pub origin: Option<Location>,
+
     /// True iff a signal specified by the condition has been caught and the
     /// action command has not yet executed.
     pub pending: bool,
 }
 
+// TODO Remove this
 /// User-visible trap setting
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Setting {
@@ -201,7 +207,7 @@ impl GrandState {
         let cond = *entry.key();
         let setting = Setting::UserSpecified(TrapState {
             action,
-            origin,
+            origin: Some(origin),
             pending: false,
         });
         let disposition = (&setting).into();
@@ -418,7 +424,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -442,7 +448,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -467,7 +473,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -494,7 +500,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Default,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -538,7 +544,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -596,7 +602,7 @@ mod tests {
         );
         assert_matches!(map[&SIGCHLD.into()].get_state(), (Some(state), None) => {
             assert_eq!(state.action, Action::Ignore);
-            assert_eq!(state.origin, origin);
+            assert_eq!(state.origin, Some(origin));
         });
         assert_eq!(system.0[&SIGCHLD], Disposition::Catch);
     }
@@ -619,7 +625,7 @@ mod tests {
         );
         assert_matches!(map[&SIGCHLD.into()].get_state(), (Some(state), None) => {
             assert_eq!(state.action, action);
-            assert_eq!(state.origin, origin);
+            assert_eq!(state.origin, Some(origin));
         });
         assert_eq!(system.0[&SIGCHLD], Disposition::Catch);
     }
@@ -646,7 +652,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -736,7 +742,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -768,7 +774,7 @@ mod tests {
             (
                 Some(&TrapState {
                     action: Action::Ignore,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
                 None
@@ -800,7 +806,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
             )
@@ -833,7 +839,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
             )
@@ -866,7 +872,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
             )
@@ -897,7 +903,7 @@ mod tests {
                 None,
                 Some(&TrapState {
                     action,
-                    origin,
+                    origin: Some(origin),
                     pending: false
                 }),
             )
@@ -982,7 +988,7 @@ mod tests {
         state.mark_as_caught();
         let expected_trap = TrapState {
             action,
-            origin,
+            origin: Some(origin),
             pending: true,
         };
         assert_eq!(state.get_state(), (Some(&expected_trap), None));

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -325,6 +325,9 @@ impl GrandState {
                 },
             ));
         }
+        if option == EnterSubshellOption::Ignore {
+            self.current_state.action = Action::Ignore;
+        }
 
         let new_setting = (&self.current_state.action).into();
         let new_disposition = match option {
@@ -905,7 +908,7 @@ mod tests {
             map[&cond].get_state(),
             (
                 Some(&TrapState {
-                    action: Action::Default, // TODO Should be Action::Ignore,
+                    action: Action::Ignore,
                     origin: Origin::Subshell,
                     pending: false
                 }),

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -320,7 +320,7 @@ impl GrandState {
                 &mut self.current_state,
                 TrapState {
                     action: Action::Default,
-                    origin: Origin::Inherited, // TODO Should be Origin::Subshell
+                    origin: Origin::Subshell,
                     pending: false,
                 },
             ));
@@ -795,7 +795,11 @@ mod tests {
         assert_eq!(
             map[&cond].get_state(),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -828,7 +832,11 @@ mod tests {
         assert_eq!(
             map[&cond].get_state(),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -861,7 +869,11 @@ mod tests {
         assert_eq!(
             map[&cond].get_state(),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -892,7 +904,11 @@ mod tests {
         assert_eq!(
             map[&cond].get_state(),
             (
-                None,
+                Some(&TrapState {
+                    action: Action::Default, // TODO Should be Action::Ignore,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
                 Some(&TrapState {
                     action,
                     origin: Origin::User(origin),
@@ -963,7 +979,17 @@ mod tests {
             .unwrap();
 
         state.clear_parent_state();
-        assert_eq!(state.get_state(), (None, None));
+        assert_eq!(
+            state.get_state(),
+            (
+                Some(&TrapState {
+                    action: Action::Default,
+                    origin: Origin::Subshell,
+                    pending: false
+                }),
+                None
+            )
+        );
     }
 
     #[test]

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -106,49 +106,6 @@ impl TrapState {
     }
 }
 
-// TODO Remove this
-/// User-visible trap setting
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Setting {
-    /// The user has not yet set a trap for the signal specified by the
-    /// condition, and the signal disposition the shell has inherited from the
-    /// pre-exec process is [`Disposition::Default`].
-    InitiallyDefaulted,
-    /// The user has not yet set a trap for the signal specified by the
-    /// condition, and the signal disposition the shell has inherited from the
-    /// pre-exec process is [`Disposition::Ignore`].
-    InitiallyIgnored,
-    /// User-defined trap
-    UserSpecified(TrapState),
-}
-
-impl Setting {
-    pub fn as_trap(&self) -> Option<&TrapState> {
-        if let Setting::UserSpecified(trap) = self {
-            Some(trap)
-        } else {
-            None
-        }
-    }
-
-    pub fn from_initial_disposition(disposition: Disposition) -> Self {
-        match disposition {
-            Disposition::Default | Disposition::Catch => Self::InitiallyDefaulted,
-            Disposition::Ignore => Self::InitiallyIgnored,
-        }
-    }
-}
-
-impl From<&Setting> for Disposition {
-    fn from(state: &Setting) -> Self {
-        match state {
-            Setting::InitiallyDefaulted => Disposition::Default,
-            Setting::InitiallyIgnored => Disposition::Ignore,
-            Setting::UserSpecified(trap) => (&trap.action).into(),
-        }
-    }
-}
-
 /// Option for [`GrandState::enter_subshell`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EnterSubshellOption {

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -159,9 +159,8 @@ impl GrandState {
         (current, parent)
     }
 
-    // TODO Rename to clear_parent_state
     /// Clears the parent trap state.
-    pub fn clear_parent_setting(&mut self) {
+    pub fn clear_parent_state(&mut self) {
         self.parent_state = None;
     }
 
@@ -946,7 +945,7 @@ mod tests {
             )
             .unwrap();
 
-        state.clear_parent_setting();
+        state.clear_parent_state();
         assert_eq!(state.get_state(), (None, None));
     }
 

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -41,6 +41,7 @@ pub async fn run_exit_trap(env: &mut Env) {
 
     let command = Rc::clone(command);
     let origin = state.origin.clone();
+    let origin = origin.expect("user-defined trap must have origin");
     let result = run_trap(env, Condition::Exit, command, origin).await;
     env.apply_result(result);
 }

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -20,6 +20,7 @@ use super::run_trap;
 use std::rc::Rc;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
+use yash_env::trap::Origin;
 use yash_env::Env;
 
 /// Executes the EXIT trap.
@@ -40,8 +41,10 @@ pub async fn run_exit_trap(env: &mut Env) {
     };
 
     let command = Rc::clone(command);
-    let origin = state.origin.clone();
-    let origin = origin.expect("user-defined trap must have origin");
+    let origin = match &state.origin {
+        Origin::Inherited | Origin::Subshell => panic!("user-defined trap must have origin"),
+        Origin::User(location) => location.clone(),
+    };
     let result = run_trap(env, Condition::Exit, command, origin).await;
     env.apply_result(result);
 }

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -24,6 +24,7 @@ use yash_env::signal;
 use yash_env::stack::Frame;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
+use yash_env::trap::Origin;
 #[cfg(doc)]
 use yash_env::trap::TrapSet;
 use yash_env::Env;
@@ -44,8 +45,10 @@ pub async fn run_trap_if_caught(env: &mut Env, signal: signal::Number) -> Option
         return None;
     };
     let code = Rc::clone(command);
-    let origin = trap_state.origin.clone();
-    let origin = origin.expect("user-defined trap must have origin");
+    let origin = match &trap_state.origin {
+        Origin::Inherited | Origin::Subshell => panic!("user-defined trap must have origin"),
+        Origin::User(location) => location.clone(),
+    };
     Some(run_trap(env, signal.into(), code, origin).await)
 }
 
@@ -87,8 +90,10 @@ pub async fn run_traps_for_caught_signals(env: &mut Env) -> Result {
             continue;
         };
         let code = Rc::clone(command);
-        let origin = state.origin.clone();
-        let origin = origin.expect("user-defined trap must have origin");
+        let origin = match &state.origin {
+            Origin::Inherited | Origin::Subshell => panic!("user-defined trap must have origin"),
+            Origin::User(location) => location.clone(),
+        };
         run_trap(env, signal.into(), code, origin).await?;
     }
 

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -45,6 +45,7 @@ pub async fn run_trap_if_caught(env: &mut Env, signal: signal::Number) -> Option
     };
     let code = Rc::clone(command);
     let origin = trap_state.origin.clone();
+    let origin = origin.expect("user-defined trap must have origin");
     Some(run_trap(env, signal.into(), code, origin).await)
 }
 
@@ -87,6 +88,7 @@ pub async fn run_traps_for_caught_signals(env: &mut Env) -> Result {
         };
         let code = Rc::clone(command);
         let origin = state.origin.clone();
+        let origin = origin.expect("user-defined trap must have origin");
         run_trap(env, signal.into(), code, origin).await?;
     }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of traps and signal dispositions in the `yash` shell. The most important changes include updates to the `trap` built-in, new methods for querying signal dispositions, and various enhancements to the `trap` module's functionality.

### Improvements to `trap` built-in:
* The `trap` built-in now includes signal dispositions that are not explicitly set by the user in its output. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR46-R47) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR24-R25)
* Updated documentation for the `trap` built-in to include new options and better describe its functionality. [[1]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L24-R66) [[2]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R128-R130)

### New methods for querying signal dispositions:
* Added `get_sigaction` method to the `System` trait to return the current signal handling configuration without modifying it. [[1]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR16-R33) [[2]](diffhunk://#diff-abca95b198472fafd2b50569bc6d9e474a3794385d78f600eaf4429e4ae7012dR260-R290)
* Implemented `get_sigaction` in various system modules (`real.rs`, `select.rs`, `shared.rs`, `virtual.rs`). [[1]](diffhunk://#diff-f41a9ca1b86464399ba6136dd8ce92b0bd9490792d3acbf9bf2fa8a029b452fcL493-R520) [[2]](diffhunk://#diff-ee46b34d0b4f4e2ad1a0da98a0d17739efc1e5b442db4aeecd51a0746eb80d5aR110-R117) [[3]](diffhunk://#diff-dc252afdb93faaa6f1e7bc8a761f6333c1ed871634eb0295a45ac6a708475412R391-R393) [[4]](diffhunk://#diff-76f9363e1f7ccc99c4126ee2d9da01cb31bf2c585977e4b026d2e535e1129b69R635-R639)

### Enhancements to `trap` module:
* Added `iter` associated function to the `trap::Condition` enum to return an iterator over all conditions.
* Added `peek_state` method to the `trap::TrapSet` struct to get the current state of a trap.
* Updated `TrapSet::get_state` method to return a `TrapState` reference even if the current action was not set by the user.

### Additional changes:
* Added tests for the new functionality and updated existing tests to reflect the changes. [[1]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R448-R462) [[2]](diffhunk://#diff-b1231056fcea3f4352ee1ad0c7612951d343b9cbe96aa1f3a6bb355dfe4ddad5L410-R413)
* Refactored the `sigaction` implementation to use a helper function for better code reuse. [[1]](diffhunk://#diff-f41a9ca1b86464399ba6136dd8ce92b0bd9490792d3acbf9bf2fa8a029b452fcR163-R184) [[2]](diffhunk://#diff-f41a9ca1b86464399ba6136dd8ce92b0bd9490792d3acbf9bf2fa8a029b452fcL493-R520)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The directory change command now supports a new option to ensure the current working directory is accurately maintained and provides clear error messages when given invalid input.
  - The trap command now displays enhanced output by including both custom traps and system-level signal dispositions.
  - Linux users benefit from improved support with an additional option for built-in commands.

- **Documentation & Improvements**
  - Updated command usage documentation for better clarity.
  - Enhanced signal handling in subshell environments for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->