### PR TITLE
Highlight correct source fragment with multi-byte characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -658,7 +658,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_matches",
  "enumset",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.6.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
 yash-semantics = { path = "yash-semantics", version = "0.8.0" }
-yash-syntax = { path = "yash-syntax", version = "0.15.0" }
+yash-syntax = { path = "yash-syntax", version = "0.15.1" }

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.15.0 → 0.15.1
+
 ## [0.9.0] - 2025-05-11
 
 ### Added
@@ -334,6 +341,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.9.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.1
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.0
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.8.0
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.7.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [features]
 default = ["yash-prompt", "yash-semantics"]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,14 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - Unreleased
+
+### Fixed
+
+- Error messages now accurately highlight the relevant source code fragment.
+  Previously, the shell could highlight the wrong section or crash when the
+  source contained multi-byte characters.
+
 ## [0.4.2] - 2025-05-11
 
 ### Changed
@@ -199,6 +207,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
+[0.4.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.3
 [0.4.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.2
 [0.4.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.1
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.0

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/yash-cli-{ version }/{ name }-{ target }{ archive-suffix }"

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- External dependency versions:
+    - yash-syntax 0.15.0 → 0.15.1
 - Internal dependency versions:
     - libc 0.2.169 → 0.2.171
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.15.0 → 0.15.1
+
 ## [0.6.0] - 2025-05-11
 
 ### Changed
@@ -76,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.6.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.1
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.0
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.4.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 futures-util = { workspace = true }

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.15.0 → 0.15.1
+
 ## [0.8.0] - 2025-05-11
 
 ### Changed
@@ -244,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.8.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.1
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - Unreleased
+
+### Added
+
+- Added the `Location::byte_range` method to obtain the byte range corresponding
+  to a character range in source code locations.
+
+### Fixed
+
+- The implementation of
+  `From<&'a source::pretty::Message<'a>> for annotate_snippets::Message<'a>` was
+  incorrectly using character ranges instead of byte ranges for source
+  annotations, which could lead to incorrect highlighting in messages.
+
 ## [0.15.0] - 2025-05-11
 
 ### Added
@@ -476,6 +490,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.0
 [0.14.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.1
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities", "parser-implementations"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true, optional = true }

--- a/yash-syntax/src/source/pretty.rs
+++ b/yash-syntax/src/source/pretty.rs
@@ -302,7 +302,7 @@ mod annotate_snippets_support {
             // into a temporary vector, and then merge annotations with the same code into a single
             // snippet.
             for annotation in &message.annotations {
-                let range = annotation.location.range.clone();
+                let range = annotation.location.byte_range();
                 let level = annotate_snippets::Level::from(annotation.r#type);
                 let as_annotation = level.span(range).label(&annotation.label);
                 let code = &*annotation.location.code;


### PR DESCRIPTION
Spans used by annotate-snippets 0.11.x must be byte ranges, but
yash-syntax was providing character ranges as used by previous versions
of annotate-snippets. This caused incorrect highlighting in error
messages when the source contained multi-byte characters, or even
crashes when the character range did not correspond to a valid byte
range.

This commit adds the `Location::byte_range` method to convert a
character range to a byte range, and uses it when converting to
`annotate_snippets::Message`.

Fixes https://github.com/magicant/yash-rs/issues/587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Error messages now highlight the correct source code fragment, including cases with multi-byte characters, preventing crashes.

- Chores
  - Updated internal dependencies and applied minor version bumps across components.
  - Disabled publishing for select packages to control distribution.

- Documentation
  - Changelogs updated with new version entries and dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->