### PR TITLE
Update annotate-snippets to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env-test-helper"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "assert_matches",
  "futures-executor",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -599,7 +599,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+checksum = "a8ee2f071d418442e50c643c4e7a4051ce3abd9dba11713cc6cdf4f4a3f3cca5"
 dependencies = [
  "anstyle",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["yash-*"]
 resolver = "2"
 
 [workspace.dependencies]
-annotate-snippets = "0.11.4"
+annotate-snippets = "0.12.4"
 assert_matches = "1.5.0"
 bitflags = "2.6.0"
 dyn-clone = "1.0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
 yash-builtin = { path = "yash-builtin", version = "0.10.0" }
-yash-env = { path = "yash-env", version = "0.8.1" }
-yash-env-test-helper = { path = "yash-env-test-helper", version = "0.6.0" }
+yash-env = { path = "yash-env", version = "0.9.0" }
+yash-env-test-helper = { path = "yash-env-test-helper", version = "0.7.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
-yash-prompt = { path = "yash-prompt", version = "0.6.0" }
+yash-prompt = { path = "yash-prompt", version = "0.7.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.9.0" }
-yash-syntax = { path = "yash-syntax", version = "0.15.2" }
+yash-semantics = { path = "yash-semantics", version = "0.10.0" }
+yash-syntax = { path = "yash-syntax", version = "0.16.0" }
 
 [workspace.lints]
 

--- a/docs/src/arithmetic.md
+++ b/docs/src/arithmetic.md
@@ -57,7 +57,7 @@ error: cannot expand unset parameter
  ::: <stdin>:2:6
   |
 2 | echo $((x + 3))
-  |      ---------- info: arithmetic expansion appeared here
+  |      ---------- arithmetic expansion appeared here
   |
   = info: unset parameters are disallowed by the nounset option
 ```
@@ -76,8 +76,7 @@ error: error evaluating the arithmetic expansion
  ::: <stdin>:2:6
   |
 2 | echo $((x + 3))
-  |      ---------- info: arithmetic expansion appeared here
-  |
+  |      ---------- arithmetic expansion appeared here
 ```
 
 Currently, variables in arithmetic expressions must have a single numeric value. In the future, more complex values may be supported.

--- a/docs/src/builtins/README.md
+++ b/docs/src/builtins/README.md
@@ -268,8 +268,7 @@ error: unexpected operand
 1 | cd /dev -P
   | --      ^^ -P: unexpected operand
   | |
-  | info: executing the cd built-in
-  |
+  | executing the cd built-in
 ```
 
 Specifying options after operands may be supported in the future.

--- a/docs/src/builtins/readonly.md
+++ b/docs/src/builtins/readonly.md
@@ -146,8 +146,7 @@ error: error assigning to variable
  ::: <stdin>:1:10
   |
 1 | readonly foo='Hello, world!'
-  |          ------------------- info: the variable was made read-only here
-  |
+  |          ------------------- the variable was made read-only here
 ```
 
 ## Compatibility

--- a/docs/src/builtins/unalias.md
+++ b/docs/src/builtins/unalias.md
@@ -45,7 +45,6 @@ error: cannot execute external utility "greet"
   |
 4 | greet world
   | ^^^^^ utility not found
-  |
 ```
 
 ## Compatibility

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -94,7 +94,6 @@ error: the compound command delimiter is unmatched
   |
 3 | echo "Oops, a syntax error";;
   |                            ^^ not in a `case` command
-  |
 ```
 <!-- markdownlint-enable MD014 -->
 

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -35,8 +35,7 @@ error: ambiguous option name "--c"
 2 | set --c
   | --- ^^^ --c
   | |
-  | info: executing the set built-in
-  |
+  | executing the set built-in
 ```
 
 Note: Future versions may add more options, so abbreviations that work now may become ambiguous later. For forward compatibility, use full option names.

--- a/docs/src/language/commands/pipelines.md
+++ b/docs/src/language/commands/pipelines.md
@@ -96,7 +96,6 @@ error: cannot execute external utility "!ls"
   |
 1 | !ls | grep .zip
   | ^^^ utility not found
-  |
 ```
 
 ## Compatibility

--- a/docs/src/language/functions.md
+++ b/docs/src/language/functions.md
@@ -53,7 +53,6 @@ error: cannot execute external utility "greet"
   |
 4 | greet
   | ^^^^^ utility not found
-  |
 ```
 
 Redirections in a function definition apply when the function is called, not when it is defined:
@@ -88,13 +87,12 @@ error: cannot redefine read-only function `greet`
  ::: <stdin>:1:1
   |
 1 | greet() { echo "Hello, World!"; }
-  | ----- info: existing function was defined here
+  | ----- existing function was defined here
   |
  ::: <stdin>:2:13
   |
 2 | typeset -fr greet
-  |             ----- info: existing function was made read-only here
-  |
+  |             ----- existing function was made read-only here
 ```
 
 The [`readonly` built-in](../builtins/readonly.md) does not yet support making functions read-only in yash-rs.
@@ -177,7 +175,6 @@ error: cannot execute external utility "greet"
   |
 3 | greet
   | ^^^^^ utility not found
-  |
 ```
 
 ## Replacing existing utilities

--- a/docs/src/language/parameters/variables.md
+++ b/docs/src/language/parameters/variables.md
@@ -81,8 +81,7 @@ error: error assigning to variable
  ::: <stdin>:1:10
   |
 1 | readonly pi=3.14
-  |          ------- info: the variable was made read-only here
-  |
+  |          ------- the variable was made read-only here
 ```
 
 Variables are read-only only in the current shell session. Exported [environment variables](#environment-variables) are not read-only in child processes.

--- a/docs/src/language/redirections/README.md
+++ b/docs/src/language/redirections/README.md
@@ -64,7 +64,6 @@ Yash-rs supports these redirection operators:
       |
     5 | echo "Another redirection" > file.txt
       |                              ^^^^^^^^ file.txt: File exists (os error 17)
-      |
     ```
 
 - **`>|`** (file): Redirects standard output to a file, overwriting it if it exists.

--- a/docs/src/language/words/README.md
+++ b/docs/src/language/words/README.md
@@ -84,7 +84,6 @@ error: the pattern is not a valid word token
   |
 2 | case foo in (foo) echo foo;;; esac
   |                             ^ expected a word
-  |
 ```
 
 ## Word expansion

--- a/docs/src/language/words/arithmetic.md
+++ b/docs/src/language/words/arithmetic.md
@@ -48,8 +48,7 @@ error: error evaluating the arithmetic expansion
  ::: <stdin>:3:6
   |
 3 | echo $((2 * seven))
-  |      -------------- info: arithmetic expansion appeared here
-  |
+  |      -------------- arithmetic expansion appeared here
 ```
 
 ## Quoting
@@ -67,6 +66,5 @@ error: error evaluating the arithmetic expansion
  ::: <stdin>:1:6
   |
 1 | echo $((\$x))
-  |      -------- info: arithmetic expansion appeared here
-  |
+  |      -------- arithmetic expansion appeared here
 ```

--- a/docs/src/language/words/keywords.md
+++ b/docs/src/language/words/keywords.md
@@ -69,7 +69,6 @@ error: cannot execute external utility "{echo"
   |
 1 | {echo Hello}
   | ^^^^^ utility not found
-  |
 ```
 
 To use `{` and `}` as reserved words, write them as separate words:

--- a/docs/src/language/words/parameters.md
+++ b/docs/src/language/words/parameters.md
@@ -137,7 +137,6 @@ error: tell me your name
   |
 4 | echo "Hello, ${user?tell me your name}!"
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ parameter `user` is not set
-  |
 ```
 
 In all cases, the following expansions are performed on `word` before use:

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `yash-builtin` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-env 0.8.1 → 0.9.0
+    - yash-semantics (optional) 0.9.0 → 0.10.0
+    - yash-syntax 0.15.2 → 0.16.0
+- Internal dependency versions:
+    - yash-prompt (optional) 0.6.0 → 0.7.0
+
 ## [0.10.0] - 2025-09-23
 
 ### Added
@@ -375,6 +386,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.11.0
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.10.0
 [0.9.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.1
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.9.0

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,12 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - Unreleased
+
+### Changed
+
+- Slightly refined the format of error messages.
+
 ## [3.0.0] - 2025-09-23
 
 This is the first stable release of yash-rs.
@@ -272,6 +278,7 @@ later.
 
 - Initial release of the shell
 
+[3.0.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.1
 [3.0.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.0
 [0.4.5]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.5
 [0.4.4]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-0.4.4

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-env-test-helper/CHANGELOG.md
+++ b/yash-env-test-helper/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to `yash-env-test-helper` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - Unreleased
+## [0.7.0] - Unreleased
 
 - External dependency versions:
-    - yash-env 0.8.0 → 0.8.1
+    - yash-env 0.8.0 → 0.9.0
 
 ## [0.6.0] - 2025-05-11
 
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env-test-helper` crate
 
-[0.6.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.6.1
+[0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.7.0
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.5.0
 [0.4.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.4.0

--- a/yash-env-test-helper/Cargo.toml
+++ b/yash-env-test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env-test-helper"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `yash-env` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+
+- External dependency versions:
+    - yash-syntax 0.15.0 → 0.16.0
+- Internal dependency versions:
+    - annotate-snippets 0.11.4 → 0.12.4
+
 ## [0.8.1] - 2025-09-23
 
 ### Added
@@ -475,6 +482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-env` crate
 
+[0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.9.0
 [0.8.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.8.1
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.7.1

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -50,13 +50,13 @@ pub const MIN_INTERNAL_FD: Fd = Fd(10);
 /// [`SharedSystem::print_error`].
 #[must_use]
 pub fn message_to_string(env: &Env, message: &Message<'_>) -> String {
-    let m = annotate_snippets::Message::from(message);
-    let r = if env.should_print_error_in_color() {
+    let group = annotate_snippets::Group::from(message);
+    let renderer = if env.should_print_error_in_color() {
         Renderer::styled()
     } else {
         Renderer::plain()
     };
-    format!("{}\n", r.render(m))
+    format!("{}\n", renderer.render(&[group]))
 }
 
 /// Convenience function for printing an error message.

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `yash-prompt` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-syntax 0.15.2 → 0.16.0
+    - yash-env 0.8.0 → 0.9.0
+- Internal dependency versions:
+    - yash-semantics 0.9.0 → 0.10.0
+
 ## [0.6.1] - 2025-09-23
 
 ### Changed
@@ -85,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.7.0
 [0.6.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.1
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.0
 [0.5.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.5.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `yash-semantics` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - Unreleased
+
+### Changed
+
+- External dependency versions:
+    - yash-env 0.8.1 → 0.9.0
+    - yash-syntax 0.15.2 → 0.16.0
+
 ## [0.9.0] - 2025-09-23
 
 ### Added
@@ -322,6 +330,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.9.0
 [0.8.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.1
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.8.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `yash-syntax` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - Unreleased
+
+### Changed
+
+- Updated the optional external dependency annotate-snippets from 0.11.4 to
+  0.12.4. Items provided by this crate have been redefined to reflect the
+  changes in the new version of annotate-snippets:
+    - `impl From<AnnotationType> for annotate_snippets::Level` →
+      `impl<'a> From<AnnotationType> for annotate_snippets::Level<'a>`
+    - Added `impl From<AnnotationType> for annotate_snippets::AnnotationKind`
+    - `impl<'a> From<&'a Message<'a>> for annotate_snippets::Message<'a>` →
+      `impl<'a> From<&'a Message<'a>> for annotate_snippets::Group<'a>`
+
 ## [0.15.2] - 2025-09-23
 
 ### Added
@@ -510,6 +523,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.16.0
 [0.15.2]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.2
 [0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.15.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.85.0"


### PR DESCRIPTION
## Description

Updates annotate-snippets from 0.11.5 to 0.12.x. This includes breaking changes.

## Checklist

- Implementation
    - [x] Bump the annotate-snippets dependency version
    - [x] Pass `check.sh`
    - [x] Honor annotation types
    - [x] Pass `check-docs.sh`
    - [x] ~~Consider reorganizing the pretty module~~ → I will do this separately
- Style
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] ~~Unit tests should be added in the same file as the code being tested~~ Conversion to annotate-snippets-defined types cannot be unit-tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Internal and external dependencies should be mentioned separately. Internal dependencies are crates whose items are not re-exported by the dependent crate. Bumping an internal dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Refined CLI and diagnostic output formatting: cleaner error snippets and removal of “info:” prefixes for clearer messages.

- Documentation
  - Updated examples and guides to match the new error message format; removed extraneous lines and improved snippet readability across multiple pages.

- Chores
  - Bumped versions across the suite (CLI 3.0.1; libraries to latest minor versions) and updated changelogs to reflect dependency upgrades and formatting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->