### PR TITLE
docs: Signals and traps

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,7 +38,7 @@
 - [Termination](termination.md)
 - [Shell options](options.md)
 - [Shell environment and subshells](environment.md)
-- [Signals and traps]()
+- [Signals and traps](traps.md)
 - [Built-in utilities]()
     - [. (dot)]()
     - [: (colon)]()

--- a/docs/src/environment.md
+++ b/docs/src/environment.md
@@ -16,7 +16,7 @@ The **shell execution environment** is the set of state the shell maintains to c
 - [Functions](language/functions.md)
 - [Aliases](language/aliases.md)
 - [Shell options](options.md)
-- Traps <!-- TODO: link to Signals and traps -->
+- [Traps](traps.md)
 - Jobs <!-- TODO: link to Job control -->
 
 ## Subshells

--- a/docs/src/termination.md
+++ b/docs/src/termination.md
@@ -27,7 +27,7 @@ When one of the above conditions occurs in a [subshell](environment.md#subshells
 
 ## `EXIT` trap
 
-You can set a trap for the `EXIT` condition to run commands when the shell exits. This can be useful for cleanup tasks or logging. The trap is executed regardless of how the shell exits, whether due to an error, end-of-file, or explicit `exit` command, except when the shell is killed by a signal, in which case the trap is not executed.
+You can set a [trap](traps.md) for the `EXIT` condition to run commands when the shell exits. This can be useful for cleanup tasks or logging. The trap is executed regardless of how the shell exits, whether due to an error, end-of-file, or explicit `exit` command, except when the shell is killed by a signal, in which case the trap is not executed.
 
 ```shell,one_shot
 $ trap 'rm -f temporary.txt; echo "Temporary file removed."' EXIT
@@ -37,6 +37,8 @@ Some data
 $ exit
 Temporary file removed.
 ```
+
+The `EXIT` trap is run at most once per shell session. Modifying the `EXIT` trap while it is running does not have any effect on trap execution.
 
 ## Exit status
 

--- a/docs/src/traps.md
+++ b/docs/src/traps.md
@@ -1,0 +1,70 @@
+# Signals and traps
+
+Signals are a method of inter-process communication used to notify a process that a specific event has occurred. The POSIX standard defines a set of signals that have well-defined meanings and behaviors across Unix-like systems. Traps are the shell's mechanism for handling signals and other events by executing custom commands when specific conditions occur.
+
+## What are signals?
+
+**Signals** are asynchronous notifications sent to a process to inform it of an event. Common signals include:
+
+- `SIGINT`: Interrupt signal, typically sent when the user presses `Ctrl+C`
+- `SIGTERM`: Termination request, used to ask a process to exit gracefully
+- `SIGQUIT`: Quit signal, typically sent when the user presses `Ctrl+\`
+- `SIGHUP`: Hangup signal, originally sent when a terminal connection was lost
+- `SIGKILL`: Kill signal that cannot be caught or ignored
+- `SIGSTOP`: Stop signal that cannot be caught or ignored
+- `SIGTSTP`: Terminal stop signal, typically sent when the user presses `Ctrl+Z`
+- `SIGCHLD`: Child process terminated or stopped
+- `SIGUSR1` and `SIGUSR2`: User-defined signals for custom applications
+
+Available signals may vary by system. For a complete list, refer to your system's documentation or use `kill -l`.
+
+When a process receives a signal, it can respond in one of three ways:
+
+1. **Default action**: Follow the system's default behavior for that signal (usually termination)
+2. **Ignore**: Do nothing when the signal is received
+3. **Custom action**: Execute a custom signal handler
+
+## What are traps?
+
+**Traps** are the shell's way of defining custom responses to signals and other events. When you set a trap, you specify:
+
+- A **condition** that triggers the trap (such as a signal or shell exit), and
+- An **action** to perform when the condition occurs.
+
+The shell checks for pending signals and executes corresponding trap actions at safe points during execution, typically before and after executing commands. This ensures that trap actions run in a consistent shell state.
+
+### Special conditions
+
+In addition to signals, the shell supports the [`EXIT` condition](termination.md#exit-trap), which is triggered when the shell exits (but not when killed by a signal). This allows you to run cleanup commands or perform other actions when the shell session ends.
+
+More conditions may be supported in future versions of the shell.
+
+### Trap inheritance and subshells
+
+When the shell creates a [subshell](environment.md#subshells):
+
+- Traps set to ignore are inherited by the subshell.
+- Traps with custom actions are reset to default behavior.
+
+External utilities inherit the signal dispositions from the shell, but not custom trap actions.
+
+## Setting traps
+
+Use the `trap` built-in to configure traps or view current traps.
+
+### Restrictions
+
+- `SIGKILL` and `SIGSTOP` cannot be caught or ignored.
+- If a non-interactive shell inherited an ignored signal, that signal cannot be trapped. Interactive shells can modify signals that were initially ignored.
+
+## How and when traps are executed
+
+Signal traps run when signals are caught.
+
+- When a signal is caught while the shell is running a command, the shell waits for the command to finish before executing the trap action.
+- If a signal is caught while the shell is reading input, the shell waits for the input to complete before executing the trap action. This behavior may change in future versions so that traps can run immediately.
+- While executing a signal trap action, other signal traps are not processed (no reentrance), except in subshells.
+
+`EXIT` traps run when the shell exits normally, after all other commands complete.
+
+The [exit status](language/commands/exit_status.md) is preserved across trap action execution, but trap actions can use the `exit` built-in to terminate the shell with a specific exit status.


### PR DESCRIPTION
## Summary by Copilot

This pull request updates the documentation to improve clarity and provide more detailed information about signals and traps in the shell. The changes include linking previously unlinked sections, adding a new `traps.md` file with comprehensive details, and enhancing the `termination.md` file with additional explanations about the `EXIT` trap.

### Documentation Improvements:

#### Linking and navigation:
- Updated `docs/src/SUMMARY.md` to link the "Signals and traps" section to the new `traps.md` file.
- Modified `docs/src/environment.md` to replace the placeholder text for "Traps" with a link to the `traps.md` file.

#### Expanded content:
- Enhanced `docs/src/termination.md` by linking the `EXIT` trap to the new `traps.md` file and adding a note that the `EXIT` trap runs at most once per shell session. [[1]](diffhunk://#diff-15f62e42cd47d796b19d563a06808018397cf4153e3206f400558ee1c9905d14L30-R30) [[2]](diffhunk://#diff-15f62e42cd47d796b19d563a06808018397cf4153e3206f400558ee1c9905d14R41-R42)
- Added a new `traps.md` file with detailed explanations of signals, traps, their inheritance in subshells, and restrictions on signal handling. This provides a comprehensive overview of the shell's mechanism for handling events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive new page explaining signals and traps in Unix-like shells, including usage, inheritance, and limitations.
  * Updated documentation links to ensure the "Signals and traps" section and related references are now properly linked to the new content.
  * Clarified the behavior of the `EXIT` trap, including its execution frequency and handling during modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->