### PR TITLE
Disable yash-semantics feature by default in yash-builtin

### DIFF
--- a/check-extra.sh
+++ b/check-extra.sh
@@ -42,7 +42,7 @@ cargo build --package 'yash-syntax' --all-targets --features annotate-snippets
 # Test with non-default feature configurations.
 #cargo test --package 'yash-arith' -- $quiet
 #cargo test --package 'yash-builtin' -- $quiet
-cargo test --package 'yash-builtin' --no-default-features -- $quiet
+cargo test --package 'yash-builtin' --features yash-semantics -- $quiet
 #cargo test --package 'yash-cli' -- $quiet
 #cargo test --package 'yash-env' -- $quiet
 #cargo test --package 'yash-fnmatch' -- $quiet

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `BUILTINS` array now includes the `command`, `eval`, `exec`, `read`,
+  `source`, `type`, and `wait` built-ins regardless of whether the
+  `yash-semantics` feature is enabled. These built-ins now require certain
+  instances to be available in the environment's `any` storage to function
+  properly.
 - The `command` built-in now requires a `yash_env::semantics::command::RunFunction`
   instance to be available in the environment's `any` storage. This instance is
   used to invoke shell functions in the `command::Invoke::execute` method.
@@ -29,6 +34,7 @@ A _private dependency_ is used internally and not visible to downstream users.
   instance to be available in the environment's `any` storage. This instance is
   used to handle trapped signals while waiting for jobs in the
   `wait::core::wait_for_any_job_or_trap` function.
+- The `enumset` dependency is no longer optional and is always included.
 - Public dependency versions:
     - yash-env 0.9.0 → 0.9.2
     - yash-semantics (optional) 0.10.0 → 0.11.0
@@ -37,6 +43,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Removed
 
+- The `yash-semantics` feature flag is no longer enabled by default.
 - The `yash-prompt` feature flag has been removed. This crate no longer depends
   on the `yash-prompt` crate directly.
 - The `read::prompt` module has been removed. It was empty and unused.

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -18,12 +18,12 @@ publish = false
 all-features = true
 
 [features]
-default = ["yash-semantics"]
-yash-semantics = ["dep:yash-semantics", "dep:enumset"]
+default = []
+yash-semantics = ["dep:yash-semantics"]
 
 [dependencies]
 either = { workspace = true }
-enumset = { workspace = true, optional = true }
+enumset = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }
 yash-env = { workspace = true }

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -34,20 +34,6 @@
 //! [stack](Env::stack) should contain a [built-in frame](Frame::Builtin) so
 //! that `Stack::current_builtin` provides the correct command word.
 //!
-//! # Optional dependencies
-//!
-//! The `yash-builtin` crate has an optional dependency on the `yash-semantics`
-//! crate, which is enabled by default. If you disable the `yash-semantics`
-//! feature, the following built-ins will be unavailable:
-//!
-//! - `command`
-//! - `eval`
-//! - `exec`
-//! - `read`
-//! - `source`
-//! - `type`
-//! - `wait`
-//!
 //! # Dependencies to be injected
 //!
 //! Some built-ins in this crate require certain dependencies to be injected
@@ -71,13 +57,10 @@ pub mod bg;
 pub mod r#break;
 pub mod cd;
 pub mod colon;
-#[cfg(feature = "yash-semantics")]
 pub mod command;
 pub mod common;
 pub mod r#continue;
-#[cfg(feature = "yash-semantics")]
 pub mod eval;
-#[cfg(feature = "yash-semantics")]
 pub mod exec;
 pub mod exit;
 pub mod export;
@@ -87,25 +70,21 @@ pub mod getopts;
 pub mod jobs;
 pub mod kill;
 pub mod pwd;
-#[cfg(feature = "yash-semantics")]
 pub mod read;
 pub mod readonly;
 pub mod r#return;
 pub mod set;
 pub mod shift;
-#[cfg(feature = "yash-semantics")]
 pub mod source;
 pub mod times;
 pub mod trap;
 pub mod r#true;
-#[cfg(feature = "yash-semantics")]
 pub mod r#type;
 pub mod typeset;
 pub mod ulimit;
 pub mod umask;
 pub mod unalias;
 pub mod unset;
-#[cfg(feature = "yash-semantics")]
 pub mod wait;
 
 #[cfg(doc)]
@@ -122,7 +101,6 @@ use std::future::ready;
 ///
 /// The array items are ordered alphabetically.
 pub const BUILTINS: &[(&str, Builtin)] = &[
-    #[cfg(feature = "yash-semantics")]
     (
         ".",
         Builtin::new(Special, |env, args| Box::pin(source::main(env, args))),
@@ -147,7 +125,6 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "cd",
         Builtin::new(Mandatory, |env, args| Box::pin(cd::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     ("command", {
         let mut builtin = Builtin::new(Mandatory, |env, args| Box::pin(command::main(env, args)));
         builtin.is_declaration_utility = None;
@@ -157,12 +134,10 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "continue",
         Builtin::new(Special, |env, args| Box::pin(r#continue::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "eval",
         Builtin::new(Special, |env, args| Box::pin(eval::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "exec",
         Builtin::new(Special, |env, args| Box::pin(exec::main(env, args))),
@@ -200,7 +175,6 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "pwd",
         Builtin::new(Substitutive, |env, args| Box::pin(pwd::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "read",
         Builtin::new(Mandatory, |env, args| Box::pin(read::main(env, args))),
@@ -222,7 +196,6 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "shift",
         Builtin::new(Special, |env, args| Box::pin(shift::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "source",
         Builtin::new(Special, |env, args| Box::pin(source::main(env, args))),
@@ -239,7 +212,6 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "true",
         Builtin::new(Substitutive, |env, args| Box::pin(r#true::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "type",
         Builtin::new(Mandatory, |env, args| Box::pin(r#type::main(env, args))),
@@ -265,7 +237,6 @@ pub const BUILTINS: &[(&str, Builtin)] = &[
         "unset",
         Builtin::new(Special, |env, args| Box::pin(unset::main(env, args))),
     ),
-    #[cfg(feature = "yash-semantics")]
     (
         "wait",
         Builtin::new(Mandatory, |env, args| Box::pin(wait::main(env, args))),

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -284,7 +284,7 @@ impl From<AssignReadOnlyError> for yash_env::variable::AssignError {
 }
 
 /// This conversion is available only when the optional `yash-semantics`
-/// dependency is enabled.
+/// feature is enabled.
 #[cfg(feature = "yash-semantics")]
 impl From<AssignReadOnlyError> for yash_semantics::expansion::AssignReadOnlyError {
     fn from(e: AssignReadOnlyError) -> Self {


### PR DESCRIPTION
## Description

The `yash-semantics` feature is now disabled by default in the `yash-builtin` crate. The `Cargo.toml` file for the `yash3` crate is not modified, so the `yash-semantics` feature is no longer enabled when building the `yash3` binary. This allows `yash-builtin` to be built before `yash-semantics` is built, improving parallelism in the build process.

Closes https://github.com/magicant/yash-rs/issues/625

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Built-in shell commands (command, eval, exec, read, source, type, and wait) are now unconditionally available instead of being feature-gated.
  * Core dependency structure updated; enumset is now always required as a mandatory dependency rather than optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->