### PR TITLE
wait: Don't treat suspended jobs as terminated jobs

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -19,6 +19,8 @@ The `trap` built-in now implements the POSIX.1-2024 behavior of showing signal
 dispositions that are not explicitly set by the user. It also supports the `-p`
 (`--print`) option.
 
+The `wait` built-in no longer treats suspended jobs as terminated jobs.
+
 ### Added
 
 - `common::report`, `common::report_simple`
@@ -62,6 +64,9 @@ dispositions that are not explicitly set by the user. It also supports the `-p`
 - The `trap::syntax::interpret` function now supports the `-p` option.
 - The output of the `trap` built-in now includes not only user-defined traps but
   also signal dispositions that are not explicitly set by the user.
+- The `wait` built-in no longer treats suspended jobs as terminated jobs. When
+  waiting for a suspended job, the built-in now waits indefinitely until the job
+  is resumed and finished.
 - External dependency versions:
     - yash-env 0.5.0 → 0.6.0
     - yash-semantics 0.5.0 → 0.6.0 (optional)

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -31,10 +31,11 @@
 //! jobs. If the jobs are already finished, the built-in returns without
 //! waiting.
 //!
-//! If a job is job-controlled (that is, running in its own process group), it
-//! is considered finished not only when it has exited but also when it has been
-//! suspended. (TODO: This behavior is contrary to POSIX 2024 and will be fixed
-//! in the future.)
+//! If you try to wait for a suspended job, the built-in will wait indefinitely
+//! until the job is resumed and finished. Currently, there is no way to
+//! cancel the wait.
+//! (TODO: Add a way to cancel the wait)
+//! (TODO: Add a way to treat a suspended job as if it were finished)
 //!
 //! # Options
 //!
@@ -94,7 +95,7 @@ use crate::common::report_simple_failure;
 use crate::common::to_single_message;
 use itertools::Itertools as _;
 use yash_env::job::Pid;
-use yash_env::option::Option::Monitor;
+use yash_env::option::State::Off;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::Env;
@@ -133,7 +134,9 @@ impl Command {
     where
         I: IntoIterator<Item = Option<usize>>,
     {
-        let job_control = env.options.get(Monitor);
+        // Currently, we ignore the job control option as required by POSIX.
+        // TODO: Add some way to specify this option
+        let job_control = Off; // env.options.get(Monitor);
 
         // Await jobs specified by the indexes
         let mut exit_status = None;

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `cd` built-in now returns different exit statuses for different errors.
 - The output of the `trap` built-in now includes not only user-defined traps but
   also signal dispositions that are not explicitly set by the user.
+- The `wait` built-in no longer treats suspended jobs as terminated jobs. When
+  waiting for a suspended job, the built-in now waits indefinitely until the job
+  is resumed and finished.
 
 ## [0.2.0] - 2024-12-14
 


### PR DESCRIPTION
When waiting for a suspended job, the built-in now waits indefinitely
until the job is resumed and finished. Currently, there is no way to
cancel the wait. This new behavior is in line with POSIX.1-2024.

The previous behavior may be re-implemented as an option in the future.

Fixes https://github.com/magicant/yash-rs/issues/459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the directory change command with a new option that ensures the current working directory is accurately updated and now errors on empty input.
  - Improved the signal trapping command to display default dispositions and support an additional display option in line with modern shell standards.
  - Adjusted the job waiting behavior so that it now waits indefinitely until suspended tasks are resumed and completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->