### PR TITLE
actions: Explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
@@ -38,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
@@ -52,6 +56,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@nightly
@@ -62,6 +68,8 @@ jobs:
       run: ./check-msrv.sh -v
   windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
@@ -88,6 +96,8 @@ jobs:
       run: cargo test --all-features --package yash-builtin
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Resolves https://github.com/magicant/yash-rs/security/code-scanning/2 etc.

For some unknown reason, only partial permissions were set in #585. This pull request sets them all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened CI job permissions to read-only across multiple workflows while leaving existing special permissions for one linting job unchanged.
  * No changes to build steps, triggers, or environments.
  * No user-facing impact; app behavior and documentation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->