### PR TITLE
Use taplo for TOML formatting and linting

### DIFF
--- a/.github/instructions/coding-agent.instructions.md
+++ b/.github/instructions/coding-agent.instructions.md
@@ -106,7 +106,7 @@ Time: ~17 seconds (output in `target/doc/`)
 ```
 **Prerequisites:** Install first with:
 ```sh
-cargo install cargo-tomlfmt cargo-semver-checks
+cargo install taplo-cli cargo-semver-checks
 ```
 This script verifies:
 - TOML formatting (all Cargo.toml files)
@@ -145,7 +145,7 @@ The CI pipeline (`.github/workflows/ci.yml`) runs on push/PR to master with 6 jo
 
 1. **check**: Runs `./check.sh -v` with `-D warnings` (fail on warnings)
 2. **clippy**: Lints code with GitHub PR review integration
-3. **extra**: Runs `./check-extra.sh -v` (requires cargo-tomlfmt, cargo-semver-checks)
+3. **extra**: Runs `./check-extra.sh -v` (requires taplo-cli, cargo-semver-checks)
 4. **msrv**: Tests MSRV on Ubuntu + macOS with `./check-msrv.sh -v`
 5. **windows**: Tests portable crates on Windows (yash-arith, yash-executor, yash-fnmatch, yash-quote, yash-syntax, yash-env, etc.)
 6. **docs**: Builds and tests documentation with `./check-docs.sh`
@@ -232,7 +232,7 @@ For yash-cli CHANGELOG: Include changes in observable behavior even if yash-cli 
 
 5. **Don't add dependencies lightly**: The `check-extra.sh` script enforces no unused dependencies with `RUSTFLAGS='-D unused_crate_dependencies'`.
 
-6. **Formatting is strict**: All Cargo.toml files must be formatted with `cargo-tomlfmt`.
+6. **Formatting is strict**: All Cargo.toml files must be formatted and linted with `taplo`.
 
 7. **Scripted tests are integration tests**: Located in `yash-cli/tests/scripted_test/`, these test actual shell behavior with `.sh` files.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - name: Install cargo-tomlfmt and cargo-semver-checks
-      run: cargo install cargo-tomlfmt cargo-semver-checks
+    - name: Install cargo-semver-checks
+      run: cargo install cargo-semver-checks
     - name: Run extra tests
       run: ./check-extra.sh -v
   msrv:

--- a/check-extra.sh
+++ b/check-extra.sh
@@ -4,18 +4,13 @@ if [ "$*" = "" ]; then quiet='--quiet'; else quiet=''; fi
 
 set -x
 
-cargo tomlfmt --dryrun --path Cargo.toml
-cargo tomlfmt --dryrun --path yash-arith/Cargo.toml
-cargo tomlfmt --dryrun --path yash-builtin/Cargo.toml
-cargo tomlfmt --dryrun --path yash-cli/Cargo.toml
-cargo tomlfmt --dryrun --path yash-env/Cargo.toml
-cargo tomlfmt --dryrun --path yash-env-test-helper/Cargo.toml
-cargo tomlfmt --dryrun --path yash-executor/Cargo.toml
-cargo tomlfmt --dryrun --path yash-fnmatch/Cargo.toml
-cargo tomlfmt --dryrun --path yash-prompt/Cargo.toml
-cargo tomlfmt --dryrun --path yash-quote/Cargo.toml
-cargo tomlfmt --dryrun --path yash-semantics/Cargo.toml
-cargo tomlfmt --dryrun --path yash-syntax/Cargo.toml
+if { ! taplo help && command -v npx; } >/dev/null 2>&1; then
+    taplo() { npx @taplo/cli "$@"; }
+fi
+
+# Check that all TOML files are properly formatted and linted.
+taplo format --check $(git ls-files | grep '\.toml$')
+taplo lint $(git ls-files | grep '\.toml$')
 
 # Make sure we don't have any unnecessary dependencies in Cargo.toml.
 RUSTFLAGS='-D unused_crate_dependencies' cargo check --lib --all-features


### PR DESCRIPTION
## Description

Updates the check script to use taplo CLI instead of cargo-tomlfmt.
Since I usually use "Even Better TOML" extension in VSCode for editing TOML files, using taplo CLI for checking formatting and linting produces more consistent results.

## Checklist

**Not applicable for this PR**

- Implementation
    - [ ] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [ ] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [ ] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [ ] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [ ] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [ ] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated TOML validation to a single Taplo-based workflow, including a fallback shim when needed.
  * Replaced prior per-file formatting checks with multi-file formatting and linting.
  * Expanded Rust/Cargo verification with additional check/build runs across multiple packages, targets and feature sets.
  * Updated CI prerequisites and job descriptions to reflect the new tooling and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->