### PR TITLE
Add -p option to trap built-in

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -41,7 +41,11 @@ dispositions that are not explicitly set by the user. It also supports the `-p`
 - `cd::target::TargetError::exit_status`
     - This method returns the exit status corresponding to the error.
 - `trap::Command::PrintAll::include_default`
-    - This field represents the new `-p` option of the `trap` built-in.
+    - This field represents the new `-p` option of the `trap` built-in used
+      without operands.
+- `trap::Command::Print`
+    - This variant represents the new `-p` option of the `trap` built-in used
+      with operands.
 - `trap::syntax::OPTION_SPECS`
     - This array slice represents the option specifications of the `trap`
       built-in.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -15,6 +15,10 @@ changing the working directory.
 
 The `cd` built-in now errors out when a given operand is an empty string.
 
+The `trap` built-in now implements the POSIX.1-2024 behavior of showing signal
+dispositions that are not explicitly set by the user. It also supports the `-p`
+(`--print`) option.
+
 ### Added
 
 - `common::report`, `common::report_simple`
@@ -36,6 +40,14 @@ The `cd` built-in now errors out when a given operand is an empty string.
       is an empty string.
 - `cd::target::TargetError::exit_status`
     - This method returns the exit status corresponding to the error.
+- `trap::Command::PrintAll::include_default`
+    - This field represents the new `-p` option of the `trap` built-in.
+- `trap::syntax::OPTION_SPECS`
+    - This array slice represents the option specifications of the `trap`
+      built-in.
+- `trap::display_all_traps`
+    - This function is an extended version of `trap::display_traps` that shows
+      traps including ones that have the default action.
 
 ### Changed
 
@@ -43,6 +55,7 @@ The `cd` built-in now errors out when a given operand is an empty string.
   `EXIT_STATUS_CHDIR_ERROR`.
 - The `cd::assign::new_pwd` function now returns `Result<PathBuf, Errno>` instead
   of `PathBuf`. Previously, it returned an empty `PathBuf` on failure.
+- The `trap::syntax::interpret` function now supports the `-p` option.
 - The output of the `trap` built-in now includes not only user-defined traps but
   also signal dispositions that are not explicitly set by the user.
 - External dependency versions:

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The shell now supports declaration utilities as defined in POSIX.
 - The `cd` built-in now supports the `-e` option as defined in POSIX.
+- The `trap` built-in now implements the POSIX.1-2024 behavior of showing
+  signal dispositions that are not explicitly set by the user. It also supports
+  the `-p` (`--print`) option.
 - The `-p` option for the `command` built-in now works on Linux.
 
 ### Changed

--- a/yash-cli/tests/scripted_test/trap-p.sh
+++ b/yash-cli/tests/scripted_test/trap-p.sh
@@ -269,6 +269,20 @@ trap 'echo trapped' USR1
 kill -s USR1 $$
 __IN__
 
+test_oE -e QUIT 'with -p and operands, only specified traps are printed' -e
+trap '' INT TERM
+trap -p TERM QUIT >printed_trap_3 # should not print INT
+trap 'echo INT' INT
+trap 'echo TERM' TERM
+trap '' QUIT
+. ./printed_trap_3 # TERM is ignored again, QUIT is now default
+kill -s INT $$ # should print INT
+kill -s TERM $$ # should be ignored
+kill -s QUIT $$
+__IN__
+INT
+__OUT__
+
 echo 'echo "$@"' > ./-
 chmod a+x ./-
 

--- a/yash-cli/tests/scripted_test/trap-p.sh
+++ b/yash-cli/tests/scripted_test/trap-p.sh
@@ -251,6 +251,24 @@ __IN__
 abc
 __OUT__
 
+test_oE -e 0 'without -p, only non-default traps are printed' -e
+trap - USR1
+trap >printed_trap_1 # should not print USR1
+trap 'echo trapped' USR1
+. ./printed_trap_1
+kill -s USR1 $$
+__IN__
+trapped
+__OUT__
+
+test_OE -e USR1 'with -p, all traps are printed' -e
+trap - USR1
+trap -p >printed_trap_2 # should print USR1
+trap 'echo trapped' USR1
+. ./printed_trap_2
+kill -s USR1 $$
+__IN__
+
 echo 'echo "$@"' > ./-
 chmod a+x ./-
 


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the `trap` built-in, implementing new features and improving existing functionality. The most significant changes include adding support for the `-p` (`--print`) option, updating the behavior to align with POSIX.1-2024 standards, and enhancing the `trap` built-in's output to include default signal dispositions.

### Enhancements to `trap` built-in:

* [`yash-builtin/CHANGELOG.md`](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR18-R21): Updated to document the new `-p` option and the inclusion of default signal dispositions in the `trap` built-in. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR18-R21) [[2]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR43-R62)
* [`yash-builtin/src/trap.rs`](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R153-R161): Added support for the `-p` option, allowing the `trap` built-in to print all traps, including default ones. Introduced new variants `PrintAll` and `Print` for the `Command` enum to handle printing traps with and without operands. [[1]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R153-R161) [[2]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L171-R253) [[3]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L221-R275) [[4]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L235-R292) [[5]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R304-R311) [[6]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L283-R374) [[7]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786L315-R407) [[8]](diffhunk://#diff-57e72207526eefac89a7482ada938d4c078034e3748f59554c384bf87d653786R555-R573)

### Syntax and option parsing:

* [`yash-builtin/src/trap/syntax.rs`](diffhunk://#diff-aaa5b5609076c664c23f398dc05b7c7532760db1746e4064fd102a167c736c18L20-R30): Added `OPTION_SPECS` to define the `-p` option. Updated the `interpret` function to handle the `-p` option and decide whether to print all traps or specific ones based on the provided operands. [[1]](diffhunk://#diff-aaa5b5609076c664c23f398dc05b7c7532760db1746e4064fd102a167c736c18L20-R30) [[2]](diffhunk://#diff-aaa5b5609076c664c23f398dc05b7c7532760db1746e4064fd102a167c736c18R88-R106) [[3]](diffhunk://#diff-aaa5b5609076c664c23f398dc05b7c7532760db1746e4064fd102a167c736c18R128-R140) [[4]](diffhunk://#diff-aaa5b5609076c664c23f398dc05b7c7532760db1746e4064fd102a167c736c18R159-R221)

### Documentation and tests:

* [`yash-cli/CHANGELOG.md`](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR18-R20): Documented the new behavior of the `trap` built-in and the addition of the `-p` option.
* [`yash-cli/tests/scripted_test/trap-p.sh`](diffhunk://#diff-2fe36e2f646dc6c85e19f642c79e9eb9efb00d824c5c279696ec158e3a7fcf68R254-R285): Added new tests to verify the behavior of the `trap` built-in with and without the `-p` option, ensuring it prints the correct traps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- The cd command now has a new option that keeps the current directory accurate and issues a clear error when used improperly.
	- The trap command has been enhanced for better compliance with POSIX standards, now offering a print option that shows both default and user-defined signal dispositions.
- Tests
	- New test cases help ensure that trap behavior works reliably in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->