### PR TITLE
Handle traps for signals caught while command input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
 yash-builtin = { path = "yash-builtin", version = "0.7.0" }
-yash-env = { path = "yash-env", version = "0.7.0" }
+yash-env = { path = "yash-env", version = "0.7.1" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.5.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,13 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - Unreleased
+
+### Fixed
+
+- The shell now correctly handles traps for signals that are caught while
+  reading a command. Previously, the shell would ignore such signals.
+
 ## [0.4.0] - 2025-04-26
 
 ### Changed
@@ -168,6 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
+[0.4.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.1
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.3.0
 [0.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.2.0

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - Unreleased
+
+### Fixed
+
+- `system::SharedSystem::wait_for_signals` now returns signals that have already
+  been caught before the call to `wait_for_signals`, if any. Previously, signals
+  that have been caught were ignored.
+
 ## [0.7.0] - 2025-04-26
 
 ### Added
@@ -439,6 +447,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env` crate
 
+[0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.5.0

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true }

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -299,6 +299,7 @@ impl AsyncIo {
 
     /// Wakes and removes all awaiters.
     pub fn wake_all(&mut self) {
+        // Dropping awaiters wakes the wakers.
         self.readers.clear();
         self.writers.clear();
     }

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -406,9 +406,15 @@ struct AsyncSignal {
     awaiters: Vec<Weak<RefCell<SignalStatus>>>,
 }
 
+/// Status of awaited signals
 #[derive(Clone, Debug)]
 pub enum SignalStatus {
+    /// No signal has been caught.
+    /// The waker will be woken when the signal is caught.
     Expected(Option<Waker>),
+
+    /// One or more signals have been caught.
+    /// The slice contains the caught signals.
     Caught(Rc<[signal::Number]>),
 }
 


### PR DESCRIPTION
Fixes #495

This pull request fixes a bug where the shell would not run traps for signals that are caught when waiting for command input. The cause of the issue was in `AsyncSignal`, which was silently discarding signals when there had been no awaiters. The fix involves retaining the signals in `AsyncSignal` and ensuring that they are passed to at least one awaiter.

## Summary by Copilot

This pull request introduces several updates and fixes across multiple components, focusing on version upgrades, changelog updates, and significant improvements to the `AsyncSignal` implementation in the `yash-env` crate. The most critical changes include enhancements to signal handling, updates to test cases, and version bumps to maintain compatibility.

### Version Updates:
* Updated `yash-env` crate version to `0.7.1` in `Cargo.toml` to reflect new changes. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L29-R29) [[2]](diffhunk://#diff-d25f8cd91b0effd6a7935b635d9b104d9070677e5b508b42e3e4f905ba040856L3-R3)

### Changelog Updates:
* Added a new changelog entry for version `0.7.1` in `yash-env/CHANGELOG.md`, documenting a fix for `system::SharedSystem::wait_for_signals` to properly return already caught signals.
* Added a new changelog entry for version `0.4.1` in `yash-cli/CHANGELOG.md`, documenting a fix for handling traps for signals caught while reading a command.

### `AsyncSignal` Enhancements:
* Refactored `AsyncSignal` from a `struct` to an `enum` to better manage synchronization between caught signals and awaiters. This change ensures signals are retained and passed to awaiters appropriately.
* Improved the `wait_for_signals` and `wake` methods to handle scenarios where signals are caught before or after awaiters are registered. This includes retaining signals for future awaiters when no awaiters are currently pending.
* Added extensive documentation and comments to clarify the behavior of `AsyncSignal` methods.

### Test Case Improvements:
* Enhanced and expanded test cases for `AsyncSignal` to cover edge cases such as waking signals before awaiters are registered, handling empty signal wakes, and ensuring proper behavior when awaiters are dropped.

### Miscellaneous:
* Added `publish = false` to `yash-env/Cargo.toml`, likely to prevent accidental publishing of the crate.
* Simplified the `wake` method in `SelectSystem` by removing unnecessary conversions.

These changes collectively improve the robustness and maintainability of the `yash-env` crate while addressing critical bugs and enhancing signal handling functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of signal notifications, allowing signals to be accumulated and delivered to awaiters even if they arrive before or after signals are caught.

- **Bug Fixes**
	- Awaiters now properly receive signals regardless of the order in which they are registered or signals are sent.
	- Shell now correctly handles traps for signals caught during command reading.

- **Documentation**
	- Enhanced documentation for signal status variants to clarify their behavior.

- **Tests**
	- Added tests to cover various signal and awaiter scenarios for increased reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->