### PR TITLE
docs: Loops

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,7 +28,7 @@
         - [Grouping](language/commands/grouping.md)
         - [Exit status and conditionals](language/commands/exit_status.md)
         - [Pattern-based branching](language/commands/case.md)
-        - [Loops]()
+        - [Loops](language/commands/loops.md)
         - [Lists and asynchronous commands]()
     - [Functions]()
     - [Aliases]()

--- a/docs/src/language/commands/exit_status.md
+++ b/docs/src/language/commands/exit_status.md
@@ -150,6 +150,8 @@ $ if [ -e "$file" ]; then
 
 The exit status of an if command is the exit status of the last command executed in the `then` or `else` clause. If no condition is met and there is no `else` clause, the exit status is 0 (success).
 
+For repeating commands depending on a condition, see [While and until loops](loops.md#while-and-until-loops).
+
 ## The `errexit` option
 
 By default, the shell continues running commands even if one fails (returns a non-zero exit status). This can cause later commands to run when they shouldn't. If you enable the `errexit` shell option, the shell will exit immediately when any command fails, stopping further execution.
@@ -169,7 +171,7 @@ The `errexit` option only applies to the result of [pipelines](pipelines.md). It
 
 - When the pipeline is negated with the `!` [reserved word].
 - When the pipeline is the left side of an [`&&` or `||`](#and-or-lists) operator.
-- When the pipeline is part of the condition in an [`if`](#if-commands) command, `while` loop, or `until` loop.
+- When the pipeline is part of the condition in an [`if` command](#if-commands) or a [`while` or `until` loop](loops.md#while-and-until-loops).
 
 Although `errexit` does not catch every error, it is recommended for scripts to avoid unexpected results from failed commands. To skip `errexit` for a specific command, append `&& true`:
 

--- a/docs/src/language/commands/loops.md
+++ b/docs/src/language/commands/loops.md
@@ -1,0 +1,161 @@
+# Loops
+
+Loops repeatedly execute a sequence of commands, either by iterating over a list or while a condition holds. They are useful for automating repetitive tasks or processing multiple items.
+
+## For loops
+
+A `for` loop iterates over a list of strings, executing a block of commands for each string. In each iteration, the string is assigned to a [variable] for use in the commands.
+
+```shell
+$ for user in alice bob charlie; do
+>     echo "Hello, $user!"
+> done
+Hello, alice!
+Hello, bob!
+Hello, charlie!
+```
+
+The word after `for` is the loop [variable], assigned to each string in the list after `in`. The `do` [reserved word] starts the command block, and `done` ends the loop.
+
+The semicolon after the list is optional if `do` is on a new line:
+
+```shell
+$ for user in alice bob charlie
+> do
+>     echo "Hello, $user!"
+> done
+Hello, alice!
+Hello, bob!
+Hello, charlie!
+```
+
+The `in` [reserved word] can also be on a separate line:
+
+```shell
+$ for user
+> in alice bob charlie; do
+>     echo "Hello, $user!"
+> done
+Hello, alice!
+Hello, bob!
+Hello, charlie!
+```
+
+[Word expansion](../words/index.html#word-expansion) is performed on the list:
+
+```shell,no_run
+$ for file in *.txt; do
+>     echo "$file contains $(wc -l -- "$file") lines"
+>     echo "First line: $(head -n 1 -- "$file")"
+> done
+file1.txt contains 10 lines
+First line: This is the first line of file1.
+file2.txt contains 5 lines
+First line: This is the first line of file2.
+```
+
+If the list is empty, the loop does not run:
+
+```shell
+$ for user in; do
+>     echo "Hello, $user!"
+> done
+```
+
+If `in` and the list are omitted, the loop iterates over the [positional parameters](../parameters/positional.md) as if `in "$@"` were specified:
+
+```shell
+$ set alice bob charlie
+$ for user do
+>     echo "Hello, $user!"
+> done
+Hello, alice!
+Hello, bob!
+Hello, charlie!
+```
+
+The [exit status] of a `for` loop is the exit status of the last command run in the loop, or 0 if the loop does not run.
+
+## While and until loops
+
+A `while` loop executes commands as long as a condition is true. An `until` loop is similar, but continues until the condition becomes true. The `do` [reserved word] separates the condition from the loop body, and `done` ends the loop.
+
+```shell
+$ count=1
+$ while [ $count -le 5 ]; do
+>     echo "Count: $count"
+>     count=$((count + 1))
+> done
+Count: 1
+Count: 2
+Count: 3
+Count: 4
+Count: 5
+```
+
+```shell
+$ count=1
+$ until [ $count -gt 3 ]; do
+>     echo "Count: $count"
+>     count=$((count + 1))
+> done
+Count: 1
+Count: 2
+Count: 3
+```
+
+See [Exit status and conditionals](exit_status.md) for details on how exit status affects loop conditions.
+
+The [exit status] of a `while` or `until` loop is that of the last command run in the loop body, or 0 if the loop body does not run. Note that the exit status of the condition does not affect the exit status of the loop.
+
+## Break and continue
+
+The `break` utility exits the current loop. The `continue` utility skips to the next iteration.
+
+```shell
+$ for i in 1 2 3 4 5; do
+>     if [ $i -eq 3 ]; then
+>         echo "Breaking at $i"
+>         break
+>     fi
+>     echo "Iteration $i"
+> done
+Iteration 1
+Iteration 2
+Breaking at 3
+```
+
+```shell
+$ for i in 1 2 3 4 5; do
+>     if [ $i -eq 3 ]; then
+>         echo "Skipping $i"
+>         continue
+>     fi
+>     echo "Iteration $i"
+> done
+Iteration 1
+Iteration 2
+Skipping 3
+Iteration 4
+Iteration 5
+```
+
+By default, `break` and `continue` affect the innermost loop. You can specify a numeric operand to affect the *n*'th outer loop:
+
+```shell
+$ for i in 1 2; do
+>     for j in a b c; do
+>         if [ "$j" = "b" ]; then
+>             echo "Breaking outer loop at $i, $j"
+>             break 2
+>         fi
+>         echo "Inner loop: $i, $j"
+>     done
+> done
+Inner loop: 1, a
+Breaking outer loop at 1, b
+```
+
+[exit status]: exit_status.md
+[reserved word]: ../words/keywords.md
+[variable]: ../parameters/variables.md


### PR DESCRIPTION
## Summary by Copilot

This pull request enhances the documentation by adding a new section on loops and updating related references across multiple files. The most significant changes include the addition of detailed documentation for `for`, `while`, and `until` loops, along with updates to ensure consistency and proper linking between sections.

### New Documentation on Loops:
* Added a comprehensive `loops.md` file explaining `for`, `while`, and `until` loops, including examples, syntax, and usage of `break` and `continue`.

### Updates to Cross-References:
* Updated the `SUMMARY.md` file to include a link to the new `loops.md` file under the "Loops" section.
* Added a reference to the new "While and until loops" section in `exit_status.md` to guide users on using loops with conditions.
* Updated the `errexit` section in `exit_status.md` to link to the "While and until loops" section for better clarity on pipeline conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive new section explaining `for`, `while`, and `until` loops, including usage examples and loop control utilities.
  - Updated the table of contents with a valid link to the new "Loops" section.
  - Improved the "Exit Status" documentation with clearer phrasing and direct links to related loop topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->