### PR TITLE
Documentation update

### DIFF
--- a/docs/src/builtins/bg.md
+++ b/docs/src/builtins/bg.md
@@ -22,8 +22,6 @@ None.
 
 Operands specify jobs to resume as [job IDs](../interactive/job_control.md#job-ids). If omitted, the built-in resumes the [current job](../interactive/job_control.md#current-and-previous-jobs).
 
-(TODO: allow omitting the leading `%`)
-
 ## Standard output
 
 The built-in writes the job number and name of each resumed job to the standard output.
@@ -47,5 +45,6 @@ See [Job control](../interactive/job_control.md).
 ## Compatibility
 
 Many implementations allow omitting the leading `%` from job IDs, though it is not required by POSIX.
+Previous versions of yash allowed it, but this is not yet supported in yash-rs.
 
 Some implementations (including the previous version of yash, but not this version) regard it is an error to resume a job that has already terminated.

--- a/docs/src/builtins/break.md
+++ b/docs/src/builtins/break.md
@@ -23,8 +23,6 @@ outermost one.
 
 None.
 
-(TODO: the `-i` option)
-
 ## Operands
 
 Operand ***n*** specifies the nest level of the loop to exit.
@@ -48,6 +46,8 @@ The behavior is unspecified in POSIX when the `break` built-in is used without a
 POSIX allows the built-in to break a loop running in the current [execution environment] that does not lexically enclose the break command. Our implementation does not do that.
 
 POSIX does not require the `break` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+
+Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.
 
 [execution environment]: ../environment/index.html
 [loop]: ../language/commands/loops.md

--- a/docs/src/builtins/break.md
+++ b/docs/src/builtins/break.md
@@ -45,7 +45,7 @@ The behavior is unspecified in POSIX when the `break` built-in is used without a
 
 POSIX allows the built-in to break a loop running in the current [execution environment] that does not lexically enclose the break command. Our implementation does not do that.
 
-POSIX does not require the `break` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In some shells, the `break` built-in lacks support for the [`--` separator](index.html#separators).
 
 Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.
 

--- a/docs/src/builtins/continue.md
+++ b/docs/src/builtins/continue.md
@@ -49,7 +49,7 @@ The behavior is unspecified in POSIX when the `continue` built-in is used withou
 
 POSIX allows the built-in to restart a loop running in the current [execution environment] that does not lexically enclose the continue command. Our implementation declines to do that.
 
-POSIX does not require the `continue` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In some shells, the `continue` built-in lacks support for the [`--` separator](index.html#separators).
 
 Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.
 

--- a/docs/src/builtins/continue.md
+++ b/docs/src/builtins/continue.md
@@ -27,8 +27,6 @@ If the affected loop is a `while` or `until` loop, the condition is re-evaluated
 
 None.
 
-(TODO: the `-i` option)
-
 ## Operands
 
 Operand ***n*** specifies the nest level of the affected loop.
@@ -52,6 +50,8 @@ The behavior is unspecified in POSIX when the `continue` built-in is used withou
 POSIX allows the built-in to restart a loop running in the current [execution environment] that does not lexically enclose the continue command. Our implementation declines to do that.
 
 POSIX does not require the `continue` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+
+Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.
 
 [execution environment]: ../environment/index.html
 [loop]: ../language/commands/loops.md

--- a/docs/src/builtins/eval.md
+++ b/docs/src/builtins/eval.md
@@ -46,6 +46,6 @@ The `eval` built-in can be dangerous if used with untrusted input, as it can exe
 
 The `eval` built-in is specified by POSIX.1-2024.
 
-POSIX does not require the `eval` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In some shells, the `eval` built-in lacks support for the [`--` separator](index.html#separators), treating it as an operand.
 
 Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.

--- a/docs/src/builtins/eval.md
+++ b/docs/src/builtins/eval.md
@@ -16,8 +16,6 @@ This built-in parses and executes the argument as a shell script in the current 
 
 None.
 
-(TODO: non-portable options)
-
 ## Operands
 
 The operand is a command string to be evaluated.
@@ -49,3 +47,5 @@ The `eval` built-in can be dangerous if used with untrusted input, as it can exe
 The `eval` built-in is specified by POSIX.1-2024.
 
 POSIX does not require the `eval` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+
+Previous versions of yash supported the non-standard `-i` option, but this is not yet supported in yash-rs.

--- a/docs/src/builtins/exit.md
+++ b/docs/src/builtins/exit.md
@@ -58,8 +58,8 @@ $ exit 42
 
 The `exit` built-in is specified by POSIX.1-2024.
 
+In some shells, the `exit` built-in lacks support for the [`--` separator](index.html#separators).
+
 The behavior is undefined in POSIX if *exit_status* is greater than 255.
 The current implementation passes such a value as is in the result, but this
 behavior may change in the future.
-
-POSIX does not require the `exit` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.

--- a/docs/src/builtins/export.md
+++ b/docs/src/builtins/export.md
@@ -19,8 +19,6 @@ values of all exported variables in a format that can be reused as input to
 restore the state of these variables. When used with operands, the option
 limits the output to the specified variables.
 
-(TODO: Other non-portable options)
-
 ## Operands
 
 The operands are the names of variables to be exported or printed. When exporting, each name may optionally be followed by `=` and a *value* to assign to the variable.
@@ -51,5 +49,7 @@ See [Environment variables](../language/parameters/variables.md#environment-vari
 
 This built-in is part of the POSIX standard. Printing variables is portable
 only when the `-p` option is used without operands.
+
+Previous versions of yash supported the non-standard `-r` and `-X` options, but these are not yet supported in yash-rs.
 
 [read-only]: ../language/parameters/variables.md#read-only-variables

--- a/docs/src/builtins/false.md
+++ b/docs/src/builtins/false.md
@@ -25,7 +25,7 @@ None.
 
 None.
 
-(TODO: In the future, the built-in may detect unexpected options or operands.)
+In the future, the built-in may detect unexpected options or operands.
 
 ## Exit Status
 

--- a/docs/src/builtins/fg.md
+++ b/docs/src/builtins/fg.md
@@ -22,14 +22,11 @@ None.
 
 Operand *job_id* specifies which job to resume. See [Job IDs](../interactive/job_control.md#job-ids) for the operand format. If omitted, the built-in resumes the [current job](../interactive/job_control.md#current-and-previous-jobs).
 
-(TODO: allow omitting the leading `%`)
-(TODO: allow multiple operands)
-
 ## Standard output
 
 The built-in writes the selected job name to the standard output.
 
-(TODO: print the job number as well)
+<!-- TODO: print the job number as well -->
 
 ## Errors
 
@@ -51,7 +48,6 @@ See [Job control](../interactive/job_control.md).
 
 ## Compatibility
 
-Many implementations allow omitting the leading `%` from job IDs and
-specifying multiple job IDs at once, though this is not required by POSIX.
+Many implementations allow omitting the leading `%` from job IDs and specifying multiple job IDs at once, though this is not required by POSIX and not yet supported in yash-rs.
 
 POSIX does not require the `fg` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.

--- a/docs/src/builtins/fg.md
+++ b/docs/src/builtins/fg.md
@@ -49,5 +49,3 @@ See [Job control](../interactive/job_control.md).
 ## Compatibility
 
 Many implementations allow omitting the leading `%` from job IDs and specifying multiple job IDs at once, though this is not required by POSIX and not yet supported in yash-rs.
-
-POSIX does not require the `fg` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.

--- a/docs/src/builtins/jobs.md
+++ b/docs/src/builtins/jobs.md
@@ -5,7 +5,7 @@ The **`jobs`** built-in reports job status.
 ## Synopsis
 
 ```sh
-jobs [-lp] [job_id…]
+jobs [-l|-p] [job_id…]
 ```
 
 ## Description
@@ -113,8 +113,6 @@ When the built-in is used in a [subshell](../environment/index.html#subshells), 
 
 The POSIX standard only defines the `-l` and `-p` options. <!-- TODO: Other options are non-portable extensions. --> Previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
-According to POSIX, the `-p` option takes precedence over the `-l` option.
-In many other shells, however, the last specified one is effective.
+POSIX does not define the behavior when both `-l` and `-p` options are used together. In most other shells, the option specified last takes effect. In yash-rs, the `-p` option takes precedence over `-l`, but this may change in future versions. Later releases of yash-rs might instead reject conflicting options.
 
-A portable job ID must start with a `%`. If an operand does not have a
-leading `%`, the built-in assumes one silently, which is not portable.
+A portable job ID must start with a `%`. If an operand does not have a leading `%`, the built-in assumes one silently, which is not portable.

--- a/docs/src/builtins/jobs.md
+++ b/docs/src/builtins/jobs.md
@@ -38,15 +38,20 @@ The last column is the command line of the job.
 
 ## Options
 
+<!--
+TODO: Uncomment when adding filtering options below
 ### Formatting
+-->
 
 You can use two options to change the output.
 
 The **`-l`** (**`--verbose`**) option displays additional details by inserting the process ID before each job state. The **`-p`** (**`--pgid-only`**) option outputs only the process ID of each job. In both cases, the process ID shown is that of the main process in the job, which is also the process group ID if the job is under job control.
 
+<!--
 ### Filtering
 
 TODO `-n`, `-r`, `-s`, `-t`
+-->
 
 ## Operands
 
@@ -106,8 +111,7 @@ $ jobs %sleep %sleep
 
 When the built-in is used in a [subshell](../environment/index.html#subshells), the built-in reports not only jobs that were started in the subshell but also jobs that were started in the parent shell. This behavior is not portable and is subject to change.
 
-The POSIX standard only defines the `-l` and `-p` options. Other options are
-non-portable extensions.
+The POSIX standard only defines the `-l` and `-p` options. <!-- TODO: Other options are non-portable extensions. --> Previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
 According to POSIX, the `-p` option takes precedence over the `-l` option.
 In many other shells, however, the last specified one is effective.

--- a/docs/src/builtins/kill.md
+++ b/docs/src/builtins/kill.md
@@ -21,9 +21,7 @@ descriptions.
 
 ## Options
 
-The **`-s`** or **`-n`** option specifies the signal to send. The signal
-name is case-insensitive, but must be specified without the `SIG` prefix.
-The default signal is `SIGTERM`. (TODO: Allow the `SIG` prefix)
+The **`-s`** or **`-n`** option specifies the signal to send. The signal name is case-insensitive, but must be specified without the `SIG` prefix. The default signal is `SIGTERM`. (Specifying a signal name with the `SIG` prefix may be allowed in the future.)
 
 The signal may be specified as a number instead of a name. If the number
 is zero, the built-in does not send a signal, but instead checks whether

--- a/docs/src/builtins/read.md
+++ b/docs/src/builtins/read.md
@@ -24,8 +24,7 @@ The `-r` option disables this behavior.
 
 ### Prompting
 
-By default, the built-in does not display a prompt before reading a
-line. (TODO: Options to display a prompt)
+By default, the built-in does not display a prompt before reading a line. <!-- TODO: Options to display a prompt -->
 
 When reading lines after the first line, the built-in displays the value of the `PS2` [variable](../language/parameters/variables.md) as a prompt if the shell is [interactive](../interactive/index.html) and the input is from a terminal. See [Command prompt](../interactive/prompt.md) for details.
 
@@ -139,7 +138,7 @@ $ printf '[%s]\n' "$line"
 
 ## Compatibility
 
-POSIX.1-2024 defines the `read` built-in with the `-d` and `-r` options.
+POSIX.1-2024 defines the `read` built-in with the `-d` and `-r` options. Previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
 In this implementation, a line continuation is always a backslash followed by a newline. Other implementations may allow a backslash followed by a delimiter to be a line continuation if the delimiter is not a newline.
 

--- a/docs/src/builtins/return.md
+++ b/docs/src/builtins/return.md
@@ -53,7 +53,9 @@ The `return` built-in is specified by POSIX.1-2024.
 POSIX only requires the `return` built-in to quit a function or [sourced](source.md) script.
 The behavior for other kinds of scripts is a non-standard extension.
 
-The `-n` (`--no-return`) option is a non-standard extension. POSIX does not require the `return` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In some shells, the `return` built-in lacks support for the [`--` separator](index.html#separators).
+
+The `-n` (`--no-return`) option is a non-standard extension.
 
 The behavior is unspecified in POSIX if *exit_status* is greater than 255.
 The current implementation passes such a value as is in the result, but this

--- a/docs/src/builtins/shift.md
+++ b/docs/src/builtins/shift.md
@@ -40,4 +40,4 @@ Zero if successful, non-zero if an error occurred.
 
 The `shift` built-in is part of POSIX.1-2024.
 
-POSIX does not require the `shift` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In some shells, the `shift` built-in lacks support for the [`--` separator](index.html#separators).

--- a/docs/src/builtins/source.md
+++ b/docs/src/builtins/source.md
@@ -63,8 +63,6 @@ The `.` built-in is specified in the POSIX standard. The built-in name `source` 
 
 POSIX defines no options for the `.` built-in, but previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
-POSIX does not require the `.` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
-
 If the pathname of the file does not contain a slash and the file is not found in the command search, some shells may fall back to the file in the current working directory. This is a non-portable extension that is not specified in POSIX. The portable way to specify a file in the current working directory is to prefix the filename with `./` as in `. ./foo.sh`.
 
 Setting the positional parameters with additional operands is a non-standard extension that is supported by some other shells. The behavior about the local variable context may differ in other shells.

--- a/docs/src/builtins/source.md
+++ b/docs/src/builtins/source.md
@@ -30,7 +30,7 @@ If there are no operands, the positional parameters are not changed and the scri
 
 None.
 
-(TODO: non-portable options)
+<!-- TODO: non-portable options -->
 
 ## Operands
 
@@ -60,6 +60,8 @@ See [Reading and executing files](../dynamic_evaluation.md#reading-and-executing
 ## Compatibility
 
 The `.` built-in is specified in the POSIX standard. The built-in name `source` is a non-standard extension that is also available in some other shells.
+
+POSIX defines no options for the `.` built-in, but previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
 POSIX does not require the `.` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
 

--- a/docs/src/builtins/times.md
+++ b/docs/src/builtins/times.md
@@ -46,8 +46,6 @@ Zero unless an error occurred.
 
 The `times` built-in is defined in POSIX.
 
-POSIX does not require the `times` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
-
 POSIX requires each field to be printed with six digits after the decimal
 point, but many implementations print less. Note that the number of digits
 does not necessarily indicate the precision of the times.

--- a/docs/src/builtins/true.md
+++ b/docs/src/builtins/true.md
@@ -24,7 +24,7 @@ None.
 
 None.
 
-(TODO: In the future, the built-in may detect unexpected options or operands.)
+In the future, the built-in may detect unexpected options or operands.
 
 ## Exit Status
 

--- a/docs/src/builtins/type.md
+++ b/docs/src/builtins/type.md
@@ -54,7 +54,7 @@ The `type` built-in is specified by POSIX.1-2024.
 
 POSIX defines no options for the `type` built-in, but previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
-POSIX does not require the `type` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
+In dash, the [`--` separator](index.html#separators) is treated as an operand.
 
 POSIX requires that the *name* operand be specified, but many implementations allow it to be omitted, in which case the built-in does nothing.
 

--- a/docs/src/builtins/type.md
+++ b/docs/src/builtins/type.md
@@ -16,7 +16,7 @@ The `type` built-in prints the description of the specified command names.
 
 None.
 
-(TODO: Non-standard options are not supported yet.)
+<!-- TODO: Non-standard options -->
 
 ## Operands
 
@@ -51,6 +51,8 @@ env: external utility at /usr/bin/env
 ## Compatibility
 
 The `type` built-in is specified by POSIX.1-2024.
+
+POSIX defines no options for the `type` built-in, but previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
 POSIX does not require the `type` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
 

--- a/docs/src/builtins/wait.md
+++ b/docs/src/builtins/wait.md
@@ -74,8 +74,6 @@ In the above example, `wait` treats the job `%` as an unknown job and returns ex
 
 The `wait` built-in is specified in POSIX.1-2024.
 
-POSIX does not require the `wait` built-in to conform to the [Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02), which means portable scripts cannot use any options or the `--` separator for the built-in.
-
 Many existing shells behave differently on various errors. POSIX requires that an unknown process ID be treated as a process that has already exited with exit status 127, but the behavior for other errors should not be considered portable.
 
 [Job ID]: ../interactive/job_control.md#job-ids


### PR DESCRIPTION
## Summary by Copilot

This pull request updates the documentation for several shell built-in commands, focusing on clarifying compatibility, POSIX compliance, and the current feature set of `yash-rs` compared to previous versions of yash and other shells. It removes outdated TODOs, adds notes about unsupported or non-standard options, and improves explanations of option handling and compatibility.

The most important changes are:

**Compatibility and Option Support Clarifications:**

* Added explicit notes about which non-standard options and features from previous yash versions are not yet implemented in `yash-rs`, including for `bg`, `fg`, `jobs`, `export`, `eval`, `continue`, `break`, `read`, `source`, and `type` built-ins. [[1]](diffhunk://#diff-161ab133e2fbfb6159aa868fe2aa0f84fce95cc6cac42cf461cd344e729c710dR48) [[2]](diffhunk://#diff-a60fe1e3b8ee8971ba3e71261b00cb95e6db21d1655c9f18231bf260fd41e77cL54-R51) [[3]](diffhunk://#diff-ef2215ba0b6c20a9f42b2af3fcb1dca0a8a92593d13f381a101f467f289e9fdeL109-R118) [[4]](diffhunk://#diff-c3a3c9e8114b100ec4ea6e5e7470e2dac0e16d0396f3c7ee3fa045d6388cfc9aR53-R54) [[5]](diffhunk://#diff-2bb640fd793f2a0fc80eaf6d3822a4e9dd00c91cc348bae1889671b22b8f6cd2L51-R51) [[6]](diffhunk://#diff-9125c730d23f7be8d4ddd4008b24e6d158b282550c8bcda8ba674a7db34b49ceL54-R54) [[7]](diffhunk://#diff-a1f9a93862c524a8bf75d5a7a7181d2282b5785faea4c8e25f93c7f305f27588L50-R50) [[8]](diffhunk://#diff-b14f06fa6ec3c295ce5d90809c6934674293dfb910032caf13a1498231063995L142-R141) [[9]](diffhunk://#diff-29038663e44fda56a874b310ec399541c4caa970ff59da7016cee6c3728fd65dL64-R64) [[10]](diffhunk://#diff-64ea798e33aa305f7b97de3bc85c1b7f99f5142fe89c94dca69c2846aa2480bbL55-R57)
* Clarified the lack of support for the `--` separator and other POSIX Utility Syntax Guidelines requirements in several built-ins, and described how some shells handle these cases differently. [[1]](diffhunk://#diff-3971f567a893ec474c59264d01eb324f3f51784420c68f122eda95f8e8ff863dL56-R58) [[2]](diffhunk://#diff-5e9de822a259242d5df31f07f4556ad687c75a1731be043139d9ece3f06a5c63L43-R43) [[3]](diffhunk://#diff-c0219e017c10929832a348676812f772fb85559f325b366503807723a5ccb23cR61-L65)

**Removal or Update of Outdated TODOs:**

* Removed or replaced outdated TODO comments in documentation for `bg`, `fg`, `break`, `continue`, `eval`, `export`, `false`, `true`, `read`, `source`, and `type`, often replacing them with compatibility notes or future-looking comments. [[1]](diffhunk://#diff-161ab133e2fbfb6159aa868fe2aa0f84fce95cc6cac42cf461cd344e729c710dL25-L26) [[2]](diffhunk://#diff-a60fe1e3b8ee8971ba3e71261b00cb95e6db21d1655c9f18231bf260fd41e77cL25-R29) [[3]](diffhunk://#diff-a1f9a93862c524a8bf75d5a7a7181d2282b5785faea4c8e25f93c7f305f27588L26-L27) [[4]](diffhunk://#diff-9125c730d23f7be8d4ddd4008b24e6d158b282550c8bcda8ba674a7db34b49ceL30-L31) [[5]](diffhunk://#diff-2bb640fd793f2a0fc80eaf6d3822a4e9dd00c91cc348bae1889671b22b8f6cd2L19-L20) [[6]](diffhunk://#diff-c3a3c9e8114b100ec4ea6e5e7470e2dac0e16d0396f3c7ee3fa045d6388cfc9aL22-L23) [[7]](diffhunk://#diff-13219f86a5ac7f9c838eeca3b8c1fa998bd49c7ce44b24919353924da4aa511cL28-R28) [[8]](diffhunk://#diff-421293007b667f4b6c499cfd130b5fda0e8478cfe9f76b36c5d563d23487cbd7L27-R27) [[9]](diffhunk://#diff-b14f06fa6ec3c295ce5d90809c6934674293dfb910032caf13a1498231063995L27-R27) [[10]](diffhunk://#diff-29038663e44fda56a874b310ec399541c4caa970ff59da7016cee6c3728fd65dL33-R33) [[11]](diffhunk://#diff-64ea798e33aa305f7b97de3bc85c1b7f99f5142fe89c94dca69c2846aa2480bbL19-R19)

**Documentation Improvements for Option Handling:**

* Improved explanations of how options like `-l` and `-p` are handled in the `jobs` built-in, including precedence rules and differences from other shells.
* Updated the synopsis and options section for `jobs` to clarify mutually exclusive options and future plans for filtering options. [[1]](diffhunk://#diff-ef2215ba0b6c20a9f42b2af3fcb1dca0a8a92593d13f381a101f467f289e9fdeL8-R8) [[2]](diffhunk://#diff-ef2215ba0b6c20a9f42b2af3fcb1dca0a8a92593d13f381a101f467f289e9fdeR41-R54)

**Clarifications on Signal Specification and Error Handling:**

* Updated the `kill` built-in documentation to clarify future support for signal names with the `SIG` prefix.
* Updated error and compatibility notes for several built-ins, such as `wait`, to better reflect POSIX requirements and implementation differences.

**General Consistency and Formatting:**

* Improved formatting and consistency across documentation files, including changing some TODOs to HTML comments and clarifying future plans or non-portable behaviors. [[1]](diffhunk://#diff-29038663e44fda56a874b310ec399541c4caa970ff59da7016cee6c3728fd65dL33-R33) [[2]](diffhunk://#diff-ef2215ba0b6c20a9f42b2af3fcb1dca0a8a92593d13f381a101f467f289e9fdeR41-R54) [[3]](diffhunk://#diff-b14f06fa6ec3c295ce5d90809c6934674293dfb910032caf13a1498231063995L27-R27)

These changes help users and contributors better understand the current state of built-in command support in `yash-rs` and how it compares to other shells and previous yash versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Cleaned up built-in docs by removing visible TODOs and replacing them with concise statements or hidden comments.
  - Added compatibility notes across multiple built-ins about limited support for the “--” separator in some shells.
  - Clarified that certain non-standard options supported by previous yash versions are not yet available in yash-rs.
  - Updated jobs usage to use -l|-p and clarified behavior when both are specified.
  - Refined kill signal description and future SIG-prefix allowance.
  - Minor wording and formatting improvements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->