### PR TITLE
Update trick to work around macOS kill(2) issue

### DIFF
--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -78,18 +78,7 @@ trap exit EXIT
 exit 1
 __IN__
 
-if [ "$(uname)" = Darwin ]; then
-    # On macOS, kill(2) does not appear to run any signal handlers
-    # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, we call the kill
-    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
-    # command generate some more SIGCHLD signals that must be handled by the
-    # shell, which makes it more likely that the signal sent by the kill built-in
-    # is delivered to the shell before the subshell exits.
-    setup <<'__EOF__'
-kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
-__EOF__
-fi
+macos_kill_workaround
 
 test_OE -e 3 'exit from signal trap with 3'
 trap '(exit 2); exit 3' INT

--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -81,12 +81,13 @@ __IN__
 if [ "$(uname)" = Darwin ]; then
     # On macOS, kill(2) does not appear to run any signal handlers
     # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, the kill
-    # built-in is called in a subshell on macOS, using the SIGCHLD signal as a
-    # synchronization trigger.
-    setup <<\__EOF__
-killx() (((command kill "$@"); :); :)
-alias kill=killx
+    # signals at a predictable time. To work around this issue, we call the kill
+    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
+    # command generate some more SIGCHLD signals that must be handled by the
+    # shell, which makes it more likely that the signal sent by the kill built-in
+    # is delivered to the shell before the subshell exits.
+    setup <<'__EOF__'
+kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
 __EOF__
 fi
 

--- a/yash-cli/tests/scripted_test/return-p.sh
+++ b/yash-cli/tests/scripted_test/return-p.sh
@@ -2,18 +2,7 @@
 
 posix="true"
 
-if [ "$(uname)" = Darwin ]; then
-    # On macOS, kill(2) does not appear to run any signal handlers
-    # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, we call the kill
-    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
-    # command generate some more SIGCHLD signals that must be handled by the
-    # shell, which makes it more likely that the signal sent by the kill built-in
-    # is delivered to the shell before the subshell exits.
-    setup <<'__EOF__'
-kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
-__EOF__
-fi
+macos_kill_workaround
 
 test_oE 'returning from function, unnested'
 fn() {

--- a/yash-cli/tests/scripted_test/run-test.sh
+++ b/yash-cli/tests/scripted_test/run-test.sh
@@ -155,6 +155,20 @@ $1"
     esac
 }
 
+macos_kill_workaround()
+if [ "$(uname)" = Darwin ]; then
+    # On macOS, kill(2) does not appear to run any signal handlers
+    # synchronously, making it impossible for the shell to respond to self-sent
+    # signals at a predictable time. To work around this issue, we call the kill
+    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
+    # command generate some more SIGCHLD signals that must be handled by the
+    # shell, which makes it more likely that the signal sent by the kill built-in
+    # is delivered to the shell before the subshell exits.
+    setup <<'__EOF__'
+kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
+__EOF__
+fi
+
 # Invokes the testee.
 # If the "posix" variable is defined non-empty, the testee is invoked as "sh".
 # If the "use_valgrind" variable is true, Valgrind is used to run the testee,

--- a/yash-cli/tests/scripted_test/trap-p.sh
+++ b/yash-cli/tests/scripted_test/trap-p.sh
@@ -2,18 +2,7 @@
 
 posix="true"
 
-if [ "$(uname)" = Darwin ]; then
-    # On macOS, kill(2) does not appear to run any signal handlers
-    # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, we call the kill
-    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
-    # command generate some more SIGCHLD signals that must be handled by the
-    # shell, which makes it more likely that the signal sent by the kill built-in
-    # is delivered to the shell before the subshell exits.
-    setup <<'__EOF__'
-kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
-__EOF__
-fi
+macos_kill_workaround
 
 test_OE -e USR1 'setting default trap'
 trap - USR1

--- a/yash-cli/tests/scripted_test/trap-p.sh
+++ b/yash-cli/tests/scripted_test/trap-p.sh
@@ -5,12 +5,13 @@ posix="true"
 if [ "$(uname)" = Darwin ]; then
     # On macOS, kill(2) does not appear to run any signal handlers
     # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, the kill
-    # built-in is called in a subshell on macOS, using the SIGCHLD signal as a
-    # synchronization trigger.
-    setup <<\__EOF__
-killx() (((command kill "$@"); :); :)
-alias kill=killx
+    # signals at a predictable time. To work around this issue, we call the kill
+    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
+    # command generate some more SIGCHLD signals that must be handled by the
+    # shell, which makes it more likely that the signal sent by the kill built-in
+    # is delivered to the shell before the subshell exits.
+    setup <<'__EOF__'
+kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
 __EOF__
 fi
 

--- a/yash-cli/tests/scripted_test/trap-y.sh
+++ b/yash-cli/tests/scripted_test/trap-y.sh
@@ -1,17 +1,6 @@
 # trap-y.sh: yash-specific test of the trap built-in
 
-if [ "$(uname)" = Darwin ]; then
-    # On macOS, kill(2) does not appear to run any signal handlers
-    # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, we call the kill
-    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
-    # command generate some more SIGCHLD signals that must be handled by the
-    # shell, which makes it more likely that the signal sent by the kill built-in
-    # is delivered to the shell before the subshell exits.
-    setup <<'__EOF__'
-kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
-__EOF__
-fi
+macos_kill_workaround
 
 test_o 'trap for EXIT is executed just once'
 "$TESTEE" -c  'trap "echo EXIT  1" EXIT;  ./_no_such_command_ '

--- a/yash-cli/tests/scripted_test/trap-y.sh
+++ b/yash-cli/tests/scripted_test/trap-y.sh
@@ -3,12 +3,13 @@
 if [ "$(uname)" = Darwin ]; then
     # On macOS, kill(2) does not appear to run any signal handlers
     # synchronously, making it impossible for the shell to respond to self-sent
-    # signals at a predictable time. To work around this issue, the kill
-    # built-in is called in a subshell on macOS, using the SIGCHLD signal as a
-    # synchronization trigger.
+    # signals at a predictable time. To work around this issue, we call the kill
+    # built-in in a nested subshell on macOS. The subshell and the dummy sleep
+    # command generate some more SIGCHLD signals that must be handled by the
+    # shell, which makes it more likely that the signal sent by the kill built-in
+    # is delivered to the shell before the subshell exits.
     setup <<'__EOF__'
-killx() (((command kill "$@"); :); :)
-alias kill=killx
+kill() (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; (trap 'sleep 0' EXIT; command kill "$@")))
 __EOF__
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved signal processing in test scenarios on macOS for enhanced reliability.
  - Adjusted expected outcomes within tests to ensure more consistent behavior during signal synchronization.
  - Introduced a new function to enhance signal handling on macOS systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->