### PR TITLE
Remove yash-semantics dependency from yash-prompt

### DIFF
--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -29,7 +29,9 @@ use yash_env::parser::IsName;
 use yash_env::prompt::GetPrompt;
 use yash_env::semantics::command::RunFunction;
 use yash_env::trap::RunSignalTrapIfCaught;
+use yash_prompt::ExpandText;
 use yash_semantics::RunReadEvalLoop;
+use yash_semantics::expansion::expand_text;
 use yash_syntax::parser::lex::Lexer;
 
 pub mod args;
@@ -147,6 +149,10 @@ fn inject_dependencies(env: &mut Env) {
         .insert(Box::new(RunSignalTrapIfCaught(|env, signal| {
             Box::pin(async move { yash_semantics::trap::run_trap_if_caught(env, signal).await })
         })));
+
+    env.any.insert(Box::new(ExpandText(|env, text| {
+        Box::pin(async move { expand_text(env, text).await.ok() })
+    })));
 
     env.any.insert(Box::new(GetPrompt(|env, context| {
         Box::pin(async move {

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -11,13 +11,24 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.8.0] - Unreleased
 
+### Added
+
+- `ExpandText`: Declares the function type for text expansion in prompts.
+
 ### Changed
 
+- `expand_posix` now requires an `ExpandText` function injected through the
+  environment's `any` storage to perform text expansion.
 - Public dependency versions:
     - yash-env 0.9.0 → 0.10.0
 - yash-syntax is now a private dependency.
 - Private dependency versions:
     - yash-syntax 0.16.0 → 0.17.0
+
+### Removed
+
+- Private dependencies:
+    - yash-semantics 0.11.0
 
 ## [0.7.1] - 2025-11-07
 

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -20,11 +20,11 @@ all-features = true
 [dependencies]
 futures-util = { workspace = true }
 yash-env = { workspace = true }
-yash-semantics = { workspace = true }
 yash-syntax = { workspace = true }
 
 [dev-dependencies]
 yash-env-test-helper = { path = "../yash-env-test-helper" }
+yash-semantics = { path = "../yash-semantics" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Description

This commit removes the direct dependency on the `yash-semantics` crate from the `yash-prompt` crate by introducing the dependency injection with the `ExpandText` function type. This change allows `yash-prompt` to remain independent of the semantics implementation details, making it more immune to changes in `yash-semantics`.

Closes #628

## Summary by Copilot

This pull request refactors the prompt string expansion logic to make it more modular and extensible by introducing the `ExpandText` function type. The expansion function is now injected into the environment, allowing for easier customization and testing. The changes also update documentation, tests, and dependency management to reflect this new approach.

**Prompt Expansion Refactoring**

* Introduced the `ExpandText` struct to declare the function type for expanding prompt strings, which must now be injected into the environment's `any` storage for prompt expansion to work. (`yash-prompt/src/expand_posix.rs`, `yash-prompt/src/lib.rs`, `yash-cli/src/startup.rs`) [[1]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eR20-R58) [[2]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL35-R74) [[3]](diffhunk://#diff-e872ec7f56eefaf1500832319a139719e43fe0ba152f5a32416a2e53ec1375b1R32-R34) [[4]](diffhunk://#diff-e872ec7f56eefaf1500832319a139719e43fe0ba152f5a32416a2e53ec1375b1R153-R156) [[5]](diffhunk://#diff-4c231af2ac82dafc75d1902173a87ff627e8877fbae72b90aa99233ddebb075eR78-R103)
* Updated `expand_posix` to rely on the injected `ExpandText` function and panic if it is missing, improving clarity of dependency requirements. (`yash-prompt/src/expand_posix.rs`) [[1]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL35-R74) [[2]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eR96-R102)

**Documentation and Example Updates**

* Revised documentation and examples to show how to inject and use the `ExpandText` function for prompt expansion, including updates to the crate-level docs and changelog. (`yash-prompt/src/lib.rs`, `yash-prompt/CHANGELOG.md`) [[1]](diffhunk://#diff-4c231af2ac82dafc75d1902173a87ff627e8877fbae72b90aa99233ddebb075eR50-R69) [[2]](diffhunk://#diff-cdd751ecf3d2cbddf613454ed9019936fd9cb7f80faabcc704663939a969b6f3R14-R32)

**Testing Improvements**

* Refactored tests to use helper functions that set up environments with the required `ExpandText` function, ensuring all prompt expansion tests are valid with the new dependency injection approach. (`yash-prompt/src/expand_posix.rs`, `yash-prompt/src/prompter.rs`, `yash-prompt/src/lib.rs`) [[1]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eR125-R133) [[2]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL101-R145) [[3]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL116-R160) [[4]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL131-R175) [[5]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL142-R194) [[6]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL160-R204) [[7]](diffhunk://#diff-23d0407a4ff7810bf542a6a82d2f4177f100f30a87df3e01713c0a5ab23de48eL170-R214) [[8]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11R96) [[9]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L109-R116) [[10]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L123-R130) [[11]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L152-R159) [[12]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L170-R177) [[13]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L186-R193) [[14]](diffhunk://#diff-4c231af2ac82dafc75d1902173a87ff627e8877fbae72b90aa99233ddebb075eR78-R103)

**Dependency Management**

* Moved `yash-semantics` from a public dependency to a dev-dependency in `Cargo.toml`, and updated the changelog to reflect this change and the removal of private dependencies. (`yash-prompt/Cargo.toml`, `yash-prompt/CHANGELOG.md`) [[1]](diffhunk://#diff-7885ee3c9e0e90eb742267c2921cc7194b64f4023bdd9cd2ef7d91d957c76a38L23-R27) [[2]](diffhunk://#diff-cdd751ecf3d2cbddf613454ed9019936fd9cb7f80faabcc704663939a969b6f3R14-R32)

**Prompter Integration**

* Updated the `Prompter` decorator and its documentation to clarify its reliance on `fetch_posix` and `expand_posix`, and the need for the injected `ExpandText` function in the environment. (`yash-prompt/src/prompter.rs`) [[1]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11R19) [[2]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11R29-R33) [[3]](diffhunk://#diff-6d88720547702fe198f66f7a907c3aa3cc1d8a2694ecebeb52a45fe390f75b11L64-R70)

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publicly-exported `ExpandText` type for managing prompt text expansion operations.

* **Documentation**
  * Improved documentation describing text expansion configuration and runtime environment requirements.

* **Refactor**
  * Updated text expansion mechanism to use dependency injection through the runtime environment for better modularity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->