### PR TITLE
Handle `--` separators in built-in arguments correctly

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly
-  handle the `--` separator between options and operands.
+- The `eval`, `exit`, `export`, `readonly`, `return`, `shift`, and `typeset`
+  built-ins now correctly handle the `--` separator between options and
+  operands.
 - The `export`, `readonly`, and `typeset` built-ins now correctly print the `--`
   separator when the name of a variable or function starts with `-`.
 - The `jobs` built-in no longer panics when reporting the same finished job more

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly
   handle the `--` separator between options and operands.
+- The `export`, `readonly`, and `typeset` built-ins now correctly print the `--`
+  separator when the name of a variable or function starts with `-`.
 - The `jobs` built-in no longer panics when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `eval`, `exit`, `return`, and `shift` built-ins now correctly handle the
-  `--` separator between options and operands.
+- The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly
+  handle the `--` separator between options and operands.
 - The `jobs` built-in no longer panics when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1] - Unreleased
 
+### Added
+
+- The `return` built-in now supports the `--no-return` option as a synonym of
+  `-n`, which returns the specified exit status without actually returning from
+  the current function or script.
+
 ### Changed
 
 - External dependency versions:
@@ -14,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `eval`, `exit`, `return`, and `shift` built-ins now correctly handle the
+  `--` separator between options and operands.
 - The `jobs` built-in no longer panics when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-builtin/src/break/syntax.rs
