### PR TITLE
Rename SwitchType to SwitchAction

### DIFF
--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -154,7 +154,7 @@ pub mod tests {
     use super::*;
     use futures_util::FutureExt;
     use yash_env::variable::{IFS, Scope};
-    use yash_syntax::syntax::{Switch, SwitchCondition, SwitchType};
+    use yash_syntax::syntax::{Switch, SwitchAction, SwitchCondition};
 
     pub fn env_with_positional_params_and_ifs() -> yash_env::Env {
         let mut env = yash_env::Env::new_virtual();
@@ -247,7 +247,7 @@ pub mod tests {
 
     #[test]
     fn alter_empty() {
-        use yash_syntax::syntax::{Switch, SwitchCondition, SwitchType};
+        use yash_syntax::syntax::{Switch, SwitchAction, SwitchCondition};
 
         let mut env = env_with_positional_params_and_ifs();
         env.variables
@@ -256,7 +256,7 @@ pub mod tests {
             .unwrap();
         let mut param = braced_variable("foo");
         param.modifier = Modifier::Switch(Switch {
-            r#type: SwitchType::Alter,
+            action: SwitchAction::Alter,
             condition: SwitchCondition::Unset,
             word: "bar".parse().unwrap(),
         });
@@ -338,7 +338,7 @@ pub mod tests {
         let mut env = Env::new(&mut env);
         let mut param = braced_variable("foo");
         param.modifier = Modifier::Switch(Switch {
-            r#type: SwitchType::Alter,
+            action: SwitchAction::Alter,
             condition: SwitchCondition::Unset,
             word: "".parse().unwrap(),
         });

--- a/yash-semantics/src/expansion/initial/param/switch.rs
+++ b/yash-semantics/src/expansion/initial/param/switch.rs
@@ -33,8 +33,8 @@ use yash_syntax::source::Location;
 use yash_syntax::syntax::Param;
 use yash_syntax::syntax::ParamType;
 use yash_syntax::syntax::Switch;
+use yash_syntax::syntax::SwitchAction;
 use yash_syntax::syntax::SwitchCondition;
-use yash_syntax::syntax::SwitchType;
 use yash_syntax::syntax::Word;
 
 /// Subdivision of [value](Value) states that may be considered as "not set"
@@ -91,7 +91,7 @@ impl std::fmt::Display for Vacancy {
     }
 }
 
-/// Error caused by a [`Switch`] of [`SwitchType::Error`]
+/// Error caused by a [`Switch`] of [`SwitchAction::Error`]
 ///
 /// `VacantError` is an error that is returned when you apply an error switch to
 /// a [vacant](Vacancy) value.
@@ -274,10 +274,10 @@ pub async fn apply(
     value: Option<&Value>,
     location: &Location,
 ) -> Option<Result<Phrase, Error>> {
-    use SwitchType::*;
+    use SwitchAction::*;
     use ValueCondition::*;
     let cond = ValueCondition::with(switch.condition, Vacancy::of(value));
-    match (switch.r#type, cond) {
+    match (switch.action, cond) {
         (Alter, Vacant(_)) | (Default, Occupied) | (Assign, Occupied) | (Error, Occupied) => None,
 
         (Alter, Occupied) | (Default, Vacant(_)) => {
@@ -308,8 +308,8 @@ mod tests {
     use futures_util::FutureExt;
     use yash_env::variable::IFS;
     use yash_syntax::syntax::SpecialParam;
+    use yash_syntax::syntax::SwitchAction::*;
     use yash_syntax::syntax::SwitchCondition::*;
-    use yash_syntax::syntax::SwitchType::*;
 
     #[test]
     fn vacancy_of_values() {
@@ -383,7 +383,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Alter,
+            action: Alter,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -400,7 +400,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Alter,
+            action: Alter,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -418,7 +418,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Default,
+            action: Default,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -435,7 +435,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Default,
+            action: Default,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -453,7 +453,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Assign,
+            action: Assign,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -483,7 +483,7 @@ mod tests {
             .unwrap();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Assign,
+            action: Assign,
             condition: Unset,
             word: "\"$@\"".parse().unwrap(),
         };
@@ -530,7 +530,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Assign,
+            action: Assign,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -552,7 +552,7 @@ mod tests {
         let save_var = var.clone();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Assign,
+            action: Assign,
             condition: UnsetOrEmpty,
             word: "foo".parse().unwrap(),
         };
@@ -580,7 +580,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Assign,
+            action: Assign,
             condition: UnsetOrEmpty,
             word: "foo".parse().unwrap(),
         };
@@ -607,7 +607,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Error,
+            action: Error,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };
@@ -629,7 +629,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Error,
+            action: Error,
             condition: UnsetOrEmpty,
             word: "bar".parse().unwrap(),
         };
@@ -652,7 +652,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Error,
+            action: Error,
             condition: UnsetOrEmpty,
             word: "".parse().unwrap(),
         };
@@ -676,7 +676,7 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         let mut env = Env::new(&mut env);
         let switch = Switch {
-            r#type: Error,
+            action: Error,
             condition: Unset,
             word: "foo".parse().unwrap(),
         };

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Renamed `syntax::SwitchType` to `syntax::SwitchAction` and
+  `syntax::Switch::type` to `syntax::Switch::action` to better reflect their
+  purpose.
 - Updated the optional public dependency annotate-snippets from 0.11.4 to
   0.12.4. Items provided by this crate have been redefined to reflect the
   changes in the new version of annotate-snippets:

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -205,8 +205,8 @@ mod tests {
     use crate::parser::lex::Lexer;
     use crate::parser::lex::WordContext;
     use crate::source::Source;
+    use crate::syntax::SwitchAction;
     use crate::syntax::SwitchCondition;
-    use crate::syntax::SwitchType;
     use crate::syntax::TrimLength;
     use crate::syntax::TrimSide;
     use assert_matches::assert_matches;
@@ -572,7 +572,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::variable("x"));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.action, SwitchAction::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "");
         });
@@ -599,7 +599,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::variable("foo"));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.action, SwitchAction::Error);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.to_string(), "'!'");
         });
