### PR TITLE
Search `PATH` after assignments in simple commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_matches",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ name = "yash-semantics"
 version = "0.8.1"
 dependencies = [
  "assert_matches",
+ "either",
  "enumset",
  "futures-executor",
  "futures-util",

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,16 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - Unreleased
+
+### Fixed
+
+- The execution of a simple command now searches for the external utility in the
+  `PATH` after performing variable assignments, as specified in POSIX-1.2024.
+  Previously, it would search for the utility before performing the redirections
+  and assignments, which could lead to incorrect behavior if the assignments
+  modified the `PATH` variable.
+
 ## [0.4.3] - 2025-09-14
 
 ### Added
@@ -219,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shell
 
+[0.4.4]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.4
 [0.4.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.3
 [0.4.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.2
 [0.4.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.1

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/yash-cli-{ version }/{ name }-{ target }{ archive-suffix }"

--- a/yash-cli/tests/scripted_test/simple-p.sh
+++ b/yash-cli/tests/scripted_test/simple-p.sh
@@ -198,6 +198,12 @@ PATH=./dir3
 ext_cmd
 __IN__
 
+test_O -d -e 127 'PATH is searched after assignments'
+# If PATH is searched before assignments,
+# this would find ls in somewhere like /bin.
+PATH=./dir3 ls
+__IN__
+
 test_o 'command name with slash'
 dir2/ext_cmd foo bar baz
 __IN__

--- a/yash-cli/tests/scripted_test/simple-p.sh
+++ b/yash-cli/tests/scripted_test/simple-p.sh
@@ -198,10 +198,16 @@ PATH=./dir3
 ext_cmd
 __IN__
 
-test_O -d -e 127 'PATH is searched after assignments'
+test_O -d -e 127 'PATH is searched after assignments (ls)'
 # If PATH is searched before assignments,
 # this would find ls in somewhere like /bin.
 PATH=./dir3 ls
+__IN__
+
+test_O -d -e 127 'PATH is searched after assignments (pwd)'
+# If PATH is searched before assignments,
+# this would find pwd in somewhere like /bin.
+PATH=./dir3 pwd
 __IN__
 
 test_o 'command name with slash'

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `command_search::classify` function has been added to classify a command
+  name without searching for an external utility.
+    - This function is used in the execution of a simple command
+      (`impl command::Command for yash_syntax::syntax::SimpleCommand`) to classify
+      the command name before performing redirections and variable assignments
+      without redundant searching for an external utility.
 - Internal dependencies:
     - either 1.9.0
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External dependency versions:
     - yash-syntax 0.15.0 → 0.15.1
 
+### Fixed
+
+- The execution of a simple command
+  (`impl command::Command for yash_syntax::syntax::SimpleCommand`)
+  now searches for the external utility in the `PATH` after performing variable
+  assignments, as specified in POSIX.1-2024. Previously, it would search for the
+  utility before performing the redirections and assignments, which could lead
+  to incorrect behavior if the assignments modified the `PATH` variable.
+
 ## [0.8.0] - 2025-05-11
 
 ### Changed

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.1] - Unreleased
 
+### Added
+
+- Internal dependencies:
+    - either 1.9.0
+
 ### Changed
 
 - External dependency versions:

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 
 [dependencies]
 assert_matches = { workspace = true }
+either = { workspace = true }
 enumset = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -23,7 +23,7 @@
 
 use crate::Handle;
 use crate::command::Command;
-use crate::command_search::search;
+use crate::command_search::classify;
 use crate::expansion::expand_word_with_mode;
 use crate::xtrace::XTrace;
 use std::ops::ControlFlow::Continue;
@@ -169,17 +169,16 @@ impl Command for syntax::SimpleCommand {
 
         use crate::command_search::Target::{Builtin, External, Function};
         if let Some(name) = fields.first() {
-            match search(env, &name.value) {
-                Some(Builtin { builtin, .. }) => {
+            match classify(env, &name.value) {
+                Builtin { builtin, path: _ } => {
                     execute_builtin(env, builtin, &self.assigns, fields, &self.redirs).await
                 }
-                Some(Function(function)) => {
+                Function(function) => {
                     execute_function(env, function, &self.assigns, fields, &self.redirs).await
                 }
-                Some(External { path: _ }) => {
+                External { path: _ } => {
                     execute_external_utility(env, &self.assigns, fields, &self.redirs).await
                 }
-                None => execute_external_utility(env, &self.assigns, fields, &self.redirs).await,
             }
         } else {
             let exit_status = exit_status.unwrap_or_default();

--- a/yash-semantics/src/command/simple_command.rs
+++ b/yash-semantics/src/command/simple_command.rs
@@ -26,7 +26,6 @@ use crate::command::Command;
 use crate::command_search::search;
 use crate::expansion::expand_word_with_mode;
 use crate::xtrace::XTrace;
-use std::ffi::CString;
 use std::ops::ControlFlow::Continue;
 use yash_env::Env;
 #[cfg(doc)]
@@ -177,13 +176,10 @@ impl Command for syntax::SimpleCommand {
                 Some(Function(function)) => {
                     execute_function(env, function, &self.assigns, fields, &self.redirs).await
                 }
-                Some(External { path }) => {
-                    execute_external_utility(env, path, &self.assigns, fields, &self.redirs).await
+                Some(External { path: _ }) => {
+                    execute_external_utility(env, &self.assigns, fields, &self.redirs).await
                 }
-                None => {
-                    let path = CString::default();
-                    execute_external_utility(env, path, &self.assigns, fields, &self.redirs).await
-                }
+                None => execute_external_utility(env, &self.assigns, fields, &self.redirs).await,
             }
         } else {
             let exit_status = exit_status.unwrap_or_default();

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Command search.
+//! Command search
 //!
 //! The [command search](search) is part of the execution of a [simple
 //! command](yash_syntax::syntax::SimpleCommand). It determines a command target
@@ -113,7 +113,7 @@ impl From<Function> for Target {
 // not implemented because of ambiguity between substitutive built-ins and
 // external utilities
 
-/// Part of the shell execution environment command path search depends on.
+/// Part of the shell execution environment command path search depends on
 pub trait PathEnv {
     /// Accesses the `$PATH` variable in the environment.
     ///
@@ -129,7 +129,7 @@ pub trait PathEnv {
     // TODO Cache the results of external utility search
 }
 
-/// Part of the shell execution environment command search depends on.
+/// Part of the shell execution environment command search depends on
 pub trait SearchEnv: PathEnv {
     /// Retrieves the built-in by name.
     #[must_use]

--- a/yash-semantics/src/command_search.rs
+++ b/yash-semantics/src/command_search.rs
@@ -226,6 +226,11 @@ pub fn search<E: SearchEnv>(env: &mut E, name: &str) -> Option<Target> {
 ///
 /// Returns the path to the executable if found. Note that the returned path may
 /// not be absolute if the `$PATH` contains a relative path.
+///
+/// This function requires a mutable reference to the environment because it may
+/// need to update a cache of the results of external utility search (TODO:
+/// which is not yet implemented). The function does not otherwise modify the
+/// environment.
 pub fn search_path<E: PathEnv>(env: &mut E, name: &str) -> Option<CString> {
     env.path()
         .split()


### PR DESCRIPTION
Fixes #530

## Summary by Copilot

This pull request updates both `yash-cli` and `yash-semantics` to comply with the POSIX.1-2024 specification regarding when the `PATH` variable is searched during the execution of simple commands. Now, variable assignments are performed before searching for external utilities, ensuring that changes to `PATH` take effect as expected. The update also introduces a new `command_search::classify` function to improve command classification, and adds new tests to verify correct behavior. Additionally, the `either` crate is added as an internal dependency.

**POSIX compliance and command search improvements:**

- The execution of a simple command now searches for external utilities in the `PATH` after performing variable assignments, as required by POSIX.1-2024. This change ensures that assignments modifying `PATH` are respected when searching for the utility. [[1]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR12-R21) [[2]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R10-R34) [[3]](diffhunk://#diff-f62043685bfb3b63112335729b9e43cdb46e303d63bc2125f21d720d78ea5e38L173-R180) [[4]](diffhunk://#diff-3377c05bd442ce70a77f70a4353b6013b8c462d62eb2a429d365a5d9b283fffdL63-R73) [[5]](diffhunk://#diff-3377c05bd442ce70a77f70a4353b6013b8c462d62eb2a429d365a5d9b283fffdR412-R443) [[6]](diffhunk://#diff-ea1e7b84d26147483c95902b783d75f46a80c51bd5fc17f8fd1116af00813a42R201-R212)
- The new `command_search::classify` function is introduced to classify command names without searching for an external utility, streamlining command execution and reducing redundant searches. [[1]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R10-R34) [[2]](diffhunk://#diff-f62043685bfb3b63112335729b9e43cdb46e303d63bc2125f21d720d78ea5e38L26-L29) [[3]](diffhunk://#diff-f62043685bfb3b63112335729b9e43cdb46e303d63bc2125f21d720d78ea5e38L173-R180)

**Testing and bug fixes:**

- Adds and updates tests to verify that command search is performed after assignments, including cases where the `PATH` variable is changed and for substitutive built-ins. [[1]](diffhunk://#diff-ea1e7b84d26147483c95902b783d75f46a80c51bd5fc17f8fd1116af00813a42R201-R212) [[2]](diffhunk://#diff-b61935a1bdd2dfd253c83973920f4e590920e1253d58c253a2ccbe00f9c16fe9R259-R317) [[3]](diffhunk://#diff-3377c05bd442ce70a77f70a4353b6013b8c462d62eb2a429d365a5d9b283fffdR412-R443)
- Fixes the behavior of substitutive built-ins to only execute if the corresponding external utility is found in the updated `PATH`. [[1]](diffhunk://#diff-b61935a1bdd2dfd253c83973920f4e590920e1253d58c253a2ccbe00f9c16fe9L61-R92) [[2]](diffhunk://#diff-b61935a1bdd2dfd253c83973920f4e590920e1253d58c253a2ccbe00f9c16fe9R259-R317)

**Dependency and metadata updates:**

- Adds the `either` crate as a new internal dependency. [[1]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R10-R34) [[2]](diffhunk://#diff-a9338db40698404c9e52097b78b1a6ad2ae18be4f5608f0fe0ff7bf841451e96R19)
- Bumps `yash-cli` version to `0.4.4` and updates the changelog and release links accordingly. [[1]](diffhunk://#diff-97ed7c14e25a622025ade6c49854e945a49f3eb404a7e86942f495b87326158bL3-R3) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR12-R21) [[3]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR232)
- Sets `publish = false` in `yash-cli/Cargo.toml`.

These changes bring the shell's behavior closer to POSIX standards and improve reliability when running commands that depend on dynamic environment changes.