### PR TITLE
Use getrusage in place of times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
 yash-builtin = { path = "yash-builtin", version = "0.11.0" }
-yash-env = { path = "yash-env", version = "0.9.0" }
+yash-env = { path = "yash-env", version = "0.9.1" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.7.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,13 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - Unreleased
+
+### Changed
+
+- The `times` built-in now uses the `getrusage` system call instead of `times`
+  to get CPU times. This provides better resolution on many systems.
+
 ## [3.0.2] - 2025-10-16
 
 ### Fixed
@@ -286,6 +293,7 @@ later.
 
 - Initial release of the shell
 
+[3.0.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.3
 [3.0.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.2
 [3.0.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.1
 [3.0.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.0

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.9.1] - Unreleased
+
+### Changed
+
+- The `times` method of `RealSystem` now uses `getrusage` instead of `times`
+  to get CPU times. This provides better resolution on many systems.
+
 ## [0.9.0] - 2025-10-13
 
 ### Added
@@ -503,6 +510,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env` crate
 
+[0.9.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.9.1
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.9.0
 [0.8.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.8.1
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.8.0

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"


### PR DESCRIPTION
## Description

**Summary by Copilot**

This pull request updates the way CPU times are measured in the `yash-env` crate and the `times` built-in command in the `yash-cli` shell. The main improvement is switching from the older `times` system call to `getrusage`, which provides better time resolution on many systems. The version numbers for affected crates are also bumped to reflect these changes.

### Improved CPU time measurement

* The `times` method in `RealSystem` (`yash-env/src/system/real.rs`) now uses the `getrusage` system call instead of `times`, improving the accuracy and resolution of reported CPU times.
* The `times` built-in command in `yash-cli` now uses `getrusage` for CPU time reporting, as documented in the changelog. [[1]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR12-R18) [[2]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR12-R18)

### Version updates

* Bumped `yash-env` crate version from `0.9.0` to `0.9.1` in both `yash-env/Cargo.toml` and `Cargo.toml` to reflect the API change. [[1]](diffhunk://#diff-d25f8cd91b0effd6a7935b635d9b104d9070677e5b508b42e3e4f905ba040856L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L29-R29)

### Documentation

* Added changelog entries and release links for version `0.9.1` of `yash-env` and version `3.0.3` of `yash-cli`, describing the change to `getrusage`. [[1]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR513) [[2]](diffhunk://#diff-160ed7f7895777264dd284427c47d0793e14ddd46f0ac37db4c809ba9deae57dR296)

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Improved CPU time measurement resolution for the times built-in command on many systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->