@@ -626,7 +626,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::from(SpecialParam::Number));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.action, SwitchAction::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
         });
@@ -653,7 +653,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::from(SpecialParam::Number));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.action, SwitchAction::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "-");
         });
@@ -680,7 +680,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::from(SpecialParam::Number));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.action, SwitchAction::Assign);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
         });
@@ -707,7 +707,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::from(SpecialParam::Number));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.action, SwitchAction::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.to_string(), "?");
         });
@@ -734,7 +734,7 @@ mod tests {
         let param = result.unwrap().unwrap();
         assert_eq!(param.param, Param::from(SpecialParam::Number));
         assert_matches!(param.modifier, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.action, SwitchAction::Default);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.to_string(), "");
         });

--- a/yash-syntax/src/parser/lex/modifier.rs
+++ b/yash-syntax/src/parser/lex/modifier.rs
@@ -24,8 +24,8 @@ use crate::parser::error::Error;
 use crate::parser::error::SyntaxError;
 use crate::syntax::Modifier;
 use crate::syntax::Switch;
+use crate::syntax::SwitchAction;
 use crate::syntax::SwitchCondition;
-use crate::syntax::SwitchType;
 use crate::syntax::Trim;
 use crate::syntax::TrimLength;
 use crate::syntax::TrimSide;
@@ -93,11 +93,11 @@ impl WordLexer<'_, '_> {
     /// `symbol`.
     async fn switch(&mut self, colon: bool, symbol: char) -> Result<Modifier> {
         self.consume_char();
-        let r#type = match symbol {
-            '+' => SwitchType::Alter,
-            '-' => SwitchType::Default,
-            '=' => SwitchType::Assign,
-            '?' => SwitchType::Error,
+        let action = match symbol {
+            '+' => SwitchAction::Alter,
+            '-' => SwitchAction::Default,
+            '=' => SwitchAction::Assign,
+            '?' => SwitchAction::Error,
             _ => unreachable!(),
         };
 
@@ -115,7 +115,7 @@ impl WordLexer<'_, '_> {
         }
 
         Ok(Modifier::Switch(Switch {
-            r#type,
+            action,
             condition,
             word,
         }))
@@ -191,7 +191,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.action, SwitchAction::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "+}");
@@ -211,7 +211,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.action, SwitchAction::Alter);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(
                 switch.word.units,
@@ -239,7 +239,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Alter);
+            assert_eq!(switch.action, SwitchAction::Alter);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":+}");
@@ -259,7 +259,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.action, SwitchAction::Default);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "-}");
@@ -279,7 +279,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Default);
+            assert_eq!(switch.action, SwitchAction::Default);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(
                 switch.word.units,
@@ -307,7 +307,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.action, SwitchAction::Assign);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), ":=}");
@@ -327,7 +327,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Assign);
+            assert_eq!(switch.action, SwitchAction::Assign);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(
                 switch.word.units,
@@ -354,7 +354,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.action, SwitchAction::Error);
             assert_eq!(switch.condition, SwitchCondition::Unset);
             assert_eq!(switch.word.units, []);
             assert_eq!(*switch.word.location.code.value.borrow(), "?}");
