### PR TITLE
Enhance `Concurrent`'s methods

### DIFF
--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -46,6 +46,15 @@ use std::time::{Duration, Instant};
 /// For system calls that do not block, such as [`Pipe`], the wrapper directly
 /// forwards the call to the inner system without any modification.
 ///
+/// This struct is designed to be used in an `Rc` to allow multiple tasks to
+/// share the same concurrent system. Some traits, such as [`Read`] and
+/// [`Write`], are implemented for `Rc<Concurrent<S>>` instead of
+/// `Concurrent<S>` to allow the methods to return futures that capture a clone
+/// of the `Rc` and keep it alive until the operation is finished. This is
+/// necessary because the futures need to access the internal state of the
+/// `Concurrent` system without capturing a reference to the original
+/// `Concurrent` struct, which may not live long enough.
+///
 /// [`Pipe`]: super::Pipe
 #[derive(Clone, Debug, Default)]
 pub struct Concurrent<S> {

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -25,7 +25,7 @@ use std::future::poll_fn;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
 use std::task::Poll::{Pending, Ready};
-use std::task::Waker;
+use std::task::{Context, Waker};
 use std::time::{Duration, Instant};
 
 /// Decorator for systems that makes blocking I/O operations concurrency-friendly
@@ -294,6 +294,18 @@ impl<S> Concurrent<S>
 where
     S: CaughtSignals + Clock + Select,
 {
+    /// Peeks for any ready events without blocking.
+    ///
+    /// This method performs a `select` system call with the file descriptors
+    /// and timeout of pending tasks, and wakes the tasks whose events are
+    /// ready. This method is similar to [`select`](Concurrent::select), but it
+    /// does not block and returns immediately.
+    pub fn peek(&self) {
+        let select = std::pin::pin!(self.select_impl(true));
+        let poll = select.poll(&mut Context::from_waker(Waker::noop()));
+        debug_assert_eq!(poll, Ready(()), "peek should not block");
+    }
+
     /// Waits for any of pending tasks to become ready.
     ///
     /// This method performs a `select` system call with the file descriptors
@@ -310,8 +322,12 @@ where
     ///     concurrent.select().await;
     /// }
     /// ```
-    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn select(&self) {
+        self.select_impl(false).await;
+    }
+
+    #[allow(clippy::await_holding_refcell_ref)]
+    async fn select_impl(&self, peek: bool) {
         // In this method, we keep the borrow of `state` across the `await` point. This is
         // intentional because the real `select` call blocks the entire process, so there cannot
         // be any other task that modifies the state while we are waiting for the `select` call to
@@ -321,10 +337,14 @@ where
         // Prepare parameters for the `select` call based on the current state
         let mut readers = state.reads.keys().cloned().collect();
         let mut writers = state.writes.keys().cloned().collect();
-        let timeout = state
-            .timeouts
-            .next_wake_time()
-            .map(|target| target.saturating_duration_since(self.inner.now()));
+        let timeout = if peek {
+            Some(Duration::ZERO)
+        } else {
+            state
+                .timeouts
+                .next_wake_time()
+                .map(|target| target.saturating_duration_since(self.inner.now()))
+        };
         let signal_mask = (state.signals.strong_count() > 0)
             .then(|| state.select_mask.as_deref())
             .flatten();
@@ -344,7 +364,7 @@ where
             wake_tasks_for_ready_fds(&mut state.reads, &readers);
             wake_tasks_for_ready_fds(&mut state.writes, &writers);
         }
-        if timeout.is_some() {
+        if !state.timeouts.is_empty() {
             state.timeouts.wake(self.inner.now());
         }
         if let Some(signal_list) = state.signals.upgrade() {
@@ -467,7 +487,12 @@ mod tests {
     use std::pin::pin;
     use std::sync::Arc;
     use std::task::Poll::{Pending, Ready};
-    use std::task::{Context, Waker};
+
+    #[test]
+    fn peek_with_no_conditions_returns_immediately() {
+        let system = Concurrent::new(VirtualSystem::new());
+        system.peek();
+    }
 
     #[test]
     fn select_with_no_conditions_never_completes() {
@@ -1107,5 +1132,48 @@ mod tests {
         assert_eq!(select_fut.as_mut().poll(&mut context4), Ready(()));
         assert!(!wake_flag1.is_woken());
         assert!(!wake_flag2.is_woken());
+    }
+
+    #[test]
+    fn signal_wait_is_made_ready_by_peek_after_caught() {
+        let system = Rc::new(Concurrent::new(VirtualSystem::new()));
+        system
+            .set_disposition(SIGINT, Disposition::Catch)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        system
+            .set_disposition(SIGCHLD, Disposition::Catch)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        system
+            .set_disposition(SIGUSR2, Disposition::Catch)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let mut wait = pin!(system.wait_for_signals());
+
+        let wake_flag = Arc::new(WakeFlag::new());
+        let waker = Waker::from(wake_flag.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(wait.as_mut().poll(&mut context), Pending);
+
+        system.peek();
+        assert!(!wake_flag.is_woken());
+
+        // Send signals to make the wait ready
+        system.raise(SIGINT).now_or_never().unwrap().unwrap();
+        system.raise(SIGCHLD).now_or_never().unwrap().unwrap();
+        system.peek();
+        assert!(wake_flag.is_woken());
+
+        let wake_flag = Arc::new(WakeFlag::new());
+        let waker = Waker::from(wake_flag.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_matches!(wait.poll(&mut context), Ready(signals) => {
+            assert_matches!(***signals, [SIGINT, SIGCHLD] | [SIGCHLD, SIGINT]);
+        });
     }
 }

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn select_with_no_conditions_never_completes() {
-        let system = Rc::new(Concurrent::new(VirtualSystem::new()));
+        let system = Concurrent::new(VirtualSystem::new());
 
         let future = pin!(system.select());
 
@@ -790,7 +790,7 @@ mod tests {
         let state = system.state.clone();
         let now = Instant::now();
         state.borrow_mut().now = Some(now);
-        let system = Rc::new(Concurrent::new(system));
+        let system = Concurrent::new(system);
 
         let mut sleep = pin!(system.sleep(Duration::from_secs(1)));
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -19,9 +19,10 @@
 use super::super::resource::{LimitPair, Resource};
 use super::super::{
     Chdir, ChildProcessStarter, Clock, Close, CpuTimes, Dir, Dup, Exec, Exit, Fcntl, FdFlag, Fork,
-    Fstat, GetCwd, GetPid, GetPw, GetRlimit, GetUid, Gid, IsExecutableFile, Isatty, Mode,
-    OfdAccess, Open, OpenFlag, Pipe, Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath,
-    Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Uid, Umask, Wait, signal,
+    Fstat, GetCwd, GetPid, GetPw, GetRlimit, GetSigaction, GetUid, Gid, IsExecutableFile, Isatty,
+    Mode, OfdAccess, Open, OpenFlag, Pipe, Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath,
+    Sigaction, Sigmask, SigmaskOp, Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Uid, Umask, Wait,
+    signal,
 };
 use super::Concurrent;
 use crate::io::Fd;
@@ -334,6 +335,74 @@ where
     #[inline]
     fn signal_number_from_name(&self, name: signal::Name) -> Option<signal::Number> {
         self.inner.signal_number_from_name(name)
+    }
+}
+
+/// Exposes the inner system's `sigmask` method.
+///
+/// This implementation of `Sigmask` simply delegates to the inner system's
+/// `sigmask` method, which bypasses the internal state of `Concurrent` and may
+/// prevent the [`peek`](Concurrent::peek) and [`select`](Concurrent::select)
+/// methods from responding to received signals without race conditions. To
+/// ensure that the signal mask is configured in a way that allows `Concurrent`
+/// to respond to signals correctly, direct calls to `sigmask` should be
+/// avoided, and, if necessary, only used to temporarily change the signal mask
+/// for specific operations while ensuring that the original mask is restored
+/// afterward before a next call to `peek`, `select`, or `set_disposition`.
+impl<S> Sigmask for Concurrent<S>
+where
+    S: Sigmask,
+{
+    #[inline]
+    fn sigmask(
+        &self,
+        op_and_signals: Option<(SigmaskOp, &[signal::Number])>,
+        old_mask: Option<&mut Vec<signal::Number>>,
+    ) -> impl Future<Output = Result<()>> + use<S> {
+        self.inner.sigmask(op_and_signals, old_mask)
+    }
+}
+
+impl<S> GetSigaction for Concurrent<S>
+where
+    S: GetSigaction,
+{
+    #[inline]
+    fn get_sigaction(&self, signal: signal::Number) -> Result<signal::Disposition> {
+        self.inner.get_sigaction(signal)
+    }
+}
+
+/// Exposes the inner system's `sigaction` method.
+///
+/// This implementation of `Sigaction` simply delegates to the inner system's
+/// `sigaction` method, which bypasses the internal state of `Concurrent` and
+/// may prevent the [`peek`](Concurrent::peek) and
+/// [`select`](Concurrent::select) methods from responding to received signals
+/// without race conditions. To ensure that signal dispositions are configured
+/// in a way that allows `Concurrent` to respond to signals correctly, direct
+/// calls to `sigaction` should be avoided, and, if necessary, only used to
+/// temporarily change the signal disposition for specific operations while
+/// ensuring that the original disposition is restored afterward before a next
+/// call to `peek`, `select`, or `set_disposition`.
+///
+/// The standard way to set a signal disposition to `Concurrent` is to use the
+/// `set_disposition` method provided by the [`SignalSystem`] trait, which
+/// ensures that the signal disposition and the signal mask are updated
+/// consistently.
+///
+/// [`SignalSystem`]: crate::trap::SignalSystem
+impl<S> Sigaction for Concurrent<S>
+where
+    S: Sigaction,
+{
+    #[inline]
+    fn sigaction(
+        &self,
+        signal: signal::Number,
+        disposition: signal::Disposition,
+    ) -> Result<signal::Disposition> {
+        self.inner.sigaction(signal, disposition)
     }
 }
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -406,11 +406,19 @@ where
     }
 }
 
-// Sigmask, GetSigaction, Sigaction, and CaughtSignals are not implemented for Concurrent<S>
-// because Concurrent needs to control the signal dispositions and the signal mask itself to
-// ensure that the select method can respond to received signals without race conditions.
-// Instead, Concurrent<S> implements the SignalSystem trait, which provides the necessary
+// CaughtSignals is not implemented for Concurrent<S> because Concurrent needs to
+// control the signal dispositions and the signal mask itself to ensure that the
+// select method can respond to received signals without race conditions. Instead,
+// Concurrent<S> implements the SignalSystem trait, which provides the necessary
 // methods for configuring signal dispositions and masks in a controlled manner.
+//
+// Note: Sigmask, GetSigaction, and Sigaction are implemented above as delegating
+// implementations. However, direct calls to sigmask() and sigaction() bypass
+// Concurrent's internal state and may prevent peek() and select() from responding
+// to received signals without race conditions. To ensure correct behavior, use the
+// set_disposition method from the SignalSystem trait instead. If direct sigmask or
+// sigaction calls are necessary, temporarily change the mask/disposition and restore
+// it afterward before calling peek(), select(), or set_disposition().
 
 impl<S> SendSignal for Concurrent<S>
 where

--- a/yash-env/src/system/concurrency/signal.rs
+++ b/yash-env/src/system/concurrency/signal.rs
@@ -44,7 +44,12 @@ where
     ///
     /// This implementation both updates the signal disposition and the signal
     /// mask to ensure that the [`select`](Concurrent::select) method can
-    /// respond to received signals without race conditions.
+    /// respond to received signals without race conditions. Specifically:
+    ///
+    /// - When setting the disposition to `Default` or `Ignore`, the signal is
+    ///   unblocked to allow it to be delivered as soon as possible.
+    /// - When setting the disposition to `Catch`, the signal is blocked so that
+    ///   it is only delivered inside the `select` method.
     fn set_disposition(
         &self,
         signal: Number,
@@ -55,7 +60,8 @@ where
             if disposition == Disposition::Catch {
                 // Before setting the disposition to `Catch`, we need to block the signal
                 // to prevent it from being delivered before the disposition is updated.
-                this.sigmask(SigmaskOp::Add, signal).await?;
+                this.update_sigmask_and_select_mask(SigmaskOp::Add, signal)
+                    .await?;
             }
 
             let old_action = this.inner.sigaction(signal, disposition)?;
@@ -63,7 +69,8 @@ where
             if disposition != Disposition::Catch {
                 // After setting the disposition to `Default` or `Ignore`, we need to unblock
                 // the signal to allow it to be delivered if it was previously blocked.
-                this.sigmask(SigmaskOp::Remove, signal).await?;
+                this.update_sigmask_and_select_mask(SigmaskOp::Remove, signal)
+                    .await?;
             }
 
             Ok(old_action)
@@ -77,7 +84,11 @@ where
 {
     /// Wrapper of the inner system's [`Sigmask::sigmask`] method that also
     /// updates the `select_mask` field.
-    async fn sigmask(&self, op: SigmaskOp, signal: Number) -> Result<(), Errno> {
+    async fn update_sigmask_and_select_mask(
+        &self,
+        op: SigmaskOp,
+        signal: Number,
+    ) -> Result<(), Errno> {
         let mut old_mask = Vec::new();
         self.inner
             .sigmask(Some((op, &[signal])), Some(&mut old_mask))
@@ -179,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn first_sigmask_updates_blocking_mask() {
+    fn first_update_sigmask_and_select_mask_updates_blocking_mask() {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
@@ -187,7 +198,7 @@ mod tests {
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         let result = system
-            .sigmask(SigmaskOp::Add, SIGTERM)
+            .update_sigmask_and_select_mask(SigmaskOp::Add, SIGTERM)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -201,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn first_sigmask_sets_select_mask() {
+    fn first_update_sigmask_and_select_mask_sets_select_mask() {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
@@ -209,7 +220,7 @@ mod tests {
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         system
-            .sigmask(SigmaskOp::Add, SIGTERM)
+            .update_sigmask_and_select_mask(SigmaskOp::Add, SIGTERM)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -221,11 +232,11 @@ mod tests {
 
     #[ignore = "current VirtualSystem::sigmask silently ignores invalid signals"]
     #[test]
-    fn first_sigmask_leaves_select_mask_unchanged_on_error() {
+    fn first_update_sigmask_and_select_mask_leaves_select_mask_unchanged_on_error() {
         let system = Rc::new(Concurrent::new(VirtualSystem::new()));
         let invalid_signal = Number::from_raw_unchecked(NonZero::new(-1).unwrap());
         let result = system
-            .sigmask(SigmaskOp::Add, invalid_signal)
+            .update_sigmask_and_select_mask(SigmaskOp::Add, invalid_signal)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(Errno::EINVAL));
@@ -233,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn second_sigmask_updates_select_mask() {
+    fn second_update_sigmask_and_select_mask_updates_select_mask() {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
@@ -241,12 +252,12 @@ mod tests {
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         system
-            .sigmask(SigmaskOp::Add, SIGTERM)
+            .update_sigmask_and_select_mask(SigmaskOp::Add, SIGTERM)
             .now_or_never()
             .unwrap()
             .unwrap();
         system
-            .sigmask(SigmaskOp::Remove, SIGQUIT)
+            .update_sigmask_and_select_mask(SigmaskOp::Remove, SIGQUIT)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/yash-env/src/system/resource.rs
+++ b/yash-env/src/system/resource.rs
@@ -20,6 +20,7 @@
 //! getting and setting resource limits.
 
 use super::Result;
+use std::rc::Rc;
 
 #[cfg(unix)]
 type RawLimit = libc::rlim_t;
@@ -154,6 +155,13 @@ pub trait GetRlimit {
     fn getrlimit(&self, resource: Resource) -> Result<LimitPair>;
 }
 
+impl<S: GetRlimit> GetRlimit for Rc<S> {
+    #[inline]
+    fn getrlimit(&self, resource: Resource) -> Result<LimitPair> {
+        (self as &S).getrlimit(resource)
+    }
+}
+
 pub trait SetRlimit {
     /// Sets the limits for the specified resource.
     ///
@@ -161,4 +169,11 @@ pub trait SetRlimit {
     ///
     /// This is a thin wrapper around the `setrlimit` system call.
     fn setrlimit(&self, resource: Resource, limits: LimitPair) -> Result<()>;
+}
+
+impl<S: SetRlimit> SetRlimit for Rc<S> {
+    #[inline]
+    fn setrlimit(&self, resource: Resource, limits: LimitPair) -> Result<()> {
+        (self as &S).setrlimit(resource, limits)
+    }
 }


### PR DESCRIPTION
## Description

Adds missing methods to `Concurrent` needed for replacing `SharedSystem` with `Concurrent`

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking readiness check for concurrent operations.
  * Expanded signal-handling delegation to expose mask and disposition operations through the concurrent wrapper.
  * Enabled resource-limit trait support for shared, reference-counted wrapper types.

* **Refactor**
  * Reorganized async selection internals to separate peek vs. regular paths and simplify timeout handling.

* **Tests**
  * Added/updated tests covering peek semantics and wake-up behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->