### PR TITLE
Treatment of variables that should not be made readonly

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - Unreleased
 
+### Added
+
+- The new constant `cd::EXIT_STATUS_ASSIGN_ERROR` represents the exit
+  status returned by the `cd` built-in when the `$PWD` or `$OLDPWD` variable is
+  read-only.
+
 ### Changed
 
 - External dependency versions:
@@ -14,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - yash-prompt (optional) 0.5.0 → 0.6.0
     - yash-semantics (optional) 0.8.0 → 0.9.0
     - yash-syntax 0.14.1 → 0.15.0
+
+### Fixed
+
+- The `cd` built-in now returns exit status 1 when the `$PWD` or `$OLDPWD`
+  variable cannot be updated because it is read-only. The new constant
+  `cd::EXIT_STATUS_ASSIGN_ERROR` represents this exit status. The `cd::main`
+  function now returns a result that includes this exit status.
+  This fix reflects the requirements in POSIX.1-2024 XBD 8.1.
 
 ## [0.8.0] - 2025-05-03
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When a tilde expansion produces a directory name that ends with a slash and
   the expansion is followed by a slash, the trailing slash in the directory name
   is now removed to maintain the correct number of slashes.
+- The `cd` built-in now returns exit status 1 if updating `$PWD` or `$OLDPWD`
+  fails because the variable is read-only. Previously, it returned status 0,
+  which did not conform to POSIX.1-2024 XBD 8.1.
 
 ## [0.4.1] - 2025-05-03
 

--- a/yash-cli/tests/scripted_test/cd-p.sh
+++ b/yash-cli/tests/scripted_test/cd-p.sh
@@ -427,3 +427,53 @@ __IN__
 test_O -d -e n 'empty operand (-P)'
 cd -P ''
 __IN__
+
+test_O -d -e n 'readonly PWD (-L)'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The cd built-in fails.
+# - The cd built-in succeeds as if the readonly built-in had not been executed.
+readonly PWD && cd -L / &&
+if [ "$PWD" = / ]; then
+    printf 'PWD successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__
+
+test_O -d -e n 'readonly PWD (-P)'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The cd built-in fails.
+# - The cd built-in succeeds as if the readonly built-in had not been executed.
+readonly PWD && cd -P / &&
+if [ "$PWD" = / ]; then
+    printf 'PWD successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__
+
+test_x -d -e n 'readonly OLDPWD (-L)'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The cd built-in fails.
+# - The cd built-in succeeds as if the readonly built-in had not been executed.
+cd /
+readonly OLDPWD && cd -L - &&
+if [ "$OLDPWD" = / ]; then
+    printf 'OLDPWD successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__
+
+test_x -d -e n 'readonly OLDPWD (-P)'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The cd built-in fails.
+# - The cd built-in succeeds as if the readonly built-in had not been executed.
+cd /
+readonly OLDPWD && cd -P - &&
+if [ "$OLDPWD" = / ]; then
+    printf 'OLDPWD successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__

--- a/yash-cli/tests/scripted_test/cd-y.sh
+++ b/yash-cli/tests/scripted_test/cd-y.sh
@@ -44,7 +44,6 @@ unset OLDPWD
 cd -
 __IN__
 
-# It is POSIXly unclear what the exit status of cd should be in this case.
 testcase "$LINENO" -d 'read-only PWD' 3<<'__IN__' 4<<__OUT__
 unset CDPATH
 readonly PWD
@@ -53,12 +52,11 @@ echo --- $?
 printf 'PWD=%s\n' "$PWD"
 pwd
 __IN__
---- 0
+--- 1
 PWD=$ORIGPWD
 $ORIGPWD/dir
 __OUT__
 
-# It is POSIXly unclear what the exit status of cd should be in this case.
 test_o -d 'unset OLDPWD'
 unset CDPATH
 readonly OLDPWD=/
@@ -66,7 +64,7 @@ cd dir
 echo --- $?
 printf 'OLDPWD=%s\n' "$OLDPWD"
 __IN__
---- 0
+--- 1
 OLDPWD=/
 __OUT__
 

--- a/yash-cli/tests/scripted_test/getopts-p.sh
+++ b/yash-cli/tests/scripted_test/getopts-p.sh
@@ -271,3 +271,27 @@ __IN__
 3[1]
 4[0]
 __OUT__
