### PR TITLE
Signal the shell process when the shell is exiting with an exit status representing a signal

### DIFF
--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -59,6 +59,9 @@
 //!
 //! In case of an error, the exit status is 2 ([`ExitStatus::ERROR`]).
 //!
+//! If the exit status indicates a signal that caused the process of the last
+//! command to terminate, the shell terminates with the same signal.
+//!
 //! # Portability
 //!
 //! The behavior is undefined in POSIX if *exit_status* is greater than 255.
@@ -79,6 +82,10 @@
 //!   use it as the exit status of the process. However, if the built-in is
 //!   invoked in a trap, the caller should use the value of `$?` before entering
 //!   trap.
+//!
+//! The exit status is meant to be passed to
+//! [`SystemEx::exit_or_raise`](yash_env::system::SystemEx::exit_or_raise) to
+//! exit (or terminate) the shell process properly.
 //!
 //! In case of an error, the result will have a [`Divert::Interrupt`] value
 //! instead, in which case the shell will not exit if it is interactive.

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shell now returns an exit status of 128 on an I/O error reading command
   input, except when reading a script in the `.` built-in, as required by
   POSIX.1-2024.
+- When a command is terminated by a signal and its exit status is used as the
+  exit status of the shell, the shell now terminates itself with the same
+  signal, as required by POSIX.1-2024.
 
 ## [0.3.0] - 2025-03-23
 

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -36,7 +36,7 @@ use yash_env::RealSystem;
 use yash_env::System;
 use yash_env::option::{Interactive, On};
 use yash_env::signal;
-use yash_env::system::{Disposition, Errno};
+use yash_env::system::{Disposition, Errno, SystemEx as _};
 use yash_executor::Executor;
 use yash_semantics::trap::run_exit_trap;
 use yash_semantics::{Divert, ExitStatus};
