### PR TITLE
Avoid build errors with Rust 1.90.0

### DIFF
--- a/yash-builtin/src/exec.rs
+++ b/yash-builtin/src/exec.rs
@@ -227,7 +227,7 @@ mod tests {
         let arguments = process.last_exec().as_ref().unwrap();
         assert_eq!(arguments.0, c"/bin/echo".to_owned());
         assert_eq!(arguments.1, [c"/bin/echo".to_owned()]);
-        assert_eq!(arguments.2, []);
+        assert_eq!(arguments.2, [] as [CString; 0]);
     }
 
     #[test]

--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn env_c_strings() {
         let mut variables = VariableSet::new();
-        assert_eq!(&variables.env_c_strings(), &[]);
+        assert_eq!(variables.env_c_strings(), [] as [CString; 0]);
 
         let mut var = variables.get_or_new("foo", Scope::Global);
         var.assign("FOO", None).unwrap();


### PR DESCRIPTION
The new compiler wants the type of empty arrays to be explicit when comparing against a slice of CString.

See <https://github.com/rust-lang/rust/issues/146782>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined assertions to explicitly compare against empty CString arrays, aligning expected and actual types.
  * Improves test clarity and robustness with no changes to production code or runtime behavior.
  * No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->