### PR TITLE
Remove impl Fork for SharedSystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env-test-helper"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "futures-executor",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -634,7 +634,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,15 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.1" }
-yash-builtin = { path = "yash-builtin", version = "0.14.0" }
-yash-env = { path = "yash-env", version = "0.11.0" }
-yash-env-test-helper = { path = "yash-env-test-helper", version = "0.9.0" }
+yash-builtin = { path = "yash-builtin", version = "0.15.0" }
+yash-env = { path = "yash-env", version = "0.12.0" }
+yash-env-test-helper = { path = "yash-env-test-helper", version = "0.10.0" }
 yash-executor = { path = "yash-executor", version = "1.0.0" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
-yash-prompt = { path = "yash-prompt", version = "0.9.0" }
+yash-prompt = { path = "yash-prompt", version = "0.10.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.13.0" }
-yash-syntax = { path = "yash-syntax", version = "0.18.0" }
+yash-semantics = { path = "yash-semantics", version = "0.14.0" }
+yash-syntax = { path = "yash-syntax", version = "0.19.0" }
 
 [workspace.lints]
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.11.0 → 0.12.0
+
 ## [0.14.0] - 2026-01-16
 
 ### Added
@@ -611,6 +618,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.13.0
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.12.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env-test-helper/CHANGELOG.md
+++ b/yash-env-test-helper/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.10.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.11.0 → 0.12.0
+
 ## [0.9.0] - 2026-01-16
 
 ### Changed
@@ -87,6 +94,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env-test-helper` crate
 
+[0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.9.0
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.8.0
 [0.7.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-test-helper-0.7.0

--- a/yash-env-test-helper/Cargo.toml
+++ b/yash-env-test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env-test-helper"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,13 +9,19 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.12.0] - Unreleased
+
+### Removed
+
+- `impl<T: Fork> Fork for SharedSystem<T>`: This implementation had not been working since 0.11.0.
+
 ## [0.11.0] - 2026-01-16
 
 ### Added
 
 - `system::SharedSystem::new_child_process`: This method has been added as a
   workaround for the now non-functional
-  `<system::SharedSystem as System>::new_child_process`.
+  `<system::SharedSystem as system::Fork>::new_child_process`.
 - The following traits have been added to the `system` module:
     - `CaughtSignals`: Declares the `caught_signals` method for retrieving
       caught signals.
@@ -769,6 +775,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env` crate
 
+[0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.11.0
 [0.10.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.10.1
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.10.0

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -605,21 +605,6 @@ impl<T: TcSetPgrp> TcSetPgrp for SharedSystem<T> {
     }
 }
 
-// TODO: This implementation should be removed after refactoring Fork API (#662).
-/// Delegates `Fork` methods to the contained implementor.
-impl<T: Fork> Fork for SharedSystem<T> {
-    /// This method is not supported for `SharedSystem` because types do not match.
-    ///
-    /// You should call the inherent method [`SharedSystem::new_child_process`] instead.
-    /// If you call this trait method, it will panic.
-    fn new_child_process(&self) -> Result<ChildProcessStarter<Self>> {
-        // self.0.borrow().new_child_process()
-        unimplemented!(
-            "new_child_process is not supported for SharedSystem because types do not match"
-        )
-    }
-}
-
 /// Delegates `Wait` methods to the contained implementor.
 impl<T: Wait> Wait for SharedSystem<T> {
     fn wait(&self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.10.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.11.0 → 0.12.0
+
 ## [0.9.0] - 2026-01-16
 
 ### Changed
@@ -138,6 +145,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.9.0
 [0.8.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.8.0
 [0.7.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.7.1

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.14.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.11.0 → 0.12.0
+
 ## [0.13.0] - 2026-01-16
 
 ### Added
@@ -435,6 +442,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.13.0
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.11.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.19.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.11.0 → 0.12.0
+
 ## [0.18.0] - 2026-01-16
 
 ### Changed
@@ -631,6 +638,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.19.0
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.17.0
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.16.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"


### PR DESCRIPTION
## Description

Removes `impl<T: Fork> Fork for SharedSystem<T>`. Should have been removed in yash-env 0.11.0.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies including yash-builtin, yash-env, yash-env-test-helper, yash-prompt, yash-semantics, and yash-syntax to their latest patch versions.

* **Changes**
  * Removed a previously unsupported, non-functional operation to improve API clarity and reduce confusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->