### PR TITLE
Deprecate yash-syntax::parser::lex::Config

### DIFF
--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -37,6 +37,7 @@ use yash_env::input::Reporter;
 use yash_env::io::Fd;
 use yash_env::option::Option::Interactive;
 use yash_env::option::State::{Off, On};
+use yash_env::parser::Config;
 use yash_env::system::Errno;
 use yash_env::system::Mode;
 use yash_env::system::OfdAccess;
@@ -88,9 +89,9 @@ pub fn prepare_input<'s: 'i + 'e, 'i, 'e>(
         input: Box<dyn InputObject + 'a>,
         source: SyntaxSource,
     ) -> Lexer<'a> {
-        let mut config = Lexer::config();
+        let mut config = Config::with_input(input);
         config.source = Some(source.into());
-        config.input(input)
+        config.into()
     }
 
     match source {

--- a/yash-env/src/parser.rs
+++ b/yash-env/src/parser.rs
@@ -44,6 +44,10 @@ use std::rc::Rc;
 /// `Config` is provided here so that other crates can use [`RunReadEvalLoop`]
 /// without depending on `yash-syntax`.
 ///
+/// Since this struct is marked as `#[non_exhaustive]`, you cannot construct it
+/// directly. Instead, use the [`with_input`](Self::with_input) function to
+/// create a `Config` instance, and then modify its fields as necessary.
+///
 /// [`RunReadEvalLoop`]: crate::semantics::RunReadEvalLoop
 #[derive(Debug)]
 #[non_exhaustive]

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -54,6 +54,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 - Public dependency:
     - annotate-snippets (optional) 0.12.4
 
+### Deprecated
+
+- `parser::lex::Config` is now deprecated. Use `yash_env::parser::Config` instead.
+
 ## [0.16.0] - 2025-10-13
 
 The most changes in this version are related to the version bump of the


### PR DESCRIPTION
## Description

**Summary by Copilot:**

This pull request deprecates the `parser::lex::Config` struct in the `yash-syntax` crate and transitions code to use the new `yash_env::parser::Config` struct instead. The changes update documentation, constructors, and usage throughout the codebase to reflect this migration, ensuring future compatibility and a clearer separation between configuration and lexer creation.

Migration to new configuration struct:

* Deprecated `parser::lex::Config` in `yash-syntax` and updated documentation to recommend using `yash_env::parser::Config` instead. [[1]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438R445-R449) [[2]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438R479-R486) [[3]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438R573-R579) [[4]](diffhunk://#diff-9547ca81d74be48a91abfe15a1199d19e60a7b4005cc569e83b6ce1607618ad8R57-R60)
* Updated constructors and helper functions for `Lexer` in `yash-syntax` to use `yash_env::parser::Config` for creating and customizing lexer instances, including `Lexer::new`, `Lexer::with_code`, and `Lexer::from_memory`. [[1]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L544-R564) [[2]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L565-R596) [[3]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L583-R607) [[4]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L598-R626) [[5]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L515-R540)

Refactoring usage in CLI startup:

* Replaced usage of the deprecated configuration in `yash-cli/src/startup/init_file.rs` and `yash-cli/src/startup/input.rs` with the new `yash_env::parser::Config`, updating input preparation and lexer instantiation logic. [[1]](diffhunk://#diff-d76959751ab954618a62d840d51bd1ac97a98cd873a802931acfaf87f69ec57fR41) [[2]](diffhunk://#diff-d76959751ab954618a62d840d51bd1ac97a98cd873a802931acfaf87f69ec57fL173-R179) [[3]](diffhunk://#diff-b46c47cd48d2fa5d914efffa6a4d9acb23f0bbca697da1896f1ec31ef06817b4R40) [[4]](diffhunk://#diff-b46c47cd48d2fa5d914efffa6a4d9acb23f0bbca697da1896f1ec31ef06817b4L91-R94)

Documentation improvements:

* Improved documentation to clarify construction and usage of configuration objects for lexer creation, including code samples and migration guidance. [[1]](diffhunk://#diff-8369900a49a881e991956d0a69d64f7ad823ec4a57280997b1451d7e071846dfR47-R50) [[2]](diffhunk://#diff-aa460ecfe7b5b67e919ac0c02bdcc2c6952c1fc4576dbe570891010117387438L515-R540)

Changelog update:

* Added a deprecation notice in the `yash-syntax/CHANGELOG.md` for `parser::lex::Config`, directing users to use `yash_env::parser::Config` going forward.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized parser configuration handling to centralize lexer initialization logic.
  * Simplified the configuration workflow for parser setup.

* **Documentation**
  * Added deprecation guidance for legacy configuration patterns.
  * Updated documentation to reflect the new recommended configuration approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->