### PR TITLE
Add -d option to read built-in

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -82,6 +82,8 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 - The `kill::print::print` function now shows signals in the ascending order of
   their numbers when given no signals.
 - The `read::syntax::parse` function now accepts the `-d` (`--delimiter`) option.
+- The `read::input::read` function now takes one more argument, `delimiter`, to
+  specify the delimiter character.
 - The `read::main` function now returns a more specific exit status depending on
   the cause of the error. It now returns `EXIT_STATUS_READ_ERROR` when finding a
   null byte in the input.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -17,6 +17,9 @@ The `cd` built-in now errors out when a given operand is an empty string.
 
 The command `kill -l` now shows signals in the ascending order of their numbers.
 
+The `read` built-in now supports the `-d` (`--delimiter`) option, which allows
+specifying a delimiter character to terminate the input.
+
 The `read` built-in now returns a more specific exit status depending on the
 cause of the error. It also rejects an input containing a null byte.
 
@@ -52,6 +55,11 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
   `read::EXIT_STATUS_SYNTAX_ERROR`
     - These constants represent exit statuses that can be returned by the `read`
       built-in.
+- `read::Command::delimiter`
+    - This field represents the new `-d` option of the `read` built-in.
+- `read::syntax::Error::MultibyteDelimiter`
+    - This error variant represents an error that occurs when a multibyte
+      character is specified as a delimiter.
 - `trap::Command::PrintAll::include_default`
     - This field represents the new `-p` option of the `trap` built-in used
       without operands.
@@ -73,6 +81,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
   of `PathBuf`. Previously, it returned an empty `PathBuf` on failure.
 - The `kill::print::print` function now shows signals in the ascending order of
   their numbers when given no signals.
+- The `read::syntax::parse` function now accepts the `-d` (`--delimiter`) option.
 - The `read::main` function now returns a more specific exit status depending on
   the cause of the error. It now returns `EXIT_STATUS_READ_ERROR` when finding a
   null byte in the input.

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -96,6 +96,14 @@
 //! The read built-in is defined in the POSIX standard with the `-d` and `-r`
 //! options.
 //!
+//! In this implementation, a line continuation is always a backslash followed
+//! by a newline. Other implementations may allow a backslash followed by a
+//! delimiter to be a line continuation if the delimiter is not a newline.
+//!
+//! When a backslash is specified as the delimiter, no escape sequences are
+//! recognized. Other implementations may recognize escape sequences in the
+//! input line, effectively never recognizing the delimiter.
+//!
 //! In this implementation, the value of the `PS2` variable is subject to
 //! parameter expansion, command substitution, and arithmetic expansion. Other
 //! implementations may not perform these expansions.
@@ -167,7 +175,7 @@ pub async fn main(env: &mut Env, args: Vec<Field>) -> crate::Result {
         Err(error) => return report(env, &error, EXIT_STATUS_SYNTAX_ERROR).await,
     };
 