+++ b/yash-builtin/src/break/syntax.rs
@@ -75,11 +75,6 @@ pub type Result = std::result::Result<NonZeroUsize, Error>;
 
 /// Parses command line arguments for the break/continue built-in.
 pub fn parse(env: &Env, args: Vec<Field>) -> Result {
-    // TODO: POSIX does not require the break/continue built-in to support XBD
-    // Utility Syntax Guidelines. That means the built-in does not have to
-    // recognize the "--" separator. We should reject the separator in the
-    // POSIXly-correct mode.
-
     let (_options, mut operands) = parse_arguments(&[], Mode::with_env(env), args)?;
 
     if operands.len() > 1 {

--- a/yash-builtin/src/eval.rs
+++ b/yash-builtin/src/eval.rs
@@ -22,6 +22,8 @@
 //! [`eval` built-in]: https://magicant.github.io/yash-rs/builtins/eval.html
 
 use crate::Result;
+use crate::common::report_error;
+use crate::common::syntax::{Mode, parse_arguments};
 use std::cell::RefCell;
 use std::rc::Rc;
 use yash_env::Env;
@@ -35,6 +37,12 @@ use yash_syntax::source::Source;
 
 /// Entry point of the `eval` built-in execution
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
+    // TODO Support non-POSIX options
+    let args = match parse_arguments(&[], Mode::with_env(env), args) {
+        Ok((_options, operands)) => operands,
+        Err(error) => return report_error(env, &error).await,
+    };
+
     let command = match join(args) {
         Some(command) => command,
         None => return Result::default(),

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -43,7 +43,8 @@
 //! In case of an error, the result will have a [`Divert::Interrupt`] value
 //! instead, in which case the shell will not exit if it is interactive.
 
-use crate::common::syntax_error;
+use crate::common::syntax::{Mode, parse_arguments};
+use crate::common::{report_error, syntax_error};
 use std::num::ParseIntError;
 use std::ops::ControlFlow::Break;
 use yash_env::Env;
@@ -63,6 +64,12 @@ async fn operand_parse_error(env: &mut Env, location: &Location, error: ParseInt
 ///
 /// See the [module-level documentation](self) for details.
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
+    // TODO Support non-POSIX options
+    let args = match parse_arguments(&[], Mode::with_env(env), args) {
+        Ok((_options, operands)) => operands,
+        Err(error) => return report_error(env, &error).await,
+    };
+
     if let Some(arg) = args.get(1) {
         return syntax_error(env, "too many operands", &arg.origin).await;
     }

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -63,11 +63,6 @@ async fn operand_parse_error(env: &mut Env, location: &Location, error: ParseInt
 ///
 /// See the [module-level documentation](self) for details.
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
-    // TODO: POSIX does not require the exit built-in to support XBD Utility
-    // Syntax Guidelines. That means the built-in does not have to recognize the
-    // "--" separator. We should reject the separator in the POSIXly-correct
-    // mode.
-
     if let Some(arg) = args.get(1) {
         return syntax_error(env, "too many operands", &arg.origin).await;
     }

--- a/yash-builtin/src/return.rs
+++ b/yash-builtin/src/return.rs
@@ -57,10 +57,6 @@ async fn operand_parse_error(env: &mut Env, location: &Location, error: ParseInt
 ///
 /// See the [module-level documentation](self) for details.
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
-    // TODO: POSIX does not require the return built-in to support XBD Utility
-    // Syntax Guidelines. That means the built-in does not have to recognize the
-    // "--" separator. We should reject the separator in the POSIXly-correct
-    // mode.
     // TODO Reject returning from an interactive session
 
     let mut i = args.iter().peekable();

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -34,11 +34,6 @@ use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
 
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
-    // TODO: POSIX does not require the shift built-in to support XBD Utility
-    // Syntax Guidelines. That means the built-in does not have to recognize the
-    // "--" separator. We should reject the separator in the POSIXly-correct
-    // mode.
-
     if let Some(arg) = args.get(1) {
         return syntax_error(env, "too many operands", &arg.origin).await;
     }

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -22,6 +22,8 @@
 //! [`shift` built-in]: https://magicant.github.io/yash-rs/builtins/shift.html
 
 use crate::common::arrange_message_and_divert;
+use crate::common::report_error;
+use crate::common::syntax::{Mode, parse_arguments};
 use crate::common::syntax_error;
 use std::borrow::Cow;
 use yash_env::Env;
@@ -34,6 +36,12 @@ use yash_syntax::source::pretty::AnnotationType;
 use yash_syntax::source::pretty::Message;
 
 pub async fn main(env: &mut Env, args: Vec<Field>) -> Result {
+    // TODO Support non-POSIX options
+    let args = match parse_arguments(&[], Mode::with_env(env), args) {
+        Ok((_options, operands)) => operands,
+        Err(error) => return report_error(env, &error).await,
+    };
+
     if let Some(arg) = args.get(1) {
         return syntax_error(env, "too many operands", &arg.origin).await;
     }

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -459,6 +459,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_many_short_options() {
+        let args = Field::dummies(["-p", "+xr"]);
+        let result = parse(ALL_OPTIONS, args.clone()).unwrap();
+        assert_matches!(&result.0[..], [option1, option2, option3] => {
+            assert_eq!(option1.spec, &PRINT_OPTION);
+            assert_eq!(option1.state, State::On);
+            assert_eq!(option1.location, Location::dummy("-p"));
+            assert_eq!(option2.spec, &EXPORT_OPTION);
+            assert_eq!(option2.state, State::Off);
+            assert_eq!(option2.location, Location::dummy("+xr"));
+            assert_eq!(option3.spec, &READONLY_OPTION);
+            assert_eq!(option3.state, State::Off);
+            assert_eq!(option3.location, Location::dummy("+xr"));
+        });
+        assert_eq!(result.1, []);
+    }
+
+    #[test]
     fn parse_long_print_option_without_operands() {
         let result = parse(ALL_OPTIONS, Field::dummies(["--print"])).unwrap();
         assert_matches!(&result.0[..], [option] => {

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -251,9 +251,6 @@ fn try_parse_long<'a, I: Iterator<Item = Field>>(
     };
 
     let (name, negate) = if let Some(name) = field.value.strip_prefix("--") {
-        if name.is_empty() {
-            return Ok(None);
-        }
         (name, false)
     } else if let Some(name) = field.value.strip_prefix("++") {
         (name, true)
@@ -297,6 +294,9 @@ pub fn parse<'a>(
     let mut args = args.into_iter().peekable();
     let mut options = Vec::new();
     loop {
+        if args.next_if(|arg| arg.value == "--").is_some() {
+            break;
+        }
         if try_parse_short(option_specs, &mut args, &mut options)? {
             continue;
         }
@@ -514,6 +514,18 @@ mod tests {
             assert_eq!(option.location, Location::dummy("++export"));
         });
         assert_eq!(result.1, []);
+    }
+
+    #[test]
+    fn parse_separator() {
+        let args = Field::dummies(["-p", "--", "-x"]);
+        let result = parse(ALL_OPTIONS, args.clone()).unwrap();
+        assert_matches!(&result.0[..], [option] => {
+            assert_eq!(option.spec, &PRINT_OPTION);
+            assert_eq!(option.state, State::On);
+            assert_eq!(option.location, Location::dummy("-p"));
+        });
+        assert_eq!(result.1, Field::dummies(["-x"]));
     }
 
     #[test]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error messages now accurately highlight the relevant source code fragment.
   Previously, the shell could highlight the wrong section or crash when the
   source contained multi-byte characters.
-- The `eval`, `exit`, `return`, and `shift` built-ins now correctly handle the
-  `--` separator between options and operands.
+- The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly
+  handle the `--` separator between options and operands.
 - The `jobs` built-in no longer crashes when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -11,11 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.3] - Unreleased
 
+### Added
+
+- The `return` built-in now supports the `--no-return` option as a synonym of
+  `-n`, which returns the specified exit status without actually returning from
+  the current function or script.
+
 ### Fixed
 
 - Error messages now accurately highlight the relevant source code fragment.
   Previously, the shell could highlight the wrong section or crash when the
   source contained multi-byte characters.
+- The `eval`, `exit`, `return`, and `shift` built-ins now correctly handle the
+  `--` separator between options and operands.
 - The `jobs` built-in no longer crashes when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source contained multi-byte characters.
 - The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly
   handle the `--` separator between options and operands.
+- The `export`, `readonly`, and `typeset` built-ins now correctly print the `--`
+  separator when the name of a variable or function starts with `-`.
 - The `jobs` built-in no longer crashes when reporting the same finished job more
   than once in a single invocation.
 

--- a/yash-cli/tests/scripted_test/eval-p.sh
+++ b/yash-cli/tests/scripted_test/eval-p.sh
@@ -19,6 +19,12 @@ foo
 bar
 __OUT__
 
+test_oE -e 0 'separator preceding operand'
+eval -- 'echo foo'
+__IN__
+foo
+__OUT__
+
 test_oE -e 0 'operands are concatenated with spaces in-between'
 eval 'echo foo' 'echo bar'
 eval 'echo 1"' '' '"2'

--- a/yash-cli/tests/scripted_test/exit-p.sh
+++ b/yash-cli/tests/scripted_test/exit-p.sh
@@ -203,3 +203,7 @@ TERM
 __OUT__
 
 )
+
+test_OE -e 56 'separator preceding operand'
+exit -- 56
+__IN__

--- a/yash-cli/tests/scripted_test/export-p.sh
+++ b/yash-cli/tests/scripted_test/export-p.sh
@@ -21,6 +21,15 @@ __IN__
 2 A B C
 __OUT__
 
+test_oE -e 0 'separator preceding operand' -e
+export -- a=foo
+echo 1 $a
+sh -c 'echo 2 $a'
+__IN__
+1 foo
+2 foo
+__OUT__
+
 test_oE -e 0 'reusing printed exported variables'
 export a=A
 e="$(export -p)"

--- a/yash-cli/tests/scripted_test/readonly-p.sh
+++ b/yash-cli/tests/scripted_test/readonly-p.sh
@@ -31,6 +31,13 @@ A B C
 A B C
 __OUT__
 
+test_oE -e 0 'separator preceding operand' -e
+readonly -- a=foo
+echo $a
+__IN__
+foo
+__OUT__
+
 # This test is in readonly-y.tst because it fails on some existing shells
 # because of pre-defined read-only variables.
 #test_x 'reusing printed read-only variables'

--- a/yash-cli/tests/scripted_test/return-p.sh
+++ b/yash-cli/tests/scripted_test/return-p.sh
@@ -293,3 +293,11 @@ fn() {
 }
 fn
 __IN__
+
+test_OE -e 56 'separator preceding operand'
+fn() {
+    return -- 56
+    echo not reached
+}
+fn
+__IN__

--- a/yash-cli/tests/scripted_test/shift-p.sh
+++ b/yash-cli/tests/scripted_test/shift-p.sh
@@ -84,3 +84,9 @@ __IN__
 [2][y  y][z]
 [3][a][b  b][c]
 __OUT__
+
+test_oE -e 0 'separator preceding operand' -es a b c d e
+shift -- 2 && bracket "$#" "$@"
+__IN__
+[3][c][d][e]
+__OUT__

--- a/yash-cli/tests/scripted_test/typeset-y.sh
+++ b/yash-cli/tests/scripted_test/typeset-y.sh
@@ -338,11 +338,36 @@ f() { :; }
 typeset -fr f
 __OUT__
 
-test_oE -e 0 'separator preceding operand starting with -' -e
+test_oE -e 0 'separator preceding value-less variable name starting with -' -e
+typeset -g -- -a
+typeset -p -- -a
+__IN__
+typeset -- -a
+__OUT__
+
+test_oE -e 0 'separator preceding scalar variable name starting with -' -e
 typeset -g -- -a=1
 typeset -p -- -a
 __IN__
-typeset -a=1
+typeset -- -a=1
+__OUT__
+
+test_oE -e 0 'separator preceding array variable name starting with -' -e
+-a=(1 2 3)
+typeset -x -- -a
+typeset -p -- -a
+__IN__
+-a=(1 2 3)
+typeset -x -- -a
+__OUT__
+
+test_oE -e 0 'separator preceding function name starting with -' -e
+-n() { :; }
+typeset -fr -- -n
+typeset -fp -- -n
+__IN__
+-n() { :; }
+typeset -fr -- -n
 __OUT__
 
 test_O -d -e 2 'invalid option -z'

--- a/yash-cli/tests/scripted_test/typeset-y.sh
+++ b/yash-cli/tests/scripted_test/typeset-y.sh
@@ -338,6 +338,13 @@ f() { :; }
 typeset -fr f
 __OUT__
 
+test_oE -e 0 'separator preceding operand starting with -' -e
+typeset -g -- -a=1
+typeset -p -- -a
+__IN__
+typeset -a=1
+__OUT__
+
 test_O -d -e 2 'invalid option -z'
 typeset -z
 __IN__


### PR DESCRIPTION
## Summary by Copilot

This pull request introduces several improvements and fixes to built-in shell command handling, focusing on more robust and standards-compliant option parsing and output formatting. The main enhancements include support for the `--` separator between options and operands, improved printing of variable and function names that start with a hyphen, and the addition of the `--no-return` option to the `return` built-in. Multiple built-ins now handle options and separators more consistently, and additional tests ensure reliability.

### Option and operand parsing improvements

* The `eval`, `exit`, `return`, `shift`, and `typeset` built-ins now correctly handle the `--` separator between options and operands, improving standards compliance and preventing parsing errors. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R26) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR14-R28) [[3]](diffhunk://#diff-d15f9b8e00ee2ea82b00f1e6d82ee922c5d0f7a5ee41132c9b96feabe5e57278R40-R45) [[4]](diffhunk://#diff-5e22023f2335cfce24ec74a2d957b4b522e8d4a8da6670f0304f8a057cd0b0a8L66-R71) [[5]](diffhunk://#diff-fa565317e326471e1effb3e4ce77c6af527a268d6c8c506af01c66b9a97c0b97L37-R43) [[6]](diffhunk://#diff-058a2dcf06017455d467cb311920cb9f4fd2685cab67de740e54702a8353d931R297-R299) [[7]](diffhunk://#diff-ea2a6a3d126977074f96d73ca0def6caccb5ef080e074ff4fbb3290b7c666e1fR22-R27) [[8]](diffhunk://#diff-7e88944323b99c90e41cf794211769b25bd42d5a4928686c4561490148412f3dR206-R209)
* The `return` built-in now supports the `--no-return` option as a synonym for `-n`, allowing users to specify an exit status without returning from the current function or script. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R26) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR14-R28) [[3]](diffhunk://#diff-728a264c1aacc8caee11191193a94b5b49e442f1c0c30878d22823fbc44c0902R53-R54) [[4]](diffhunk://#diff-728a264c1aacc8caee11191193a94b5b49e442f1c0c30878d22823fbc44c0902L60-R83)

### Output formatting fixes

* The `export`, `readonly`, and `typeset` built-ins now correctly print the `--` separator when the name of a variable or function starts with a hyphen, ensuring output is unambiguous and POSIX-compliant. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R26) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR14-R28) [[3]](diffhunk://#diff-3830f3c067a24879776cf0208b588b5bfb8eda1002def61dc3a6948e0a58703fR90-R99) [[4]](diffhunk://#diff-3830f3c067a24879776cf0208b588b5bfb8eda1002def61dc3a6948e0a58703fR224-R242) [[5]](diffhunk://#diff-a5c1100d40f5cc654ab01485feb4edcb0c6232f3e258343e7978f22de6c8dd6dR83-R91) [[6]](diffhunk://#diff-a5c1100d40f5cc654ab01485feb4edcb0c6232f3e258343e7978f22de6c8dd6dL102-R114) [[7]](diffhunk://#diff-a5c1100d40f5cc654ab01485feb4edcb0c6232f3e258343e7978f22de6c8dd6dR446-R492)

### Test coverage improvements

* New tests were added to verify correct handling of option/operand separators and output formatting for variables and functions with hyphenated names, as well as for invalid options. [[1]](diffhunk://#diff-728a264c1aacc8caee11191193a94b5b49e442f1c0c30878d22823fbc44c0902R230-R237) [[2]](diffhunk://#diff-728a264c1aacc8caee11191193a94b5b49e442f1c0c30878d22823fbc44c0902L242-R278) [[3]](diffhunk://#diff-3830f3c067a24879776cf0208b588b5bfb8eda1002def61dc3a6948e0a58703fR224-R242) [[4]](diffhunk://#diff-a5c1100d40f5cc654ab01485feb4edcb0c6232f3e258343e7978f22de6c8dd6dR446-R492) [[5]](diffhunk://#diff-058a2dcf06017455d467cb311920cb9f4fd2685cab67de740e54702a8353d931R461-R478) [[6]](diffhunk://#diff-058a2dcf06017455d467cb311920cb9f4fd2685cab67de740e54702a8353d931R537-R548)

### Refactoring and codebase consistency

* Refactored option parsing logic in several built-ins to use a shared approach, improving maintainability and consistency. [[1]](diffhunk://#diff-d15f9b8e00ee2ea82b00f1e6d82ee922c5d0f7a5ee41132c9b96feabe5e57278R25-R26) [[2]](diffhunk://#diff-5e22023f2335cfce24ec74a2d957b4b522e8d4a8da6670f0304f8a057cd0b0a8L46-R47) [[3]](diffhunk://#diff-728a264c1aacc8caee11191193a94b5b49e442f1c0c30878d22823fbc44c0902L40-R41) [[4]](diffhunk://#diff-fa565317e326471e1effb3e4ce77c6af527a268d6c8c506af01c66b9a97c0b97R25-R26)

### Minor fixes

* Fixed handling of finished jobs in the `jobs` built-in to prevent panics or crashes when reporting the same job multiple times. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR10-R26) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR14-R28)

These changes collectively make the shell built-ins more robust, predictable, and standards-compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - return supports --no-return (alias of -n) to set an exit status without leaving the current function or script.

- **Bug Fixes**
  - eval, exit, return, shift, and typeset honor the -- end-of-options separator.
  - export, readonly, and typeset print -- when names start with -.
  - jobs no longer panics when reporting the same finished job multiple times.

- **Documentation**
  - Changelogs updated for option and separator handling.

- **Tests**
  - Added unit and scripted tests for -- separator and hyphen-prefixed names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->