### PR TITLE
Write simple command documentation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,8 +23,7 @@
         - [Special parameters](language/parameters/special.md)
         - [Positional parameters](language/parameters/positional.md)
     - [Commands]()
-        - [Assignment]()
-        - [Simple command details]()
+        - [Simple commands](language/commands/simple.md)
         - [Pipelines]()
         - [Compound commands]()
             - [Grouping]() <!-- incl. subshells -->

--- a/docs/src/language/commands/simple.md
+++ b/docs/src/language/commands/simple.md
@@ -4,9 +4,9 @@
 
 ## Outline
 
-Despite the name, the behavior of simple commands is quite complex. This section outlines the key aspects of simple commands before diving into the details later.
+Despite the name, simple commands can have complex behavior. This section summarizes the main aspects before covering details.
 
-Most simple commands run a utility, which is a program that performs a specific task. A simple command that runs a utility contains a word that specifies the utility name, followed by zero or more words that specify arguments to the utility:
+Most simple commands run a utility—a program that performs a specific task. A simple command that runs a utility contains a word specifying the utility name, followed by zero or more words as arguments:
 
 ```shell
 $ echo "Hello!"
@@ -15,7 +15,7 @@ Hello!
 
 The words are [expanded](../words/index.html#word-expansion) before the utility runs.
 
-A simple command can assign values to [variables](../parameters/variables.md). To perform an assignment, join the variable name and value with an equals sign (`=`) without spaces:
+A simple command can assign values to [variables](../parameters/variables.md). To assign a value, join the variable name and value with an equals sign (`=`) without spaces:
 
 ```shell
 $ greeting="Hello!"
@@ -23,7 +23,7 @@ $ echo "$greeting"
 Hello!
 ```
 
-If assignments are used with utility-invoking words, they must appear before the utility name and they (usually) affect only that utility invocation:
+If assignments are used with utility-invoking words, they must appear before the utility name and they usually affect only that utility invocation:
 
 ```shell,no_run
 $ TZ='America/Los_Angeles' date
@@ -32,7 +32,7 @@ $ TZ='Asia/Tokyo' date
 Sun Jun  1 10:49:30 PM JST 2025
 ```
 
-A simple command can also redirect input and output using redirection operators. For example, to redirect the output of a command to a file, use the `>` operator:
+A simple command can also redirect input and output using redirection operators. For example, to redirect output to a file:
 
 ```shell
 $ echo "Hello!" > output.txt
@@ -40,11 +40,11 @@ $ cat output.txt
 Hello!
 ```
 
-Redirections can appear anywhere in a simple command, but they are conventionally placed at the end.
+Redirections can appear anywhere in a simple command, but are typically placed at the end.
 
 ## Syntax
 
-The formal syntax of a simple command, written in [Extended Backus-Naur Form (EBNF)](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form), is as follows:
+The formal syntax of a simple command, written in [Extended Backus-Naur Form (EBNF)](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form):
 
 ```ebnf
 simple_command            := normal_utility - reserved_word, [ normal_argument_part ] |