+
+test_O -d -e n 'readonly OPTIND'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The getopts built-in fails.
+# - The getopts built-in succeeds ignoring the readonlyness of the variable.
+readonly OPTIND && getopts a opt -- x &&
+if [ "$OPTIND" = 2 ]; then
+    printf 'OPTIND successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__
+
+test_O -d -e n 'readonly OPTARG'
+# As specified in POSIX XBD 8.1, one of the following should happen:
+# - The readonly built-in fails.
+# - The getopts built-in fails.
+# - The getopts built-in succeeds ignoring the readonlyness of the variable.
+readonly OPTARG && getopts a: opt -a foo &&
+if [ "$OPTARG" = foo ]; then
+    printf 'OPTARG successfully changed\n' >&2
+    false # The expected exit status of this test is non-zero.
+fi
+__IN__


### PR DESCRIPTION
See also https://github.com/magicant/yash/pull/169

## Summary by Copilot

This pull request introduces changes to the `cd` built-in command to handle cases where the `$PWD` or `$OLDPWD` variables are read-only, ensuring compliance with POSIX.1-2024 XBD 8.1. It also updates related constants, functions, and tests to reflect this behavior. Below is a summary of the most important changes:

### Enhancements to `cd` Built-in Behavior:
* Added a new constant, `cd::EXIT_STATUS_ASSIGN_ERROR`, to represent the exit status when `$PWD` or `$OLDPWD` cannot be updated due to being read-only (`yash-builtin/src/cd.rs`).
* Updated the `cd::main` function to return a result that includes the new exit status when encountering read-only variables (`yash-builtin/src/cd.rs`). [[1]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L306-R307) [[2]](diffhunk://#diff-fd5581c11e523940cb14b382e25873f1b8d97ae849d891047667978ec76d57d6L316-R320)

### Documentation Updates:
* Updated the documentation in `cd.rs` to clarify the behavior of the `cd` built-in when `$PWD` or `$OLDPWD` is read-only, including the corresponding exit statuses (`yash-builtin/src/cd.rs`).

### Test Coverage:
* Added new test cases to validate the behavior of the `cd` built-in when `$PWD` or `$OLDPWD` is read-only, ensuring it returns the correct exit status (`yash-cli/tests/scripted_test/cd-p.sh`, `yash-cli/tests/scripted_test/cd-y.sh`). [[1]](diffhunk://#diff-dcb7edf559bd7bce2643bb64be0615cb8371659d1e5d7b79825895974a78e0b5R430-R479) [[2]](diffhunk://#diff-9ab2b520dcfea7ff8a6aae90906628ccbf5cb4dfc76638eb22136b4876cf94a8L47) [[3]](diffhunk://#diff-9ab2b520dcfea7ff8a6aae90906628ccbf5cb4dfc76638eb22136b4876cf94a8L56-R67)

### Refactoring in Variable Assignment:
* Modified `set_oldpwd` and `set_pwd` functions to return results and propagate errors when attempting to assign values to read-only variables (`yash-builtin/src/cd/assign.rs`). [[1]](diffhunk://#diff-907f18166dcaf9a1f23ef61270b16108d67a11912fd22542381c482a91f0b1e6L42-R42) [[2]](diffhunk://#diff-907f18166dcaf9a1f23ef61270b16108d67a11912fd22542381c482a91f0b1e6L54-R59) [[3]](diffhunk://#diff-907f18166dcaf9a1f23ef61270b16108d67a11912fd22542381c482a91f0b1e6R68-R74)
* Updated error handling for read-only variables to return the new exit status and print error messages instead of warnings (`yash-builtin/src/cd/assign.rs`). [[1]](diffhunk://#diff-907f18166dcaf9a1f23ef61270b16108d67a11912fd22542381c482a91f0b1e6R68-R74) [[2]](diffhunk://#diff-907f18166dcaf9a1f23ef61270b16108d67a11912fd22542381c482a91f0b1e6L84-R83)

### Changelog Updates:
* Documented the new behavior and exit status for the `cd` built-in in the `CHANGELOG.md` files for both `yash-builtin` and `yash-cli` projects (`yash-builtin/CHANGELOG.md`, `yash-cli/CHANGELOG.md`). [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R15) [[2]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR24-R31) [[3]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR25-R27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The `cd` command now correctly returns an exit status of 1 when updating `$PWD` or `$OLDPWD` fails due to these variables being read-only, ensuring compliance with POSIX.1-2024 standards.

- **Documentation**
  - Updated documentation to clarify the behavior and exit statuses of the `cd` command in scenarios involving read-only environment variables.

- **Tests**
  - Added and updated test cases to verify correct exit status and behavior of the `cd` and `getopts` commands when environment variables are read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->