### PR TITLE
Augment `ConflictingOptionAndOperand` with operand location

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -69,6 +69,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   `UnsetVariablesError` instead of a `Result<(), _>`.
 - `unset::semantics::unset_functions` now returns a vector of
   `UnsetFunctionsError` instead of a `Result<(), _>`.
+- `unalias::syntax::Error::ConflictingOptionAndOperand` now contains the
+  locations of both the `-a` option and the first operand.
 - Public dependency versions:
     - yash-env 0.8.1 → 0.9.0
     - yash-semantics (optional) 0.9.0 → 0.10.0


### PR DESCRIPTION
## Description

This pull request modifies the declaration of `yash_builtin::syntax::Error::ConflictingOptionAndOperand`. The enum variant now contains not only the location of the `-a` option but also the location of the first operand, allowing for more informative error messages.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for unalias when an option conflicts with an operand: diagnostics now highlight both the option and the first operand locations for easier troubleshooting.

* **Refactor**
  * Internal changes to support clearer multi-span diagnostics in conflict scenarios.

* **Documentation**
  * Changelog updated to reflect enhanced conflict reporting behavior in version 0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->