@@ -136,7 +136,7 @@ pub fn main() -> ! {
     let executor = Executor::new();
     let task = Box::pin(async {
         run_as_shell_process(&mut env).await;
-        env.system.exit(env.exit_status).await;
+        env.system.exit_or_raise(env.exit_status).await;
     });
     // SAFETY: We never create new threads in the whole process, so wakers are
     // never shared between threads.

--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -112,7 +112,7 @@ then
     skip=true
 fi
 
-test_o 'exit built-in kills shell according to exit status'
+test_o 'exit built-in kills shell according to exit status (TERM)'
 "$TESTEE" -s <<'__END__'
 # This `sh` kills itself with SIGTERM
 sh -c 'kill $$'
@@ -128,6 +128,24 @@ echo "exit status $exit_status is not greater than 256"
 kill -l "$exit_status"
 __IN__
 TERM
+__OUT__
+
+test_o 'exit built-in kills shell according to exit status (KILL)'
+"$TESTEE" -s <<'__END__'
+# This `sh` kills itself with SIGKILL
+sh -c 'kill -s KILL $$'
+# Now the exit status should be a value greater than 256
+# indicating that the previous command was terminated by SIGKILL.
+# The exit built-in should kill the shell with the same signal
+# to propagate the exit status.
+exit
+__END__
+exit_status=$?
+test "$exit_status" -gt 256 ||
+echo "exit status $exit_status is not greater than 256"
+kill -l "$exit_status"
+__IN__
+KILL
 __OUT__
 
 test_o 'exit built-in kills subshell according to exit status'

--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -167,6 +167,8 @@ __OUT__
 
 test_o 'subshell kills itself according to final exit status'
 (
+# This dummy trap suppresses possible auto-exec optimization
+trap 'echo foo' TERM
 # This `sh` kills itself with SIGTERM
 sh -c 'kill $$'
 # Now the exit status should be a value greater than 256

--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -99,3 +99,87 @@ kill -INT $$
 __IN__
 2
 __OUT__
+
+(
+# The test cases below are applicable only if the shell uses exit statuses
+# greater than 256 for commands terminated by signals.
+if
+testee -s <<'__END__'
+sh -c 'kill $$'
+test $? -le 256
+__END__
+then
+    skip=true
+fi
+
+test_o 'exit built-in kills shell according to exit status'
+"$TESTEE" -s <<'__END__'
+# This `sh` kills itself with SIGTERM
+sh -c 'kill $$'
+# Now the exit status should be a value greater than 256
+# indicating that the previous command was terminated by SIGTERM.
+# The exit built-in should kill the shell with the same signal
+# to propagate the exit status.
+exit
+__END__
+exit_status=$?
+test "$exit_status" -gt 256 ||
+echo "exit status $exit_status is not greater than 256"
+kill -l "$exit_status"
+__IN__
+TERM
+__OUT__
+
+test_o 'exit built-in kills subshell according to exit status'
+(
+# This `sh` kills itself with SIGTERM
+sh -c 'kill $$'
+# Now the exit status should be a value greater than 256
+# indicating that the previous command was terminated by SIGTERM.
+# The exit built-in should kill the subshell with the same signal
+# to propagate the exit status.
+exit
+)
+exit_status=$?
+test "$exit_status" -gt 256 ||
+echo "exit status $exit_status is not greater than 256"
+kill -l "$exit_status"
+__IN__
+TERM
+__OUT__
+
+test_o 'shell kills itself according to final exit status'
+"$TESTEE" -s <<'__END__'
+# This `sh` kills itself with SIGTERM
+sh -c 'kill $$'
+# Now the exit status should be a value greater than 256
+# indicating that the previous command was terminated by SIGTERM.
+# When reaching the end of the script, the shell should kill
+# itself with the same signal to propagate the exit status.
+__END__
+exit_status=$?
+test "$exit_status" -gt 256 ||
+echo "exit status $exit_status is not greater than 256"
+kill -l "$exit_status"
+__IN__
+TERM
+__OUT__
+
+test_o 'subshell kills itself according to final exit status'
+(
+# This `sh` kills itself with SIGTERM
+sh -c 'kill $$'
+# Now the exit status should be a value greater than 256
+# indicating that the previous command was terminated by SIGTERM.
+# When reaching the end of the script, the subshell should kill
+# itself with the same signal to propagate the exit status.
+)
+exit_status=$?
+test "$exit_status" -gt 256 ||
+echo "exit status $exit_status is not greater than 256"
+kill -l "$exit_status"
+__IN__
+TERM
+__OUT__
+
+)

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `System` trait now has the `getsid` method.
     - This method returns the session ID of the process with the given PID.
+- The `System` trait now has the `exit` method.
+    - This method terminates the process with the given exit status.
 - The `semantics::ExitStatus` struct now has the `READ_ERROR` constant.
     - This constant represents an exit status indicating an unrecoverable
       read error. Its value is 128.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The definition of `system::ChildProcessTask` is updated so that the `Output`
+  type of the returned `Future` is now `std::convert::Infallible` instead of
+  `()`.
 - External dependency versions:
     - Rust 1.85.0 → 1.86.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `semantics::ExitStatus` struct now has the `READ_ERROR` constant.
     - This constant represents an exit status indicating an unrecoverable
       read error. Its value is 128.
+- The `semantics::ExitStatus` struct now has the `to_signal` method.
+    - This method converts the exit status to a signal name and number if
+      applicable.
 - Internal dependencies:
     - dyn-clone 1.0.19
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This method terminates the process with the given exit status.
 - The `System` trait now has the `raise` method.
     - This method sends a signal to the calling process.
+- The `SystemEx` trait now has the `exit_or_raise` method.
+    - This method terminates the current process with the given exit status,
+      possibly sending a signal to kill the process.
 - The `semantics::ExitStatus` struct now has the `READ_ERROR` constant.
     - This constant represents an exit status indicating an unrecoverable
       read error. Its value is 128.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This method returns the session ID of the process with the given PID.
 - The `System` trait now has the `exit` method.
     - This method terminates the process with the given exit status.
+- The `System` trait now has the `raise` method.
+    - This method sends a signal to the calling process.
 - The `semantics::ExitStatus` struct now has the `READ_ERROR` constant.
     - This constant represents an exit status indicating an unrecoverable
       read error. Its value is 128.

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -35,7 +35,7 @@ use crate::system::ChildProcessTask;
 use crate::system::Errno;
 use crate::system::SigmaskOp;
 use crate::system::System;
-use crate::system::SystemEx;
+use crate::system::SystemEx as _;
 use std::pin::Pin;
 
 /// Job state of a newly created subshell
@@ -192,7 +192,7 @@ where
                 );
 
                 (self.task)(env, job_control).await;
-                env.system.exit(env.exit_status).await
+                env.system.exit_or_raise(env.exit_status).await
             })
         });
 

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -191,7 +191,8 @@ where
                     keep_internal_dispositions_for_stoppers,
                 );
 
