### PR TITLE
Inject yash-semantics dependency into wait built-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "yash-executor",
  "yash-prompt",
  "yash-quote",
+ "yash-semantics",
  "yash-syntax",
 ]
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -16,6 +16,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `read` built-in now requires a `yash_env::prompt::GetPrompt` instance to
   be available in the environment's `any` storage. This instance is used to
   generate prompts when reading input in the `read::input::read` function.
+- The `wait` built-in now requires a
+  `yash_env::trap::RunSignalTrapIfCaught` instance to be available in the
+  environment's `any` storage. This instance is used to handle trapped signals
+  while waiting for jobs in the `wait::core::wait_for_any_job_or_trap` function.
 
 ### Removed
 

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -54,8 +54,11 @@
 //! into the environment's [`any`](yash_env::Env::any) storage. If these
 //! dependencies are not injected, the built-in may not function correctly.
 //!
-//! The `read` built-in requires a [`GetPrompt`](yash_env::prompt::GetPrompt)
-//! instance in the `any` storage to generate prompts when reading input.
+//! - The `read` built-in requires a [`GetPrompt`](yash_env::prompt::GetPrompt)
+//!   instance in the `any` storage to generate prompts when reading input.
+//! - The `wait` built-in requires a
+//!   [`RunSignalTrapIfCaught`](yash_env::trap::RunSignalTrapIfCaught) instance
+//!   in the `any` storage to handle trapped signals while waiting for jobs.
 
 pub mod alias;
 pub mod bg;

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -23,8 +23,10 @@
 //!
 //! # Implementation notes
 //!
-//! The built-in treats disowned jobs as if they were finished with an exit
-//! status of 127.
+//! The built-in expects that an instance of
+//! [`RunSignalTrapIfCaught`](yash_env::trap::RunSignalTrapIfCaught) is stored
+//! in [`Env::any`] to handle trapped signals while waiting for jobs. If there
+//! is no such instance, the built-in will ignore all signals.
 
 use crate::common::report::{merge_reports, report_error, report_simple_failure};
 use itertools::Itertools as _;

--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -24,6 +24,7 @@ use yash_env::io::Fd;
 use yash_env::option::Option::{Interactive, Monitor, Stdin};
 use yash_env::option::State::On;
 use yash_env::prompt::GetPrompt;
+use yash_env::trap::RunSignalTrapIfCaught;
 
 pub mod args;
 pub mod init_file;
@@ -113,4 +114,9 @@ fn inject_dependencies(env: &mut Env) {
             yash_prompt::expand_posix(env, &prompt, false).await
         })
     })));
+
+    env.any
+        .insert(Box::new(RunSignalTrapIfCaught(|env, signal| {
+            Box::pin(async move { yash_semantics::trap::run_trap_if_caught(env, signal).await })
+        })));
 }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -16,6 +16,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `prompt` module
     - This module currently contains the `GetPrompt` struct, which wraps
       a prompt-generating function.
+- `trap::RunSignalTrapIfCaught`
+    - This struct wraps a function that runs a signal trap if the signal has been
+      caught.
 
 ## [0.9.1] - 2025-10-18
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -43,6 +43,7 @@ assert_matches = { workspace = true }
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["channel"] }
 yash-prompt = { workspace = true }
+yash-semantics = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Description

This is part of the ongoing effort to flatten the dependency graph by removing yash-semantics as a direct dependency of yash-builtin <https://github.com/magicant/yash-rs/issues/625>. This commit introduces a new dependency injection for the `wait` built-in, allowing it to use the `RunSignalTrapIfCaught` functionality from yash-env instead of relying on yash-semantics directly.

## Summary by Copilot

This pull request introduces a new dependency injection mechanism for handling trapped signals in the `wait` built-in command. Specifically, it adds the `RunSignalTrapIfCaught` struct, which wraps a function for running signal traps, and ensures that this dependency is injected and used where needed. The documentation, tests, and startup logic are updated to reflect and support this new requirement.

**Dependency injection for trapped signal handling:**

* Introduced the `RunSignalTrapIfCaught` struct in `yash_env::trap`, which wraps a function to run a signal trap if the signal has been caught. This struct is now required in the environment's `any` storage for the `wait` built-in to handle trapped signals. [[1]](diffhunk://#diff-ad045c61bdf756e7394b305ff4e4f5ffaec8b602f1294ce00b2d4f2bd0fb062bR489-R520) [[2]](diffhunk://#diff-a5373660fafe0b19e00a740f942209ebbcf87e20f39262f8f6d31c651d37c8fbR19-R21)
* Updated the documentation in `yash-builtin` and `yash-env` to describe the new requirement for `RunSignalTrapIfCaught` and how it should be injected and used. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR19-R22) [[2]](diffhunk://#diff-ac5222e649f8a09ff4e9cb19512ccd7cf6e97182a61c28337728789bcae8b173L57-R61) [[3]](diffhunk://#diff-06acca72af2ddeb4d5ec9f1b6a4f7cafb0095599a632021dcd8f4884c84d71c4L26-R29)

**Code changes for signal trap handling:**

* Modified `wait::core::wait_for_any_job_or_trap` to retrieve and use `RunSignalTrapIfCaught` from the environment's `any` storage, defaulting to ignoring signals if not present. [[1]](diffhunk://#diff-4e3de362654525156a7fbd673257672525704036d000ca77541dd06c1e21326dL29-R29) [[2]](diffhunk://#diff-4e3de362654525156a7fbd673257672525704036d000ca77541dd06c1e21326dR53-R70)
* Updated tests for the `wait` built-in to inject the new dependency and ensure proper signal trap handling during testing.

**Integration and dependency management:**

* Updated the shell startup logic to inject the `RunSignalTrapIfCaught` dependency into the environment at startup, using the implementation from `yash-semantics`. [[1]](diffhunk://#diff-e872ec7f56eefaf1500832319a139719e43fe0ba152f5a32416a2e53ec1375b1R27) [[2]](diffhunk://#diff-e872ec7f56eefaf1500832319a139719e43fe0ba152f5a32416a2e53ec1375b1R117-R121)
* Added `yash-semantics` as a dependency in `yash-env/Cargo.toml` to provide the standard implementation of the trap handler.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the wait built-in to properly handle trapped signals while waiting for jobs, improving signal responsiveness and consistency.

* **Documentation**
  * Updated documentation to clarify signal handling expectations and behavior during wait operations when traps are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->