### PR TITLE
Improve documentation for parameter expansion modifiers

### DIFF
--- a/docs/src/language/words/parameters.md
+++ b/docs/src/language/words/parameters.md
@@ -142,16 +142,14 @@ error: tell me your name
 
 In all cases, the following expansions are performed on `word` before use:
 
-- [Tilde expansion](../words/tilde.md)
+- [Tilde expansion](../words/tilde.md) (unless the parameter expansion is in [double quotes](quoting.md#double-quotes))
 - Parameter expansion (recursive!)
-- Command substitution
-- Arithmetic expansion
+- [Command substitution](command_substitution.md)
+- [Arithmetic expansion](arithmetic.md)
 
-For the `=` and `:=` forms, quote removal is also performed before assignment.
+For the `=` and `:=` forms, [quote removal](quoting.md#quote-removal) is also performed before assignment. Assignment only works for [variables](../parameters/variables.md), not [special](../parameters/special.md) or [positional parameters](../parameters/positional.md).
 
 If `word` is empty in the `?` and `:?` forms, a default error message is used.
-
-Assignment with `=` and `:=` only works for variables, not special or positional parameters.
 
 The `nounset` option does not apply to expansions with a switch modifier.
 
@@ -164,7 +162,7 @@ The **trim** modifier removes leading or trailing characters matching a pattern 
 - `${parameter%pattern}` – Remove the shortest match of `pattern` from the end.
 - `${parameter%%pattern}` – Remove the longest match of `pattern` from the end.
 
-The value is matched against the pattern, and the matching part is removed. <!-- TODO: link to [pattern matching] -->
+The value is matched against the [pattern](../../patterns.md), and the matching part is removed.
 
 ```shell
 $ var="banana"
@@ -182,8 +180,8 @@ The pattern is expanded before use:
 
 - [Tilde expansion](../words/tilde.md)
 - Parameter expansion (recursive!)
-- Command substitution
-- Arithmetic expansion
+- [Command substitution](command_substitution.md)
+- [Arithmetic expansion](arithmetic.md)
 
 You can quote part or all of the pattern to treat it literally:
 


### PR DESCRIPTION
This pull request updates the documentation in `docs/src/language/words/parameters.md` to improve clarity and provide additional links for better navigation. The most important changes include adding links to related topics, clarifying the behavior of parameter expansions, and removing redundant information.

### Documentation improvements:

* **Parameter expansions:** Clarified that tilde expansion does not occur when parameter expansion is in double quotes and added links to relevant sections for quote removal, special parameters, and positional parameters. Removed redundant explanation about assignment limitations. (`[docs/src/language/words/parameters.mdL145-L155](diffhunk://#diff-954f4c800737ce465e15600b12d7facc213d9a744ccdcbcd2233ffd358c3e939L145-L155)`)
* **Pattern matching:** Added a link to the `patterns.md` file to explain pattern matching in the trim modifier section. (`[docs/src/language/words/parameters.mdL167-R165](diffhunk://#diff-954f4c800737ce465e15600b12d7facc213d9a744ccdcbcd2233ffd358c3e939L167-R165)`)
* **Pattern expansion:** Added links to `command_substitution.md` and `arithmetic.md` for better understanding of command substitution and arithmetic expansion during pattern expansion. (`[docs/src/language/words/parameters.mdL185-R184](diffhunk://#diff-954f4c800737ce465e15600b12d7facc213d9a744ccdcbcd2233ffd358c3e939L185-R184)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in parameter expansion documentation.
  - Added and updated links to related topics, including command substitution, arithmetic expansion, and pattern matching.
  - Clarified behavior of tilde expansion within double quotes.
  - Expanded explanation of assignment restrictions for variables.
  - Removed redundant statements for conciseness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->