### PR TITLE
Remove redundant trailing slash in tilde expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -667,7 +667,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "assert_matches",
  "enumset",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
-yash-builtin = { path = "yash-builtin", version = "0.8.0" }
-yash-env = { path = "yash-env", version = "0.7.1" }
+yash-builtin = { path = "yash-builtin", version = "0.9.0" }
+yash-env = { path = "yash-env", version = "0.8.0" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.5.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
-yash-prompt = { path = "yash-prompt", version = "0.5.0" }
+yash-prompt = { path = "yash-prompt", version = "0.6.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.7.1" }
-yash-syntax = { path = "yash-syntax", version = "0.14.1" }
+yash-semantics = { path = "yash-semantics", version = "0.8.0" }
+yash-syntax = { path = "yash-syntax", version = "0.15.0" }

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-env 0.8.0 → 0.9.0
+    - yash-prompt (optional) 0.5.0 → 0.6.0
+    - yash-semantics (optional) 0.8.0 → 0.9.0
+    - yash-syntax 0.14.1 → 0.15.0
+
 ## [0.8.0] - 2025-05-03
 
 ### Added
@@ -309,6 +319,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.0
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.8.0
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.6.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [features]
 default = ["yash-prompt", "yash-semantics"]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,14 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - Unreleased
+
+### Fixed
+
+- When a tilde expansion produces a directory name that ends with a slash and
+  the expansion is followed by a slash, the trailing slash in the directory name
+  is now removed to maintain the correct number of slashes.
+
 ## [0.4.1] - 2025-05-03
 
 ### Fixed
@@ -182,6 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
+[0.4.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.2
 [0.4.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.1
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.3.0

--- a/yash-cli/tests/scripted_test/tilde-p.sh
+++ b/yash-cli/tests/scripted_test/tilde-p.sh
@@ -106,6 +106,27 @@ __IN__
 []
 __OUT__
 
+test_oE -e 0 'HOME with trailing slash'
+HOME=/foo/bar/
+bracket ~ ~/~
+__IN__
+[/foo/bar/][/foo/bar/~]
+__OUT__
+
+test_oE -e 0 'HOME=/'
+HOME=/
+bracket ~ ~/foo
+__IN__
+[/][/foo]
+__OUT__
+
+test_oE -e 0 'HOME=//'
+HOME=//
+bracket ~ ~/foo
+__IN__
+[//][//foo]
+__OUT__
+
 (
 if
     logname=$(logname)

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.14.1 → 0.15.0
+
 ## [0.7.1] - 2025-05-03
 
 ### Changed
@@ -455,6 +462,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env` crate
 
+[0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.6.0

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true }

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - Unreleased
+## [0.6.0] - Unreleased
 
 ### Changed
 
 - External dependency versions:
-    - yash-syntax 0.14.0 → 0.14.1
+    - yash-env 0.7.0 → 0.8.0
+    - yash-semantics 0.7.0 → 0.8.0
+    - yash-syntax 0.14.0 → 0.15.0
 
 ## [0.5.0] - 2025-04-26
 
@@ -71,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-prompt` crate
 
-[0.5.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.1
+[0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.0
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.4.0
 [0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.3.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 futures-util = { workspace = true }

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-env 0.7.1 → 0.8.0
+    - yash-syntax 0.14.1 → 0.15.0
+
 ## [0.7.1] - 2025-05-03
 
 ### Changed
@@ -229,6 +237,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.6.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- When a tilde expansion produces a directory name that ends with a slash and
+  the expansion is followed by a slash, the trailing slash in the directory name
+  is now removed to maintain the correct number of slashes.
+    - This is done by removing the trailing slash from the directory name in
+      `impl expansion::initial::Expand for WordUnit`. This is done only if the
+      `followed_by_slash` flag is set to `true` in the tilde expansion
+      (`WordUnit::Tilde`).
 - External dependency versions:
     - yash-env 0.7.1 → 0.8.0
     - yash-syntax 0.14.1 → 0.15.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -148,7 +148,7 @@ impl Expand for WordUnit {
             Tilde {
                 name,
                 followed_by_slash,
-            } => Ok(super::tilde::expand(name, env.inner).into()),
+            } => Ok(super::tilde::expand(name, *followed_by_slash, env.inner).into()),
         }
     }
 }

--- a/yash-semantics/src/expansion/initial/word.rs
+++ b/yash-semantics/src/expansion/initial/word.rs
@@ -145,7 +145,10 @@ impl Expand for WordUnit {
                 Ok(phrase)
             }
             DollarSingleQuote(string) => Ok(dollar_single_quote(&string.unquote().0)),
-            Tilde(name) => Ok(super::tilde::expand(name, env.inner).into()),
+            Tilde {
+                name,
+                followed_by_slash,
+            } => Ok(super::tilde::expand(name, env.inner).into()),
         }
     }
 }

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - Unreleased
+
+### Changed
+
+- The associated value of the `syntax::WordUnit::Tilde` enum variant has been
+  changed to have two named fields: `name: String` and `followed_by_slash: bool`.
+  This is needed to support correct adjustment of the number of slashes in the
+  tilde expansion that is followed by a slash.
+
 ## [0.14.1] - 2025-05-03
 
 ### Added
@@ -449,6 +458,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.0
 [0.14.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.1
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.13.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities", "parser-implementations"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true, optional = true }

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -400,7 +400,13 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.word.units, [WordUnit::Tilde("".to_string())]);
+            assert_eq!(
+                switch.word.units,
+                [WordUnit::Tilde {
+                    name: "".to_string(),
+                    followed_by_slash: false
+                }]
+            );
         });
     }
 
