### PR TITLE
docs: Interactive shell

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,7 +44,7 @@
 - [Termination](termination.md)
 - [Dynamic command evaluation](dynamic_evaluation.md)
 - [Script debugging](debugging.md)
-- [Interactive shell]()
+- [Interactive shell](interactive.md)
     - [Command prompt]()
     - [Job control]()
 - [Built-in utilities](builtins/README.md)

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -172,7 +172,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
 
 - **`exec`** (**`+n`**): If set (default), the shell executes commands. If unset, it only parses commands (useful for [syntax checking](../debugging.md#checking-syntax)).
     - Once unset, it cannot be set again in the same session.
-    - In interactive shells, this option is ignored and commands are always executed.
+    - In [interactive shells], this option is ignored and commands are always executed.
 
 - **`glob`** (**`+f`**): If set (default), the shell performs [pathname expansion](../language/words/globbing.md) on words containing metacharacters. If unset, pathname expansion is skipped.
 
@@ -181,9 +181,9 @@ Below is a list of all shell options in yash-rs, with their long and short names
     - Many shells implement `-h` differently, so behavior may vary.
 
 - **`ignoreeof`**: If set, the shell ignores end-of-file (usually `Ctrl+D`) and does not exit. See [Preventing accidental exits](../termination.md#preventing-accidental-exits).
-    - Only takes effect if the shell is interactive and input is a terminal. <!-- TODO: link to interactive shell -->
+    - Only takes effect if the shell is [interactive] and input is a terminal.
 
-- **`interactive`** (**`-i`**): If set, the shell is interactive. <!-- TODO: link to interactive -->
+- **`interactive`** (**`-i`**): If set, the shell is [interactive].
     - Enabled on startup if `stdin` is enabled and standard input and error are terminals.
 
 - **`log`**: Deprecated and has no effect. Remains for compatibility.
@@ -192,7 +192,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
     - ⚠️ Currently has no effect in yash-rs. In the future, login shells will read extra initialization files.
 
 - **`monitor`** (**`-m`**): If set, the shell performs job control for background jobs and suspended processes. <!-- TODO: link to job control -->
-    - Enabled by default in interactive shells.
+    - Enabled by default in [interactive] shells.
 
 - **`notify`** (**`-b`**): If set, the shell notifies you of background job completions and suspensions as soon as they occur. If unset, notifications are delayed until the next prompt. <!-- TODO: link to job control -->
     - ⚠️ Currently has no effect in yash-rs. In the future, it will enable immediate notifications for background jobs.
@@ -213,7 +213,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
 - **`verbose`** (**`-v`**): If set, the shell prints each command before executing it. See [Reviewing command input](../debugging.md#reviewing-command-input) for details.
 
 - **`vi`**: If set, the shell uses vi-style keybindings for command line editing. <!-- TODO: link to interactive shell and command line editing -->
-    - ⚠️ Currently has no effect in yash-rs. In the future, it will enable vi-style editing in interactive shells.
+    - ⚠️ Currently has no effect in yash-rs. In the future, it will enable vi-style editing in [interactive shells].
 
 - **`xtrace`** (**`-x`**): If set, the shell prints each field after [expansion](../language/words/index.html#word-expansion), before executing it. See [Tracing command execution](../debugging.md#tracing-command-execution) for details.
 
@@ -253,4 +253,6 @@ POSIX.1-2024 options:
 - `-o pipefail`
 - `-o vi`
 
+[interactive]: ../interactive.md
+[interactive shells]: ../interactive.md
 [variables]: ../language/parameters/variables.md

--- a/docs/src/environment/traps.md
+++ b/docs/src/environment/traps.md
@@ -68,3 +68,12 @@ Signal traps run when signals are caught.
 `EXIT` traps run when the shell exits normally, after all other commands complete.
 
 The [exit status](../language/commands/exit_status.md) is preserved across trap action execution, but trap actions can use the `exit` built-in to terminate the shell with a specific exit status.
+
+## Auto-ignored signals
+
+In an [interactive shell](../interactive.md), certain signals are automatically ignored by default to prevent the shell from being terminated or stopped unintentionally. Specifically:
+
+- `SIGINT`, `SIGTERM`, and `SIGQUIT` are always ignored.
+- If job control is enabled, `SIGTSTP`, `SIGTTIN`, and `SIGTTOU` are also ignored.
+
+This ensures the shell remains responsive and in control, even if these signals are sent. You can still set traps for these signals if needed. In [subshells](index.html#subshells), which are non-interactive, this automatic ignoring does not apply.

--- a/docs/src/interactive.md
+++ b/docs/src/interactive.md
@@ -1,0 +1,56 @@
+# Interactive shell
+
+When the `interactive` [shell option](environment/options.md) is enabled, the shell behaves in a way that is more suitable for interactive use. Currently, only the essential features are implemented, but more will be added in the future.
+
+## Enabling interactive mode
+
+When you start the shell without arguments in a terminal, it usually enables interactive mode by default:
+
+```sh
+yash3
+```
+
+Specifically, interactive mode is enabled if:
+
+- you do not specify `+i`,
+- [the `-s` option is active, either explicitly or implicitly](startup.md#modes-of-operation), and
+- [standard input and standard error](language/redirections/index.html#what-are-file-descriptors) are terminals.
+
+To force the shell to be interactive, use the `-i` option:
+
+```sh
+yash3 -i
+```
+
+Interactive mode can only be set at startup. To change the interactive mode, you must restart the shell.
+
+## Telling if the shell is interactive
+
+To determine if the shell is running in interactive mode, check whether the `-` [special parameter] contains `i`:
+
+```sh
+case $- in
+  *i*) echo "Interactive shell" ;;
+  *)   echo "Non-interactive shell" ;;
+esac
+```
+
+See [Viewing current options](environment/options.md#viewing-current-options) for additional methods.
+
+## What happens in interactive mode
+
+When the shell is interactive:
+
+- The shell executes an [rcfile](startup.md#interactive-shell) during startup.
+- The `-` [special parameter] includes `i`.
+- The `exec` [shell option](environment/options.md) is always considered set.
+- The `ignoreeof` [shell option](environment/options.md) is honored.
+- [Starting an asynchronous command prints its job number and process ID](language/commands/lists.md#asynchronous-commands).
+- The shell does not exit immediately on most [shell errors](termination.md#shell-errors).
+- [Some signals are automatically ignored](environment/traps.md#auto-ignored-signals).
+- [Signals ignored on entry can be trapped](environment/traps.md#restrictions).
+- Command prompts are displayed when reading input.
+- Job status changes are reported before prompting for input if job control is enabled.
+- The `read` built-in displays a prompt when reading a second or subsequent line of input.
+
+[special parameter]: language/parameters/special.md

--- a/docs/src/language/redirections/README.md
+++ b/docs/src/language/redirections/README.md
@@ -8,9 +8,9 @@ A **file descriptor** is a non-negative integer that identifies an open file or 
 
 The first three file descriptors have standard meanings:
 
-- **0**: Standard Input – the source of input data
-- **1**: Standard Output – the destination for command results
-- **2**: Standard Error – the destination for error messages and diagnostics
+- **0**: Standard input – the source of input data
+- **1**: Standard output – the destination for command results
+- **2**: Standard error – the destination for error messages and diagnostics
 
 By default, these are connected to the terminal, but they can be redirected to files or other destinations.
 


### PR DESCRIPTION
## Summary by Copilot

This pull request updates the documentation for the yash-rs shell to enhance clarity and provide additional details about interactive shell behavior. The most significant changes include the addition of a new page for interactive shells, updates to existing documentation to link to the new page, and minor improvements to terminology consistency.

### New Interactive Shell Documentation:

* [`docs/src/interactive.md`](diffhunk://#diff-82fd61f0df8a3b7d3b4f5ef90e63f1f8a46f32bb0b9e866bb11d13abe6a39b72R1-R56): Added a comprehensive guide to interactive shell behavior, including how to enable interactive mode, determine if the shell is in interactive mode, and the specific behaviors of the shell in this mode.

### Updates to Documentation Links:

* [`docs/src/environment/options.md`](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L175-R175): Updated references to "interactive shells" to use consistent markdown links pointing to the new interactive shell documentation. This affects several shell options, such as `exec`, `ignoreeof`, `interactive`, `monitor`, and `vi`. [[1]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L175-R175) [[2]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L184-R186) [[3]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L195-R195) [[4]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L216-R216) [[5]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506R256-R257)
* [`docs/src/environment/traps.md`](diffhunk://#diff-152c45d1fd45310d408b283bba3d9eda2df075b944bc9f4aec465101cc22d564R71-R79): Added a new section on "Auto-ignored signals" in interactive shells, with links to the interactive shell documentation.

### Minor Terminology Improvements:

* [`docs/src/language/redirections/README.md`](diffhunk://#diff-35aaa9ac3acd9d5042333bb1d17dfb2c07718159e64aa628d95f0138a67590b9L11-R13): Standardized capitalization for terms like "Standard input," "Standard output," and "Standard error."

### Table of Contents Update:

* [`docs/src/SUMMARY.md`](diffhunk://#diff-6e490221db20aaa056f2ed2c63443806b309ec63182541ddea9dd0b84e7eb501L47-R47): Updated the table of contents to include the new "Interactive shell" page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new page detailing the shell's interactive mode, including activation methods and behavior.
  * Updated references to "interactive shells" in environment options to use consistent markdown links.
  * Improved the summary entry for the "Interactive shell" section with a valid link.
  * Added a section explaining auto-ignored signals in interactive shells.
  * Standardized capitalization for standard input, output, and error in redirections documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->