### PR TITLE
Reject `{n}` redirection prefix

### DIFF
--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.2] - Unreleased
 
+### Changed
+
+- The shell now recognizes the I/O location notation attached to a redirection
+  operator as in `{n}<file`. Currently, the shell does not support this
+  notation, but it is reserved for future use.
+
 ### Fixed
 
 - When a tilde expansion produces a directory name that ends with a slash and

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `parser::lex::Lexer::token` method now returns a `Token` with the
+  `TokenId::IoLocation` variant if the token is of the form `{...}` and
+  immediately precedes a redirection operator.
 - The associated value of the `syntax::WordUnit::Tilde` enum variant has been
   changed to have two named fields: `name: String` and `followed_by_slash: bool`.
   This is needed to support correct adjustment of the number of slashes in the

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0] - Unreleased
 
+### Added
+
+- The `parser::lex::TokenId` enum now has the `IoLocation` variant.
+
 ### Changed
 
 - The associated value of the `syntax::WordUnit::Tilde` enum variant has been

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -11,15 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `parser::lex::TokenId` enum now has the `IoLocation` variant.
 - The `parser::SyntaxError` enum now has the `InvalidIoLocation` variant.
-    - Currently, the parser does not support parsing of I/O location tokens
-      (e.g., `{n}>/dev/null`). This error is returned whenever the parser
-      finds an I/O location token attached to a redirection operator.
 
 ### Changed
 
 - The `parser::lex::Lexer::token` method now returns a `Token` with the
   `TokenId::IoLocation` variant if the token is of the form `{...}` and
   immediately precedes a redirection operator.
