### PR TITLE
Format syntax error messages correctly in kill built-in

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -44,6 +44,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `trap::CondSpec` enum has been removed. Use `yash_env::trap::Condition`
   instead.
 
+### Fixed
+
+- `kill::syntax::Error::to_report` now correctly formats error messages for
+  invalid options and signal specifications.
+
 ## [0.14.0] - 2026-01-16
 
 ### Added

--- a/yash-builtin/src/kill/syntax.rs
+++ b/yash-builtin/src/kill/syntax.rs
@@ -88,7 +88,7 @@ impl Error {
         report.snippets = match self {
             Self::UnknownOption(field) => Snippet::with_primary_span(
                 &field.origin,
-                format!("{field:?} is not a valid option").into(),
+                format!("{:?} is not a valid option", field.value).into(),
             ),
 
             Self::ConflictingOptions {
@@ -124,14 +124,14 @@ impl Error {
             Self::MultipleSignals(field1, field2) => {
                 let mut snippets = Snippet::with_primary_span(
                     &field1.origin,
-                    format!("first signal {field1:?}").into(),
+                    format!("first signal {:?}", field1.value).into(),
                 );
                 add_span(
                     &field2.origin.code,
                     Span {
                         range: field2.origin.byte_range(),
                         role: SpanRole::Primary {
-                            label: format!("second signal {field2:?}").into(),
+                            label: format!("second signal {:?}", field2.value).into(),
                         },
                     },
                     &mut snippets,
@@ -141,7 +141,7 @@ impl Error {
 
             Self::InvalidSignal(field) => Snippet::with_primary_span(
                 &field.origin,
-                format!("{field:?} is not a valid signal name or number").into(),
+                format!("{:?} is not a valid signal name or number", field.value).into(),
             ),
 
             Self::MissingTarget => vec![],

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This change allows sending custom signals that are not recognized by the
   shell, if the operating system supports them.
 
+### Fixed
+
+- The `kill` built-in now correctly formats error messages for invalid options
+  and signal specifications.
+
 ## [3.0.4] - 2025-11-07
 
 ### Changed


### PR DESCRIPTION
## Description

Fixes #703

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message formatting in the kill built-in for invalid options and signal specifications, improving clarity in error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->