### PR TITLE
Ignore remaining commands after a foreground job stops

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -79,6 +79,8 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
   `EXIT_STATUS_CHDIR_ERROR`.
 - The `cd::assign::new_pwd` function now returns `Result<PathBuf, Errno>` instead
   of `PathBuf`. Previously, it returned an empty `PathBuf` on failure.
+- The `fg::main` function now returns with `Divert::Interrupt` when the resumed
+  job is suspended.
 - The `kill::print::print` function now shows signals in the ascending order of
   their numbers when given no signals.
 - The `read::syntax::parse` function now accepts the `-d` (`--delimiter`) option.

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- When a foreground job is suspended in an interactive shell, the shell now
+  discards any remaining commands in the current command line and prompts for
+  the next command line. This behavior basically conforms to POSIX.1-2024, but
+  differs in that the shell does not resume with the remaining commands
+  following the next asynchronous and-or list.
 - The `cd` built-in now errors out when a given operand is an empty string.
 - The `cd` built-in now returns different exit statuses for different errors.
 - The command `kill -l` now shows signals in the ascending order of their

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -11,12 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the `expand_word_multiple` and `expand_word_with_mode` functions to the
   `expansion` module.
+- Added the `job` module, which contains the `add_job_if_suspended` utility
+  function.
 
 ### Changed
 
 - The execution of a simple command
   (`impl command::Command for yash_syntax::syntax::SimpleCommand`)
   now honors the `ExpansionMode` specified for the words in the command.
+- The `command::simple_command::start_external_utility_in_subshell_and_wait`
+  function now returns `Result<ExitStatus>` instead of `ExitStatus`.
 - External dependency versions:
     - Rust 1.82.0 → 1.85.0
     - yash-env 0.5.0 → 0.6.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now honors the `ExpansionMode` specified for the words in the command.
 - The `command::simple_command::start_external_utility_in_subshell_and_wait`
   function now returns `Result<ExitStatus>` instead of `ExitStatus`.
+- When a foreground job is suspended in an interactive shell, the shell now
+  discards any remaining commands in the current command line and prompts for
+  the next command line.
 - External dependency versions:
     - Rust 1.82.0 → 1.85.0
     - yash-env 0.5.0 → 0.6.0

--- a/yash-semantics/src/job.rs
+++ b/yash-semantics/src/job.rs
@@ -16,9 +16,10 @@
 
 //! Utilities for job control
 
+use std::ops::ControlFlow::{Break, Continue};
 use yash_env::Env;
 use yash_env::job::{Job, Pid, ProcessResult};
-use yash_env::semantics::ExitStatus;
+use yash_env::semantics::{Divert, ExitStatus};
 
 /// Adds a job if the process is suspended.
 ///
@@ -28,7 +29,9 @@ use yash_env::semantics::ExitStatus;
 /// If the process result indicates that the process is stopped, this function
 /// adds a job to the job list. The job is marked as job-controlled and its
 /// state is derived from the process result. The job name is set to the result
-/// of the `name` closure.
+/// of the `name` closure. If the current environment is interactive, this
+/// function returns `Break(Divert::Interrupt(Some(exit_status)))` to indicate
+/// that the shell should be interrupted.
 ///
 /// If the process is not stopped, this function does not add a job.
 ///
@@ -43,16 +46,88 @@ pub fn add_job_if_suspended<F>(
 where
     F: FnOnce() -> String,
 {
+    let exit_status = result.into();
+
     if result.is_stopped() {
         let mut job = Job::new(pid);
         job.job_controlled = true;
         job.state = result.into();
         job.name = name();
         env.jobs.add(job);
+
+        if env.is_interactive() {
+            return Break(Divert::Interrupt(Some(exit_status)));
+        }
     }
 
-    // TODO Break if stopped
-    // TODO What if non-interactive?
+    Continue(exit_status)
+}
 
-    crate::Result::Continue(result.into())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZero;
+    use yash_env::job::ProcessState;
+    use yash_env::option::Option::Interactive;
+    use yash_env::option::State::On;
+    use yash_env::signal;
+
+    #[test]
+    fn do_not_add_job_if_exited() {
+        let mut env = Env::new_virtual();
+        let result = add_job_if_suspended(
+            &mut env,
+            Pid(123),
+            ProcessResult::Exited(ExitStatus(42)),
+            || "foo".to_string(),
+        );
+        assert_eq!(result, Continue(ExitStatus(42)));
+        assert_eq!(env.jobs.len(), 0);
+    }
+
+    #[test]
+    fn do_not_add_job_if_signaled() {
+        let mut env = Env::new_virtual();
+        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+        let result = add_job_if_suspended(
+            &mut env,
+            Pid(123),
+            ProcessResult::Signaled {
+                signal,
+                core_dump: false,
+            },
+            || "foo".to_string(),
+        );
+        assert_eq!(result, Continue(ExitStatus(42 + 0x180)));
+        assert_eq!(env.jobs.len(), 0);
+    }
+
+    #[test]
+    fn add_job_if_stopped() {
+        let mut env = Env::new_virtual();
+        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+        let process_result = ProcessResult::Stopped(signal);
+        let result = add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
+        assert_eq!(result, Continue(ExitStatus(42 + 0x180)));
+        assert_eq!(env.jobs.len(), 1);
+        let job = env.jobs.get(0).unwrap();
+        assert_eq!(job.pid, Pid(123));
+        assert!(job.job_controlled);
+        assert_eq!(job.state, ProcessState::Halted(process_result));
+        assert_eq!(job.name, "foo");
+    }
+
+    #[test]
+    fn break_if_stopped_and_interactive() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+        let process_result = ProcessResult::Stopped(signal);
+        let result = add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
+        assert_eq!(
+            result,
+            Break(Divert::Interrupt(Some(ExitStatus(42 + 0x180))))
+        );
+        assert_eq!(env.jobs.len(), 1);
+    }
 }

