### PR TITLE
Proposing `Fork::run_in_child_process`

### DIFF
--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -944,6 +944,62 @@ impl TcSetPgrp for VirtualSystem {
 }
 
 impl Fork for VirtualSystem {
+    /// Runs a task in a new child process.
+    ///
+    /// This method implements [`Fork::run_in_child_process`] by adding a new
+    /// process to the system state and running the given task concurrently in
+    /// the same real process. It does not create any real child process.
+    ///
+    /// To run the concurrent task, this function needs an executor that has
+    /// been set in the [`SystemState`]. If the system state does not have an
+    /// executor, this function fails with `Errno::ENOSYS`.
+    ///
+    /// The process ID of the child will be the maximum of existing process IDs
+    /// plus 1. If there are no other processes, it will be 2.
+    fn run_in_child_process<D, F>(&self, shared_data: D, child_task: F) -> Result<(Pid, D)>
+    where
+        Self: Sized,
+        D: Clone + 'static,
+        F: AsyncFnOnce(Self, D) -> ExitStatus + 'static,
+    {
+        let mut state = self.state.borrow_mut();
+        let executor = state.executor.clone().ok_or(Errno::ENOSYS)?;
+        let child_process_id = state
+            .processes
+            .keys()
+            .max()
+            .map_or(Pid(2), |pid| Pid(pid.0 + 1));
+        let parent_process = &state.processes[&self.process_id];
+        let child_process = Process::fork_from(self.process_id, parent_process);
+        // TODO: We cannot set the selector here because we don't have the Env here.
+        // What's the implication of this?
+        state.processes.insert(child_process_id, child_process);
+        drop(state);
+
+        let child_system = VirtualSystem {
+            state: Rc::clone(&self.state),
+            process_id: child_process_id,
+        };
+        let child_system_2 = child_system.clone();
+        let data_clone = shared_data.clone();
+        let task_future = Box::pin(async move {
+            let child_system_3 = child_system_2.clone();
+            let exit_status = child_task(child_system_2, data_clone).await;
+            child_system_3.exit(exit_status).await
+        });
+        let runner = ProcessRunner {
+            task: task_future,
+            system: child_system,
+            waker: Rc::new(Cell::new(None)),
+        };
+
+        executor
+            .spawn(Box::pin(runner))
+            .expect("the executor failed to start the child process task");
+
+        Ok((child_process_id, shared_data))
+    }
+
     /// Creates a new child process.
     ///
     /// This implementation does not create any real child process. Instead,
@@ -1317,7 +1373,7 @@ pub trait Executor: Debug {
 
 /// Concurrent task that manages the execution of a process.
 ///
-/// This struct is a helper for [`VirtualSystem::new_child_process`].
+/// This struct is a helper for [`VirtualSystem::run_in_child_process`].
 /// It basically runs the given task, but pauses or cancels it depending on
 /// the state of the process.
 struct ProcessRunner<'a> {


### PR DESCRIPTION
## Description

This is a first attempt for #662. As of f7334737ea22271ea4cddcd9cc154d34033edc15, this PR is still WIP.

## Checklist

- Implementation
    - [ ] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [ ] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [ ] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [ ] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [ ] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [ ] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)