@@ -540,7 +546,13 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Trim(trim) => {
-            assert_eq!(trim.pattern.units, [WordUnit::Tilde("".to_string())]);
+            assert_eq!(
+                trim.pattern.units,
+                [WordUnit::Tilde {
+                    name: "".to_string(),
+                    followed_by_slash: false
+                }]
+            );
         });
     }
 

--- a/yash-syntax/src/parser/lex/tilde.rs
+++ b/yash-syntax/src/parser/lex/tilde.rs
@@ -78,7 +78,7 @@ impl Word {
     /// # use yash_syntax::syntax::{Word, WordUnit::Tilde};
     /// let mut word = Word::from_str("~").unwrap();
     /// word.parse_tilde_front();
-    /// assert_eq!(word.units, [Tilde("".to_string())]);
+    /// assert_eq!(word.units, [Tilde { name: "".to_string(), followed_by_slash: false }]);
     /// ```
     ///
     /// ```
@@ -86,7 +86,7 @@ impl Word {
     /// # use yash_syntax::syntax::{Word, WordUnit::Tilde};
     /// let mut word = Word::from_str("~foo").unwrap();
     /// word.parse_tilde_front();
-    /// assert_eq!(word.units, [Tilde("foo".to_string())]);
+    /// assert_eq!(word.units, [Tilde { name: "foo".to_string(), followed_by_slash: false }]);
     /// ```
     ///
     /// If there is no leading tilde, `self.units` will have the same content
@@ -116,7 +116,13 @@ impl Word {
     #[inline]
     pub fn parse_tilde_front(&mut self) {
         if let Some((len, name)) = parse_tilde(&self.units, false) {
-            self.units.splice(..len, std::iter::once(Tilde(name)));
+            self.units.splice(
+                ..len,
+                std::iter::once(Tilde {
+                    name,
+                    followed_by_slash: false,
+                }),
+            );
         }
     }
 
@@ -135,13 +141,13 @@ impl Word {
     /// assert_eq!(
     ///     word.units,
     ///     [
-    ///         Tilde("".to_string()),
+    ///         Tilde { name: "".to_string(), followed_by_slash: false },
     ///         Unquoted(Literal(':')),
-    ///         Tilde("a".to_string()),
+    ///         Tilde { name: "a".to_string(), followed_by_slash: false },
     ///         Unquoted(Literal('/')),
     ///         Unquoted(Literal('b')),
     ///         Unquoted(Literal(':')),
-    ///         Tilde("c".to_string()),
+    ///         Tilde { name: "c".to_string(), followed_by_slash: false },
     ///     ]
     /// );
     /// ```
@@ -175,11 +181,11 @@ impl Word {
     ///         Unquoted(Literal('=')),
     ///         // This tilde is parsed because it is at index 2,
     ///         // even though it is not after a colon.
-    ///         Tilde("a".to_string()),
+    ///         Tilde { name: "a".to_string(), followed_by_slash: false },
     ///         Unquoted(Literal('/')),
     ///         Unquoted(Literal('b')),
     ///         Unquoted(Literal(':')),
-    ///         Tilde("c".to_string()),
+    ///         Tilde { name: "c".to_string(), followed_by_slash: false },
     ///     ]
     /// );
     /// ```
@@ -191,7 +197,13 @@ impl Word {
         loop {
             // Parse a tilde expansion at index `i`.
             if let Some((len, name)) = parse_tilde(&self.units[i..], true) {
-                self.units.splice(i..i + len, std::iter::once(Tilde(name)));
+                self.units.splice(
+                    i..i + len,
+                    std::iter::once(Tilde {
+                        name,
+                        followed_by_slash: false,
+                    }),
+                );
                 i += 1;
             }
 
@@ -247,7 +259,13 @@ mod tests {
         let input = Word::from_str("~").unwrap();
         let result = parse_tilde_front(&input);
         assert_eq!(result.location, input.location);
-        assert_eq!(result.units, [Tilde("".to_string())]);
+        assert_eq!(
+            result.units,
+            [Tilde {
+                name: "".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]
@@ -255,7 +273,13 @@ mod tests {
         let input = Word::from_str("~foo").unwrap();
         let result = parse_tilde_front(&input);
         assert_eq!(result.location, input.location);
-        assert_eq!(result.units, [Tilde("foo".to_string())]);
+        assert_eq!(
+            result.units,
+            [Tilde {
+                name: "foo".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]
@@ -266,7 +290,10 @@ mod tests {
         assert_eq!(
             result.units,
             [
-                Tilde("bar".to_string()),
+                Tilde {
+                    name: "bar".to_string(),
+                    followed_by_slash: false, // FIXME: this should be true
+                },
                 Unquoted(Literal('/')),
                 SingleQuote("".to_string()),
             ]
@@ -278,7 +305,13 @@ mod tests {
         let input = Word::from_str("~bar:baz").unwrap();
         let result = parse_tilde_front(&input);
         assert_eq!(result.location, input.location);
-        assert_eq!(result.units, [Tilde("bar:baz".to_string())]);
+        assert_eq!(
+            result.units,
+            [Tilde {
+                name: "bar:baz".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]
@@ -364,7 +397,10 @@ mod tests {
         assert_eq!(
             result.units,
             [
-                Tilde("a".to_string()),
+                Tilde {
+                    name: "a".to_string(),
+                    followed_by_slash: false // FIXME: this should be true
+                },
                 Unquoted(Literal('/')),
                 Unquoted(Literal('b')),
                 Unquoted(Literal(':')),
@@ -396,7 +432,13 @@ mod tests {
         let input = Word::from_str("~").unwrap();
         let result = parse_tilde_everywhere(&input);
         assert_eq!(result.location, input.location);
-        assert_eq!(result.units, [Tilde("".to_string())]);
+        assert_eq!(
+            result.units,
+            [Tilde {
+                name: "".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]
@@ -404,7 +446,13 @@ mod tests {
         let input = Word::from_str("~foo").unwrap();
         let result = parse_tilde_everywhere(&input);
         assert_eq!(result.location, input.location);
-        assert_eq!(result.units, [Tilde("foo".to_string())]);
+        assert_eq!(
+            result.units,
+            [Tilde {
+                name: "foo".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]
@@ -415,7 +463,10 @@ mod tests {
         assert_eq!(
             result.units,
             [
-                Tilde("bar".to_string()),
+                Tilde {
+                    name: "bar".to_string(),
+                    followed_by_slash: false
+                },
                 Unquoted(Literal('/')),
                 SingleQuote("".to_string()),
             ]
@@ -430,7 +481,10 @@ mod tests {
         assert_eq!(
             result.units,
             [
-                Tilde("bar".to_string()),
+                Tilde {
+                    name: "bar".to_string(),
+                    followed_by_slash: false
+                },
                 Unquoted(Literal(':')),
                 DoubleQuote(Text(vec![])),
             ]
@@ -490,7 +544,13 @@ mod tests {
         assert_eq!(result.location, input.location);
         assert_eq!(
             result.units,
-            [Unquoted(Literal(':')), Tilde("".to_string())]
+            [
+                Unquoted(Literal(':')),
+                Tilde {
+                    name: "".to_string(),
+                    followed_by_slash: false
+                }
+            ]
         );
 
         let input = Word::from_str(":~foo/a:~bar").unwrap();
@@ -500,11 +560,17 @@ mod tests {
             result.units,
             [
                 Unquoted(Literal(':')),
-                Tilde("foo".to_string()),
+                Tilde {
+                    name: "foo".to_string(),
+                    followed_by_slash: false // FIXME: this should be true
+                },
                 Unquoted(Literal('/')),
                 Unquoted(Literal('a')),
                 Unquoted(Literal(':')),
-                Tilde("bar".to_string()),
+                Tilde {
+                    name: "bar".to_string(),
+                    followed_by_slash: false
+                },
             ]
         );
 
@@ -514,16 +580,25 @@ mod tests {
         assert_eq!(
             result.units,
             [
-                Tilde("a".to_string()),
+                Tilde {
+                    name: "a".to_string(),
+                    followed_by_slash: false, // FIXME: this should be true
+                },
                 Unquoted(Literal('/')),
                 Unquoted(Literal('b')),
                 Unquoted(Literal(':')),
-                Tilde("c".to_string()),
+                Tilde {
+                    name: "c".to_string(),
+                    followed_by_slash: false, // FIXME: this should be true
+                },
                 Unquoted(Literal('/')),
                 Unquoted(Literal('d')),
                 Unquoted(Literal(':')),
                 Unquoted(Literal(':')),
-                Tilde("".to_string()),
+                Tilde {
+                    name: "".to_string(),
+                    followed_by_slash: false
+                },
             ]
         );
     }

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -131,7 +131,13 @@ mod tests {
         let mut lexer = Lexer::with_code("~a:~");
 
         let t = lexer.token().now_or_never().unwrap().unwrap();
-        assert_eq!(t.word.units, [WordUnit::Tilde("a:~".to_string())]);
+        assert_eq!(
+            t.word.units,
+            [WordUnit::Tilde {
+                name: "a:~".to_string(),
+                followed_by_slash: false
+            }]
+        );
     }
 
     #[test]

--- a/yash-syntax/src/parser/lex/word.rs
+++ b/yash-syntax/src/parser/lex/word.rs
@@ -649,7 +649,13 @@ mod tests {
             .unwrap();
         assert_matches!(result.units[..], [Unquoted(BracedParam(ref param))] => {
             assert_matches!(param.modifier, Modifier::Switch(ref switch) => {
-                assert_eq!(switch.word.units, [Tilde("".to_string())]);
+                assert_eq!(
+                    switch.word.units,
+                    [Tilde {
+                        name: "".to_string(),
+                        followed_by_slash: false,
+                    }]
+                );
             });
         });
     }

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -250,9 +250,15 @@ mod tests {
             [
                 WordUnit::Unquoted(TextUnit::Literal('~')),
                 WordUnit::Unquoted(TextUnit::Literal('=')),
-                WordUnit::Tilde("".to_string()),
+                WordUnit::Tilde {
+                    name: "".to_string(),
+                    followed_by_slash: false
+                },
                 WordUnit::Unquoted(TextUnit::Literal(':')),
-                WordUnit::Tilde("b".to_string()),
+                WordUnit::Tilde {
+                    name: "b".to_string(),
+                    followed_by_slash: false
+                },
             ]
         );
         assert_eq!(mode, ExpansionMode::Single);

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -412,9 +412,19 @@ pub enum WordUnit {
     /// String surrounded with a pair of single quotations and preceded by a dollar sign
     DollarSingleQuote(EscapedString),
     /// Tilde expansion
-    ///
-    /// The `String` value does not contain the initial tilde.
-    Tilde(String),
+    Tilde {
+        /// User name part of the tilde expansion
+        ///
+        /// This is the string that follows the tilde in the source code, up to
+        /// (but not including) the following delimiter. The name may be empty.
+        name: String,
+        /// Whether the tilde expansion is followed by a slash
+        ///
+        /// This value is `true` if and only if this word unit is followed by
+        /// `WordUnit::Unquoted(TextUnit::Literal('/'))`. It affects the
+        /// expansion to directory names that end with a slash.
+        followed_by_slash: bool,
+    },
 }
 
 pub use WordUnit::*;

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -457,8 +457,8 @@ impl Unquote for WordUnit {
             }
             DoubleQuote(inner) => inner.write_unquoted(w),
             DollarSingleQuote(inner) => inner.write_unquoted(w),
-            Tilde(s) => {
-                write!(w, "~{s}")?;
+            Tilde { name, .. } => {
+                write!(w, "~{name}")?;
                 Ok(false)
             }
         }
@@ -927,7 +927,10 @@ mod tests {
         assert_eq!(word.to_string_if_literal(), None);
 
         let word = Word {
-            units: vec![Tilde("foo".to_string())],
+            units: vec![Tilde {
+                name: "foo".to_string(),
+                followed_by_slash: false,
+            }],
             ..word
         };
         assert_eq!(word.to_string_if_literal(), None);
@@ -976,9 +979,15 @@ mod tests {
             assert_eq!(
                 value.units,
                 [
-                    WordUnit::Tilde("".to_string()),
+                    WordUnit::Tilde{
+                        name: "".to_string(),
+                        followed_by_slash: false,
+                    },
                     WordUnit::Unquoted(TextUnit::Literal(':')),
-                    WordUnit::Tilde("b".to_string()),
+                    WordUnit::Tilde {
+                        name: "b".to_string(),
+                        followed_by_slash: false,
+                    },
                 ]
             );
         });

--- a/yash-syntax/src/syntax/impl_display.rs
+++ b/yash-syntax/src/syntax/impl_display.rs
@@ -165,7 +165,7 @@ impl fmt::Display for WordUnit {
             SingleQuote(s) => write!(f, "'{s}'"),
             DoubleQuote(content) => write!(f, "\"{content}\""),
             DollarSingleQuote(content) => write!(f, "$'{content}'"),
-            Tilde(s) => write!(f, "~{s}"),
+            Tilde { name, .. } => write!(f, "~{name}"),
         }
     }
 }
@@ -621,9 +621,15 @@ mod tests {
         ]));
         assert_eq!(dollar_single_quote.to_string(), r"$'A\\'");
 
-        let tilde = Tilde("".to_string());
+        let tilde = Tilde {
+            name: "".to_string(),
+            followed_by_slash: false,
+        };
         assert_eq!(tilde.to_string(), "~");
-        let tilde = Tilde("foo".to_string());
+        let tilde = Tilde {
+            name: "foo".to_string(),
+            followed_by_slash: true,
+        };
         assert_eq!(tilde.to_string(), "~foo");
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tilde expansion to correctly handle cases where a tilde expansion is immediately followed by a slash, ensuring correct path formatting.

- **Bug Fixes**
  - Fixed an issue where tilde expansion could result in an incorrect number of slashes when the expanded directory name ends with a slash and is followed by another slash.

- **Documentation**
  - Updated changelogs to reflect new versions and changes in tilde expansion behavior.

- **Tests**
  - Added and updated test cases to cover edge cases in tilde expansion, especially for HOME values with trailing slashes and root-like paths.

- **Chores**
  - Updated package versions and internal dependency versions.
  - Marked several packages as not intended for publishing to a public registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->