-                (self.task)(env, job_control).await
+                (self.task)(env, job_control).await;
+                env.system.exit(env.exit_status).await
             })
         });
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -756,8 +756,10 @@ pub trait SystemEx: System {
                 .setrlimit(Resource::CORE, LimitPair { soft: 0, hard: 0 })
                 .ok()?;
 
-            // Reset signal disposition
-            system.sigaction(signal.1, Disposition::Default).ok()?;
+            if signal.0 != signal::Name::Kill {
+                // Reset signal disposition
+                system.sigaction(signal.1, Disposition::Default).ok()?;
+            }
 
             // Unblock the signal
             system

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -328,6 +328,15 @@ pub trait System: Debug {
         signal: Option<signal::Number>,
     ) -> Pin<Box<dyn Future<Output = Result<()>>>>;
 
+    /// Sends a signal to the current process.
+    ///
+    /// This is a thin wrapper around the `raise` system call.
+    ///
+    /// The virtual system version of this function blocks the calling thread if
+    /// the signal stops or terminates the current process, hence returning a
+    /// future. See [`VirtualSystem::kill`] for details.
+    fn raise(&mut self, signal: signal::Number) -> Pin<Box<dyn Future<Output = Result<()>>>>;
+
     /// Waits for a next event.
     ///
     /// This is a low-level function used internally by

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -435,6 +435,11 @@ pub trait System: Debug {
     /// This is a thin wrapper around the `execve` system call.
     fn execve(&mut self, path: &CStr, args: &[CString], envs: &[CString]) -> Result<Infallible>;
 
+    /// Terminates the current process.
+    ///
+    /// This function is a thin wrapper around the `_exit` system call.
+    fn exit(&mut self, exit_status: ExitStatus) -> Pin<Box<dyn Future<Output = Infallible>>>;
+
     /// Returns the current working directory path.
     fn getcwd(&self) -> Result<PathBuf>;
 

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -549,8 +549,12 @@ pub enum Disposition {
 /// executed in a child process initiated by the starter. The environment passed
 /// to the task is a clone of the parent environment, but it has a different
 /// process ID than the parent.
+///
+/// Note that the output type of the task is `Infallible`. This is to ensure that
+/// the task [exits](System::exit) cleanly or [kills](System::kill) itself with
+/// a signal.
 pub type ChildProcessTask =
-    Box<dyn for<'a> FnOnce(&'a mut Env) -> Pin<Box<dyn Future<Output = ()> + 'a>>>;
+    Box<dyn for<'a> FnOnce(&'a mut Env) -> Pin<Box<dyn Future<Output = Infallible> + 'a>>>;
 
 /// Abstract function that starts a child process
 ///

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -676,7 +676,7 @@ impl System for RealSystem {
             let executor = Executor::new();
             let task = Box::pin(async move {
                 task(env).await;
-                std::process::exit(env.exit_status.0)
+                env.system.exit(env.exit_status).await;
             });
             // SAFETY: We never create new threads in the whole process, so wakers are
             // never shared between threads.

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -674,10 +674,7 @@ impl System for RealSystem {
             // other concurrent tasks in the parent process do not interfere with the
             // child process.
             let executor = Executor::new();
-            let task = Box::pin(async move {
-                task(env).await;
-                env.system.exit(env.exit_status).await;
-            });
+            let task = Box::pin(async move { match task(env).await {} });
             // SAFETY: We never create new threads in the whole process, so wakers are
             // never shared between threads.
             unsafe { executor.spawn_pinned(task) }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -55,6 +55,7 @@ use crate::job::ProcessResult;
 use crate::job::ProcessState;
 use crate::path::Path;
 use crate::path::PathBuf;
+use crate::semantics::ExitStatus;
 use crate::str::UnixStr;
 use crate::str::UnixString;
 use enumset::EnumSet;
@@ -747,6 +748,10 @@ impl System for RealSystem {
                 return Err(errno);
             }
         }
+    }
+
+    fn exit(&mut self, exit_status: ExitStatus) -> Pin<Box<dyn Future<Output = Infallible>>> {
+        unsafe { libc::_exit(exit_status.0) }
     }
 
     fn getcwd(&self) -> Result<PathBuf> {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -554,6 +554,14 @@ impl System for RealSystem {
         })
     }
 
