### PR TITLE
Treat $! as unset until an async command is executed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -658,7 +658,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "assert_matches",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
-yash-builtin = { path = "yash-builtin", version = "0.9.1" }
+yash-builtin = { path = "yash-builtin", version = "0.10.0" }
 yash-env = { path = "yash-env", version = "0.8.0" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.6.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.6.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.8.1" }
+yash-semantics = { path = "yash-semantics", version = "0.9.0" }
 yash-syntax = { path = "yash-syntax", version = "0.15.1" }

--- a/docs/src/language/parameters/special.md
+++ b/docs/src/language/parameters/special.md
@@ -54,7 +54,7 @@ Below are the special parameters and their meanings:
 
 - **`!`**: Process ID of the last [asynchronous command](../commands/lists.md#asynchronous-commands).
     - Updated when an asynchronous command is started or [resumed in the background](../../builtins/bg.md).
-    - The value is `0` until any asynchronous command is executed in the current [shell environment]. However, the behavior may be changed in the future so that it works like an unset parameter. <!-- TODO: The value is unset until any asynchronous command is executed. -->
+    - Since 0.4.6, this parameter is unset if no asynchronous command has been started in the current [shell environment]. Previously, it was set to `0` in such cases.
 
 - **`0`**: Name of the shell or script being executed.
     - Set at shell [startup](../../startup.md) and remains constant.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - Unreleased
+
+- External dependency versions:
+    - yash-semantics (optional) 0.8.1 → 0.9.0
+
 ## [0.9.1] - 2025-09-20
 
 ### Added
@@ -358,6 +363,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.10.0
 [0.9.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.1
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.0
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.8.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [features]
 default = ["yash-prompt", "yash-semantics"]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,13 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - Unreleased
+
+### Changed
+
+- The special parameter `!` is now considered unset if no asynchronous command
+  has been executed.
+
 ## [0.4.5] - 2025-09-20
 
 ### Added
@@ -250,6 +257,7 @@ later.
 
 - Initial release of the shell
 
+[0.4.6]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.6
 [0.4.5]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.5
 [0.4.4]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.4
 [0.4.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.3

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/yash-cli-{ version }/{ name }-{ target }{ archive-suffix }"

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External dependency versions:
     - yash-syntax 0.15.0 → 0.15.1
 - Internal dependency versions:
-    - yash-semantics 0.8.0 → 0.8.1
+    - yash-semantics 0.8.0 → 0.9.0
 
 ## [0.6.0] - 2025-05-11
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+
+### Changed
+
+- The special parameter `!` is now considered unset if no asynchronous command
+  has been executed, that is, if `JobList::last_async_pid()` is zero.
+    - This change is observed in the results of the `expand` method of
+      `impl expansion::initial::Expand for yash_syntax::syntax::TextUnit`.
+
 ## [0.8.1] - 2025-09-20
 
 ### Added
@@ -279,6 +288,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.9.0
 [0.8.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.1
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.7.1

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 either = { workspace = true }

--- a/yash-semantics/src/expansion/initial/text.rs
+++ b/yash-semantics/src/expansion/initial/text.rs
@@ -55,7 +55,9 @@ use yash_syntax::syntax::Unquote;
 ///
 /// - `?` expands to the [last exit status](yash_env::Env::exit_status).
 /// - `!` expands to the [process ID of the last asynchronous
-///   command](yash_env::job::JobList::last_async_pid).
+///   command](yash_env::job::JobList::last_async_pid). If no asynchronous
+///   command has been executed (that is, if the value is zero), the parameter
+///   is considered unset.
 /// - `@` expands to all positional parameters. When expanded in double-quotes
 ///   as in `"${@}"`, it produces the correct number of fields exactly matching
 ///   the current positional parameters. Especially if there are zero positional


### PR DESCRIPTION
The `!` special parameter, which expands to the process ID of the last
asynchronous command, is now treated as unset if no asynchronous command
has been executed in the current shell environment, like other shells
including bash, dash, ksh, and mksh. Previously, it expanded to `0` in
such cases.

Closes https://github.com/magicant/yash-rs/issues/527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Special parameter ! is now unset when no asynchronous command has run (previously returned 0), ensuring accurate expansions.

- Documentation
  - Updated guidance for the ! parameter to reflect the new behavior.
  - Clarified that ${@} expands to zero fields when there are no positional parameters.

- Chores
  - Version bumps and dependency updates across components.
  - Adjusted internal packaging settings to prevent publishing of certain internal modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->