@@ -66,14 +66,14 @@ declaration_argument_part := ( assignment_word | word - assignment_word | redire
                              [ declaration_argument_part ];
 ```
 
-As shown above:
+Key points:
 
 - A simple command cannot start with a [reserved word](../words/keywords.md) unless it is [quoted](../words/quoting.md).
-- An assignment word must start with a non-empty [variable name](../parameters/variables.md#variable-names), but the variable value can be empty.
-- To treat a word containing an equals sign as a command name, quote the variable name or equal sign.
+- An assignment word must start with a non-empty [variable name](../parameters/variables.md#variable-names), but the value can be empty.
+- To treat a word containing `=` as a command name, quote the variable name or the equals sign.
 - Redirections can appear anywhere in a simple command.
 
-There must be no space around the equals sign in an assignment word. If you need to include spaces in the value, quote them:
+There must be no space around the equals sign in an assignment word. If you need spaces in the value, quote them:
 
 ```shell
 $ greeting="Hello, world!"
@@ -81,56 +81,56 @@ $ echo "$greeting"
 Hello, world!
 ```
 
-The utility names `export`, `readonly`, and `typeset` are called **declaration utilities**; when one of these is used as a command name, following argument words are parsed as assignment words if possible, or as normal words otherwise. This affects how the argument words are expanded. The utility name `command` is also special; it delegates to the next word the determination of whether it is a declaration utility or a normal utility. (More utility names can be regarded as declaration utilities in the future.)
+The utility names `export`, `readonly`, and `typeset` are **declaration utilities**; when used as a command name, following argument words are parsed as assignment words if possible, or as normal words otherwise. This affects how arguments are expanded. The utility name `command` is also special; it delegates to the next word the determination of whether it is a declaration utility or a normal utility. (More utility names may be treated as declaration utilities in the future.)
 
 ## Semantics
 
-A simple command is executed by the shell in the following steps:
+A simple command is executed by the shell in these steps:
 
-1. Command words (name and arguments) are [expanded](../words/index.html#word-expansion) in the order they appear, if any.
-    - If the command name word is a declaration utility, argument words that have the form of an assignment word are expanded in the same manner as an assignment word (see below), and the rest are expanded as normal words. Otherwise, all arguments are expanded as normal words.
-    - Since command words are expanded before assignments, command words are not affected by assignments in the same simple command.
+1. Command words (name and arguments) are [expanded](../words/index.html#word-expansion) in order.
+    - If the command name is a declaration utility, argument words that look like assignment words are expanded as assignments; the rest are expanded as normal words. Otherwise, all arguments are expanded as normal words.
+    - Command words are expanded before assignments, so assignments do not affect command words in the same command.
     - Expansions in assignments and redirections are not yet performed in this step.
-    - The result of expansion is a sequence of words, specifically called **fields**.
-    - If expansion fails, the error is reported and the command execution is aborted.
-2. Redirections are performed, if any. in the order they appear.
-    - If the previous step produced any fields, the redirections are processed in the current shell environment. If a redirection fails, the error is reported and the command execution is aborted.
-    - If there are no fields, the redirections are processed in a subshell. This means that the redirections do not affect the current shell environment and that errors in redirections are reported but do not abort the command execution.
-3. Assignments are performed, if any, in the order they appear.
-    - The value of each assignment is expanded and assigned to the variable in the current shell environment. See the [Defining variables](../parameters/variables.md#defining-variables) section for the basic assignment behavior.
-    - The assigned variables are exported if there are any fields in the previous step or the `allexport` option is enabled.
-    - If an assigned variable is read-only, the error is reported and the command execution is aborted.
-4. If there are any fields, the shell determines the target to be executed based on the first field (the command name), following the steps described in the [Command search](#command-search) subsection below. <!-- TODO: #530 - Since this step is performed after the assignments, the command search can be affected by the assignments in the previous step. -->
-5. The shell executes the target.
-    - If the target is an external utility, it is executed in a subshell with the fields as arguments. If the `execve` system call fails with `ENOEXEC`, the shell tries to execute the target as a script in a new shell process.
+    - The result is a sequence of words called **fields**.
+    - If expansion fails, the error is reported and the command is aborted.
+2. Redirections are performed, in order.
+    - If there are any fields, redirections are processed in the current shell environment. If a redirection fails, the error is reported and the command is aborted.
+    - If there are no fields, redirections are processed in a subshell. In this case, redirections do not affect the current shell, and errors are reported but do not abort the command.
+3. Assignments are performed, in order.
+    - Each assignment value is expanded and assigned to the variable in the current shell environment. See [Defining variables](../parameters/variables.md#defining-variables) for details.
+    - Assigned variables are exported if there are any fields or if the `allexport` option is enabled.
+    - If an assigned variable is read-only, the error is reported and the command is aborted.
+4. If there are any fields, the shell determines the target to execute based on the first field (the command name), as described in [Command search](#command-search) below. <!-- TODO: #530 - Since this step is performed after the assignments, the command search can be affected by the assignments in the previous step. -->
+5. The shell executes the target:
+    - If the target is an external utility, it is executed in a subshell with the fields as arguments. If the `execve` call used to execute the target fails with `ENOEXEC`, the shell tries to execute it as a script in a new shell process.
     - If the target is a built-in, it is executed in the current shell environment with the fields (except the first) as arguments.
-    - If the target is a function, it is executed in the current shell environment. When entering a function, the positional parameters are set to the fields (except the first). The positional parameters are restored to their previous values when the function returns.
-    - If no target was found in the previous step, the shell reports an error.
-    - If there was no command name (the first field), the shell does not execute anything.
+    - If the target is a function, it is executed in the current shell environment. When entering a function, positional parameters are set to the fields (except the first), and restored when the function returns.
+    - If no target is found, the shell reports an error.
+    - If there was no command name (the first field), nothing is executed.
 
-The assigned variables are removed unless the target was a special built-in or there were no fields resulting from the expansion, in which case the assigned variables persist after the command.
-The effect of the redirections is canceled unless the target was the `exec` special built-in (or the `command` built-in executing `exec`), in which case the redirections persist after the command.
+Assigned variables are removed unless the target was a special built-in or there were no fields after expansion, in which case the assignments persist.
+Redirections are canceled unless the target was the `exec` special built-in (or the `command` built-in executing `exec`), in which case the redirections persist.
 
 ### Command search
 
-**Command search** determines the target to be executed based on the command name (the first field of the simple command). The search follows these steps:
+**Command search** determines the target to execute based on the command name (the first field):
 
-1. If the command name contains a slash (`/`), it is treated as a pathname to an executable file, concluding the search regardless of whether the file exists or is executable.
-2. If the command name is a special built-in (like `exec` and `exit`), it is determined to be the target.
-3. If the command name is a function, it is determined to be the target.
-4. If the command name is a built-in other than a substitutive built-in, it is determined to be the target. <!-- TODO: reject elective and extension built-ins in POSIX mode -->
-5. The shell searches for the command name in the directories listed in the `PATH` [variable](../parameters/variables.md). If found, the first matching executable regular file is a candidate target.
-    - The value of `PATH` treated as a sequence of pathnames separated by colons (`:`). An empty pathname in `PATH` refers to the current directory. For example, in the simple command `PATH=/bin:/usr/bin: ls`, the shell searches for `ls` in `/bin`, then `/usr/bin`, and finally the current directory.
-    - If `PATH` is an array, each element is treated as a pathname to search.
+1. If the command name contains a slash (`/`), it is treated as a pathname to an executable file target, regardless of whether the file exists or is executable.
+2. If the command name is a special built-in (like `exec` or `exit`), it is used as the target.
+3. If the command name is a function, it is used as the target.
+4. If the command name is a built-in other than a substitutive built-in, it is used as the target. <!-- TODO: reject elective and extension built-ins in POSIX mode -->
+5. The shell searches for the command name in the directories listed in the `PATH` [variable](../parameters/variables.md). The first matching executable regular file is a candidate target.
+    - The value of `PATH` is treated as a sequence of pathnames separated by colons (`:`). An empty pathname in `PATH` refers to the current directory. For example, in the simple command `PATH=/bin:/usr/bin: ls`, the shell searches for `ls` in `/bin`, then `/usr/bin`, and finally the current directory.
+    - If `PATH` is an array, each element is a pathname to search.
 6. If a candidate target is found:
-    - If the command name is a substitutive built-in (like `echo` and `pwd`), the built-in is determined to be the target.
-    - Otherwise, the executable file is determined to be the target.
+    - If the command name is a substitutive built-in (like `echo` or `pwd`), the built-in is used as the target.
+    - Otherwise, the executable file is used as the target.
 7. If no candidate target is found, the command search fails.
 
 An executable file target is called an **external utility**.
 
 ### Exit status
 
-- If the simple command executed a target, the exit status of the simple command is the exit status of the target.
-- If there were no fields after expansion, the exit status of the simple command is the exit status of the last [command substitution](../words/command_substitution.md) executed in the simple command, or zero if there were no command substitutions.
-- If the simple command was aborted due to an error in expansion, redirection, assignment, or command search, the exit status is non-zero. Specifically, the exit status is 127 if the command search failed, or 126 if the command search succeeded but the target could not be executed (e.g., unsupported file type or permission denied).
+- If a target was executed, the exit status of the simple command is the exit status of the target.
+- If there were no fields after expansion, the exit status is that of the last [command substitution](../words/command_substitution.md) in the command, or zero if there were none.
+- If the command was aborted due to an error in expansion, redirection, assignment, or command search, the exit status is non-zero: 127 if command search failed, or 126 if the target could not be executed (e.g., unsupported file type or permission denied).

--- a/docs/src/language/commands/simple.md
+++ b/docs/src/language/commands/simple.md
@@ -1,0 +1,136 @@
+# Simple commands
+
+**Simple commands** are the basic building blocks of shell commands. They consist of command line words, assignments, and redirections.
+
+## Outline
+
+Despite the name, the behavior of simple commands is quite complex. This section outlines the key aspects of simple commands before diving into the details later.
+
+Most simple commands run a utility, which is a program that performs a specific task. A simple command that runs a utility contains a word that specifies the utility name, followed by zero or more words that specify arguments to the utility:
+
+```shell
+$ echo "Hello!"
+Hello!
+```
+
+The words are [expanded](../words/index.html#word-expansion) before the utility runs.
+
+A simple command can assign values to [variables](../parameters/variables.md). To perform an assignment, join the variable name and value with an equals sign (`=`) without spaces:
+
+```shell
+$ greeting="Hello!"
+$ echo "$greeting"
+Hello!
+```
+
+If assignments are used with utility-invoking words, they must appear before the utility name and they (usually) affect only that utility invocation:
+
+```shell,no_run
+$ TZ='America/Los_Angeles' date
+Sun Jun  1 06:49:30 AM PDT 2025
+$ TZ='Asia/Tokyo' date
+Sun Jun  1 10:49:30 PM JST 2025
+```
+
+A simple command can also redirect input and output using redirection operators. For example, to redirect the output of a command to a file, use the `>` operator:
+
+```shell
+$ echo "Hello!" > output.txt
+$ cat output.txt
+Hello!
+```
+
+Redirections can appear anywhere in a simple command, but they are conventionally placed at the end.
+
+## Syntax
+
+The formal syntax of a simple command, written in [Extended Backus-Naur Form (EBNF)](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form), is as follows:
+
+```ebnf
+simple_command            := normal_utility - reserved_word, [ normal_argument_part ] |
+                             declaration_utility, [ declaration_argument_part ] |
+                             assignment_part, [ utility_part ] |
+                             "command", [ utility_part ];
+utility_part              := normal_utility, [ normal_argument_part ] |
+                             declaration_utility, [ declaration_argument_part ] |
+                             "command", [ utility_part ];
+assignment_part           := ( assignment_word | redirection ), [ assignment_part ];
+assignment_word           := ? a word that starts with a literal variable name
+                               immediately followed by an unquoted equals sign and
+                               optionally followed by a value part ?;
+command_name              := word - assignment_word;
+declaration_utility       := "export" | "readonly" | "typeset";
+normal_utility            := command_name - declaration_utility - "command";
+normal_argument_part      := ( word | redirection ), [ normal_argument_part ];
+declaration_argument_part := ( assignment_word | word - assignment_word | redirection ),
+                             [ declaration_argument_part ];
+```
+
+As shown above:
+
+- A simple command cannot start with a [reserved word](../words/keywords.md) unless it is [quoted](../words/quoting.md).
+- An assignment word must start with a non-empty [variable name](../parameters/variables.md#variable-names), but the variable value can be empty.
+- To treat a word containing an equals sign as a command name, quote the variable name or equal sign.
+- Redirections can appear anywhere in a simple command.
+
+There must be no space around the equals sign in an assignment word. If you need to include spaces in the value, quote them:
+
+```shell
+$ greeting="Hello, world!"
+$ echo "$greeting"
+Hello, world!
+```
+
+The utility names `export`, `readonly`, and `typeset` are called **declaration utilities**; when one of these is used as a command name, following argument words are parsed as assignment words if possible, or as normal words otherwise. This affects how the argument words are expanded. The utility name `command` is also special; it delegates to the next word the determination of whether it is a declaration utility or a normal utility. (More utility names can be regarded as declaration utilities in the future.)
+
+## Semantics
+
+A simple command is executed by the shell in the following steps:
+
+1. Command words (name and arguments) are [expanded](../words/index.html#word-expansion) in the order they appear, if any.
+    - If the command name word is a declaration utility, argument words that have the form of an assignment word are expanded in the same manner as an assignment word (see below), and the rest are expanded as normal words. Otherwise, all arguments are expanded as normal words.
+    - Since command words are expanded before assignments, command words are not affected by assignments in the same simple command.
+    - Expansions in assignments and redirections are not yet performed in this step.
+    - The result of expansion is a sequence of words, specifically called **fields**.
+    - If expansion fails, the error is reported and the command execution is aborted.
+2. Redirections are performed, if any. in the order they appear.
+    - If the previous step produced any fields, the redirections are processed in the current shell environment. If a redirection fails, the error is reported and the command execution is aborted.
+    - If there are no fields, the redirections are processed in a subshell. This means that the redirections do not affect the current shell environment and that errors in redirections are reported but do not abort the command execution.
+3. Assignments are performed, if any, in the order they appear.
+    - The value of each assignment is expanded and assigned to the variable in the current shell environment. See the [Defining variables](../parameters/variables.md#defining-variables) section for the basic assignment behavior.
+    - The assigned variables are exported if there are any fields in the previous step or the `allexport` option is enabled.
+    - If an assigned variable is read-only, the error is reported and the command execution is aborted.
+4. If there are any fields, the shell determines the target to be executed based on the first field (the command name), following the steps described in the [Command search](#command-search) subsection below. <!-- TODO: #530 - Since this step is performed after the assignments, the command search can be affected by the assignments in the previous step. -->
+5. The shell executes the target.
+    - If the target is an external utility, it is executed in a subshell with the fields as arguments. If the `execve` system call fails with `ENOEXEC`, the shell tries to execute the target as a script in a new shell process.
+    - If the target is a built-in, it is executed in the current shell environment with the fields (except the first) as arguments.
+    - If the target is a function, it is executed in the current shell environment. When entering a function, the positional parameters are set to the fields (except the first). The positional parameters are restored to their previous values when the function returns.
+    - If no target was found in the previous step, the shell reports an error.
+    - If there was no command name (the first field), the shell does not execute anything.
+
+The assigned variables are removed unless the target was a special built-in or there were no fields resulting from the expansion, in which case the assigned variables persist after the command.
+The effect of the redirections is canceled unless the target was the `exec` special built-in (or the `command` built-in executing `exec`), in which case the redirections persist after the command.
+
+### Command search
+
+**Command search** determines the target to be executed based on the command name (the first field of the simple command). The search follows these steps:
+
+1. If the command name contains a slash (`/`), it is treated as a pathname to an executable file, concluding the search regardless of whether the file exists or is executable.
+2. If the command name is a special built-in (like `exec` and `exit`), it is determined to be the target.
+3. If the command name is a function, it is determined to be the target.
+4. If the command name is a built-in other than a substitutive built-in, it is determined to be the target. <!-- TODO: reject elective and extension built-ins in POSIX mode -->
+5. The shell searches for the command name in the directories listed in the `PATH` [variable](../parameters/variables.md). If found, the first matching executable regular file is a candidate target.
+    - The value of `PATH` treated as a sequence of pathnames separated by colons (`:`). An empty pathname in `PATH` refers to the current directory. For example, in the simple command `PATH=/bin:/usr/bin: ls`, the shell searches for `ls` in `/bin`, then `/usr/bin`, and finally the current directory.
+    - If `PATH` is an array, each element is treated as a pathname to search.
+6. If a candidate target is found:
+    - If the command name is a substitutive built-in (like `echo` and `pwd`), the built-in is determined to be the target.
+    - Otherwise, the executable file is determined to be the target.
+7. If no candidate target is found, the command search fails.
+
+An executable file target is called an **external utility**.
+
+### Exit status
+
+- If the simple command executed a target, the exit status of the simple command is the exit status of the target.
+- If there were no fields after expansion, the exit status of the simple command is the exit status of the last [command substitution](../words/command_substitution.md) executed in the simple command, or zero if there were no command substitutions.
+- If the simple command was aborted due to an error in expansion, redirection, assignment, or command search, the exit status is non-zero. Specifically, the exit status is 127 if the command search failed, or 126 if the command search succeeded but the target could not be executed (e.g., unsupported file type or permission denied).

--- a/docs/src/language/parameters/variables.md
+++ b/docs/src/language/parameters/variables.md
@@ -49,7 +49,7 @@ $ echo $star # unquoted, the value is subject to field splitting and pathname ex
 Documents  Downloads  Music  Pictures  Videos
 ```
 
-See the [Simple commands](../commands/simple.md) section for more information on assignment syntax and semantics.
+See the [Simple commands](../commands/simple.md) section for more information on assignment behavior.
 
 ## Environment variables
 

--- a/docs/src/language/parameters/variables.md
+++ b/docs/src/language/parameters/variables.md
@@ -22,11 +22,11 @@ This creates a variable named `user` with the value `Alice`. There must be no sp
 
 Before a value is assigned, the following expansions are performed, if any:
 
-- Tilde expansion
-- Parameter expansion
-- Command substitution
-- Arithmetic expansion
-- Quote removal
+- [Tilde expansion](../words/tilde.md)
+- [Parameter expansion](../words/parameters.md)
+- [Command substitution](../words/command_substitution.md)
+- [Arithmetic expansion](../words/arithmetic.md)
+- [Quote removal](../words/quoting.md#quote-removal)
 
 ```shell,hidelines=#
 #$ HOME=/home/alice
@@ -39,7 +39,7 @@ $ echo $rawdir
 ~/$user
 ```
 
-Note that <!-- TODO: brace expansion, --> field splitting and pathname expansion do not happen during variable assignment.
+Note that <!-- TODO: brace expansion, --> [field splitting](../words/field_splitting.md) and [pathname expansion](../words/globbing.md) do not happen during variable assignment.
 
 ```shell,no_run
 $ star=* # assigns a literal `*` to the variable `star`
@@ -49,7 +49,7 @@ $ echo $star # unquoted, the value is subject to field splitting and pathname ex
 Documents  Downloads  Music  Pictures  Videos
 ```
 
-See the Simple command details section for more information on assignment syntax and semantics.
+See the [Simple commands](../commands/simple.md) section for more information on assignment syntax and semantics.
 
 ## Environment variables
 

--- a/docs/src/language/words/README.md
+++ b/docs/src/language/words/README.md
@@ -93,17 +93,17 @@ The shell performs several kinds of **word expansion** before running a utility,
 
 The following expansions happen first:
 
-- Tilde expansion
-- Parameter expansion
-- Command substitution
-- Arithmetic expansion
+- [Tilde expansion](tilde.md)
+- [Parameter expansion](parameters.md)
+- [Command substitution](command_substitution.md)
+- [Arithmetic expansion](arithmetic.md)
 
 After these, the shell performs these steps in order:
 
 <!-- Brace expansion is not yet implemented. -->
-1. Field splitting
-2. Pathname expansion
-3. Quote removal
+1. [Field splitting](field_splitting.md)
+2. [Pathname expansion](globbing.md)
+3. [Quote removal](quoting.md#quote-removal)
 
 The result is a list of words passed to the utility. Each word resulting from these expansions is called a **field**.
 


### PR DESCRIPTION
This pull request includes updates to improve the documentation of shell scripting concepts and refactors the `doctest.sh` script for better readability and functionality. The most important changes are grouped into documentation enhancements and script refactoring.

### Documentation Enhancements:

* [`docs/src/SUMMARY.md`](diffhunk://#diff-6e490221db20aaa056f2ed2c63443806b309ec63182541ddea9dd0b84e7eb501L26-R26): Updated the table of contents to include a new section for "Simple commands" with a proper link to its detailed documentation.
* [`docs/src/language/commands/simple.md`](diffhunk://#diff-12bef2eac088a26153ef7a603a2d3eba2d07db56174e374ac6ce62de46b9ed32R1-R136): Added a comprehensive new section explaining "Simple commands," including syntax, semantics, command search, and exit status, with examples and formal grammar in EBNF.
* [`docs/src/language/parameters/variables.md`](diffhunk://#diff-889e7178a562838b9d3009eb2d84882e5b4cadbaacac96f68bb32b74dc28ae09L25-R29): Improved clarity by linking to detailed sections for expansions (e.g., tilde, parameter, command substitution) and updated references to the new "Simple commands" section. [[1]](diffhunk://#diff-889e7178a562838b9d3009eb2d84882e5b4cadbaacac96f68bb32b74dc28ae09L25-R29) [[2]](diffhunk://#diff-889e7178a562838b9d3009eb2d84882e5b4cadbaacac96f68bb32b74dc28ae09L42-R42) [[3]](diffhunk://#diff-889e7178a562838b9d3009eb2d84882e5b4cadbaacac96f68bb32b74dc28ae09L52-R52)
* [`docs/src/language/words/README.md`](diffhunk://#diff-f99e056a6859e7e29eeb2d9c9253c76d237a23787afe9909d07d7767843b8230L96-R106): Enhanced descriptions of word expansions by adding links to detailed sections for each type of expansion (e.g., field splitting, pathname expansion).

### Script Refactoring:

* [`docs/doctest.sh`](diffhunk://#diff-c2528918480f9ad17a8ec31229a319f1f462367c4592f69e165cc087450db84cR40-R51): Improved handling of the `$YASH` variable to ensure proper resolution of relative paths and updated the temporary directory naming convention for better clarity and uniqueness.
* [`docs/doctest.sh`](diffhunk://#diff-c2528918480f9ad17a8ec31229a319f1f462367c4592f69e165cc087450db84cL92-R99): Refactored the `checkoutput` function to change to the temporary directory before executing the script, ensuring that relative paths are resolved correctly during testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive documentation for simple shell commands, including syntax, semantics, and execution details.
  - Improved clarity and navigation by updating links and references in variable assignment and word expansion documentation.
  - Updated summary navigation to consolidate and properly link command-related sections.
- **Chores**
  - Enhanced the test script for better path handling, safer directory creation, and improved test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->