### PR TITLE
Inject read-eval-loop runner into eval and source built-ins

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,13 +13,19 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `eval` built-in now requires a `yash_env::semantics::RunReadEvalLoop`
+  instance to be available in the environment's `any` storage. This instance is
+  used to run the read-eval loop in the `eval::main` function.
 - The `read` built-in now requires a `yash_env::prompt::GetPrompt` instance to
   be available in the environment's `any` storage. This instance is used to
   generate prompts when reading input in the `read::input::read` function.
-- The `wait` built-in now requires a
-  `yash_env::trap::RunSignalTrapIfCaught` instance to be available in the
-  environment's `any` storage. This instance is used to handle trapped signals
-  while waiting for jobs in the `wait::core::wait_for_any_job_or_trap` function.
+- The `source` built-in now requires a `yash_env::semantics::RunReadEvalLoop`
+  instance to be available in the environment's `any` storage. This instance is
+  used to run the read-eval loop in the `source::Command::execute` function.
+- The `wait` built-in now requires a `yash_env::trap::RunSignalTrapIfCaught`
+  instance to be available in the environment's `any` storage. This instance is
+  used to handle trapped signals while waiting for jobs in the
+  `wait::core::wait_for_any_job_or_trap` function.
 
 ### Removed
 

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -52,8 +52,11 @@
 //!
 //! Some built-ins in this crate require certain dependencies to be injected
 //! into the environment's [`any`](yash_env::Env::any) storage. If these
-//! dependencies are not injected, the built-in may not function correctly.
+//! dependencies are not injected, the built-in may **panic** at runtime.
 //!
+//! - The `eval` and `source` built-ins require a
+//!   [`RunReadEvalLoop`](yash_env::semantics::RunReadEvalLoop) instance in the
+//!   `any` storage to run the read-eval loop for executing commands.
 //! - The `read` built-in requires a [`GetPrompt`](yash_env::prompt::GetPrompt)
 //!   instance in the `any` storage to generate prompts when reading input.
 //! - The `wait` built-in requires a

--- a/yash-builtin/src/source.rs
+++ b/yash-builtin/src/source.rs
@@ -27,6 +27,11 @@
 //! [variable context](yash_env::variable::Context) is pushed to secure the
 //! existing positional parameters. The context is popped when the execution of
 //! the file is finished.
+//!
+//! This built-in requires a [`RunReadEvalLoop`] instance to be available in the
+//! environment's [`any`](yash_env::Env::any) storage.
+//!
+//! [`RunReadEvalLoop`]: yash_env::semantics::RunReadEvalLoop
 
 use crate::Result;
 use yash_env::Env;

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -16,6 +16,8 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `prompt` module
     - This module currently contains the `GetPrompt` struct, which wraps
       a prompt-generating function.
+- `semantics::RunReadEvalLoop`
+    - This struct wraps a function that runs the read-eval loop.
 - `trap::RunSignalTrapIfCaught`
     - This struct wraps a function that runs a signal trap if the signal has been
       caught.


### PR DESCRIPTION
## Description

This is part of the ongoing effort to decouple yash built-ins from the
yash-semantics crate by injecting dependencies via the environment's
`any` storage. This commit removes direct calls to the `read_eval_loop`
function from the `eval` and `source` built-ins, and instead uses a
`RunReadEvalLoop` instance injected into the environment to run the
read-eval loop.

See <https://github.com/magicant/yash-rs/issues/625>.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal dependency injection architecture for built-in commands to improve modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->