### PR TITLE
Inject external utility execution via Env::any

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,9 +13,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
-- The `command` built-in now requires a `yash_env::semantics::command::RunFunction`
-  instance to be available in the environment's `any` storage. This instance is
-  used to invoke shell functions in the `command::Invoke::execute` method.
+- The `command` built-in now requires `yash_env::semantics::command::RunFunction`
+  and `yash_env::semantics::command::RunExternalUtilityInSubshell` instances to
+  be available in the environment's `any` storage. These instances are used to
+  invoke shell functions and run external utilities in the
+  `command::Invoke::execute` method.
 - The `eval` built-in now requires a `yash_env::semantics::RunReadEvalLoop`
   instance to be available in the environment's `any` storage. This instance is
   used to run the read-eval loop in the `eval::main` function.

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -27,13 +27,15 @@
 //! search path. See the source code of [`RealSystem::confstr_path`] for the
 //! platforms supported on the real system.
 //!
-//! Function invocation depends on an instance of [`RunFunction`] being present
-//! in the environment's [`any`](Env::any) storage. If no such instance is found,
-//! the built-in will **panic**.
+//! Function invocation depends on instances of [`RunFunction`] and
+//! [`RunExternalUtilityInSubshell`] being present in the environment's
+//! [`any`](Env::any) storage. If either instance is missing, the built-in will
+//! **panic**.
 //!
 //! The [`type`] built-in is equivalent to the `command` built-in with the `-V`
 //! option.
 //!
+//! [`RunExternalUtilityInSubshell`]: yash_env::semantics::command::RunExternalUtilityInSubshell
 //! [`RunFunction`]: yash_env::semantics::command::RunFunction
 //! [`type`]: crate::type
 

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -54,15 +54,17 @@
 //! into the environment's [`any`](yash_env::Env::any) storage. If these
 //! dependencies are not injected, the built-in may **panic** at runtime.
 //!
-//! - The `command` built-in requires a
-//!   [`RunFunction`](yash_env::semantics::command::RunFunction) instance in the
-//!   `any` storage to invoke shell functions.
-//! - The `eval` and `source` built-ins require a
+//! - The [`command`] built-in requires
+//!   [`RunFunction`](yash_env::semantics::command::RunFunction) and
+//!   [`RunExternalUtilityInSubshell`](yash_env::semantics::command::RunExternalUtilityInSubshell)
+//!   instances in the `any` storage to invoke shell functions and run external
+//!   utilities, respectively.
+//! - The [`eval`] and [`source`] built-ins require a
 //!   [`RunReadEvalLoop`](yash_env::semantics::RunReadEvalLoop) instance in the
 //!   `any` storage to run the read-eval loop for executing commands.
 //! - The `read` built-in requires a [`GetPrompt`](yash_env::prompt::GetPrompt)
 //!   instance in the `any` storage to generate prompts when reading input.
-//! - The `wait` built-in requires a
+//! - The [`wait`] built-in requires a
 //!   [`RunSignalTrapIfCaught`](yash_env::trap::RunSignalTrapIfCaught) instance
 //!   in the `any` storage to handle trapped signals while waiting for jobs.
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -22,6 +22,8 @@ A _private dependency_ is used internally and not visible to downstream users.
     - This struct wraps a function that runs a signal trap if the signal has been
       caught.
 - `semantics::command` module
+    - `RunExternalUtilityInSubshell`: Struct that wraps a function for invoking
+      external utilities in a subshell.
     - `RunFunction`: Struct that wraps a function for invoking shell functions.
 - `semantics::expansion` module
     - The content of this module has been moved from `yash_semantics::expansion`

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -20,13 +20,14 @@
 
 use crate::Env;
 use crate::function::Function;
-use crate::semantics::Field;
+use crate::semantics::{ExitStatus, Field, Result};
+use std::ffi::CString;
 use std::pin::Pin;
 use std::rc::Rc;
 
 type EnvPrepHook = fn(&mut Env) -> Pin<Box<dyn Future<Output = ()>>>;
 
-type RunFunctionResult<'a> = Pin<Box<dyn Future<Output = crate::semantics::Result> + 'a>>;
+type FutureResult<'a, T = ()> = Pin<Box<dyn Future<Output = Result<T>> + 'a>>;
 
 /// Wrapper for a function that runs a shell function
 ///
@@ -47,8 +48,8 @@ type RunFunctionResult<'a> = Pin<Box<dyn Future<Output = crate::semantics::Resul
 ///     - This hook is called after setting up the local variable context. It can inject
 ///       additional setup logic or modify the environment before the function is executed.
 ///
-/// The function returns a future that resolves to a [`Result`](crate::semantics::Result)
-/// indicating the outcome of the function execution.
+/// The function returns a future that resolves to a [`Result`] indicating the
+/// outcome of the function execution.
 ///
 /// The most standard implementation of this type is provided in the
 /// [`yash-semantics` crate](https://crates.io/crates/yash-semantics):
@@ -66,10 +67,46 @@ type RunFunctionResult<'a> = Pin<Box<dyn Future<Output = crate::semantics::Resul
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct RunFunction(
-    pub  for<'a> fn(
-        &'a mut Env,
-        Rc<Function>,
-        Vec<Field>,
-        Option<EnvPrepHook>,
-    ) -> RunFunctionResult<'a>,
+    pub for<'a> fn(&'a mut Env, Rc<Function>, Vec<Field>, Option<EnvPrepHook>) -> FutureResult<'a>,
+);
+
+/// Wrapper for running an external utility in a subshell
+///
+/// This struct declares a function type that runs an external utility in a
+/// subshell. It is used to inject command execution behavior into the shell
+/// environment. An instance of this struct can be stored in the shell
+/// environment ([`Env::any`]) and used by modules that need to run external
+/// utilities in a subshell.
+///
+/// The wrapped function takes three arguments:
+///
+/// 1. A mutable reference to the shell environment (`&'a mut Env`)
+/// 2. A `CString` representing the path to the external utility to be executed
+/// 3. A vector of [`Field`]s representing the arguments to be passed to the utility
+///
+/// The vector must not be empty; the first element is the utility name and may
+/// be used for error messages.
+///
+/// Errors creating the subshell or executing the utility should be handled in
+/// the wrapped function itself, and the function should return a future that
+/// resolves to an [`ExitStatus`] indicating the outcome of the execution.
+///
+/// The most standard implementation of this type is provided in the
+/// [`yash-semantics` crate](https://crates.io/crates/yash-semantics):
+///
+/// ```
+/// # use yash_env::semantics::command::RunExternalUtilityInSubshell;
+/// let mut env = yash_env::Env::new_virtual();
+/// env.any.insert(Box::new(RunExternalUtilityInSubshell(
+///     |env, path, fields| Box::pin(async move {
+///         yash_semantics::command::simple_command::start_external_utility_in_subshell_and_wait(
+///             env, path, fields,
+///         )
+///         .await
+///     }),
+/// )));
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct RunExternalUtilityInSubshell(
+    pub for<'a> fn(&'a mut Env, CString, Vec<Field>) -> FutureResult<'a, ExitStatus>,
 );


### PR DESCRIPTION
## Description

This is part of the ongoing effort to flatten the dependency graph by
removing direct dependency on yash-semantics from yash-builtin
(<https://github.com/magicant/yash-rs/issues/625>). By injecting the
ability to run external utilities in a subshell via the environment's
`any` storage, we can decouple the `command` built-in from
yash-semantics.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External utilities can now be invoked and run in a subshell through the command built-in.

* **API Changes**
  * Introduced a new public API type for managing external utility subshell execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->