### PR TITLE
User manual: command substitution and arithmetic expansion

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,7 +16,7 @@
         - [Tilde expansion](language/words/tilde.md)
         - [Parameter expansion](language/words/parameters.md)
         - [Command substitution](language/words/command_substitution.md)
-        - [Arithmetic expansion]()
+        - [Arithmetic expansion](language/words/arithmetic.md)
         - [Field splitting]()
         - [Pathname expansion]()
         - [Quote removal]()
@@ -85,5 +85,5 @@
     - [Job control]()
 - [Script debugging]() <!-- errexit, noexec, xtrace, etc. -->
 - [Pattern matching]()
-- [Arithmetic evaluation]()
+- [Arithmetic expressions](arithmetic.md)
 - [FAQ and troubleshooting]()

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,7 +15,7 @@
         - [Comments](language/words/comments.md)
         - [Tilde expansion](language/words/tilde.md)
         - [Parameter expansion](language/words/parameters.md)
-        - [Command substitution]()
+        - [Command substitution](language/words/command_substitution.md)
         - [Arithmetic expansion]()
         - [Field splitting]()
         - [Pathname expansion]()
@@ -84,4 +84,6 @@
     - [Command prompt]()
     - [Job control]()
 - [Script debugging]() <!-- errexit, noexec, xtrace, etc. -->
+- [Pattern matching]()
+- [Arithmetic evaluation]()
 - [FAQ and troubleshooting]()

