### PR TITLE
Run scripted tests as root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run basic tests
       run: ./check.sh -v
     - name: Run scripted tests as root
-      run: sudo cargo test --package yash-cli --test scripted_test
+      run: sudo `which cargo` test --package yash-cli --test scripted_test
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run basic tests
       run: ./check.sh -v
+    - name: Run scripted tests as root
+      run: sudo cargo test --package yash-cli --test scripted_test
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The scripted tests includes test cases that depend on external state. Especially, some tests behave differently depending on the executing user's permissions. To make sure that the tests succeed when run with superuser permissions, this commit adds a step to run the tests as root.