### PR TITLE
Add dedicated error variants for unsupported syntaxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External dependency versions:
     - yash-env 0.8.0 → 0.8.1
     - yash-semantics (optional) 0.8.1 → 0.9.0
+    - yash-syntax 0.15.1 → 0.15.2
 
 ## [0.9.1] - 2025-09-20
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The special parameter `!` is now considered unset if no asynchronous command
   has been executed.
+- The shell now displays a more informative error message when the `function`
+  or `[[` reserved word is used, indicating that these syntaxes are not yet
+  supported.
 
 ## [0.4.5] - 2025-09-20
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - External dependency versions:
-    - yash-syntax 0.15.0 → 0.15.1
+    - yash-syntax 0.15.0 → 0.15.2
 - Internal dependency versions:
     - libc 0.2.169 → 0.2.171
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - External dependency versions:
-    - yash-syntax 0.15.0 → 0.15.1
+    - yash-syntax 0.15.0 → 0.15.2
 - Internal dependency versions:
     - yash-semantics 0.8.0 → 0.9.0
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       `impl expansion::initial::Expand for yash_syntax::syntax::TextUnit`.
 - External dependency versions:
     - yash-env 0.8.0 → 0.8.1
+    - yash-syntax 0.15.1 → 0.15.2
 
 ## [0.8.1] - 2025-09-20
 

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - Unreleased
+
+### Added
+
+- New error variants in `parser::SyntaxError`:
+    - `UnsupportedFunctionDefinitionSyntax`
+    - `UnsupportedDoubleBracketCommand`
+
+### Changed
+
+- The command parser (`parser::Parser::command`) now raises
+  `SyntaxError::UnsupportedFunctionDefinitionSyntax` and
+  `SyntaxError::UnsupportedDoubleBracketCommand` when it encounters the
+  `function` and `[[` reserved words, respectively. These syntaxes are not yet
+  supported.
+
 ## [0.15.1] - 2025-09-14
 
 ### Added