--- a/yash-semantics/src/job.rs
+++ b/yash-semantics/src/job.rs
@@ -1,0 +1,58 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2025 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Utilities for job control
+
+use yash_env::Env;
+use yash_env::job::{Job, Pid, ProcessResult};
+use yash_env::semantics::ExitStatus;
+
+/// Adds a job if the process is suspended.
+///
+/// This is a convenience function for handling the result of
+/// [`Subshell::start_and_wait`](yash_env::subshell::Subshell::start_and_wait).
+///
+/// If the process result indicates that the process is stopped, this function
+/// adds a job to the job list. The job is marked as job-controlled and its
+/// state is derived from the process result. The job name is set to the result
+/// of the `name` closure.
+///
+/// If the process is not stopped, this function does not add a job.
+///
+/// Returns the exit status of the process that should be assigned to
+/// `env.exit_status`.
+pub fn add_job_if_suspended<F>(
+    env: &mut Env,
+    pid: Pid,
+    result: ProcessResult,
+    name: F,
+) -> crate::Result<ExitStatus>
+where
+    F: FnOnce() -> String,
+{
+    if result.is_stopped() {
+        let mut job = Job::new(pid);
+        job.job_controlled = true;
+        job.state = result.into();
+        job.name = name();
+        env.jobs.add(job);
+    }
+
+    // TODO Break if stopped
+    // TODO What if non-interactive?
+
+    crate::Result::Continue(result.into())
+}

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -30,6 +30,7 @@ pub mod assign;
 pub mod command;
 pub mod command_search;
 pub mod expansion;
+pub mod job;
 pub mod redir;
 pub mod trap;
 pub mod xtrace;


### PR DESCRIPTION
Closes #478

---

This pull request includes several changes to improve the handling of job control and process states in the `yash` shell. The most significant changes involve updating various functions to use the `ProcessResult` type instead of `ProcessState`, and introducing a utility function to handle suspended jobs. Additionally, there are updates to the changelogs and the use of the `add_job_if_suspended` function across multiple files.

### Improvements to job control and process state handling:

* [`yash-builtin/src/command/invoke.rs`](diffhunk://#diff-9705c56a434768a6b44cf72728d2031dfbecc472864b750e4745cc1ce323217bL73-R79): Updated the `invoke_target` function to handle `Break` and `Continue` control flow for external utilities.

* `yash-builtin/src/fg.rs`: 
  - Updated `wait_until_halt`, `resume_job_by_index`, and `resume_job_by_id` functions to use `ProcessResult` instead of `ProcessState`. [[1]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L104-R110) [[2]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L120-R121) [[3]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L135-R143) [[4]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L149-R174)
  - Modified tests to check for `ProcessResult` instead of `ProcessState`. [[1]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L295-R305) [[2]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L325-R335) [[3]](diffhunk://#diff-ea6b67386ca46861351cde64340c1f15eb98912b3dc2c3e41c640dabc5389d00L374-R384)

### Introduction of utility function for suspended jobs:

* [`yash-semantics/src/command/compound_command/subshell.rs`](diffhunk://#diff-cbdcfaeb14e2f05845fbb8319e716f3116526796db55e115c6bf78d1d75fe3f6L41-R41): Replaced manual job handling with the `add_job_if_suspended` utility function.
* [`yash-semantics/src/command/pipeline.rs`](diffhunk://#diff-0b4de61bf9d45be521fa19dba7564f7c5ab077feb6a31386fb1f31b5f2b55f36L148-R147): Updated the `execute_job_controlled_pipeline` function to use `add_job_if_suspended`.
* `yash-semantics/src/command/simple_command/absent.rs` and `external.rs`: Replaced manual job handling with `add_job_if_suspended`. [[1]](diffhunk://#diff-024f44fc85ffe1cd987e608cdf843209410fa80debdd40e0653bd90317071bfcL71-R76) [[2]](diffhunk://#diff-3377c05bd442ce70a77f70a4353b6013b8c462d62eb2a429d365a5d9b283fffdL113-R113)

### Changelog updates:

* [`yash-cli/CHANGELOG.md`](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR27-R31): Noted changes in behavior when a foreground job is suspended in an interactive shell.
* [`yash-semantics/CHANGELOG.md`](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R14-R26): Added details about new functions and changes in job handling.

These changes enhance the robustness of job control in the `yash` shell and simplify the code by centralizing job suspension handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced interactive shell behavior: When a foreground job is suspended, pending commands are cleared and a fresh prompt is shown.
  - Improved job control: More robust management of suspended and resumed jobs in both interactive and non-interactive modes.
  - Updated signal display: Signal listings (e.g., for the kill command) are now sorted in ascending order.

- **Bug Fixes**
  - Enhanced error feedback for operations like directory changes and external command execution.

- **Tests**
  - Added test cases to ensure reliable job management and improved foreground job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->