-    let (input, newline_found) = match input::read(env, command.is_raw).await {
+    let (input, newline_found) = match input::read(env, command.delimiter, command.is_raw).await {
         Ok(input) => input,
         Err(error) => return report(env, &error, EXIT_STATUS_READ_ERROR).await,
     };

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -140,6 +140,11 @@ pub const EXIT_STATUS_SYNTAX_ERROR: ExitStatus = ExitStatus(4);
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct Command {
+    /// Delimiter specified by the `-d` option
+    ///
+    /// When the option is not specified, this field is `b'\n'`.
+    pub delimiter: u8,
+
     /// Whether the `-r` option is specified
     ///
     /// If this field is `true`, backslashes are not interpreted.

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -21,7 +21,7 @@
 //! # Synopsis
 //!
 //! ```sh
-//! read [-r] variable…
+//! read [-d delimiter] [-r] variable…
 //! ```
 //!
 //! # Description
@@ -33,6 +33,13 @@
 //! there are more fields than variables, the last variable receives all
 //! remaining fields, including the field separators, but not trailing
 //! whitespace separators.
+//!
+//! ## Non-default delimiters
+//!
+//! By default, the read built-in reads a line up to a newline character. The
+//! `-d` option changes the delimiter to the character specified by the
+//! `delimiter` value. If the `delimiter` value is empty, the read built-in reads
+//! a line up to the first nul byte.
 //!
 //! ## Escaping
 //!
@@ -55,7 +62,13 @@
 //!
 //! # Options
 //!
-//! The **`-r`** option disables the interpretation of backslashes.
+//! The **`-d`** (**`--delimiter`**) option takes an argument and changes the
+//! delimiter to the character specified by the argument. If the `delimiter`
+//! value is empty, the read built-in reads a line up to the first nul byte.
+//! Multibyte characters are not supported.
+//!
+//! The **`-r`** (**`--raw-mode`**) option disables the interpretation of
+//! backslashes.
 //!
 //! # Operands
 //!
@@ -67,20 +80,21 @@
 //! This built-in fails if:
 //!
 //! - The standard input is not readable.
-//! - The input contains a nul byte.
+//! - The delimiter is not a single-byte character.
+//! - The delimiter is not a nul byte and the input contains a nul byte.
 //! - A variable to be assigned is read-only.
 //!
 //! # Exit status
 //!
 //! The exit status is zero if a line was read successfully and non-zero
 //! otherwise. If the built-in reaches the end of the input before finding a
-//! newline, the exit status is one, but the variables are still assigned with
+//! delimiter, the exit status is one, but the variables are still assigned with
 //! the line read so far. On other errors, the exit status is two or higher.
 //!
 //! # Portability
 //!
-//! The read built-in is defined in the POSIX standard. The `-r` option is the
-//! only option defined in the POSIX standard.
+//! The read built-in is defined in the POSIX standard with the `-d` and `-r`
+//! options.
 //!
 //! In this implementation, the value of the `PS2` variable is subject to
 //! parameter expansion, command substitution, and arithmetic expansion. Other
@@ -88,8 +102,9 @@
 //!
 //! # Implementation notes
 //!
-//! Reading from an unseekable input may be slow because the built-in reads the
-//! input byte by byte to make sure it does not read past the end of the line.
+//! The built-in reads the input byte by byte. This is inefficient, but it is
+//! necessary not to read past the delimiter.
+//! (TODO: Use a buffered reader if the input is seekable)
 
 use crate::common::report;
 use crate::common::report_simple;

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The shell now supports declaration utilities as defined in POSIX.
 - The `cd` built-in now supports the `-e` option as defined in POSIX.
+- The `read` built-in now supports the `-d` (`--delimiter`) option, which allows
+  specifying a delimiter character to terminate the input.
 - The `trap` built-in now implements the POSIX.1-2024 behavior of showing
   signal dispositions that are not explicitly set by the user. It also supports
   the `-p` (`--print`) option.

--- a/yash-cli/tests/scripted_test/read-p.sh
+++ b/yash-cli/tests/scripted_test/read-p.sh
@@ -268,6 +268,18 @@ __IN__
 0 [ A B  C  D\E-F\-G ] [] [] []
 __OUT__
 
+test_oE 'non-default delimiters'
+{
+read -d : a b
+read -d x c d
+} <<\END
+A B:C D ExF
+END
+echoraw $? "[${a-unset}]" "[${b-unset}]" "[${c-unset}]" "[${d-unset}]"
+__IN__
+0 [A] [B] [C] [D E]
+__OUT__
+
 test_oE 'raw mode - backslash not in IFS'
 IFS=' -' read -r a b c d <<\END
 A\A\\ B-C\- D\

--- a/yash-cli/tests/scripted_test/read-y.sh
+++ b/yash-cli/tests/scripted_test/read-y.sh
@@ -28,6 +28,28 @@ test_O -d -e 3 'input containing null byte'
 printf 'A\0B\n' | read a
 __IN__
 
+# Regardless of the -d option, only backslash-newline is treated as line continuation.
+test_oE 'line continuation with non-default delimiter'
+read -d : a <<'END'
+A\
+B:C
+END
+echoraw $? "[${a-unset}]"
+__IN__
+0 [AB]
+__OUT__
+
+# When the delimiter is backslash, no escape sequence is recognized.
+test_oE 'backslash as delimiter'
+read -d \\ a <<'END'
+A\
+B
+END
+echoraw $? "[${a-unset}]"
+__IN__
+0 [A]
+__OUT__
+
 (
 skip=true # TODO the empty-last-field option not yet implemented
 setup 'set --empty-last-field'


### PR DESCRIPTION
This pull request introduces enhancements to the `read` built-in command by adding support for a delimiter option and updating related documentation and tests. The most important changes include adding the `-d` option, updating the `read` built-in's behavior and documentation, and modifying the tests to accommodate the new functionality.

Enhancements to the `read` built-in:

* Added support for the `-d` (`--delimiter`) option to the `read` built-in, allowing users to specify a character to terminate the input. If the delimiter is empty, the input is terminated by a null byte. [[1]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189L24-R24) [[2]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189L58-R71) [[3]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189R151-R155) [[4]](diffhunk://#diff-e2b9c74ff5976786bcf914d9bad7d0cf0ca2bd51dd7d5ff4dae708aa42719259L65-R112)
* Updated the `read` built-in to handle the new delimiter option, including changes to the `read::input::read` function to accept a delimiter argument and modifications to the `read::syntax::parse` function to parse the delimiter option. [[1]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL103-R116) [[2]](diffhunk://#diff-e2b9c74ff5976786bcf914d9bad7d0cf0ca2bd51dd7d5ff4dae708aa42719259R123)

Documentation updates:

* Updated the synopsis, description, and options sections in `yash-builtin/src/read.rs` to include information about the new `-d` option and its behavior. [[1]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189L24-R24) [[2]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189R37-R43) [[3]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189L58-R71) [[4]](diffhunk://#diff-46e84e38f4e967e7dd4d87099afd8ee2d00e9f5d777433a49f0167fce228d189L70-R115)

Test modifications:

* Added new tests for the `-d` option, including cases for null byte delimiters and alphabetic delimiters. Updated existing tests to include the delimiter argument where necessary. [[1]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL231-R236) [[2]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL241-R252) [[3]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL257-R265) [[4]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL270-R314) [[5]](diffhunk://#diff-f849c9c513e3dd2f16c3624ee9e238d4cb9ba412989a4a393804a738cb7d5afbL290-R324) [[6]](diffhunk://#diff-e2b9c74ff5976786bcf914d9bad7d0cf0ca2bd51dd7d5ff4dae708aa42719259L97-R140)

Changelog updates:

* Documented the new `-d` option and its associated changes in the `yash-builtin/CHANGELOG.md` file. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR20-R22) [[2]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR58-R62) [[3]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR84-R86)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom delimiter option (-d/--delimiter) for the read command, allowing users to specify how input is terminated.
	- Enhanced error reporting with more specific exit statuses and validation for invalid or multibyte delimiters.
- **Documentation**
	- Updated the command synopsis and help details to reflect the new delimiter behavior.
- **Tests**
	- Added new test cases to verify the functionality and edge-case handling of custom delimiters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->