### PR TITLE
Move command_search module from yash-semantics to yash-env

### DIFF
--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -31,10 +31,9 @@ use yash_env::builtin::{Builtin, Type};
 use yash_env::path::PathBuf;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::semantics::command::search::{Target, search};
 use yash_env::str::UnixStr;
 use yash_quote::quoted;
-use yash_semantics::command_search::Target;
-use yash_semantics::command_search::search;
 use yash_syntax::alias::Alias;
 use yash_syntax::parser::lex::Keyword;
 #[allow(deprecated)]

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -27,8 +27,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::semantics::command::RunFunction;
 use yash_env::semantics::command::run_external_utility_in_subshell;
-use yash_semantics::command_search::Target;
-use yash_semantics::command_search::search;
+use yash_env::semantics::command::search::{Target, search};
 
 impl Invoke {
     /// Execute the command

--- a/yash-builtin/src/command/search.rs
+++ b/yash-builtin/src/command/search.rs
@@ -16,8 +16,8 @@
 
 //! Command search
 //!
-//! This module provides the search functionality of the `command` built-in.
-//! It is based on the [`yash_semantics::command_search`] module, but it adds
+//! This module provides the search functionality of the `command` built-in. It
+//! is based on the [`yash_env::semantics::command::search`] module, but it adds
 //! the ability to select the category of the command to search for.
 
 use super::Category;
@@ -32,17 +32,18 @@ use yash_env::variable::Expansion;
 
 /// Environment adapter for applying the search parameters
 ///
-/// This type implements the [`yash_semantics::command_search::ClassifyEnv`]
-/// and [`yash_semantics::command_search::PathEnv`] traits by filtering the
-/// results from an underlying [`yash_env::Env`] according to the
-/// [`Search`] parameters.
+/// This type implements the
+/// [`yash_env::semantics::command::search::ClassifyEnv`] and
+/// [`yash_env::semantics::command::search::PathEnv`] traits by filtering the
+/// results from an underlying [`yash_env::Env`] according to the [`Search`]
+/// parameters.
 #[derive(Debug)]
 pub struct SearchEnv<'a> {
     pub env: &'a mut Env,
     pub params: &'a Search,
 }
 
-impl yash_semantics::command_search::PathEnv for SearchEnv<'_> {
+impl yash_env::semantics::command::search::PathEnv for SearchEnv<'_> {
     /// Returns the path.
     ///
     /// If [`Search::standard_path`] is `true`, this function retrieves the
@@ -68,7 +69,7 @@ impl yash_semantics::command_search::PathEnv for SearchEnv<'_> {
     }
 }
 
-impl yash_semantics::command_search::ClassifyEnv for SearchEnv<'_> {
+impl yash_env::semantics::command::search::ClassifyEnv for SearchEnv<'_> {
     fn builtin(&self, name: &str) -> Option<Builtin> {
         if self.params.categories.contains(Category::Builtin) {
             self.env.builtin(name)
@@ -91,12 +92,11 @@ mod tests {
     use super::*;
     use enumset::EnumSet;
     use yash_env::builtin::Type::Special;
+    use yash_env::semantics::command::search::{ClassifyEnv as _, PathEnv as _};
     use yash_env::str::UnixString;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::variable::PATH;
     use yash_env::variable::Scope;
-    use yash_semantics::command_search::ClassifyEnv as _;
-    use yash_semantics::command_search::PathEnv as _;
     use yash_syntax::source::Location;
     use yash_syntax::syntax::FullCompoundCommand;
 

--- a/yash-builtin/src/exec.rs
+++ b/yash-builtin/src/exec.rs
@@ -39,11 +39,9 @@ use std::ffi::CString;
 use std::ops::ControlFlow::Break;
 use yash_env::Env;
 use yash_env::builtin::Result;
-use yash_env::semantics::Field;
+use yash_env::semantics::command::search::search_path;
 use yash_env::semantics::command::{ReplaceCurrentProcessError, replace_current_process};
-use yash_semantics::Divert::Abort;
-use yash_semantics::ExitStatus;
-use yash_semantics::command_search::search_path;
+use yash_env::semantics::{Divert::Abort, ExitStatus, Field};
 use yash_syntax::source::Location;
 use yash_syntax::source::pretty::{Report, ReportType, Snippet};
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -33,6 +33,7 @@ A _private dependency_ is used internally and not visible to downstream users.
       with an external utility.
     - `run_external_utility_in_subshell`: Function that runs an external utility
       in a subshell.
+    - `search`: module for command search functionality.
 - `semantics::expansion` module
     - The content of this module has been moved from `yash_semantics::expansion`
       to here for better modularity. Currently, it contains the following

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -18,6 +18,8 @@
 //!
 //! This module provides functionality related to command execution semantics.
 
+pub mod search;
+
 use crate::Env;
 use crate::function::Function;
 use crate::job::add_job_if_suspended;

--- a/yash-env/src/semantics/command/search.rs
+++ b/yash-env/src/semantics/command/search.rs
@@ -34,17 +34,17 @@
 //! as a target, a corresponding executable file must be present in a directory
 //! specified in the `$PATH` variable.
 
+use crate::Env;
+use crate::System;
+use crate::builtin::Builtin;
+use crate::builtin::Type::{Special, Substitutive};
+use crate::function::Function;
+use crate::path::PathBuf;
+use crate::variable::Expansion;
+use crate::variable::PATH;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::rc::Rc;
-use yash_env::Env;
-use yash_env::System;
-use yash_env::builtin::Builtin;
-use yash_env::builtin::Type::{Special, Substitutive};
-use yash_env::function::Function;
-use yash_env::path::PathBuf;
-use yash_env::variable::Expansion;
-use yash_env::variable::PATH;
 
 /// Target of a simple command execution
 ///
@@ -286,12 +286,12 @@ pub fn search_path<E: PathEnv>(env: &mut E, name: &str) -> Option<CString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builtin::Type::{Elective, Extension, Mandatory};
+    use crate::function::FunctionSet;
+    use crate::variable::Value;
     use assert_matches::assert_matches;
     use std::collections::HashMap;
     use std::collections::HashSet;
-    use yash_env::builtin::Type::{Elective, Extension, Mandatory};
-    use yash_env::function::FunctionSet;
-    use yash_env::variable::Value;
     use yash_syntax::source::Location;
     use yash_syntax::syntax::CompoundCommand;
     use yash_syntax::syntax::FullCompoundCommand;

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -32,6 +32,7 @@ A _private dependency_ is used internally and not visible to downstream users.
       preparation hook.
 - The following modules are no longer defined in this crate and are
   re-exported from `yash-env` instead:
+    - `command_search`
     - `expansion::attr`
     - `expansion::attr_strip`
     - `expansion::quote_removal`

--- a/yash-semantics/src/lib.rs
+++ b/yash-semantics/src/lib.rs
@@ -28,13 +28,14 @@
 
 pub mod assign;
 pub mod command;
-pub mod command_search;
 pub mod expansion;
 pub mod job;
 pub mod redir;
 pub mod trap;
 pub mod xtrace;
 
+#[doc(no_inline)]
+pub use yash_env::semantics::command::search as command_search;
 #[doc(no_inline)]
 pub use yash_env::semantics::*;
 


### PR DESCRIPTION
## Description

The implementation of the command search functionality does not depend on yash-semantics-specific features. This commit moves the `command_search` module from the `yash-semantics` crate to the `yash-env` crate, under the `semantics::command::search` path. This change allows other components like yash-builtin to directly use the command search functionality without relying on yash-semantics.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization: command search functionality has been restructured across modules for improved architecture. No changes to user-facing behavior or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->