@@ -374,7 +374,7 @@ mod tests {
 
         let result = lexer.suffix_modifier().now_or_never().unwrap().unwrap();
         assert_matches!(result, Modifier::Switch(switch) => {
-            assert_eq!(switch.r#type, SwitchType::Error);
+            assert_eq!(switch.action, SwitchAction::Error);
             assert_eq!(switch.condition, SwitchCondition::UnsetOrEmpty);
             assert_eq!(
                 switch.word.units,

--- a/yash-syntax/src/syntax.rs
+++ b/yash-syntax/src/syntax.rs
@@ -171,7 +171,7 @@ pub struct Param {
 
 /// Flag that specifies how the value is substituted in a [switch](Switch)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SwitchType {
+pub enum SwitchAction {
     /// Alter an existing value, if any. (`+`)
     Alter,
     /// Substitute a missing value with a default. (`-`)
@@ -185,7 +185,7 @@ pub enum SwitchType {
 /// Condition that triggers a [switch](Switch)
 ///
 /// In the lexical grammar of the shell language, a switch condition is an
-/// optional colon that precedes a switch type.
+/// optional colon that precedes a switch action.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SwitchCondition {
     /// Without a colon, the switch is triggered if the parameter is unset.
@@ -200,12 +200,12 @@ pub enum SwitchCondition {
 ///
 /// Examples of switches include `+foo`, `:-bar` and `:=baz`.
 ///
-/// A switch is composed of a [condition](SwitchCondition) (an optional `:`), a
-/// [type](SwitchType) (one of `+`, `-`, `=` and `?`) and a [word](Word).
+/// A switch is composed of a [condition](SwitchCondition) (an optional `:`), an
+/// [action](SwitchAction) (one of `+`, `-`, `=` and `?`) and a [word](Word).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Switch {
     /// How the value is substituted
-    pub r#type: SwitchType,
+    pub action: SwitchAction,
     /// Condition that determines whether the value is substituted or not
     pub condition: SwitchCondition,
     /// Word that substitutes the parameter value

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -215,7 +215,7 @@ impl From<usize> for Param {
 
 impl Unquote for Switch {
     fn write_unquoted<W: fmt::Write>(&self, w: &mut W) -> UnquoteResult {
-        write!(w, "{}{}", self.condition, self.r#type)?;
+        write!(w, "{}{}", self.condition, self.action)?;
         self.word.write_unquoted(w)
     }
 }
@@ -650,7 +650,7 @@ mod tests {
     #[test]
     fn switch_unquote() {
         let switch = Switch {
-            r#type: SwitchType::Default,
+            action: SwitchAction::Default,
             condition: SwitchCondition::UnsetOrEmpty,
             word: "foo bar".parse().unwrap(),
         };
@@ -659,7 +659,7 @@ mod tests {
         assert_eq!(is_quoted, false);
 
         let switch = Switch {
-            r#type: SwitchType::Error,
+            action: SwitchAction::Error,
             condition: SwitchCondition::Unset,
             word: r"e\r\ror".parse().unwrap(),
         };
@@ -727,7 +727,7 @@ mod tests {
         assert_eq!(is_quoted, false);
 
         let switch = Switch {
-            r#type: SwitchType::Assign,
+            action: SwitchAction::Assign,
             condition: SwitchCondition::UnsetOrEmpty,
             word: "'bar'".parse().unwrap(),
         };

--- a/yash-syntax/src/syntax/impl_display.rs
+++ b/yash-syntax/src/syntax/impl_display.rs
@@ -31,9 +31,9 @@ impl fmt::Display for Param {
     }
 }
 
-impl fmt::Display for SwitchType {
+impl fmt::Display for SwitchAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use SwitchType::*;
+        use SwitchAction::*;
         let c = match self {
             Alter => '+',
             Default => '-',
@@ -56,7 +56,7 @@ impl fmt::Display for SwitchCondition {
 
 impl fmt::Display for Switch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}{}", self.condition, self.r#type, self.word)
+        write!(f, "{}{}{}", self.condition, self.action, self.word)
     }
 }
 
@@ -427,28 +427,28 @@ mod tests {
     #[test]
     fn switch_display() {
         let switch = Switch {
-            r#type: SwitchType::Alter,
+            action: SwitchAction::Alter,
             condition: SwitchCondition::Unset,
             word: "".parse().unwrap(),
         };
         assert_eq!(switch.to_string(), "+");
 
         let switch = Switch {
-            r#type: SwitchType::Default,
+            action: SwitchAction::Default,
             condition: SwitchCondition::UnsetOrEmpty,
             word: "foo".parse().unwrap(),
         };
         assert_eq!(switch.to_string(), ":-foo");
 
         let switch = Switch {
-            r#type: SwitchType::Assign,
+            action: SwitchAction::Assign,
             condition: SwitchCondition::UnsetOrEmpty,
             word: "bar baz".parse().unwrap(),
         };
         assert_eq!(switch.to_string(), ":=bar baz");
 
         let switch = Switch {
-            r#type: SwitchType::Error,
+            action: SwitchAction::Error,
             condition: SwitchCondition::Unset,
             word: "?error".parse().unwrap(),
         };
@@ -502,7 +502,7 @@ mod tests {
         assert_eq!(param.to_string(), "${#foo}");
 
         let switch = Switch {
-            r#type: SwitchType::Assign,
+            action: SwitchAction::Assign,
             condition: SwitchCondition::UnsetOrEmpty,
             word: "bar baz".parse().unwrap(),
         };


### PR DESCRIPTION
## Summary by Copilot

This pull request refactors the handling of shell parameter expansion switch types throughout the codebase, improving clarity and consistency. The main change is renaming `SwitchType` to `SwitchAction` and updating all related code to use the new terminology. This affects struct fields, pattern matching, imports, documentation, and test assertions.

**Refactor: SwitchType → SwitchAction**

* Renamed the enum `SwitchType` to `SwitchAction` and the struct field `Switch::type` to `Switch::action` across all relevant modules (`yash-syntax` and `yash-semantics`) to better reflect their purpose.
* Updated all usages, imports, and pattern matches from `SwitchType` to `SwitchAction`, including in parameter expansion logic, parser modules, and tests (`switch.rs`, `modifier.rs`, `braced_param.rs`, and `param.rs`). [[1]](diffhunk://#diff-13032a66951e38789fff940669d57e9cf776aec2c82492e208807845cd48b369R36-L37) [[2]](diffhunk://#diff-b7258c0231aafa355ff03896db2507dc22b97bfa89fc89cd08c0e1c743fa1221R27-L28) [[3]](diffhunk://#diff-d2712793b173ac89cd0a230a9825672bacdf94190646f1b6a3b8a2540fd090d2L157-R157) [[4]](diffhunk://#diff-018c94d493da7c97f882331267a48b241f852ffad74200a462fc29e35c1d78e8R208-L209)
* Changed all references to the struct field from `switch.r#type` to `switch.action` in logic and tests, ensuring consistency in field naming. [[1]](diffhunk://#diff-13032a66951e38789fff940669d57e9cf776aec2c82492e208807845cd48b369L277-R280) [[2]](diffhunk://#diff-b7258c0231aafa355ff03896db2507dc22b97bfa89fc89cd08c0e1c743fa1221L118-R118) [[3]](diffhunk://#diff-018c94d493da7c97f882331267a48b241f852ffad74200a462fc29e35c1d78e8L575-R575) [[4]](diffhunk://#diff-d2712793b173ac89cd0a230a9825672bacdf94190646f1b6a3b8a2540fd090d2L259-R259)
* Updated documentation comments to reference `SwitchAction` instead of `SwitchType` where appropriate.
* Modified test assertions and test setup to use the new `SwitchAction` enum and field name, ensuring all tests reflect the refactored naming. [[1]](diffhunk://#diff-018c94d493da7c97f882331267a48b241f852ffad74200a462fc29e35c1d78e8L602-R602) [[2]](diffhunk://#diff-b7258c0231aafa355ff03896db2507dc22b97bfa89fc89cd08c0e1c743fa1221L194-R194) [[3]](diffhunk://#diff-d2712793b173ac89cd0a230a9825672bacdf94190646f1b6a3b8a2540fd090d2L341-R341) [[4]](diffhunk://#diff-13032a66951e38789fff940669d57e9cf776aec2c82492e208807845cd48b369L386-R386)

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested (N/A)
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`) (N/A)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog (N/A)
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior (N/A)
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix) (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed public enum SwitchType to SwitchAction.
  - Renamed Switch field from type to action.
  - Updated parsing, display, and conversion paths to use action; no behavior change.

- Documentation
  - Changelog updated to reflect the SwitchType → SwitchAction and type → action renames.

- Tests
  - Updated tests to use SwitchAction and the action field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->