### PR TITLE
Document alias built-in

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -42,7 +42,7 @@
 - [Built-in utilities](builtins/README.md)
     - [. (dot)]()
     - [: (colon)]()
-    - [alias]()
+    - [alias](builtins/alias.md)
     - [bg]()
     - [break]()
     - [cd]()

--- a/docs/src/builtins/alias.md
+++ b/docs/src/builtins/alias.md
@@ -1,0 +1,41 @@
+# Alias built-in
+
+The **`alias`** built-in defines [aliases](../language/aliases.md) or prints alias definitions.
+
+## Synopsis
+
+```sh
+alias [name[=value]…]
+```
+
+## Description
+
+The `alias` built-in defines aliases or prints existing alias definitions, depending on the operands. With no operands, it prints all alias definitions in a quoted assignment form suitable for reuse as input to `alias`.
+
+## Options
+
+None.
+
+Non-POSIX options may be added in the future.
+
+## Operands
+
+Each operand must be of the form `name=value` or `name`. The first form defines an alias named *name* that expands to *value*. The second form prints the definition of the alias named *name*.
+
+## Errors
+
+It is an error if an operand without `=` refers to an alias that does not exist.
+
+## Exit status
+
+Zero unless an error occurs.
+
+## Examples
+
+See [Aliases](../language/aliases.md).
+
+## Compatibility
+
+The `alias` built-in is specified by POSIX.1-2024.
+
+Some shells have predefined aliases that are printed even if you have not defined any explicitly.

--- a/docs/src/language/aliases.md
+++ b/docs/src/language/aliases.md
@@ -4,7 +4,7 @@
 
 ## Basic usage
 
-Define an alias with the `alias` built-in. When the first word in a [simple command](commands/simple.md) matches an alias, the shell replaces it with the alias definition before parsing the rest of the command.
+Define an alias with the [`alias` built-in](../builtins/alias.md). When the first word in a [simple command](commands/simple.md) matches an alias, the shell replaces it with the alias definition before parsing the rest of the command.
 
 ```shell,no_run
 $ alias ll='ls -l'

--- a/docs/src/language/commands/grouping.md
+++ b/docs/src/language/commands/grouping.md
@@ -4,7 +4,7 @@ A **grouping** command combines multiple commands so they are treated as a singl
 
 ## Braces
 
-Commands grouped in braces `{ ... }` run in the current shell environment.
+Commands grouped in braces `{ … }` run in the current shell environment.
 
 ```shell
 $ { echo "Hello"; echo "World"; }
@@ -39,7 +39,7 @@ $ test -f ~/cache/file || { mkdir -p ~/cache; > ~/cache/file; }
 
 ## Subshells
 
-Commands grouped in parentheses `( ... )` run in a subshell—a copy of the current shell environment. Changes made in a subshell do not affect the parent shell.
+Commands grouped in parentheses `( … )` run in a subshell—a copy of the current shell environment. Changes made in a subshell do not affect the parent shell.
 
 ```shell
 $ greeting="Morning"

--- a/docs/src/language/commands/pipelines.md
+++ b/docs/src/language/commands/pipelines.md
@@ -7,7 +7,7 @@ A **pipeline** is a sequence of commands connected by pipes (`|`). The output of
 The syntax for a pipeline is:
 
 ```sh
-command1 | command2 | command3 ...
+command1 | command2 | command3 …
 ```
 
 For example, to list files and filter the output:

--- a/docs/src/language/redirections/README.md
+++ b/docs/src/language/redirections/README.md
@@ -214,7 +214,7 @@ Read: One
 Read: One
 Read: One
 Read: One
-(The loop never ends...)
+(The loop never ends…)
 ```
 
 If a command has multiple redirections, they are applied in order. If several affect the same file descriptor, the last one takes effect:

--- a/docs/src/language/words/quoting.md
+++ b/docs/src/language/words/quoting.md
@@ -116,7 +116,7 @@ To treat a newline literally rather than as a line continuation, use single or d
 
 ## Dollar single quotes
 
-**Dollar single quotes** (`$'...'`) are used to specify strings with escape sequences, similar to those in C. The content inside the quotes is parsed, and recognized escape sequences are replaced with their corresponding characters.
+**Dollar single quotes** (`$'…'`) are used to specify strings with escape sequences, similar to those in C. The content inside the quotes is parsed, and recognized escape sequences are replaced with their corresponding characters.
 
 For example, `\n` is replaced with a newline character:
 

--- a/docs/src/patterns.md
+++ b/docs/src/patterns.md
@@ -29,10 +29,10 @@ The following characters have special meanings in patterns:
 
 - `?` – Matches any single character.
 - `*` – Matches any number of characters, including none.
-- `[...]` – Matches any single character from the set of characters inside the brackets. For example, `[abc]` matches `a`, `b`, or `c`. Ranges can be specified with a hyphen, like `[a-z]` for lowercase letters.
-- `[!...]` and `[^...]` – Matches any single character not in the set of characters inside the brackets. For example, `[!abc]` matches any character except `a`, `b`, or `c`.
+- `[…]` – Matches any single character from the set of characters inside the brackets. For example, `[abc]` matches `a`, `b`, or `c`. Ranges can be specified with a hyphen, like `[a-z]` for lowercase letters.
+- `[!…]` and `[^…]` – Matches any single character not in the set of characters inside the brackets. For example, `[!abc]` matches any character except `a`, `b`, or `c`.
 
