### PR TITLE
Fix failing type inference during test compilation

### DIFF
--- a/yash-builtin/src/exec.rs
+++ b/yash-builtin/src/exec.rs
@@ -281,7 +281,7 @@ mod tests {
         let arguments = process.last_exec().as_ref().unwrap();
         assert_eq!(arguments.0, c"/bin/echo".to_owned());
         assert_eq!(arguments.1, [c"/bin/echo".to_owned()]);
-        assert_eq!(arguments.2, []);
+        assert!(arguments.2.is_empty());
     }
 
     #[test]

--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn env_c_strings() {
         let mut variables = VariableSet::new();
-        assert_eq!(&variables.env_c_strings(), &[]);
+        assert!(&variables.env_c_strings().is_empty());
 
         let mut var = variables.get_or_new("foo", Scope::Global);
         var.assign("FOO", None).unwrap();


### PR DESCRIPTION
While running `cargo test --release` for Alpine Linux, I meet the following errors:
```
error[E0282]: type annotations needed
   --> yash-builtin/src/exec.rs:284:9
    |
284 |         assert_eq!(arguments.2, []);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0282]: type annotations needed
    --> yash-env/src/variable.rs:1341:9
     |
1341 |         assert_eq!(&variables.env_c_strings(), &[]);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
```

This patch changes the `assert_eq!` to `assert!` and uses `.is_empty()` on the variables for the same effect,  fixing the type inference issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use the `.is_empty()` method for checking empty collections, improving clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->