### PR TITLE
Minimize trait bounds for Prompter implementation

### DIFF
--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -16,8 +16,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - Public dependency versions:
     - Rust 1.86.0 → 1.87.0
     - yash-env 0.10.0 → 0.11.0
-- Every type and function now takes a type parameter representing the concrete
-  `System` type due to changes in the `yash-env` crate.
+- Every type and function now takes a type parameter representing the required
+  system interface due to the introduction of the type parameter to `Env` in
+  the `yash-env` crate.
 
 ## [0.8.0] - 2025-11-26
 

--- a/yash-prompt/src/prompter.rs
+++ b/yash-prompt/src/prompter.rs
@@ -20,7 +20,7 @@ use super::expand_posix;
 use std::cell::RefCell;
 use yash_env::Env;
 use yash_env::input::{Context, Input, Result};
-use yash_env::system::System;
+use yash_env::system::{Fcntl, Write};
 use yash_env::variable::{PS1, PS2, VariableSet};
 
 /// [`Input`] decorator that shows a command prompt
@@ -64,7 +64,7 @@ impl<S, T: Clone> Clone for Prompter<'_, '_, S, T> {
 
 impl<S, T> Input for Prompter<'_, '_, S, T>
 where
-    S: System + 'static,
+    S: Fcntl + Write + 'static,
     T: Input,
 {
     #[allow(clippy::await_holding_refcell_ref)]
@@ -76,7 +76,7 @@ where
 
 async fn print_prompt<S>(env: &mut Env<S>, context: &Context)
 where
-    S: System + 'static,
+    S: Fcntl + Write + 'static,
 {
     // Obtain the prompt string
     let prompt = fetch_posix(&env.variables, context);


### PR DESCRIPTION
## Description

The `System` trait will soon be deprecated. Before doing so, use of the trait should be replaced with proper alternatives. This PR updates the code in the yash-prompt crate.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal type system constraints to improve code precision and maintainability.

* **Documentation**
  * Updated changelog to clarify recent type system improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->