@@ -490,6 +506,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.15.2]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.2
 [0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.0
 [0.14.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.14.1

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -12,6 +12,7 @@ repository = "https://github.com/magicant/yash-rs"
 license = "GPL-3.0-or-later"
 keywords = ["posix", "shell"]
 categories = ["command-line-utilities", "parser-implementations"]
+publish = false
 
 [dependencies]
 annotate-snippets = { workspace = true, optional = true }

--- a/yash-syntax/src/parser/command.rs
+++ b/yash-syntax/src/parser/command.rs
@@ -22,6 +22,9 @@
 use super::core::Parser;
 use super::core::Rec;
 use super::core::Result;
+use super::lex::Keyword::{Function, OpenBracketBracket};
+use super::lex::TokenId::Token;
+use super::{Error, SyntaxError};
 use crate::syntax::Command;
 
 impl Parser<'_, '_> {
@@ -32,10 +35,28 @@ impl Parser<'_, '_> {
     pub async fn command(&mut self) -> Result<Rec<Option<Command>>> {
         match self.simple_command().await? {
             Rec::AliasSubstituted => Ok(Rec::AliasSubstituted),
-            Rec::Parsed(None) => self
-                .full_compound_command()
-                .await
-                .map(|c| Rec::Parsed(c.map(Command::Compound))),
+
+            Rec::Parsed(None) => {
+                if let Some(compound) = self.full_compound_command().await? {
+                    return Ok(Rec::Parsed(Some(Command::Compound(compound))));
+                }
+
+                let next = self.peek_token().await?;
+                match next.id {
+                    Token(Some(Function)) => {
+                        let cause = SyntaxError::UnsupportedFunctionDefinitionSyntax.into();
+                        let location = next.word.location.clone();
+                        Err(Error { cause, location })
+                    }
+                    Token(Some(OpenBracketBracket)) => {
+                        let cause = SyntaxError::UnsupportedDoubleBracketCommand.into();
+                        let location = next.word.location.clone();
+                        Err(Error { cause, location })
+                    }
+                    _ => Ok(Rec::Parsed(None)),
+                }
+            }
+
             Rec::Parsed(Some(c)) => self
                 .short_function_definition(c)
                 .await
@@ -46,11 +67,13 @@ impl Parser<'_, '_> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::ErrorCause;
     use super::super::lex::Lexer;
     use super::super::lex::TokenId::EndOfInput;
     use super::*;
+    use crate::source::Source;
     use assert_matches::assert_matches;
-    use futures_util::FutureExt;
+    use futures_util::FutureExt as _;
 
     #[test]
     fn parser_command_simple() {
@@ -83,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn parser_command_function() {
+    fn parser_command_short_function() {
         let mut lexer = Lexer::with_code("fun () ( echo )");
         let mut parser = Parser::new(&mut lexer);
 
@@ -95,6 +118,38 @@ mod tests {
 
         let next = parser.peek_token().now_or_never().unwrap().unwrap();
         assert_eq!(next.id, EndOfInput);
+    }
+
+    #[test]
+    fn parser_command_long_function() {
+        let mut lexer = Lexer::with_code("  function fun { echo; }");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::UnsupportedFunctionDefinitionSyntax)
+        );
+        assert_eq!(*e.location.code.value.borrow(), "  function fun { echo; }");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 2..10);
+    }
+
+    #[test]
+    fn parser_command_double_bracket() {
+        let mut lexer = Lexer::with_code(" [[ foo ]]");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::UnsupportedDoubleBracketCommand)
+        );
+        assert_eq!(*e.location.code.value.borrow(), " [[ foo ]]");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 1..3);
     }
 
     #[test]

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -185,6 +185,10 @@ pub enum SyntaxError {
     IncompleteLongUnicodeEscape,
     /// A Unicode escape (`\u...` or `\U...`) is out of range in a dollar-single-quoted string.
     UnicodeEscapeOutOfRange,
+    /// The unsupported version of function definition syntax is used.
+    UnsupportedFunctionDefinitionSyntax,
+    /// A `[[ ... ]]` command is used.
+    UnsupportedDoubleBracketCommand,
 }
 
 impl SyntaxError {
@@ -270,6 +274,9 @@ impl SyntaxError {
                 "the Unicode escape is incomplete"
             }
             UnicodeEscapeOutOfRange => "the Unicode escape is out of range",
+            UnsupportedFunctionDefinitionSyntax | UnsupportedDoubleBracketCommand => {
+                "unsupported syntax"
+            }
         }
     }
 
@@ -349,6 +356,8 @@ impl SyntaxError {
             IncompleteShortUnicodeEscape => r"expected a hexadecimal digit after `\u`",
             IncompleteLongUnicodeEscape => r"expected a hexadecimal digit after `\U`",
             UnicodeEscapeOutOfRange => "not a valid Unicode scalar value",
+            UnsupportedFunctionDefinitionSyntax => "the `function` keyword is not yet supported",
+            UnsupportedDoubleBracketCommand => "the `[[ ... ]]` command is not yet supported",
         }
     }
 


### PR DESCRIPTION
Currently, the `function` and `[[` reserved words are recognized but not
supported. However, the parser did not provide specific error messages
for these cases, which could confuse users:

```
$ function foo() { :; }
error: a separator is missing between the commands
 --> <stdin>:1:1
  |
1 | function foo() { :; }
  | ^^^^^^^^ expected `;` or `&` before this token
  |
```

This commit introduces two new error variants in `parser::SyntaxError`:

- `UnsupportedFunctionDefinitionSyntax`
- `UnsupportedDoubleBracketCommand`

The command parser (`parser::Parser::command`) now raises these errors
when it encounters the `function` and `[[` reserved words, respectively.
These syntaxes are not yet supported, but at least users will now see
more informative error messages.

Fixes https://github.com/magicant/yash-rs/issues/513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More informative errors when using unsupported syntax: function definitions via the function keyword and the [[ ... ]] command now report clear, precise messages with locations.

- Chores
  - Dependency updates across packages to yash-syntax 0.15.2 for consistent parsing behavior.

- Documentation
  - Changelogs updated to reflect improved error reporting and dependency version bumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->