### PR TITLE
Specify Rust components to install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Run basic tests
       run: ./check.sh -v
@@ -32,6 +34,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
     - uses: Swatinem/rust-cache@v2
     - uses: giraffate/clippy-action@v1
       with:


### PR DESCRIPTION
dtolnay/rust-toolchain by default installs only the minimal Rust toolchain without any additional components. This change adds the `clippy` and `rustfmt` components to the CI workflow, ensuring that linting and formatting checks can be performed during the CI process.

I don't know why past builds worked without this, but it's likely that the components were previously cached or installed in some other way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration by adding Rust linting and formatting tools to automated checks, improving code quality and consistency across builds.
  * Strengthens pre-merge validation to catch style and potential issues earlier, supporting more reliable releases.
  * No user-facing changes in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->