+    fn raise(&mut self, signal: signal::Number) -> Pin<Box<dyn Future<Output = Result<()>>>> {
+        Box::pin(async move {
+            let raw = signal.as_raw();
+            unsafe { libc::raise(raw) }.errno_if_m1()?;
+            Ok(())
+        })
+    }
+
     fn select(
         &mut self,
         readers: &mut Vec<Fd>,

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -46,6 +46,7 @@ use crate::Env;
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::job::ProcessState;
+use crate::semantics::ExitStatus;
 use enumset::EnumSet;
 use std::cell::RefCell;
 use std::convert::Infallible;
@@ -442,6 +443,9 @@ impl System for &SharedSystem {
     fn execve(&mut self, path: &CStr, args: &[CString], envs: &[CString]) -> Result<Infallible> {
         self.0.borrow_mut().execve(path, args, envs)
     }
+    fn exit(&mut self, exit_status: ExitStatus) -> Pin<Box<dyn Future<Output = Infallible>>> {
+        self.0.borrow_mut().exit(exit_status)
+    }
     fn getcwd(&self) -> Result<PathBuf> {
         self.0.borrow().getcwd()
     }
@@ -664,6 +668,10 @@ impl System for SharedSystem {
     #[inline]
     fn execve(&mut self, path: &CStr, args: &[CString], envs: &[CString]) -> Result<Infallible> {
         (&mut &*self).execve(path, args, envs)
+    }
+    #[inline]
+    fn exit(&mut self, exit_status: ExitStatus) -> Pin<Box<dyn Future<Output = Infallible>>> {
+        (&mut &*self).exit(exit_status)
     }
     #[inline]
     fn getcwd(&self) -> Result<PathBuf> {

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -404,6 +404,9 @@ impl System for &SharedSystem {
     ) -> Pin<Box<(dyn Future<Output = Result<()>>)>> {
         self.0.borrow_mut().kill(target, signal)
     }
+    fn raise(&mut self, signal: signal::Number) -> Pin<Box<dyn Future<Output = Result<()>>>> {
+        self.0.borrow_mut().raise(signal)
+    }
     fn select(
         &mut self,
         readers: &mut Vec<Fd>,
@@ -618,6 +621,10 @@ impl System for SharedSystem {
         signal: Option<signal::Number>,
     ) -> Pin<Box<dyn Future<Output = Result<()>>>> {
         (&mut &*self).kill(target, signal)
+    }
+    #[inline]
+    fn raise(&mut self, signal: signal::Number) -> Pin<Box<dyn Future<Output = Result<()>>>> {
+        (&mut &*self).raise(signal)
     }
     #[inline]
     fn select(

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -702,6 +702,11 @@ impl System for VirtualSystem {
         })
     }
 
+    fn raise(&mut self, signal: signal::Number) -> Pin<Box<dyn Future<Output = Result<()>>>> {
+        let target = self.process_id;
+        self.kill(target, Some(signal))
+    }
+
     /// Waits for a next event.
     ///
     /// The `VirtualSystem` implementation for this method does not actually


### PR DESCRIPTION
POSIX.1-2024 updated the requirements on the [`exit` built-in](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#exit).

> If _n_ is specified and has a value between 0 and 255 inclusive, the wait status of the shell or subshell shall indicate that it exited with exit status _n_. If _n_ is specified and has a value greater than 256 that corresponds to an exit status the shell assigns to commands terminated by a valid signal (see [2.8.2 Exit Status for Commands](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_08_02)), the wait status of the shell or subshell shall indicate that it was terminated by that signal. No other actions associated with the signal, such as execution of [trap](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#trap) actions or creation of a core image, shall be performed by the shell.

To implement this, we examine the exit status to see if it indicates that a process has been terminated by a signal, and if so, we kill the shell by resending the signal to the shell.

- [x] Define `System::exit`
- [x] Use `System::exit` when exiting from the main shell process
- [x] Use `System::exit` when exiting from subshells
- [x] Add `ExitStatus::to_signal`, which returns `Option<(signal::Name, signal::Number)>`
- [x] Define `SystemEx::exit_or_raise`
    - Unblock and restore the signal action
    - Prevent creation of core images
    - Raise the signal
    - Exit
- [x] Use `SystemEx::exit_or_raise` instead of `System::exit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved shell behavior to terminate with the same signal as a command when appropriate, aligning with updated POSIX standards.
  - Added new methods for process control, including sending signals and explicit process termination.
  - Enhanced ability to interpret and propagate signal-based exit statuses.

- **Bug Fixes**
  - Improved handling of exit statuses for signal-terminated commands, ensuring correct status propagation in both main and subshell contexts.

- **Tests**
  - Added comprehensive tests verifying correct signal propagation and exit status behavior for both main shell and subshell scenarios.

- **Documentation**
  - Updated changelogs and built-in documentation to clarify exit status handling and signal termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->