### PR TITLE
Mark Ifs::new and Ifs::empty as must_use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -591,7 +591,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "assert_matches",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.7.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.10.1" }
+yash-semantics = { path = "yash-semantics", version = "0.10.2" }
 yash-syntax = { path = "yash-syntax", version = "0.16.0" }
 
 [workspace.lints]

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -26,6 +26,11 @@ A _private dependency_ is used internally and not visible to downstream users.
   instance to be available in the environment's `any` storage. This instance is
   used to handle trapped signals while waiting for jobs in the
   `wait::core::wait_for_any_job_or_trap` function.
+- Public dependency versions:
+    - yash-env 0.9.0 → 0.9.2
+    - yash-semantics (optional) 0.10.0 → 0.10.2
+- Private dependency versions:
+    - yash-prompt (optional) 0.7.0 → 0.7.1
 
 ### Removed
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.7.1] - Unreleased
+
+### Changed
+
+- Private dependency versions:
+    - yash-semantics 0.10.0 → 0.10.2
+
 ## [0.7.0] - 2025-10-13
 
 ### Changed
@@ -99,6 +106,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.7.1
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.7.0
 [0.6.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.1
 [0.6.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.6.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,15 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.10.2] - Unreleased
+
+### Changed
+
+- `expansion::split::Ifs`'s `new` and `empty` functions are now marked with
+  the `must_use` attribute.
+- Public dependency versions:
+    - yash-env 0.9.0 → 0.9.2
+
 ## [0.10.1] - 2025-10-16
 
 ### Changed
@@ -342,6 +351,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.10.2]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.10.2
 [0.10.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.10.1
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.9.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-semantics/src/expansion/split/ifs.rs
+++ b/yash-semantics/src/expansion/split/ifs.rs
@@ -71,6 +71,7 @@ impl<'a> Ifs<'a> {
     /// Creates a new IFS consisting of the given separators.
     ///
     /// The argument is treated as a list of separator characters.
+    #[must_use = "just creating an `Ifs` has no effect"]
     pub fn new(chars: &'a str) -> Self {
         Ifs {
             chars,
@@ -79,6 +80,8 @@ impl<'a> Ifs<'a> {
     }
 
     /// Creates a new IFS containing no separators.
+    #[inline]
+    #[must_use = "just creating an `Ifs` has no effect"]
     pub fn empty() -> Self {
         Self::new("")
     }


### PR DESCRIPTION
## Description

**Summary by Copilot**

This pull request updates dependency versions across several crates and adds minor improvements to the `yash-semantics` crate. The most significant changes are dependency bumps for `yash-semantics`, `yash-prompt`, and related crates, as well as marking certain functions in `yash-semantics` with `#[must_use]` to improve code safety.

### Dependency version updates

* Bumped `yash-semantics` to version `0.10.2` in the workspace and as a dependency in `yash-prompt` and `yash-builtin`, and updated `yash-env` and `yash-prompt` dependencies where relevant. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L35-R35) [[2]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR29-R33) [[3]](diffhunk://#diff-cdd751ecf3d2cbddf613454ed9019936fd9cb7f80faabcc704663939a969b6f3R12-R18) [[4]](diffhunk://#diff-a9338db40698404c9e52097b78b1a6ad2ae18be4f5608f0fe0ff7bf841451e96L3-R3) [[5]](diffhunk://#diff-7885ee3c9e0e90eb742267c2921cc7194b64f4023bdd9cd2ef7d91d957c76a38L3-R3)

### Changelog and metadata updates

* Added changelog entries for the new `yash-semantics` and `yash-prompt` versions, including details of dependency bumps and new release links. [[1]](diffhunk://#diff-ea95c3bf03309c0839bc17276b81eed8d5cf3a21106c8dfde2133b60df5ad11bR29-R33) [[2]](diffhunk://#diff-cdd751ecf3d2cbddf613454ed9019936fd9cb7f80faabcc704663939a969b6f3R12-R18) [[3]](diffhunk://#diff-cdd751ecf3d2cbddf613454ed9019936fd9cb7f80faabcc704663939a969b6f3R109) [[4]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R12-R20) [[5]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R354)

### Code quality improvements

* Marked the `Ifs::new` and `Ifs::empty` functions in `yash-semantics` with the `#[must_use]` attribute to catch potential misuse where the return value is ignored. [[1]](diffhunk://#diff-a19bd2deb17a61b8484b5ab4db6a6030aed84ef0f9ee63e01582662954116e1dR74) [[2]](diffhunk://#diff-a19bd2deb17a61b8484b5ab4db6a6030aed84ef0f9ee63e01582662954116e1dR83-R84) [[3]](diffhunk://#diff-81cd306a68191a4fba9d1035a095e55c7478aa5c747a874fa504edb9407b7959R12-R20)

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies to latest versions.
  * Bumped package versions: yash-semantics → 0.10.2, yash-prompt → 0.7.1, yash-env → 0.9.2.
  * Updated changelogs to document the dependency/version changes and add release references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->