### PR TITLE
More correct handling of ill-named variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
-yash-builtin = { path = "yash-builtin", version = "0.7.0" }
+yash-builtin = { path = "yash-builtin", version = "0.7.1" }
 yash-env = { path = "yash-env", version = "0.7.1" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.5.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
@@ -33,4 +33,4 @@ yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.5.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
 yash-semantics = { path = "yash-semantics", version = "0.7.0" }
-yash-syntax = { path = "yash-syntax", version = "0.14.0" }
+yash-syntax = { path = "yash-syntax", version = "0.14.1" }

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The `read::syntax::Error` enum now has the `InvalidVariableName` variant,
-  which indicates that the variable name is invalid.
+- The `getopts::report::Error` and `read::syntax::Error` enums now have the
+  `InvalidVariableName` variant, which indicates that the variable name is
+  invalid.
 
 ### Fixed
 
+- The `getopts` built-in now fails when the second operand is not a valid
+  variable name. The `getopts::model::Result::report` function now returns the
+  `InvalidVariableName` error in this case.
 - The `read` built-in now fails when a specified variable name contains an `=`
   character. The `read::syntax::parse` function returns the
   `InvalidVariableName` error in this case.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `read` built-in now fails when a specified variable name contains an `=`
   character. The `read::syntax::parse` function returns the
   `InvalidVariableName` error in this case.
+- The `export`, `readonly`, and `typeset` built-ins no longer print variables
+  with a name containing an `=` character.
+  The `typeset::PrintVariables::execute` function now ignores such variables.
 
 ## [0.7.0] - 2025-04-26
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - Unreleased
+
+### Added
+
+- The `read::syntax::Error` enum now has the `InvalidVariableName` variant,
+  which indicates that the variable name is invalid.
+
+### Fixed
+
+- The `read` built-in now fails when a specified variable name contains an `=`
+  character. The `read::syntax::parse` function returns the
+  `InvalidVariableName` error in this case.
+
 ## [0.7.0] - 2025-04-26
 
 ### Changed
@@ -277,6 +290,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.5.0

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidVariableName` variant, which indicates that the variable name is
   invalid.
 
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.14.0 → 0.14.1
+
 ### Fixed
 
 - The `getopts` built-in now fails when the second operand is not a valid
@@ -24,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `export`, `readonly`, and `typeset` built-ins no longer print variables
   with a name containing an `=` character.
   The `typeset::PrintVariables::execute` function now ignores such variables.
+- The `set` built-in without arguments no longer prints variables that have an
+  invalid name. The `set::main` function now excludes such variables from the
+  output.
 
 ## [0.7.0] - 2025-04-26
 

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [features]
 default = ["yash-prompt", "yash-semantics"]

--- a/yash-builtin/src/getopts.rs
+++ b/yash-builtin/src/getopts.rs
@@ -102,6 +102,7 @@
 //! The following conditions are considered errors of the built-in:
 //!
 //! - The built-in is invoked with less than two operands.
+//! - The second operand is not a valid variable name.
 //! - `$OPTIND`, `$OPTARG`, or the specified variable is read-only.
 //! - The built-in is re-invoked with different arguments or a different value
 //!   of `$OPTIND` than the previous invocation (except when `$OPTIND` is reset
@@ -161,6 +162,11 @@
 //! The getopts built-in is specified by POSIX. Only ASCII alphanumeric
 //! characters are allowed for option names, though this implementation allows
 //! any characters but `:`.
+//!
+//! The current implementation considers variable names containing a `=` as
+//! invalid names. However, more names many be considered invalid in the future.
+//! For best forward-compatibility and portability, only use portable name
+//! characters (ASCII alphanumerics and underscore).
 //!
 //! Although POSIX requires the built-in to support the Utility Syntax
 //! Guidelines 3 to 10, some implementations do not support the `--` separator

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -82,6 +82,7 @@
 //! - The standard input is not readable.
 //! - The delimiter is not a single-byte character.
 //! - The delimiter is not a nul byte and the input contains a nul byte.
+//! - A variable name is not valid.
 //! - A variable to be assigned is read-only.
 //!
 //! # Exit status
@@ -107,6 +108,11 @@
 //! In this implementation, the value of the `PS2` variable is subject to
 //! parameter expansion, command substitution, and arithmetic expansion. Other
 //! implementations may not perform these expansions.
+//!
+//! The current implementation considers variable names containing a `=` as
+//! invalid names. However, more names many be considered invalid in the future.
+//! For best forward-compatibility and portability, only use portable name
+//! characters (ASCII alphanumerics and underscore).
 //!
 //! # Implementation notes
 //!

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The shell now correctly handles traps for signals that are caught while
   reading a command. Previously, the shell would ignore such signals.
+- The `read` built-in now fails when a specified variable name contains an `=`
+  character.
 
 ## [0.4.0] - 2025-04-26
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading a command. Previously, the shell would ignore such signals.
 - The `getopts` and `read` built-ins now fail when a specified variable name
   contains an `=` character.
+- The `set` built-in without arguments no longer prints variables that have an
+  invalid name.
 
 ## [0.4.0] - 2025-04-26
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The shell now correctly handles traps for signals that are caught while
   reading a command. Previously, the shell would ignore such signals.
-- The `read` built-in now fails when a specified variable name contains an `=`
-  character.
+- The `getopts` and `read` built-ins now fail when a specified variable name
+  contains an `=` character.
 
 ## [0.4.0] - 2025-04-26
 

--- a/yash-cli/tests/scripted_test/read-y.sh
+++ b/yash-cli/tests/scripted_test/read-y.sh
@@ -231,8 +231,7 @@ test_O -d -e 4 'missing operand'
 read
 __IN__
 
-# TODO should be a command line syntax error
-test_O -d -e 4 -f 'invalid variable name'
+test_O -d -e 4 'invalid variable name'
 read a=b
 __IN__
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - Unreleased
 
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.14.0 → 0.14.1
+
 ### Fixed
 
 - `system::SharedSystem::wait_for_signals` now returns signals that have already

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `system::SharedSystem::wait_for_signals` now returns signals that have already
   been caught before the call to `wait_for_signals`, if any. Previously, signals
   that have been caught were ignored.
+- `variable::VariableSet::env_c_strings` now excludes variables with a name that
+  contains a `=` character because the variable name would never be interpreted
+  correctly by the program that would receive the exported variable.
 
 ## [0.7.0] - 2025-04-26
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.14.0 → 0.14.1
+
 ## [0.5.0] - 2025-04-26
 
 ### Changed
@@ -64,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.5.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.1
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.0
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.3.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.14.0 → 0.14.1
+
 ## [0.7.0] - 2025-04-26
 
 ### Changed
@@ -217,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.5.0

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - Unreleased
+
+### Added
+
+- `parser::lex::is_name` and `parser::lex::is_portable_name`
+    - These functions can be used to check if a string is a valid name.
+
 ## [0.14.0] - 2025-03-23
 
 This version adds support for declaration utilities. It also reorganizes how the
@@ -442,6 +449,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.14.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.1
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.13.0
 [0.12.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.12.1

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities", "parser-implementations"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true, optional = true }

--- a/yash-syntax/src/parser/lex.rs
+++ b/yash-syntax/src/parser/lex.rs
@@ -38,6 +38,7 @@ mod tilde;
 mod token;
 mod word;
 
+pub use self::braced_param::is_name;
 pub use self::braced_param::is_name_char;
 pub use self::core::*;
 pub use self::keyword::Keyword;
@@ -46,6 +47,7 @@ pub use self::op::Operator;
 pub use self::op::ParseOperatorError;
 pub use self::op::TryFromOperatorError;
 pub use self::op::is_operator_char;
+pub use self::raw_param::is_portable_name;
 pub use self::raw_param::is_portable_name_char;
 pub use self::raw_param::is_single_char_name;
 pub use self::raw_param::is_special_parameter_char;

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -17,6 +17,7 @@
 //! Part of the lexer that parses braced parameter expansion
 
 use super::core::WordLexer;
+use super::raw_param::is_portable_name;
 use super::raw_param::is_portable_name_char;
 use crate::parser::core::Result;
 use crate::parser::error::Error;
@@ -35,6 +36,15 @@ use std::num::IntErrorKind;
 pub fn is_name_char(c: char) -> bool {
     // TODO support other Unicode name characters
     is_portable_name_char(c)
+}
+
+/// Tests if a string is a valid name.
+///
+/// The current implementation is the same as [`is_portable_name`].
+/// Other (POSIXly non-portable) characters may be allowed in the future.
+pub fn is_name(s: &str) -> bool {
+    // TODO support other Unicode name characters
+    is_portable_name(s)
 }
 
 /// Determines the type of the parameter.

--- a/yash-syntax/src/parser/lex/raw_param.rs
+++ b/yash-syntax/src/parser/lex/raw_param.rs
@@ -27,9 +27,22 @@ use crate::syntax::TextUnit;
 ///
 /// Returns true if the character is an ASCII alphanumeric or underscore.
 ///
-/// Note that a valid name cannot start with a digit.
+/// Note that a valid name cannot start with a digit, but this function
+/// returns true for digits as well.
+///
+/// Use [`is_portable_name`] to check if a string is a valid name.
 pub const fn is_portable_name_char(c: char) -> bool {
     matches!(c, '0'..='9' | 'A'..='Z' | '_' | 'a'..='z')
+}
+
+/// Tests if a string is a valid POSIXly-portable name.
+///
+/// Returns true if the string is non-empty, the first character is not a digit,
+/// and all characters are ASCII alphanumeric or underscore.
+///
+/// Use [`is_portable_name_char`] to check each character.
+pub fn is_portable_name(s: &str) -> bool {
+    s.starts_with(|c: char| !c.is_ascii_digit()) && s.chars().all(is_portable_name_char)
 }
 
 /// Tests if a character names a special parameter.
@@ -95,6 +108,15 @@ mod tests {
     use crate::syntax::Param;
     use assert_matches::assert_matches;
     use futures_util::FutureExt;
+
+    #[test]
+    fn test_is_portable_name() {
+        assert!(!is_portable_name(""));
+        assert!(is_portable_name("valid_name"));
+        assert!(!is_portable_name("1invalid_name"));
+        assert!(is_portable_name("valid_name_123"));
+        assert!(is_portable_name("_VALID_NAME"));
+    }
 
     #[test]
     fn lexer_raw_param_special_parameter() {


### PR DESCRIPTION
Fixes #448

In the internal implementation, the `VariableSet` struct allows the definition and export of variables with arbitrary names. On the other hand, the shell must avoid non-conforming behavior, so internal users of `VariableSet` must ensure that they do not exhibit behavior that is not allowed by POSIX. This pull request updates the implementation to work in a conforming manner.

## Summary by Copilot 

This pull request introduces a version bump for the `yash-builtin` crate to `0.7.1`, along with several enhancements, bug fixes, and dependency updates across the `yash` project. The most significant changes include stricter validation for variable names, updates to external dependencies, and improvements to built-in commands' behavior.

### Version Updates and Dependency Changes:
* Updated `yash-builtin` crate version from `0.7.0` to `0.7.1` in `Cargo.toml` and added `publish = false` to prevent publishing this version. [[1]](diffhunk://#diff-07ae834b7eb0a25e9511788609ebbaa84e95e701074d88d1d232a7abd6897fb3L3-R3) [[2]](diffhunk://#diff-07ae834b7eb0a25e9511788609ebbaa84e95e701074d88d1d232a7abd6897fb3R15)
* Updated `yash-syntax` dependency from `0.14.0` to `0.14.1` in multiple `Cargo.toml` files. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L28-R36) [[2]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR10-R22)

### Stricter Variable Name Validation:
* Introduced the `InvalidVariableName` error variant in `getopts` and `read` built-ins to handle invalid variable names (e.g., names containing `=`). [[1]](diffhunk://#diff-f7ca4dd070ea4eab53de7ba497f72b4d9cdc6e3f448436dae9f304e4ade31d68R42-R45) [[2]](diffhunk://#diff-e2b9c74ff5976786bcf914d9bad7d0cf0ca2bd51dd7d5ff4dae708aa42719259R46-R49)
* Modified the `getopts` and `read` built-ins to fail when encountering invalid variable names and added corresponding validation logic. (Fd0f3a53L153R168, [yash-builtin/src/read/syntax.rsR145-R157](diffhunk://#diff-e2b9c74ff5976786bcf914d9bad7d0cf0ca2bd51dd7d5ff4dae708aa42719259R145-R157))
* Updated the `set` and `typeset` built-ins to exclude variables with invalid names from their output. [[1]](diffhunk://#diff-d06e1aba7aa30b9ac5eabe078a51041b82526d084212f87c532ae7b7a266ccecL222-L229) [[2]](diffhunk://#diff-a5c1100d40f5cc654ab01485feb4edcb0c6232f3e258343e7978f22de6c8dd6dR63-R69)

### Bug Fixes:
* Fixed the `getopts` built-in to correctly handle invalid variable names in the `report` function and added tests for this behavior.
* Addressed issues in the `read` built-in to ensure it fails gracefully when encountering invalid variable names.
* Updated `VariableSet::env_c_strings` to exclude variables with invalid names when exporting environment variables.

### Documentation and Changelog Updates:
* Added a new entry for version `0.7.1` in the `yash-builtin` and `yash-env` changelogs, documenting the changes and fixes. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR8-R35) [[2]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR10-R22)
* Updated the `yash-cli` changelog to reflect changes to the `getopts`, `read`, and `set` built-ins.

These changes improve the robustness of the `yash` project by enforcing stricter rules for variable names, fixing edge cases, and ensuring compatibility with updated dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Built-in commands now provide clearer error messages when variable names are invalid, specifically when containing the '=' character.
  - Variable name validation functions are now available for improved compatibility and error detection.

- **Bug Fixes**
  - The `getopts` and `read` built-ins fail as expected when given invalid variable names.
  - The `set`, `export`, `readonly`, and `typeset` built-ins no longer display or process variables with invalid names.
  - Exported environment variables with invalid names are excluded to prevent misinterpretation.

- **Documentation**
  - Updated documentation and changelogs to reflect changes in variable name handling and new validation rules.

- **Chores**
  - Dependency versions updated for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->