-The `[^...]` form is not supported in all shells; prefer using `[!...]` for compatibility.
+The `[^…]` form is not supported in all shells; prefer using `[!…]` for compatibility.
 
 ```shell,no_run
 $ echo ?????? # prints all six-character long filenames

--- a/docs/src/startup.md
+++ b/docs/src/startup.md
@@ -7,9 +7,9 @@ This section describes how yash-rs is started and configured.
 Start the shell by running the `yash3` executable. The general syntax is:
 
 ```sh
-yash3 [options] [file [arguments...]]
-yash3 [options] -c command [command_name [arguments...]]
-yash3 [options] -s [arguments...]
+yash3 [options] [file [arguments…]]
+yash3 [options] -c command [command_name [arguments…]]
+yash3 [options] -s [arguments…]
 ```
 
 The shell's behavior is determined by the options and operands you provide.

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -16,48 +16,10 @@
 
 //! Alias built-in.
 //!
-//! The **`alias`** built-in defines [aliases] or prints alias definitions.
+//! This module implements the [`alias` built-in], which defines aliases or prints
+//! alias definitions.
 //!
-//! [aliases]: yash_syntax::alias
-//!
-//! # Synopsis
-//!
-//! ```sh
-//! alias [name[=value]…]
-//! ```
-//!
-//! # Description
-//!
-//! The alias built-in defines aliases or prints alias definitions as specified
-//! by the operands. If there are no operands, the alias built-in prints all
-//! alias definitions. The printed definitions are in the form of assignments
-//! with proper quoting that can be used as operands to the alias built-in to
-//! restore the definitions.
-//!
-//! # Options
-//!
-//! None. (TODO: Non-POSIX options)
-//!
-//! # Operands
-//!
-//! Each operand must be of the form `name=value` or `name`. The first form
-//! defines an alias named *name* that expands to *value*. The second form
-//! prints the definition of the alias named *name*.
-//!
-//! # Errors
-//!
-//! It is an error if an operand without `=` names a non-existent alias.
-//!
-//! # Exit status
-//!
-//! Zero unless an error occurs.
-//!
-//! # Portability
-//!
-//! The alias built-in is specified in POSIX.
-//!
-//! Some shells have a set of predefined aliases that are printed even if you
-//! don't define any explicitly.
+//! [`alias` built-in]: https://magicant.github.io/yash-rs/builtins/alias.html
 
 use crate::common::output;
 use crate::common::report_error;


### PR DESCRIPTION
## Summary by Copilot

This pull request updates the documentation and codebase for improved clarity, consistency, and functionality. Key changes include adding a new `alias` built-in documentation, refining references across files, and standardizing the use of ellipses and special characters for better readability and compatibility.

### Documentation Improvements:

* **Added documentation for the `alias` built-in**:
  - Created a new file, `docs/src/builtins/alias.md`, detailing the usage, syntax, and compatibility of the `alias` built-in.
  - Updated the `SUMMARY.md` file to link to the new `alias` documentation.

* **Improved cross-references**:
  - Updated the `aliases.md` file to include a link to the new `alias` built-in documentation.
  - Revised the `yash-builtin/src/alias.rs` file to link to the online `alias` documentation instead of duplicating its content.

### Consistency Enhancements:

* **Standardized ellipses**:
  - Replaced three periods (`...`) with proper ellipses (`…`) across multiple files for consistency. Affected files include `grouping.md`, `pipelines.md`, `redirections/README.md`, `words/quoting.md`, `patterns.md`, and `startup.md`. [[1]](diffhunk://#diff-e8355cd420d9c19afac814f339e1218b6447c61d2d9b529e807ad877981707beL7-R7) [[2]](diffhunk://#diff-e8355cd420d9c19afac814f339e1218b6447c61d2d9b529e807ad877981707beL42-R42) [[3]](diffhunk://#diff-ac39d93d9038681bb9caa0b4f5a29cad12a008164f08b64d1077b9753fd55555L10-R10) [[4]](diffhunk://#diff-35aaa9ac3acd9d5042333bb1d17dfb2c07718159e64aa628d95f0138a67590b9L217-R217) [[5]](diffhunk://#diff-1311c7cd42f39260c69fcbb1d313c28ff3ae6058cc0add2817316ccf93ba2b12L119-R119) [[6]](diffhunk://#diff-ab7b17bc9515afadc720b2678c20618105768e81375167adfd762f565c234edfL32-R35) [[7]](diffhunk://#diff-2ea0508fbbe47f263794af3690d5f6a897ff78e25a01328e245a082f88598b51L10-R12)

* **Improved character formatting**:
  - Updated bracketed patterns in `patterns.md` to use proper Unicode brackets for better readability.