+- The `parser::Parser::redirection` method now fails with a
+  `SyntaxError::InvalidIoLocation` if it encounters an I/O location token
+  (e.g., `{n}>/dev/null`) preceding a redirection operator.
+    - Currently, the parser does not support parsing of I/O location tokens.
+      This error is returned whenever the parser finds an I/O location token
+      attached to a redirection operator.
 - The associated value of the `syntax::WordUnit::Tilde` enum variant has been
   changed to have two named fields: `name: String` and `followed_by_slash: bool`.
   This is needed to support correct adjustment of the number of slashes in the

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `parser::lex::TokenId` enum now has the `IoLocation` variant.
+- The `parser::SyntaxError` enum now has the `InvalidIoLocation` variant.
+    - Currently, the parser does not support parsing of I/O location tokens
+      (e.g., `{n}>/dev/null`). This error is returned whenever the parser
+      finds an I/O location token attached to a redirection operator.
 
 ### Changed
 

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -64,6 +64,8 @@ pub enum SyntaxError {
     MissingSeparator,
     /// The file descriptor specified for a redirection cannot be used.
     FdOutOfRange,
+    /// An I/O location prefix attached to a redirection has an unsupported format.
+    InvalidIoLocation,
     /// A redirection operator is missing its operand.
     MissingRedirOperand,
     /// A here-document operator is missing its delimiter token.
@@ -208,6 +210,7 @@ impl SyntaxError {
             InvalidCommandToken => "the command starts with an inappropriate token",
             MissingSeparator => "a separator is missing between the commands",
             FdOutOfRange => "the file descriptor is too large",
+            InvalidIoLocation => "the I/O location prefix is not valid",
             MissingRedirOperand => "the redirection operator is missing its operand",
             MissingHereDocDelimiter => "the here-document operator is missing its delimiter",
             MissingHereDocContent => "content of the here-document is missing",
@@ -310,6 +313,7 @@ impl SyntaxError {
             InvalidCommandToken => "does not begin a valid command",
             MissingSeparator => "expected `;` or `&` before this token",
             FdOutOfRange => "unsupported file descriptor",
+            InvalidIoLocation => "unsupported I/O location prefix",
             MissingRedirOperand => "expected a redirection operand",
             MissingHereDocDelimiter => "expected a delimiter word",
             MissingHereDocContent => "content not found",

--- a/yash-syntax/src/parser/for_loop.rs
+++ b/yash-syntax/src/parser/for_loop.rs
@@ -23,7 +23,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Keyword::{Do, For, In};
 use super::lex::Operator::{Newline, Semicolon};
-use super::lex::TokenId::{EndOfInput, IoNumber, Operator, Token};
+use super::lex::TokenId::{EndOfInput, IoLocation, IoNumber, Operator, Token};
 use crate::source::Location;
 use crate::syntax::CompoundCommand;
 use crate::syntax::List;
@@ -46,7 +46,7 @@ impl Parser<'_, '_> {
                 let location = name.word.location;
                 return Err(Error { cause, location });
             }
-            Token(_) | IoNumber => (),
+            Token(_) | IoNumber | IoLocation => (),
         }
 
         // TODO reject non-portable names in POSIXly-correct mode
@@ -100,7 +100,7 @@ impl Parser<'_, '_> {
         loop {
             let next = self.take_token_auto(&[]).await?;
             match next.id {
-                Token(_) | IoNumber => {
+                Token(_) | IoNumber | IoLocation => {
                     values.push(next.word);
                 }
                 Operator(Semicolon) | Operator(Newline) | EndOfInput => {

--- a/yash-syntax/src/parser/lex/core.rs
+++ b/yash-syntax/src/parser/lex/core.rs
@@ -84,6 +84,8 @@ pub enum TokenId {
     Operator(Operator),
     /// `IO_NUMBER`
     IoNumber,
+    /// `IO_LOCATION`
+    IoLocation,
     /// Imaginary token identifier for the end of input
     EndOfInput,
 }
@@ -102,6 +104,7 @@ impl TokenId {
             Token(None) => false,
             Operator(operator) => operator.is_clause_delimiter(),
             IoNumber => false,
+            IoLocation => false,
             EndOfInput => true,
         }
     }

--- a/yash-syntax/src/parser/lex/token.rs
+++ b/yash-syntax/src/parser/lex/token.rs
@@ -179,6 +179,24 @@ mod tests {
     }
 
     #[test]
+    fn lexer_token_digit_not_followed_by_less_or_greater() {
+        let mut lexer = Lexer::with_code("12;");
+
+        let t = lexer.token().now_or_never().unwrap().unwrap();
+        assert_eq!(t.word.units.len(), 2);
+        assert_eq!(t.word.units[0], WordUnit::Unquoted(TextUnit::Literal('1')));
+        assert_eq!(t.word.units[1], WordUnit::Unquoted(TextUnit::Literal('2')));
+        assert_eq!(*t.word.location.code.value.borrow(), "12;");
+        assert_eq!(t.word.location.code.start_line_number.get(), 1);
+        assert_eq!(*t.word.location.code.source, Source::Unknown);
+        assert_eq!(t.word.location.range, 0..2);
+        assert_eq!(t.id, TokenId::Token(None));
+        assert_eq!(t.index, 0);
+
+        assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(Some(';')));
+    }
+
+    #[test]
     fn lexer_token_after_blank() {
         let mut lexer = Lexer::with_code(" a  ");
 

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -22,7 +22,7 @@ use super::core::Result;
 use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Operator::{And, Newline, Semicolon};
-use super::lex::TokenId::{self, EndOfInput, IoNumber, Operator, Token};
+use super::lex::TokenId::{self, EndOfInput, IoLocation, IoNumber, Operator, Token};
 use crate::syntax::Item;
 use crate::syntax::List;
 use std::pin::Pin;
@@ -34,7 +34,7 @@ fn error_type_for_trailing_token_in_command_line(token_id: TokenId) -> Option<Sy
     use SyntaxError::*;
     match token_id {
         EndOfInput => None,
-        Token(None) | IoNumber => Some(MissingSeparator),
+        Token(None) | IoNumber | IoLocation => Some(MissingSeparator),
         Token(Some(keyword)) => match keyword {
             Bang | OpenBracketBracket | Case | For | Function | If | Until | While | OpenBrace => {
                 Some(MissingSeparator)

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -21,7 +21,7 @@ use super::core::Result;
 use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Operator::{LessLess, LessLessDash};
-use super::lex::TokenId::{EndOfInput, IoNumber, Operator, Token};
+use super::lex::TokenId::{EndOfInput, IoLocation, IoNumber, Operator, Token};
 use crate::source::Location;
 use crate::syntax::Fd;
 use crate::syntax::HereDoc;
@@ -39,7 +39,7 @@ impl Parser<'_, '_> {
         match operand.id {
             Token(_) => (),
             Operator(_) | EndOfInput => return Ok(Err(operand.word.location)),
-            IoNumber => (), // TODO reject if POSIXly-correct
+            IoNumber | IoLocation => (), // TODO reject if POSIXly-correct
         }
         Ok(Ok(operand.word))
     }

--- a/yash-syntax/src/parser/redir.rs
+++ b/yash-syntax/src/parser/redir.rs
@@ -103,18 +103,27 @@ impl Parser<'_, '_> {
     /// [`MissingRedirOperand`](SyntaxError::MissingRedirOperand) or
     /// [`MissingHereDocDelimiter`](SyntaxError::MissingHereDocDelimiter).
     pub async fn redirection(&mut self) -> Result<Option<Redir>> {
-        let fd = if self.peek_token().await?.id == IoNumber {
-            let token = self.take_token_raw().await?;
-            if let Ok(fd) = token.word.to_string().parse() {
-                Some(Fd(fd))
-            } else {
+        let fd = match self.peek_token().await?.id {
+            IoNumber => {
+                let token = self.take_token_raw().await?;
+                if let Ok(fd) = token.word.to_string().parse() {
+                    Some(Fd(fd))
+                } else {
+                    return Err(Error {
+                        cause: SyntaxError::FdOutOfRange.into(),
+                        location: token.word.location,
+                    });
+                }
+            }
+            IoLocation => {
+                let token = self.take_token_raw().await?;
+                // TODO parse the I/O location
                 return Err(Error {
-                    cause: SyntaxError::FdOutOfRange.into(),
+                    cause: SyntaxError::InvalidIoLocation.into(),
                     location: token.word.location,
                 });
             }
-        } else {
-            None
+            _ => None,
         };
 
         Ok(self
@@ -345,6 +354,19 @@ mod tests {
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(*e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 0..40);
+    }
+
+    #[test]
+    fn parser_redirection_io_location() {
+        let mut lexer = Lexer::with_code("{n}< /dev/null\n");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.redirection().now_or_never().unwrap().unwrap_err();
+        assert_eq!(e.cause, ErrorCause::Syntax(SyntaxError::InvalidIoLocation));
+        assert_eq!(*e.location.code.value.borrow(), "{n}< /dev/null\n");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 0..3);
     }
 
     #[test]


### PR DESCRIPTION
This pull request implements recognition of I/O location tokens that are always rejected as a syntax error. The shell may validly accept the I/O location syntax and semantics in the future.

----

This pull request introduces a new `IoLocation` variant to the `TokenId` enum in the `yash-syntax` project, along with updates to integrate this new variant into the parser logic. These changes enhance the parser's ability to handle tokens related to IO locations. Below are the most significant updates:

### Addition of `IoLocation` Variant

* Added the `IoLocation` variant to the `TokenId` enum in `yash-syntax/src/parser/lex/core.rs`, including its documentation and integration into the `is_clause_delimiter` method. (`[[1]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438R87-R88)`, `[[2]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438R107)`)

### Parser Updates to Support `IoLocation`

* Updated token matching logic in `yash-syntax/src/parser/for_loop.rs` to handle the `IoLocation` variant in multiple places, ensuring proper parsing of IO location tokens. (`[[1]](diffhunk://#diff-d4162d7a704d579f5989639b2ce15a7e80c0d8de9dcc1723f083521607f89ad6L49-R49)`, `[[2]](diffhunk://#diff-d4162d7a704d579f5989639b2ce15a7e80c0d8de9dcc1723f083521607f89ad6L103-R103)`)
* Modified the `error_type_for_trailing_token_in_command_line` function in `yash-syntax/src/parser/list.rs` to include `IoLocation` in its matching logic. (`[yash-syntax/src/parser/list.rsL37-R37](diffhunk://#diff-a3822587c89f802c2883b7d823bd532e3c319ea378a9877674c1c88933eb8639L37-R37)`)
* Adjusted the operand validation logic in `yash-syntax/src/parser/redir.rs` to account for `IoLocation` tokens. (`[yash-syntax/src/parser/redir.rsL42-R42](diffhunk://#diff-d7f0405ba223b23147cc6d8f0538f1b5a97b89ea32b527d4429f6dbdca49b9f4L42-R42)`)

### Import Adjustments

* Updated import statements across several parser modules (`for_loop.rs`, `list.rs`, `redir.rs`) to include the new `IoLocation` variant. (`[[1]](diffhunk://#diff-d4162d7a704d579f5989639b2ce15a7e80c0d8de9dcc1723f083521607f89ad6L26-R26)`, `[[2]](diffhunk://#diff-a3822587c89f802c2883b7d823bd532e3c319ea378a9877674c1c88933eb8639L25-R25)`, `[[3]](diffhunk://#diff-d7f0405ba223b23147cc6d8f0538f1b5a97b89ea32b527d4429f6dbdca49b9f4L24-R24)`)

### Documentation Update

* Documented the addition of the `IoLocation` variant in the `CHANGELOG.md` file under the "Added" section for the upcoming release. (`[yash-syntax/CHANGELOG.mdR10-R13](diffhunk://#diff-9547ca81d74be48a91abfe15a1199d19e60a7b4005cc569e83b6ce1607618ad8R10-R13)`)]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing I/O location tokens (e.g., `{...}` before redirection operators) in the parser.
  - Improved error messages for unsupported I/O location prefixes, providing clearer feedback.

- **Bug Fixes**
  - Enhanced error handling for incomplete for loops, now indicating when a loop body is missing.

- **Tests**
  - Added new tests to verify detection and error reporting for I/O location tokens in redirections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->