### PR TITLE
Pipefail option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env-test-helper"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
 yash-builtin = { path = "yash-builtin", version = "0.10.0" }
-yash-env = { path = "yash-env", version = "0.8.0" }
+yash-env = { path = "yash-env", version = "0.8.1" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.6.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -10,12 +10,7 @@ Many utilities return a non-zero exit status when they fail, but by default the 
 
 By default, the exit status of a pipeline reflects only the last command, ignoring failures in earlier commands. To make the pipeline fail if any command fails, enable the `pipefail` [shell option]. With `pipefail`, the pipeline's exit status is that of the last command that returned a non-zero status, or zero if all returned zero. This helps catch errors in pipelines.
 
-<!-- markdownlint-disable-next-line MD033 -->
-<p class="warning">
-The `pipefail` option is not yet implemented in yash-rs.
-</p>
-
-<!-- TODO: Move the description and add examples to pipelines.md, and leave a link here -->
+See the [pipeline documentation](language/commands/pipelines.md#catching-errors-across-pipeline-components) for details.
 
 ## Blocking unset parameters
 

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -106,6 +106,7 @@ log              on
 login            off
 monitor          off
 notify           off
+pipefail         off
 posixlycorrect   off
 stdin            on
 unset            on
@@ -131,6 +132,7 @@ set -o log
 set +o login
 set +o monitor
 set +o notify
+set +o pipefail
 set +o posixlycorrect
 #set -o stdin
 set -o unset

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -198,8 +198,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
     - ⚠️ Currently has no effect in yash-rs. In the future, it will enable immediate notifications for background jobs.
     - Only takes effect if `interactive` and `monitor` are enabled.
 
-- **`pipefail`**: If set, the shell returns the [exit status](../language/commands/exit_status.md) of the last command in a [pipeline](../language/commands/pipelines.md) that failed, instead of the last command's exit status. See [Catching errors across pipeline components](../debugging.md#catching-errors-across-pipeline-components) for details.
-    - ⚠️ Not yet implemented in yash-rs.
+- **`pipefail`**: If set, the shell returns the [exit status](../language/commands/exit_status.md) of the last command in a [pipeline](../language/commands/pipelines.md) that failed, instead of the last command's exit status. See [Catching errors across pipeline components](../language/commands/pipelines.md#catching-errors-across-pipeline-components) for details.
 
 - **`posixlycorrect`**: If set, the shell behaves as POSIX-compliant as possible. Useful for portable scripts. <!-- TODO: link to POSIX compliance -->
     - Enabled on startup if the shell is started as `sh`.

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -200,7 +200,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
     - ⚠️ Currently has no effect in yash-rs. In the future, it will enable immediate notifications for background jobs.
     - Only takes effect if `interactive` and `monitor` are enabled.
 
-- **`pipefail`**: If set, the shell returns the [exit status](../language/commands/exit_status.md) of the last command in a [pipeline](../language/commands/pipelines.md) that failed, instead of the last command's exit status. See [Catching errors across pipeline components](../language/commands/pipelines.md#catching-errors-across-pipeline-components) for details.
+- **`pipefail`**: (Since 0.4.6) If set, the shell returns the [exit status](../language/commands/exit_status.md) of the last command in a [pipeline](../language/commands/pipelines.md) that failed, instead of the last command's exit status. See [Catching errors across pipeline components](../language/commands/pipelines.md#catching-errors-across-pipeline-components) for details.
 
 - **`posixlycorrect`**: If set, the shell behaves as POSIX-compliant as possible. Useful for portable scripts. <!-- TODO: link to POSIX compliance -->
     - Enabled on startup if the shell is started as `sh`.

--- a/docs/src/language/commands/pipelines.md
+++ b/docs/src/language/commands/pipelines.md
@@ -44,10 +44,27 @@ $ ls \
 
 If a pipeline contains only one command, the shell runs that command directly. For multiple commands, the shell creates a [subshell](../../environment/index.html#subshells) for each and connects them with pipes. Each command's [standard output](../redirections/index.html#what-are-file-descriptors) is connected to the next command's [standard input](../redirections/index.html#what-are-file-descriptors). The first command's input and the last command's output are not changed. All commands in the pipeline run concurrently.
 
-The shell waits for all commands in the pipeline to finish before proceeding. The [exit status](exit_status.md#exit-status) of the pipeline is the exit status of the last command in the pipeline. (In the future, yash-rs may only wait for the last command to finish.)
+The shell waits for all commands in the pipeline to finish before proceeding. In the future, yash-rs may only wait for commands needed to determine the pipeline's exit status. By default, the [exit status](exit_status.md#exit-status) of the pipeline is the exit status of the last command in the pipeline, but see the next section for how to change this behavior.
 
-<!-- TODO: ## Pipefail -->
-<!-- TODO: Description and example of `pipefail`. -->
+## Catching errors across pipeline components
+
+By default, the exit status of a pipeline reflects only the last command, ignoring failures in earlier commands. To make the pipeline fail if any command fails, enable the `pipefail` [shell option](../../environment/options.md). With `pipefail`, the pipeline's exit status is that of the last command that returned a non-zero status, or zero if all returned zero. This helps catch errors in pipelines.
+
+```shell
+$ set +o pipefail
+$ echo foo | ( cat; exit 42 ) | grep foo
+foo
+$ echo $?
+0
+```
+
+```shell
+$ set -o pipefail
+$ echo foo | ( cat; exit 42 ) | grep foo
+foo
+$ echo $?
+42
+```
 
 ## Negation
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - Unreleased
 
 - External dependency versions:
+    - yash-env 0.8.0 → 0.8.1
     - yash-semantics (optional) 0.8.1 → 0.9.0
 
 ## [0.9.1] - 2025-09-20
@@ -45,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - External dependency versions:
-    - yash-env 0.8.0 → 0.9.0
+    - yash-env 0.7.1 → 0.8.0
     - yash-semantics (optional) 0.7.1 → 0.8.0
     - yash-syntax 0.14.1 → 0.15.0
 - Internal dependency versions:

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -247,6 +247,7 @@ log              on
 login            off
 monitor          off
 notify           off
+pipefail         off
 posixlycorrect   off
 stdin            off
 unset            off

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.6] - Unreleased
 
+### Added
+
+- The `pipefail` shell option is now supported.
+    - When this option is enabled, the exit status of a pipeline reflects the
+      failure of any command in the pipeline, not just the last command.
+
 ### Changed
 
 - The special parameter `!` is now considered unset if no asynchronous command

--- a/yash-cli/tests/scripted_test/option-p.sh
+++ b/yash-cli/tests/scripted_test/option-p.sh
@@ -177,13 +177,11 @@ test_OE -e 0 'pipefail on: multi-command successful pipe' -o pipefail
 true | true | true | true
 __IN__
 
-# TODO not yet implemented
-test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe' -o pipefail
+test_OE -e 7 'pipefail on: multi-command unsuccessful pipe' -o pipefail
 true | exit 2 | true | exit 7 | true | true
 __IN__
 
-# TODO not yet implemented
-test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe in subshell' \
+test_OE -e 7 'pipefail on: multi-command unsuccessful pipe in subshell' \
     -o pipefail
 (true | exit 2 | true | exit 7 | true | true)
 __IN__

--- a/yash-cli/tests/scripted_test/option-p.sh
+++ b/yash-cli/tests/scripted_test/option-p.sh
@@ -165,6 +165,29 @@ __IN__
 
 }
 
+test_OE -e 0 'pipefail on: single command successful pipe' -o pipefail
+true
+__IN__
+
+test_OE -e 13 'pipefail on: single command unsuccessful pipe' -o pipefail
+(exit 13)
+__IN__
+
+test_OE -e 0 'pipefail on: multi-command successful pipe' -o pipefail
+true | true | true | true
+__IN__
+
+# TODO not yet implemented
+test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe' -o pipefail
+true | exit 2 | true | exit 7 | true | true
+__IN__
+
+# TODO not yet implemented
+test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe in subshell' \
+    -o pipefail
+(true | exit 2 | true | exit 7 | true | true)
+__IN__
+
 test_x -e 0 'nounset (short) on: $-' -u
 printf '%s\n' "$-" | grep -q u
 __IN__

--- a/yash-cli/tests/scripted_test/option-y.sh
+++ b/yash-cli/tests/scripted_test/option-y.sh
@@ -35,32 +35,6 @@ printed
 __OUT__
 
 # TODO not yet implemented
-test_OE -e 0 -f 'pipefail on: single command successful pipe' --pipefail
-true
-__IN__
-
-# TODO not yet implemented
-test_OE -e 13 -f 'pipefail on: single command unsuccessful pipe' --pipefail
-(exit 13)
-__IN__
-
-# TODO not yet implemented
-test_OE -e 0 -f 'pipefail on: multi-command successful pipe' --pipefail
-true | true | true | true
-__IN__
-
-# TODO not yet implemented
-test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe' --pipefail
-true | exit 2 | true | exit 7 | true | true
-__IN__
-
-# TODO not yet implemented
-test_OE -e 7 -f 'pipefail on: multi-command unsuccessful pipe in subshell' \
-    --pipefail
-(true | exit 2 | true | exit 7 | true | true)
-__IN__
-
-# TODO not yet implemented
 test_oE -f 'traceall on: effect' --traceall
 exec 2>&1
 COMMAND_NOT_FOUND_HANDLER='echo not found $* >&2; HANDLED=1'

--- a/yash-env-test-helper/CHANGELOG.md
+++ b/yash-env-test-helper/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to `yash-env-test-helper` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - Unreleased
+
+- External dependency versions:
+    - yash-env 0.8.0 → 0.8.1
+
 ## [0.6.0] - 2025-05-11
 
 - External dependency versions:
@@ -49,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env-test-helper` crate
 
+[0.6.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.6.1
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.5.0
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.4.0

--- a/yash-env-test-helper/Cargo.toml
+++ b/yash-env-test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env-test-helper"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities"]
+publish = false
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.1] - Unreleased
 
+### Added
+
+- The `pipefail` shell option (`option::Option::PipeFail`)
+
 ### Changed
 
 - External dependency versions:

--- a/yash-env/src/option.rs
+++ b/yash-env/src/option.rs
@@ -124,6 +124,8 @@ pub enum Option {
     Monitor,
     /// Automatically reports the results of asynchronous jobs.
     Notify,
+    /// Makes a pipeline reflect the exit status of the last failed component.
+    PipeFail,
     /// Disables most non-POSIX extensions.
     PosixlyCorrect,
     /// Reads commands from the standard input.
@@ -172,6 +174,7 @@ impl Option {
             Login => Some(('l', On)),
             Monitor => Some(('m', On)),
             Notify => Some(('b', On)),
+            PipeFail => None,
             PosixlyCorrect => None,
             Stdin => Some(('s', On)),
             Unset => Some(('u', Off)),
@@ -201,6 +204,7 @@ impl Option {
             Login => "login",
             Monitor => "monitor",
             Notify => "notify",
+            PipeFail => "pipefail",
             PosixlyCorrect => "posixlycorrect",
             Stdin => "stdin",
             Unset => "unset",
@@ -265,6 +269,7 @@ impl FromStr for Option {
             ("login", Login),
             ("monitor", Monitor),
             ("notify", Notify),
+            ("pipefail", PipeFail),
             ("posixlycorrect", PosixlyCorrect),
             ("stdin", Stdin),
             ("unset", Unset),

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has been executed, that is, if `JobList::last_async_pid()` is zero.
     - This change is observed in the results of the `expand` method of
       `impl expansion::initial::Expand for yash_syntax::syntax::TextUnit`.
+- External dependency versions:
+    - yash-env 0.8.0 → 0.8.1
 
 ## [0.8.1] - 2025-09-20
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - Unreleased
 
+### Added
+
+- Support for the `pipefail` shell option in pipeline execution
+    - When this option is enabled, the exit status of a pipeline reflects the
+      failure of any command in the pipeline, not just the last command.
+    - This is implemented in
+      `impl command::Command for yash_syntax::syntax::Pipeline`.
+
 ### Changed
 
 - The special parameter `!` is now considered unset if no asynchronous command

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -153,11 +153,11 @@ fn to_job_name(commands: &[Rc<syntax::Command>]) -> String {
 
 async fn execute_multi_command_pipeline(env: &mut Env, commands: &[Rc<syntax::Command>]) -> Result {
     // Start commands
-    let mut commands = commands.iter().cloned().peekable();
+    let mut commands = commands.iter().cloned();
     let mut pipes = PipeSet::new();
     let mut pids = Vec::new();
     while let Some(command) = commands.next() {
-        let has_next = commands.peek().is_some();
+        let has_next = commands.len() > 0; // TODO ExactSizeIterator::is_empty
         shift_or_fail(env, &mut pipes, has_next).await?;
 
         let pipes = pipes;

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -27,8 +27,8 @@ use yash_env::Env;
 use yash_env::System;
 use yash_env::io::Fd;
 use yash_env::job::Pid;
-use yash_env::option::Option::{Exec, Interactive};
-use yash_env::option::State::Off;
+use yash_env::option::Option::{Exec, Interactive, PipeFail};
+use yash_env::option::State::{Off, On};
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
@@ -174,15 +174,21 @@ async fn execute_multi_command_pipeline(env: &mut Env, commands: &[Rc<syntax::Co
 
     shift_or_fail(env, &mut pipes, false).await?;
 
-    // Await the last command
+    // Wait for all commands to finish, collecting the exit statuses
+    let mut final_exit_status = ExitStatus::SUCCESS;
+    let pipefail = env.options.get(PipeFail) == On;
     for pid in pids {
-        // TODO Report if the child was signaled and the shell is interactive
-        env.exit_status = env
+        let exit_status = env
             .wait_for_subshell_to_finish(pid)
             .await
             .expect("cannot receive exit status of child process")
             .1;
+        if !exit_status.is_successful() || !pipefail {
+            final_exit_status = exit_status;
+        }
     }
+    env.exit_status = final_exit_status;
+
     Continue(())
 }
 
@@ -317,9 +323,7 @@ mod tests {
     use yash_env::builtin::Type::Special;
     use yash_env::job::ProcessResult;
     use yash_env::job::ProcessState;
-    use yash_env::option::Option::ErrExit;
-    use yash_env::option::Option::Monitor;
-    use yash_env::option::State::On;
+    use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::semantics::Field;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::SIGSTOP;
@@ -361,13 +365,54 @@ mod tests {
     }
 
     #[test]
-    fn multi_command_pipeline_returns_last_command_exit_status() {
+    fn multi_command_pipeline_without_pipefail_returns_last_command_exit_status() {
         in_virtual_system(|mut env, _state| async move {
             env.builtins.insert("return", return_builtin());
+            env.options.set(PipeFail, Off);
+
+            let pipeline: syntax::Pipeline = "return -n 0 | return -n 0".parse().unwrap();
+            let result = pipeline.execute(&mut env).await;
+            assert_eq!(result, Continue(()));
+            assert_eq!(env.exit_status, ExitStatus(0));
+
             let pipeline: syntax::Pipeline = "return -n 10 | return -n 20".parse().unwrap();
             let result = pipeline.execute(&mut env).await;
             assert_eq!(result, Continue(()));
             assert_eq!(env.exit_status, ExitStatus(20));
+
+            let pipeline: syntax::Pipeline = "return -n 0 | return -n 20 | return -n 0 |\
+                return -n 30 | return -n 0 | return -n 0"
+                .parse()
+                .unwrap();
+            let result = pipeline.execute(&mut env).await;
+            assert_eq!(result, Continue(()));
+            assert_eq!(env.exit_status, ExitStatus(0));
+        });
+    }
+
+    #[test]
+    fn multi_command_pipeline_with_pipefail_returns_last_failed_command_exit_status() {
+        in_virtual_system(|mut env, _state| async move {
+            env.builtins.insert("return", return_builtin());
+            env.options.set(PipeFail, On);
+
+            let pipeline: syntax::Pipeline = "return -n 0 | return -n 0".parse().unwrap();
+            let result = pipeline.execute(&mut env).await;
+            assert_eq!(result, Continue(()));
+            assert_eq!(env.exit_status, ExitStatus(0));
+
+            let pipeline: syntax::Pipeline = "return -n 10 | return -n 20".parse().unwrap();
+            let result = pipeline.execute(&mut env).await;
+            assert_eq!(result, Continue(()));
+            assert_eq!(env.exit_status, ExitStatus(20));
+
+            let pipeline: syntax::Pipeline = "return -n 0 | return -n 20 | return -n 0 |\
+                return -n 30 | return -n 0 | return -n 0"
+                .parse()
+                .unwrap();
+            let result = pipeline.execute(&mut env).await;
+            assert_eq!(result, Continue(()));
+            assert_eq!(env.exit_status, ExitStatus(30));
         });
     }
 


### PR DESCRIPTION
Implements the `pipefail` shell option.

Closes #533

## Summary by Copilot

This pull request implements support for the `pipefail` shell option throughout the codebase, ensuring that when enabled, the exit status of a pipeline reflects the last failed command rather than always the last command. It also updates documentation, tests, and dependency versions to reflect this new feature.

**Feature: pipefail shell option**

* Added support for the `pipefail` shell option in the shell, environment, and semantics crates. When enabled, the pipeline's exit status is that of the last command that failed, or zero if all succeeded. (`yash-env/src/option.rs`, `yash-semantics/src/command/pipeline.rs`, `yash-cli/CHANGELOG.md`, `yash-env/CHANGELOG.md`, `yash-semantics/CHANGELOG.md`, `yash-builtin/src/set.rs`, `Cargo.toml`) [[1]](diffhunk://#diff-61930f396ca5df03a70ca89de7f0a1e328ea3e920c615b5aa20906dc62cd6b9fR127-R128) [[2]](diffhunk://#diff-61930f396ca5df03a70ca89de7f0a1e328ea3e920c615b5aa20906dc62cd6b9fR207) [[3]](diffhunk://#diff-61930f396ca5df03a70ca89de7f0a1e328ea3e920c615b5aa20906dc62cd6b9fR272) [[4]](diffhunk://#diff-0b4de61bf9d45be521fa19dba7564f7c5ab077feb6a31386fb1f31b5f2b55f36L177-R191) [[5]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR14-R19) [[6]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR10-R13) [[7]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R10-R25) [[8]](diffhunk://#diff-d06e1aba7aa30b9ac5eabe078a51041b82526d084212f87c532ae7b7a266ccecR250) [[9]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L29-R29)
* Updated pipeline execution logic to collect exit statuses from all commands and apply the `pipefail` logic when the option is enabled. (`yash-semantics/src/command/pipeline.rs`)
* Added and updated tests to verify correct behavior of `pipefail` in various scenarios, including single and multi-command pipelines, and subshells. (`yash-cli/tests/scripted_test/option-p.sh`, `yash-cli/tests/scripted_test/option-y.sh`, `yash-semantics/src/command/pipeline.rs`) [[1]](diffhunk://#diff-da096d9b82b4d8744a96e30d02beaec3172cb58583c8665b50cbbac2cbd6bc19R168-R188) [[2]](diffhunk://#diff-6d701ecbf8577b23b46f159610834a101c6309310538544ecd6fd0ee9290396bL37-L62) [[3]](diffhunk://#diff-0b4de61bf9d45be521fa19dba7564f7c5ab077feb6a31386fb1f31b5f2b55f36L364-R415)

**Documentation updates**

* Expanded and clarified documentation for the `pipefail` option, including new examples and references, and removed outdated warnings about lack of support. (`docs/src/debugging.md`, `docs/src/environment/options.md`, `docs/src/language/commands/pipelines.md`) [[1]](diffhunk://#diff-d5895884b993dcd588426f2d50f159f749a8980c7418ee4e48a5bc3fd8f37145L13-R13) [[2]](diffhunk://#diff-33d334ba3aefb357f9572dc767c65d1987e839ac242169ea9a0a9b931c6a0506L201-R201) [[3]](diffhunk://#diff-ac39d93d9038681bb9caa0b4f5a29cad12a008164f08b64d1077b9753fd55555L47-R67)

**Dependency and changelog updates**

* Bumped versions and updated changelogs for affected crates to reflect the new feature and dependency changes. (`Cargo.toml`, `yash-builtin/CHANGELOG.md`, `yash-env/CHANGELOG.md`, `yash-semantics/CHANGELOG.md`, `yash-env-test-helper/CHANGELOG.md`, `yash-env-test-helper/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L29-R29) [[2]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR11) [[3]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bL48-R49) [[4]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR10-R13) [[5]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R10-R25) [[6]](diffhunk://#diff-bb34084f0a0aed435ce8e663448ababb7fc649e59003adff95a199cc138bed48R8-R12) [[7]](diffhunk://#diff-bb34084f0a0aed435ce8e663448ababb7fc649e59003adff95a199cc138bed48R57) [[8]](diffhunk://#diff-9302dc9b0ab99abd75bd9e349919ce39086a44421a88dc917dda8c8d216eacafL3-R3) [[9]](diffhunk://#diff-9302dc9b0ab99abd75bd9e349919ce39086a44421a88dc917dda8c8d216eacafR15)

These changes collectively enable robust error detection in pipelines, improve documentation, and ensure version consistency across the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for the pipefail shell option; pipelines can report failure if any component fails (configurable via set -o/+o).
  - set output now shows pipefail state.

- Documentation
  - Updated pipeline exit-status docs, added a dedicated pipefail section, refreshed examples and external links; removed “not implemented” notes.

- Tests
  - Added scripted tests for pipefail and reorganized/removed overlapping cases.

- Chores
  - Bumped dependencies, updated changelogs, and adjusted package metadata (version/publish settings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->