--- a/docs/src/arithmetic.md
+++ b/docs/src/arithmetic.md
@@ -1,0 +1,143 @@
+# Arithmetic expressions
+
+**Arithmetic expressions** in [arithmetic expansion](language/words/arithmetic.md) are similar to C expressions. They can include numbers, variables, operators, and parentheses.
+
+## Numeric constants
+
+Numeric constants can be:
+
+- Decimal, written as-is (e.g., `42`)
+- Octal, starting with `0` (e.g., `042`)
+- Hexadecimal, starting with `0x` or `0X` (e.g., `0x2A`)
+
+```shell
+$ echo $((42))   # decimal
+42
+$ echo $((042))  # octal
+34
+$ echo $((0x2A)) # hexadecimal
+42
+```
+
+All integers are signed 64-bit values, ranging from `-9223372036854775808` to `9223372036854775807`.
+
+C-style integer suffixes (`U`, `L`, `LL`, etc.) are not supported.
+
+Floating-point constants are not supported, but may be added in the future.
+
+## Variables
+
+Variable names consist of [Unicode alphanumerics](https://doc.rust-lang.org/std/primitive.char.html#method.is_alphanumeric) and ASCII underscores, but cannot start with an ASCII digit. Variables must have numeric values.
+
+```shell
+$ a=5 b=10
+$ echo $((a + b))
+15
+```
+
+If a variable is unset and the `nounset` shell option is off, it is treated as zero:
+
+```shell
+$ unset x; set +o nounset
+$ echo $((x + 3))
+3
+```
+
+If the `nounset` option is on, an error occurs when trying to use an unset variable:
+
+```shell
+$ unset x; set -o nounset
+$ echo $((x + 3))
+error: cannot expand unset parameter
+ --> <arithmetic_expansion>:1:1
+  |
+1 | x + 3
+  | ^ parameter `x` is not set
+  |
+ ::: <stdin>:2:6
+  |
+2 | echo $((x + 3))
+  |      ---------- info: arithmetic expansion appeared here
+  |
+  = info: unset parameters are disallowed by the nounset option
+```
+
+If a variable has a non-numeric value, an error occurs.
+
+```shell
+$ x=foo
+$ echo $((x + 3))
+error: error evaluating the arithmetic expansion
+ --> <arithmetic_expansion>:1:1
+  |
+1 | x + 3
+  | ^ invalid variable value: "foo"
+  |
+ ::: <stdin>:2:6
+  |
+2 | echo $((x + 3))
+  |      ---------- info: arithmetic expansion appeared here
+  |
+```
+
+Currently, variables in arithmetic expressions must have a single numeric value. In the future, more complex values may be supported.
+
+## Operators
+
+The following operators are supported, in order of precedence:
+
+1. `(` `)` – grouping
+2. Postfix:
+    - `++` – increment
+    - `--` – decrement
+3. Prefix:
+    - `+` – no-op
+    - `-` – numeric negation
+    - `~` – bitwise negation
+    - `!` – logical negation
+    - `++` – increment
+    - `--` – decrement
+4. Binary (left associative):
+    - `*` – multiplication
+    - `/` – division
+    - `%` – modulus
+5. Binary (left associative):
+    - `+` – addition
+    - `-` – subtraction
+6. Binary (left associative):
+    - `<<` – left shift
+    - `>>` – right shift
+7. Binary (left associative):
+    - `<` – less than
+    - `<=` – less than or equal to
+    - `>` – greater than
+    - `>=` – greater than or equal to
+8. Binary:
+    - `==` – equal to
+    - `!=` – not equal to
+9. Binary:
+    - `&` – bitwise and
+10. Binary:
+    - `|` – bitwise or
+11. Binary:
+    - `^` – bitwise xor
+12. Binary:
+    - `&&` – logical and
+13. Binary:
+    - `||` – logical or
+14. Ternary (right associative):
+    - `?` `:` – conditional expression
+15. Binary (right associative):
+    - `=` – assignment
+    - `+=` – addition assignment
+    - `-=` – subtraction assignment
+    - `*=` – multiplication assignment
+    - `/=` – division assignment
+    - `%=` – modulus assignment
+    - `<<=` – left shift assignment
+    - `>>=` – right shift assignment
+    - `&=` – bitwise and assignment
+    - `|=` – bitwise or assignment
+    - `^=` – bitwise xor assignment
+
+Other operators, such as `sizeof`, are not supported.

--- a/docs/src/language/words/arithmetic.md
+++ b/docs/src/language/words/arithmetic.md
@@ -1,0 +1,70 @@
+# Arithmetic expansion
+
+[arithmetic expression]: ../../arithmetic.md
+
+**Arithmetic expansion** evaluates an [arithmetic expression] and replaces it with the result. The syntax is `$((expression))`.
+
+```shell
+$ echo $((1 + 2))
+3
+$ echo $((2 * 3 + 4))
+10
+$ echo $((2 * (3 + 4)))
+14
+```
+
+Arithmetic expansion works in two steps. First, the expression is processed for [parameter expansion](parameters.md), nested arithmetic expansion, [command substitution](command_substitution.md), and quote removal. Then, the resulting string is parsed as an [arithmetic expression], and the result replaces the expansion.
+
+```shell
+$ x=2
+$ echo $(($x + $((3 * 4)) + $(echo 5)))
+19
+```
+
+## Variables
+
+The value of variables appearing as [parameter expansions](parameters.md) does not have to be numeric, but the resulting [arithmetic expression] must be valid.
+
+```shell
+$ seven=7
+$ var='6 * sev'
+$ echo $((${var}en)) # expands to $((6 * seven))
+42
+```
+
+```shell
+$ seven='3 + 4'
+$ echo $((2 * $seven)) # expands to $((2 * 3 + 4)), mind the precedence
+10
+$ echo $((2 * seven))
+error: error evaluating the arithmetic expansion
+ --> <arithmetic_expansion>:1:5
+  |
+1 | 2 * seven
+  |     ^^^^^ invalid variable value: "3 + 4"
+  |
+ ::: <stdin>:3:6
+  |
+3 | echo $((2 * seven))
+  |      -------------- info: arithmetic expansion appeared here
+  |
+```
+
+## Quoting
+
+[Backslash escaping](quoting.md#backslash) is the only supported quoting mechanism in arithmetic expansion. It can escape `$`, `` ` ``, and `\`. However, escaped characters would never produce a valid [arithmetic expression] after quote removal, so they are not useful in practice.
+
+```shell
+$ echo $((\$x))
+error: error evaluating the arithmetic expansion
+ --> <arithmetic_expansion>:1:1
+  |
+1 | $x
+  | ^ invalid character
+  |
+ ::: <stdin>:1:6
+  |
+1 | echo $((\$x))
+  |      -------- info: arithmetic expansion appeared here
+  |
+```

--- a/docs/src/language/words/command_substitution.md
+++ b/docs/src/language/words/command_substitution.md
@@ -1,0 +1,39 @@
+# Command substitution
+
+**Command substitution** expands to the output of a command. It has two forms: the preferred `$(command)` form and the deprecated backquote form `` `command` ``.
+
+For example, this runs `dirname -- "$0"` and passes its output to `cd`:
+
+```shell
+$ cd -P -- "$(dirname -- "$0")"
+```
+
+This changes the working directory to the directory containing the script, regardless of the current directory.
+
+## Syntax
+
+The `$(…)` form evaluates the command inside the parentheses. It supports nesting and is easier to read than backquotes:
+
+```shell
+$ echo $(echo $(echo hello))
+hello
+$ echo "$(echo "$(echo hello)")"
+hello
+```
+
+In the backquote form, backslashes [escape](quoting.md#backslash) `$`, `` ` ``, and `\`. If backquotes appear inside double quotes, backslashes also escape `"`. These escapes are processed before the command is run. A backquote-form equivalent to the previous example is:
+
+```shell
+$ echo `echo \`echo hello\``
+hello
+$ echo "`echo \"\`echo hello\`\"`"
+hello
+```
+
+The `$(…)` form can be confused with arithmetic expansion. Command substitution is only recognized if the code is not a valid arithmetic expression. For example, `$((echo + 1))` is arithmetic expansion, but `$((echo + 1); (echo + 2))` is command substitution. To force command substitution starting with a subshell, insert a space: `$( (echo + 1); (echo + 2))`.
+
+## Semantics
+
+The command runs in a subshell, and its standard output is captured. Standard error is not captured unless redirected. Trailing newlines are removed, and the result replaces the command substitution in the command line.
+
+Currently, yash parses the command when the substitution is executed, not when it is parsed. This may change in the future, affecting when syntax errors are detected and when aliases are substituted.

--- a/docs/src/language/words/quoting.md
+++ b/docs/src/language/words/quoting.md
@@ -100,7 +100,7 @@ $ echo "${var#*\}}"
 bar
 ```
 
-Within backquotes, backslashes only escape `$`, `` ` ``, and `\`. If backquotes appear inside double quotes, backslashes also escape `"`. See an example in the [Command substitution](command_substitution.md#syntax) section.
+Within backquotes and arithmetic expansions, backslashes only escape `$`, `` ` ``, and `\`. If backquotes appear inside double quotes, backslashes also escape `"`. See examples in the [Command substitution](command_substitution.md#syntax) and [Arithmetic expansion](arithmetic.md#quoting) sections.
 
 ### Line continuation
 

--- a/docs/src/language/words/quoting.md
+++ b/docs/src/language/words/quoting.md
@@ -100,6 +100,8 @@ $ echo "${var#*\}}"
 bar
 ```
 
+Within backquotes, backslashes only escape `$`, `` ` ``, and `\`. If backquotes appear inside double quotes, backslashes also escape `"`. See an example in the [Command substitution](command_substitution.md#syntax) section.
+
 ### Line continuation
 
 **Line continuation** allows you to split long commands into multiple lines for better readability. Use a backslash followed by a newline to indicate that the command continues on the next line. A backslash-newline pair is ignored by the shell as if it were not there. Line continuation can be used inside and outside double quotes, but not inside single quotes.


### PR DESCRIPTION
This pull request enhances the documentation by adding detailed explanations for arithmetic expressions, arithmetic expansion, and command substitution. It also updates the table of contents to include these new sections and clarifies some existing documentation.

### Additions to Documentation:

* **Arithmetic Expressions**:
  - Added a new file `docs/src/arithmetic.md` explaining arithmetic expressions, including numeric constants, variables, operators, and error handling.

* **Arithmetic Expansion**:
  - Added a new file `docs/src/language/words/arithmetic.md` describing how arithmetic expansion works, its syntax, variable handling, and quoting rules.

* **Command Substitution**:
  - Added a new file `docs/src/language/words/command_substitution.md` explaining command substitution, its preferred and deprecated forms, syntax, and semantics.

### Updates to Table of Contents:

* **Links Added**:
  - Updated `docs/src/SUMMARY.md` to include links to the new files for command substitution and arithmetic expansion.
  - Added new sections for "Pattern matching" and "Arithmetic expressions" in the table of contents.

### Cross-References and Clarifications:

* **Quoting Behavior**:
  - Updated `docs/src/language/words/quoting.md` to clarify the behavior of backslashes within backquotes and arithmetic expansions, with references to the new sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new documentation on arithmetic expansion, arithmetic expressions, and command substitution in shell scripting, including detailed syntax, examples, and error cases.
  - Improved navigation by linking previously unlinked topics and adding new sections to the documentation index.
  - Clarified quoting and backslash escaping rules within backquotes and arithmetic expansions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->