### PR TITLE
Don't ignore errors in `tcsetpgrp_with_block` and `tcsetpgrp_without_block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
 yash-builtin = { path = "yash-builtin", version = "0.13.0" }
-yash-env = { path = "yash-env", version = "0.10.0" }
+yash-env = { path = "yash-env", version = "0.10.1" }
 yash-env-test-helper = { path = "yash-env-test-helper", version = "0.8.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,15 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.10.1] - Unreleased
+
+### Fixed
+
+- `system::SystemEx::tcsetpgrp_with_block` and
+  `system::SystemEx::tcsetpgrp_without_block` now correctly return errors if
+  any underlying system calls fail. Previously, it may return `Ok(())` even if
+  some system calls failed.
+
 ## [0.10.0] - 2025-11-26
 
 ### Added
@@ -619,6 +628,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env` crate
 
+[0.10.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.10.1
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.10.0
 [0.9.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.9.2
 [0.9.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.9.1

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.86.0"

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -657,7 +657,7 @@ pub trait SystemEx: System {
 
         let result_2 = self.sigmask(Some((SigmaskOp::Set, &old_mask)), None);
 
-        result.or(result_2)
+        result.and(result_2)
     }
 
     /// Switches the foreground process group with the default SIGTTOU settings.
@@ -696,13 +696,13 @@ pub trait SystemEx: System {
 
                         let result_2 = self.sigmask(Some((SigmaskOp::Set, &old_mask)), None);
 
-                        result.or(result_2)
+                        result.and(result_2)
                     }
                 };
 
                 let result_2 = self.sigaction(sigttou, old_handling).map(drop);
 
-                result.or(result_2)
+                result.and(result_2)
             }
         }
     }


### PR DESCRIPTION
## Description

This commit fixes an issue where `system::SystemEx::tcsetpgrp_with_block` and `system::SystemEx::tcsetpgrp_without_block` would ignore errors from underlying system calls, potentially leading to silent failures.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [ ] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in process group operations to properly propagate system call errors instead of silently ignoring failures during restoration steps. Both operations must now succeed for the overall operation to report success.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->