### PR TITLE
Replace SharedSystem with Concurrent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+
+[*.json]
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+
+[*.toml]
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.insertSpaces": true,
+  "[rust]": {
+    "editor.tabSize": 4
+  },
+  "[toml]": {
+    "editor.tabSize": 2
+  },
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "[shellscript]": {
+    "editor.tabSize": 4
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,6 @@ dependencies = [
  "thiserror",
  "yash-builtin",
  "yash-env",
- "yash-executor",
  "yash-prompt",
  "yash-semantics",
  "yash-syntax",

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -28,8 +28,6 @@ use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 #[cfg(doc)]
 use yash_env::stack::Stack;
-#[cfg(doc)]
-use yash_env::system::SharedSystem;
 use yash_env::system::{Chdir, Errno, Fcntl, Isatty, Write};
 
 /// Error invoking the underlying system call
@@ -85,7 +83,9 @@ pub fn failure_message<S: Isatty>(
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`failure_message`] and prints it
-/// with [`SharedSystem::print_error`].
+/// with [`Concurrent::print_error`].
+///
+/// [`Concurrent::print_error`]: yash_env::system::Concurrent::print_error
 pub async fn report_failure<S>(
     env: &mut Env<S>,
     operand: Option<&Field>,

--- a/yash-builtin/src/common/report.rs
+++ b/yash-builtin/src/common/report.rs
@@ -21,8 +21,6 @@
 
 use std::ops::ControlFlow::{Break, Continue};
 use yash_env::Env;
-#[cfg(doc)]
-use yash_env::SharedSystem;
 use yash_env::semantics::{Divert, ExitStatus};
 use yash_env::source::Location;
 use yash_env::source::pretty::{
@@ -49,9 +47,11 @@ use yash_env::system::{Fcntl, Isatty, Write};
 /// in a built-in. This ensures that the message contains the built-in name
 /// in a unified format.
 ///
-/// Use [`SharedSystem::print_error`] to print the returned message and
+/// Use [`Concurrent::print_error`] to print the returned message and
 /// [`crate::Result::with_exit_status_and_divert`] to return the divert value
 /// along with an exit status.
+///
+/// [`Concurrent::print_error`]: yash_env::system::Concurrent::print_error
 #[must_use = "returned message should be printed"]
 pub fn prepare_report_message_and_divert<'e, 'r, S>(
     env: &'e Env<S>,

--- a/yash-builtin/src/read/input.rs
+++ b/yash-builtin/src/read/input.rs
@@ -156,7 +156,7 @@ where
         // Read from the standard input byte by byte so that we don't consume
         // more than one character.
         let byte = std::slice::from_mut(&mut buffer[len]);
-        let count = env.system.read_async(Fd::STDIN, byte).await?;
+        let count = env.system.read(Fd::STDIN, byte).await?;
         if count == 0 {
             // End of input
             return if len == 0 {

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -81,11 +81,11 @@ where
 {
     if env.options.get(Interactive) == State::On && env.options.get(Monitor) == State::On {
         env.traps
-            .enable_internal_dispositions_for_stoppers(&mut env.system)
+            .enable_internal_dispositions_for_stoppers(&env.system)
             .await
     } else {
         env.traps
-            .disable_internal_dispositions_for_stoppers(&mut env.system)
+            .disable_internal_dispositions_for_stoppers(&env.system)
             .await
     }
     .ok();

--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -24,8 +24,7 @@ use std::ffi::CString;
 use std::ops::ControlFlow;
 use std::rc::Rc;
 use yash_env::Env;
-use yash_env::input::Echo;
-use yash_env::input::FdReader;
+use yash_env::input::{Echo, FdReader2};
 use yash_env::io::Fd;
 use yash_env::io::move_fd_internal;
 use yash_env::parser::Config;
@@ -65,7 +64,7 @@ impl Command {
             .expect("`source` built-in requires `RunReadEvalLoop` in `Env::any`");
         let system = env.system.clone();
         let ref_env = RefCell::new(&mut *env);
-        let input = Box::new(Echo::new(FdReader::new(fd, system), &ref_env));
+        let input = Box::new(Echo::new(FdReader2::new(fd, system), &ref_env));
         let mut config = Config::with_input(input);
         config.source = Some(Rc::new(Source::DotScript {
             name: self.file.value,

--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -106,7 +106,7 @@ where
             .into_unix_string()
             .into_vec();
         if let Ok(c_path) = CString::new(path) {
-            if let Ok(fd) = open_file(&mut env.system, &c_path).await {
+            if let Ok(fd) = open_file(&env.system, &c_path).await {
                 return Ok(fd);
             }
         }
@@ -118,7 +118,7 @@ where
 ///
 /// The returned file descriptor is opened with the `O_CLOEXEC` flag and is at
 /// least [`MIN_INTERNAL_FD`](yash_env::io::MIN_INTERNAL_FD).
-async fn open_file<S>(system: &mut S, path: &CStr) -> Result<Fd, Errno>
+async fn open_file<S>(system: &S, path: &CStr) -> Result<Fd, Errno>
 where
     S: Open + Close + Dup + ?Sized,
 {
@@ -254,15 +254,15 @@ mod tests {
 
     #[test]
     fn open_file_result_lower_bound() {
-        let mut system = system_with_file("/foo/file", "");
-        let result = open_file(&mut system, c"/foo/file").now_or_never().unwrap();
+        let system = system_with_file("/foo/file", "");
+        let result = open_file(&system, c"/foo/file").now_or_never().unwrap();
         assert_matches!(result, Ok(fd) if fd >= MIN_INTERNAL_FD);
     }
 
     #[test]
     fn open_file_result_cloexec() {
-        let mut system = system_with_file("/foo/file", "");
-        let fd = open_file(&mut system, c"/foo/file")
+        let system = system_with_file("/foo/file", "");
+        let fd = open_file(&system, c"/foo/file")
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -39,7 +39,7 @@ use yash_env::option::State::On;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::{Fcntl, Isatty, SharedSystem, Sigaction, Sigmask, Signals, Write};
+use yash_env::system::{Fcntl, Isatty, Sigaction, Sigmask, Signals, Write};
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
 use yash_env::trap::SetActionError;
@@ -195,17 +195,14 @@ impl<'a> From<&'a Error> for Report<'a> {
 /// Updates an action for a condition in the trap set.
 ///
 /// This is a utility function for implementing [`Command::execute`].
-async fn set_action<S>(
+async fn set_action<S: SignalSystem>(
     traps: &mut TrapSet,
-    system: &mut SharedSystem<S>,
+    system: &S,
     cond: Condition,
     field: Field,
     action: Action,
     override_ignore: bool,
-) -> Result<(), Error>
-where
-    S: Signals + Sigmask + Sigaction,
-{
+) -> Result<(), Error> {
     traps
         .set_action(
             system,
@@ -252,7 +249,7 @@ impl Command {
                 for (cond, field) in conditions {
                     if let Err(error) = set_action(
                         &mut env.traps,
-                        &mut env.system,
+                        &env.system,
                         cond,
                         field,
                         action.clone(),

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -580,7 +580,7 @@ mod tests {
         let args = Field::dummies(["", "TERM"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         env.traps
-            .enter_subshell(&mut env.system, false, false)
+            .enter_subshell(&env.system, false, false)
             .now_or_never()
             .unwrap();
 
@@ -601,7 +601,7 @@ mod tests {
         let args = Field::dummies(["", "TERM"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         env.traps
-            .enter_subshell(&mut env.system, false, false)
+            .enter_subshell(&env.system, false, false)
             .now_or_never()
             .unwrap();
         let args = Field::dummies(["ls", "QUIT"]);

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -23,10 +23,10 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Span, SpanRole, add_span};
+#[cfg(doc)]
+use yash_env::system::Concurrent;
 use yash_env::system::Fcntl;
 use yash_env::system::Isatty;
-#[cfg(doc)]
-use yash_env::system::SharedSystem;
 use yash_env::system::Write;
 use yash_env::variable::Scope::Global;
 
@@ -157,7 +157,7 @@ where
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`unset_variables_error_message`]
-/// and prints it with [`SharedSystem::print_error`].
+/// and prints it with [`Concurrent::print_error`].
 #[deprecated(
     note = "use `merge_reports` and `report_failure` directly",
     since = "0.11.0"
@@ -292,7 +292,7 @@ where
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`unset_functions_error_message`]
-/// and prints it with [`SharedSystem::print_error`].
+/// and prints it with [`Concurrent::print_error`].
 #[deprecated(
     note = "use `merge_reports` and `report_failure` directly",
     since = "0.11.0"

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -73,7 +73,7 @@ where
     // don't miss any `SIGCHLD` that may arrive between `wait` and
     // `wait_for_signals`.  See also Env::wait_for_subshell.
     env.traps
-        .enable_internal_disposition_for_sigchld(&mut env.system)
+        .enable_internal_disposition_for_sigchld(&env.system)
         .await?;
 
     loop {
@@ -208,7 +208,7 @@ mod tests {
             // Set a trap for SIGTERM.
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     SIGTERM,
                     Action::Command("foo=bar".into()),
                     Location::dummy("somewhere"),

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -28,7 +28,6 @@ path = "src/main.rs"
 thiserror = { workspace = true }
 yash-builtin = { workspace = true }
 yash-env = { workspace = true }
-yash-executor = { workspace = true }
 yash-prompt = { workspace = true }
 yash-semantics = { workspace = true }
 yash-syntax = { workspace = true }

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -151,5 +151,5 @@ pub fn main() -> ! {
         run_as_shell_process(&mut env).await;
         exit_or_raise(&env.system, env.exit_status).await
     };
-    system.run_sync(task)
+    system.run_real(task)
 }

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -30,11 +30,11 @@ use self::startup::init_file::run_rcfile;
 use self::startup::input::prepare_input;
 use std::cell::RefCell;
 use std::ops::ControlFlow::{Break, Continue};
+use std::rc::Rc;
 use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::option::{Interactive, On};
 use yash_env::semantics::{Divert, ExitStatus, exit_or_raise};
-use yash_env::system::real::run_loop;
 use yash_env::system::resource::GetRlimit;
 use yash_env::system::{
     Chdir, Disposition, Errno, Fcntl, GetCwd, GetUid, Isatty, Sigaction, Signals, Sysconf,
@@ -146,10 +146,10 @@ pub fn main() -> ! {
         .sigaction(RealSystem::SIGPIPE, Disposition::Default)
         .ok();
 
-    let system = env.system.clone();
+    let system = Rc::clone(&env.system);
     let task = async {
         run_as_shell_process(&mut env).await;
         exit_or_raise(&env.system, env.exit_status).await
     };
-    run_loop(&system, task)
+    system.run_sync(task)
 }

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -30,17 +30,16 @@ use self::startup::init_file::run_rcfile;
 use self::startup::input::prepare_input;
 use std::cell::RefCell;
 use std::ops::ControlFlow::{Break, Continue};
-use std::task::{Context, Poll, Waker};
 use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::option::{Interactive, On};
 use yash_env::semantics::{Divert, ExitStatus, exit_or_raise};
+use yash_env::system::real::run_loop;
 use yash_env::system::resource::GetRlimit;
 use yash_env::system::{
     Chdir, Disposition, Errno, Fcntl, GetCwd, GetUid, Isatty, Sigaction, Signals, Sysconf,
     TcGetPgrp, Times, Umask, Write,
 };
-use yash_executor::Executor;
 use yash_semantics::trap::run_exit_trap;
 use yash_semantics::{Runtime, interactive_read_eval_loop, read_eval_loop};
 
@@ -148,19 +147,9 @@ pub fn main() -> ! {
         .ok();
 
     let system = env.system.clone();
-    let executor = Executor::new();
-    let task = Box::pin(async {
+    let task = async {
         run_as_shell_process(&mut env).await;
         exit_or_raise(&env.system, env.exit_status).await
-    });
-    // SAFETY: We never create new threads in the whole process, so wakers are
-    // never shared between threads.
-    unsafe { executor.spawn_pinned(task) }
-    loop {
-        executor.run_until_stalled();
-
-        let select_future = std::pin::pin!(system.select());
-        let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
-        debug_assert_eq!(poll, Poll::Ready(()));
-    }
+    };
+    run_loop(&system, task)
 }

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -30,6 +30,7 @@ use self::startup::init_file::run_rcfile;
 use self::startup::input::prepare_input;
 use std::cell::RefCell;
 use std::ops::ControlFlow::{Break, Continue};
+use std::task::{Context, Poll, Waker};
 use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::option::{Interactive, On};
@@ -157,6 +158,9 @@ pub fn main() -> ! {
     unsafe { executor.spawn_pinned(task) }
     loop {
         executor.run_until_stalled();
-        system.select(false).ok();
+
+        let select_future = std::pin::pin!(system.select());
+        let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
+        debug_assert_eq!(poll, Poll::Ready(()));
     }
 }

--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -99,12 +99,12 @@ where
     // Configure internal dispositions for signals
     if env.options.get(Interactive) == On {
         env.traps
-            .enable_internal_dispositions_for_terminators(&mut env.system)
+            .enable_internal_dispositions_for_terminators(&env.system)
             .await
             .ok();
         if env.options.get(Monitor) == On {
             env.traps
-                .enable_internal_dispositions_for_stoppers(&mut env.system)
+                .enable_internal_dispositions_for_stoppers(&env.system)
                 .await
                 .ok();
         }

--- a/yash-cli/src/startup/init_file.rs
+++ b/yash-cli/src/startup/init_file.rs
@@ -158,7 +158,7 @@ where
         return;
     }
 
-    async fn open_fd<S>(system: &mut S, path: String) -> Result<Fd, Errno>
+    async fn open_fd<S>(system: &S, path: String) -> Result<Fd, Errno>
     where
         S: Close + Dup + Open,
     {
@@ -174,7 +174,7 @@ where
         move_fd_internal(system, fd)
     }
 
-    let fd = match open_fd(&mut env.system, path.to_owned()).await {
+    let fd = match open_fd(&env.system, path.to_owned()).await {
         Ok(fd) => fd,
         Err(errno) => {
             env.system

--- a/yash-cli/src/startup/init_file.rs
+++ b/yash-cli/src/startup/init_file.rs
@@ -33,7 +33,7 @@ use std::ffi::CString;
 use std::rc::Rc;
 use thiserror::Error;
 use yash_env::Env;
-use yash_env::input::{Echo, FdReader};
+use yash_env::input::{Echo, FdReader2};
 use yash_env::io::Fd;
 use yash_env::io::move_fd_internal;
 use yash_env::option::Option::Interactive;
@@ -190,7 +190,7 @@ where
     let env = &mut *env.push_frame(Frame::InitFile);
     let system = env.system.clone();
     let ref_env = RefCell::new(&mut *env);
-    let input = Box::new(Echo::new(FdReader::new(fd, system), &ref_env));
+    let input = Box::new(Echo::new(FdReader2::new(fd, system), &ref_env));
     let mut config = Config::with_input(input);
     config.source = Some(Rc::new(Source::InitFile {
         path: path.to_owned(),

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -30,7 +30,7 @@ use std::ffi::CString;
 use thiserror::Error;
 use yash_env::Env;
 use yash_env::input::Echo;
-use yash_env::input::FdReader;
+use yash_env::input::FdReader2;
 use yash_env::input::IgnoreEof;
 use yash_env::input::Reporter;
 use yash_env::io::Fd;
@@ -153,7 +153,7 @@ where
 
 /// Creates an input object from a file descriptor.
 ///
-/// This function creates an [`FdReader`] object from the given file descriptor
+/// This function creates an [`FdReader2`] object from the given file descriptor
 /// and wraps it with the [`Echo`] decorator. If the [`Interactive`] option is
 /// enabled, the [`Prompter`], [`Reporter`], and [`IgnoreEof`] decorators are
 /// applied to the input object.
@@ -164,7 +164,7 @@ where
     let env = ref_env.borrow();
     let system = env.system.clone();
 
-    let basic_input = Echo::new(FdReader::new(fd, system), ref_env);
+    let basic_input = Echo::new(FdReader2::new(fd, system), ref_env);
 
     if env.options.get(Interactive) == Off {
         Box::new(basic_input)

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -170,9 +170,11 @@ A _private dependency_ is used internally and not visible to downstream users.
   `system::Concurrent::run_virtual`, which calls `system::Concurrent::select`
   while the task is pending so that the task can be woken up by events in the
   virtual system.
-- The `test_helper::in_virtual_system` function now internally uses nested loops
-  with two executors to better simulate the concurrent execution of the shell
-  processes.
+- The `test_helper::in_virtual_system` function now internally uses
+  `system::Concurrent::run_virtual` to run the provided task, which better
+  simulates the execution of shell processes driven by
+  `system::Concurrent::run_real`. It now also uses `yash_executor::Executor`
+  as the executor instead of `futures_executor::LocalPool`.
 - Private dependency versions:
     - derive_more 2.0.1 → 2.1.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -31,9 +31,6 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `pending_open_wakers: WakerSet`: Wakers of tasks waiting to open the pipe
     - `pending_read_wakers: WakerSet`: Wakers of tasks waiting to read from the pipe
     - `pending_write_wakers: WakerSet`: Wakers of tasks waiting to write to the pipe
-- The `system::real::run_loop` function has been added to run a task in the
-  current process using the real system implementation. This function serves as
-  the main loop of the shell process when running on a real system.
 - The `system::virtual::VirtualSystem::get_open_file_description` method has
   been added to retrieve the open file description for a given file descriptor
   in the current process.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -22,7 +22,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `impl system::Stat for system::virtual::Stat`
 - The `system::Concurrent` struct has been added as a wrapper around a `System`
   implementation to provide concurrent execution of blocking operations. This
-  struct will replace the existing `system::SharedSystem` struct.
+  struct replaces the existing `system::SharedSystem` struct.
 - The `select_async` method has been added to the `system::SharedSystem` struct.
 - The `system::virtual::FileBody` enum now has the following methods:
     - `is_seekable`: Returns whether the file supports seeking.
@@ -101,6 +101,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `Env::system` field now holds an `Rc<Concurrent<S>>` instead of a
+  `SharedSystem<S>`.
+- The `Env::wait_for_signals` method now returns `Rc<system::SignalList>`
+  instead of `Rc<[signal::Number]>`.
+- The `Env::poll_signals` method now returns `Option<Rc<system::SignalList>>`
+  instead of `Option<Rc<[signal::Number]>>`.
 - The `trap::SignalSystem::set_disposition` method signature has changed:
     - The receiver is now `&self` instead of `&mut self`.
     - The return type is now

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -31,6 +31,9 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `pending_open_wakers: WakerSet`: Wakers of tasks waiting to open the pipe
     - `pending_read_wakers: WakerSet`: Wakers of tasks waiting to read from the pipe
     - `pending_write_wakers: WakerSet`: Wakers of tasks waiting to write to the pipe
+- The `system::real::run_loop` function has been added to run a task in the
+  current process using the real system implementation. This function serves as
+  the main loop of the shell process when running on a real system.
 - The `system::virtual::VirtualSystem::get_open_file_description` method has
   been added to retrieve the open file description for a given file descriptor
   in the current process.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -93,7 +93,9 @@ A _private dependency_ is used internally and not visible to downstream users.
   new `test-helper` feature is enabled.
 - The `system::virtual::Executor` trait is now implemented for
   the `yash_executor::Spawner` type, allowing it to be used as an executor for
-  the virtual system.
+  the virtual system. This implementation is conditionally compiled when the new
+  `yash-executor` feature is enabled, which is transitively enabled by the
+  `test-helper` feature.
 - Private dependencies:
     - assert_matches (optional) 1.5.0
     - futures-executor (optional) 0.3.31

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -146,6 +146,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 - Private dependency versions:
     - derive_more 2.0.1 → 2.1.0
 
+### Deprecated
+
+- `system::virtual::SystemState::select_all`: This method is no longer necessary
+  because virtual processes are now automatically woken up when they are ready
+  to make progress.
+
 ### Removed
 
 - The `system::virtual::FileBody::Fifo` variant no longer has the `awaiters`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -23,6 +23,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `system::Concurrent` struct has been added as a wrapper around a `System`
   implementation to provide concurrent execution of blocking operations. This
   struct will replace the existing `system::SharedSystem` struct.
+- The `select_async` method has been added to the `system::SharedSystem` struct.
 - The `system::virtual::FileBody` enum now has the following methods:
     - `is_seekable`: Returns whether the file supports seeking.
 - The following fields have been added to the `system::virtual::FileBody::Fifo`
@@ -90,6 +91,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `test_helper` module has been added with items migrated from the
   `yash-env-test-helper` crate. This module is conditionally compiled when the
   new `test-helper` feature is enabled.
+- The `system::virtual::Executor` trait is now implemented for
+  the `yash_executor::Spawner` type, allowing it to be used as an executor for
+  the virtual system.
 - Private dependencies:
     - assert_matches (optional) 1.5.0
     - futures-executor (optional) 0.3.31
@@ -143,6 +147,9 @@ A _private dependency_ is used internally and not visible to downstream users.
   to perform operations that may require borrowing the system's state again.
 - The `is_ready_for_reading` and `is_ready_for_writing` methods of
   `system::virtual::OpenFileDescription` now return `true` for symbolic links.
+- The `test_helper::in_virtual_system` function now internally uses nested loops
+  with two executors to better simulate the concurrent execution of the shell
+  processes.
 - Private dependency versions:
     - derive_more 2.0.1 → 2.1.0
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -165,6 +165,11 @@ A _private dependency_ is used internally and not visible to downstream users.
   to perform operations that may require borrowing the system's state again.
 - The `is_ready_for_reading` and `is_ready_for_writing` methods of
   `system::virtual::OpenFileDescription` now return `true` for symbolic links.
+- Virtual processes created by
+  `system::virtual::VirtualSystem::new_child_process` now run tasks using
+  `system::Concurrent::run_virtual`, which calls `system::Concurrent::select`
+  while the task is pending so that the task can be woken up by events in the
+  virtual system.
 - The `test_helper::in_virtual_system` function now internally uses nested loops
   with two executors to better simulate the concurrent execution of the shell
   processes.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -106,6 +106,16 @@ A _private dependency_ is used internally and not visible to downstream users.
     - The return type is now
       `impl Future<Output = Result<Disposition, Errno>> + use<Self>` instead of
       `Result<Disposition, Errno>`, making the method async.
+- The following methods of `trap::TrapSet` now take `&S` instead of `&mut S` for
+  the system parameter:
+    - `disable_internal_dispositions`
+    - `disable_internal_dispositions_for_stoppers`
+    - `disable_internal_dispositions_for_terminators`
+    - `enable_internal_disposition_for_sigchld`
+    - `enable_internal_dispositions_for_terminators`
+    - `enable_internal_dispositions_for_stoppers`
+    - `enter_subshell`
+    - `set_action`
 - The following `trap::TrapSet` methods are now async:
     - `set_action`
     - `enter_subshell`

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -20,7 +20,12 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [features]
 default = []
-test-helper = ["assert_matches", "futures-executor", "futures-util"]
+test-helper = [
+  "dep:assert_matches",
+  "dep:yash-executor",
+  "dep:futures-executor",
+  "futures-util/channel",
+]
 
 [dependencies]
 annotate-snippets = { workspace = true }
@@ -32,7 +37,7 @@ either = { workspace = true }
 enumset = { workspace = true }
 errno = { workspace = true, default-features = false }
 futures-executor = { workspace = true, optional = true }
-futures-util = { workspace = true, features = ["channel"], optional = true }
+futures-util = { workspace = true }
 itertools = { workspace = true }
 slab = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
@@ -40,7 +45,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 unix_path = { workspace = true }
 unix_str = { workspace = true }
-yash-executor = { workspace = true }
+yash-executor = { workspace = true, optional = true }
 yash-quote = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -50,6 +55,7 @@ libc = { workspace = true, default-features = false }
 assert_matches = { workspace = true }
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["channel"] }
+yash-executor = { path = "../yash-executor" }
 yash-prompt = { path = "../yash-prompt" }
 yash-semantics = { path = "../yash-semantics" }
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -20,7 +20,12 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [features]
 default = []
-test-helper = ["assert_matches", "futures-executor", "futures-util"]
+test-helper = [
+    "assert_matches",
+    "dep:yash-executor",
+    "futures-executor",
+    "futures-util",
+]
 
 [dependencies]
 annotate-snippets = { workspace = true }
@@ -40,6 +45,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 unix_path = { workspace = true }
 unix_str = { workspace = true }
+yash-executor = { workspace = true, optional = true }
 yash-quote = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -50,7 +56,6 @@ yash-executor = { workspace = true }
 assert_matches = { workspace = true }
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["channel"] }
-yash-executor = { path = "../yash-executor" }
 yash-prompt = { path = "../yash-prompt" }
 yash-semantics = { path = "../yash-semantics" }
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -20,12 +20,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [features]
 default = []
-test-helper = [
-  "assert_matches",
-  "dep:yash-executor",
-  "futures-executor",
-  "futures-util",
-]
+test-helper = ["assert_matches", "futures-executor", "futures-util"]
 
 [dependencies]
 annotate-snippets = { workspace = true }
@@ -45,18 +40,16 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 unix_path = { workspace = true }
 unix_str = { workspace = true }
-yash-executor = { workspace = true, optional = true }
+yash-executor = { workspace = true }
 yash-quote = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true, default-features = false }
-yash-executor = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["channel"] }
-yash-executor = { path = "../yash-executor" }
 yash-prompt = { path = "../yash-prompt" }
 yash-semantics = { path = "../yash-semantics" }
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -56,6 +56,7 @@ yash-executor = { workspace = true }
 assert_matches = { workspace = true }
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["channel"] }
+yash-executor = { path = "../yash-executor" }
 yash-prompt = { path = "../yash-prompt" }
 yash-semantics = { path = "../yash-semantics" }
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -21,10 +21,10 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 [features]
 default = []
 test-helper = [
-    "assert_matches",
-    "dep:yash-executor",
-    "futures-executor",
-    "futures-util",
+  "assert_matches",
+  "dep:yash-executor",
+  "futures-executor",
+  "futures-util",
 ]
 
 [dependencies]

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -20,9 +20,10 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [features]
 default = []
+yash-executor = ["dep:yash-executor"]
 test-helper = [
   "dep:assert_matches",
-  "dep:yash-executor",
+  "yash-executor",
   "dep:futures-executor",
   "futures-util/channel",
 ]

--- a/yash-env/src/executor_helper.rs
+++ b/yash-env/src/executor_helper.rs
@@ -1,0 +1,39 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Implementation of traits defined in this crate for external items
+
+use std::pin::Pin;
+
+/// Allows `Spawner` to be used as an `Executor` in the virtual system.
+///
+/// Remember that `yash_executor::Spawner` is for single-threaded processes.
+/// It is not safe to use it in a multi-threaded context, e.g. by spawning a
+/// task that creates threads and uses wakers from the executor in those
+/// threads.
+impl<'a> crate::system::r#virtual::Executor for yash_executor::Spawner<'a> {
+    fn spawn(
+        &self,
+        task: Pin<Box<dyn Future<Output = ()>>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // SAFETY: Actually this is not safe if the task creates a thread and
+        // a waker from the executor is used in the thread. However, the shell
+        // process must be single-threaded to work correctly, so we assume the
+        // task does not create threads.
+        (unsafe { self.spawn_pinned(task) })
+            .map_err(|_| "failed to spawn task: the executor has been dropped".into())
+    }
+}

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -121,6 +121,9 @@ pub use memory::Memory;
 mod fd_reader;
 pub use fd_reader::FdReader;
 
+mod fd_reader_2;
+pub use fd_reader_2::FdReader2;
+
 mod echo;
 pub use echo::Echo;
 

--- a/yash-env/src/input/fd_reader_2.rs
+++ b/yash-env/src/input/fd_reader_2.rs
@@ -14,93 +14,64 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// `FdReader` definition
+// `FdReader2` definition
 
 use super::{Context, Input, Result};
 use crate::io::Fd;
-use crate::option::State;
-use crate::system::{Fcntl, Read, SharedSystem, Write};
-use std::cell::Cell;
+use crate::system::{Concurrent, Fcntl, Read};
 use std::rc::Rc;
 use std::slice::from_mut;
 
-/// Input function that reads from a file descriptor.
+/// [Input function](Input) that reads from a file descriptor
 ///
-/// An instance of `FdReader` contains a [`SharedSystem`] to interact with the
-/// file descriptor.
+/// An instance of `FdReader2<S>` contains a `Rc<Concurrent<S>>` to read input
+/// from a file descriptor.
 ///
-/// Although `FdReader` implements `Clone`, it does not mean you can create and
-/// keep a copy of a `FdReader` instance to replay the input later. Since both
-/// the original and clone share the same `SharedSystem`, reading a line from
+/// Although `FdReader2` implements `Clone`, it does not mean you can create and
+/// keep a copy of a `FdReader2` instance to replay the input later. Since both
+/// the original and clone share the same `Concurrent<S>`, reading a line from
 /// one instance will affect the next read from the other.
 ///
-/// Use [`FdReader2`](super::FdReader2) if you want an `Input` that depends on
-/// [`Concurrent`](crate::system::Concurrent) instead of `SharedSystem`.
+/// `FdReader2` is a variant of [`FdReader`](super::FdReader) that depends on
+/// `Concurrent<S>` instead of [`SharedSystem`](crate::system::SharedSystem).
 #[derive(Debug)]
-#[must_use = "FdReader does nothing unless used by a parser"]
-pub struct FdReader<S> {
+#[must_use = "FdReader2 does nothing unless used by a parser"]
+pub struct FdReader2<S> {
     /// File descriptor to read from
     fd: Fd,
     /// System to interact with the FD
-    system: SharedSystem<S>,
-    /// Whether lines read are echoed to stderr
-    echo: Option<Rc<Cell<State>>>,
+    system: Rc<Concurrent<S>>,
 }
 
-impl<S> FdReader<S> {
-    /// Creates a new `FdReader` instance.
+impl<S> FdReader2<S> {
+    /// Creates a new `FdReader2` instance.
     ///
     /// The `fd` argument is the file descriptor to read from. It should be
     /// readable, have the close-on-exec flag set, and remain open for the
-    /// lifetime of the `FdReader` instance.
-    pub fn new(fd: Fd, system: SharedSystem<S>) -> Self {
-        let echo = None;
-        FdReader { fd, system, echo }
-    }
-
-    /// Sets the "echo" flag.
-    ///
-    /// You can use this setter function to set a shared option state that
-    /// controls whether the input function echoes lines it reads to the
-    /// standard error. If `echo` is `None` or some shared cell containing
-    /// `Off`, the function does not echo. If a cell has `On`, the function
-    /// prints every line it reads to the standard error.
-    ///
-    /// This option implements the behavior of the `verbose` shell option. You
-    /// can change the state of the shared cell through the lifetime of the
-    /// input function to reflect the option dynamically changed, which will
-    /// affect the next `next_line` call.
-    ///
-    /// # Deprecation
-    ///
-    /// This function is deprecated in favor of the [`Echo`] struct.
-    ///
-    /// [`Echo`]: super::Echo
-    #[deprecated = "use Echo instead"]
-    pub fn set_echo(&mut self, echo: Option<Rc<Cell<State>>>) {
-        self.echo = echo;
+    /// lifetime of the `FdReader2` instance.
+    pub fn new(fd: Fd, system: Rc<Concurrent<S>>) -> Self {
+        FdReader2 { fd, system }
     }
 }
 
 // Not derived automatically because S may not implement Clone
-impl<S> Clone for FdReader<S> {
+impl<S> Clone for FdReader2<S> {
     fn clone(&self) -> Self {
         Self {
             fd: self.fd,
             system: self.system.clone(),
-            echo: self.echo.clone(),
         }
     }
 }
 
-impl<S: Fcntl + Read + Write> Input for FdReader<S> {
+impl<S: Fcntl + Read> Input for FdReader2<S> {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
         let mut bytes = Vec::new();
         loop {
             let mut byte = 0;
-            match self.system.read_async(self.fd, from_mut(&mut byte)).await {
+            match self.system.read(self.fd, from_mut(&mut byte)).await {
                 // End of input
                 Ok(0) => break,
 
@@ -120,12 +91,6 @@ impl<S: Fcntl + Read + Write> Input for FdReader<S> {
         let line = String::from_utf8(bytes)
             .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into());
 
-        if let Some(echo) = &self.echo {
-            if echo.get() == State::On {
-                let _ = self.system.write_all(Fd::STDERR, line.as_bytes()).await;
-            }
-        }
-
         Ok(line)
     }
 }
@@ -141,14 +106,13 @@ mod tests {
     use crate::system::r#virtual::FileBody;
     use crate::system::r#virtual::Inode;
     use crate::system::r#virtual::VirtualSystem;
-    use assert_matches::assert_matches;
-    use futures_util::FutureExt;
+    use futures_util::FutureExt as _;
 
     #[test]
     fn empty_reader() {
         let system = VirtualSystem::new();
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
+        let system = Rc::new(Concurrent::new(system));
+        let mut reader = FdReader2::new(Fd::STDIN, system);
 
         let line = reader
             .next_line(&Context::default())
@@ -166,8 +130,8 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"echo ok\n");
         }
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
+        let system = Rc::new(Concurrent::new(system));
+        let mut reader = FdReader2::new(Fd::STDIN, system);
 
         let line = reader
             .next_line(&Context::default())
@@ -191,8 +155,8 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"#!/bin/sh\necho ok\nexit");
         }
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
+        let system = Rc::new(Concurrent::new(system));
+        let mut reader = FdReader2::new(Fd::STDIN, system);
 
         let line = reader
             .next_line(&Context::default())
@@ -228,7 +192,7 @@ mod tests {
             let file = Rc::new(Inode::new("echo file\n").into());
             state.file_system.save("/foo", file).unwrap();
         }
-        let system = SharedSystem::new(system);
+        let system = Rc::new(Concurrent::new(system));
         let path = c"/foo";
         let fd = system
             .open(
@@ -240,7 +204,7 @@ mod tests {
             .now_or_never()
             .unwrap()
             .unwrap();
-        let mut reader = FdReader::new(fd, system);
+        let mut reader = FdReader2::new(fd, system);
 
         let line = reader
             .next_line(&Context::default())
@@ -260,8 +224,8 @@ mod tests {
     fn reader_error() {
         let system = VirtualSystem::new();
         system.current_process_mut().close_fd(Fd::STDIN);
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
+        let system = Rc::new(Concurrent::new(system));
+        let mut reader = FdReader2::new(Fd::STDIN, system);
 
         let error = reader
             .next_line(&Context::default())
@@ -269,68 +233,5 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(error.raw_os_error(), Some(Errno::EBADF.0));
-    }
-
-    #[test]
-    fn echo_off() {
-        let system = VirtualSystem::new();
-        let state = Rc::clone(&system.state);
-        {
-            let state = state.borrow();
-            let file = state.file_system.get("/dev/stdin").unwrap();
-            file.borrow_mut().body = FileBody::new(*b"one\ntwo");
-        }
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
-        #[allow(deprecated)]
-        reader.set_echo(Some(Rc::new(Cell::new(State::Off))));
-
-        let _ = reader
-            .next_line(&Context::default())
-            .now_or_never()
-            .unwrap();
-        let state = state.borrow();
-        let file = state.file_system.get("/dev/stderr").unwrap();
-        assert_matches!(&file.borrow().body, FileBody::Regular { content, .. } => {
-            assert_eq!(content, &[]);
-        });
-    }
-
-    #[test]
-    fn echo_on() {
-        let system = VirtualSystem::new();
-        let state = Rc::clone(&system.state);
-        {
-            let state = state.borrow();
-            let file = state.file_system.get("/dev/stdin").unwrap();
-            file.borrow_mut().body = FileBody::new(*b"one\ntwo");
-        }
-        let system = SharedSystem::new(system);
-        let mut reader = FdReader::new(Fd::STDIN, system);
-        #[allow(deprecated)]
-        reader.set_echo(Some(Rc::new(Cell::new(State::On))));
-
-        let _ = reader
-            .next_line(&Context::default())
-            .now_or_never()
-            .unwrap();
-        {
-            let state = state.borrow();
-            let file = state.file_system.get("/dev/stderr").unwrap();
-            assert_matches!(&file.borrow().body, FileBody::Regular { content, .. } => {
-                assert_eq!(content, b"one\n");
-            });
-        }
-        let _ = reader
-            .next_line(&Context::default())
-            .now_or_never()
-            .unwrap();
-        {
-            let state = state.borrow();
-            let file = state.file_system.get("/dev/stderr").unwrap();
-            assert_matches!(&file.borrow().body, FileBody::Regular { content, .. } => {
-                assert_eq!(content, b"one\ntwo");
-            });
-        }
     }
 }

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -19,8 +19,6 @@
 use crate::Env;
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
-#[cfg(doc)]
-use crate::system::SharedSystem;
 use crate::system::{Close, Dup, Fcntl, FdFlag, Isatty, Write};
 use annotate_snippets::Renderer;
 use std::borrow::Cow;
@@ -103,7 +101,7 @@ where
 /// `env` allows it. The string will end with a newline.
 ///
 /// To print the returned string to the standard error, you can use
-/// [`SharedSystem::print_error`].
+/// [`Concurrent::print_error`](crate::system::Concurrent::print_error).
 #[must_use]
 pub fn report_to_string<S: Isatty>(env: &Env<S>, report: &Report<'_>) -> String {
     let renderer = if env.should_print_error_in_color() {

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -624,6 +624,8 @@ pub mod trap;
 pub mod variable;
 pub mod waker;
 
+#[cfg(any(test, feature = "yash-executor"))]
+mod executor_helper;
 #[cfg(any(test, feature = "test-helper"))]
 pub mod test_helper;
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -59,6 +59,7 @@ use self::stack::Stack;
 use self::system::CaughtSignals;
 use self::system::Clock;
 use self::system::Close;
+use self::system::Concurrent;
 use self::system::Dup;
 use self::system::Errno;
 use self::system::Fstat;
@@ -73,6 +74,7 @@ use self::system::Select;
 pub use self::system::SharedSystem;
 use self::system::Sigaction;
 use self::system::Sigmask;
+use self::system::SignalList;
 use self::system::Signals;
 #[allow(deprecated)]
 pub use self::system::System;
@@ -162,7 +164,7 @@ pub struct Env<S> {
     pub any: DataSet,
 
     /// Interface to the system-managed parts of the environment
-    pub system: SharedSystem<S>,
+    pub system: Rc<Concurrent<S>>,
 }
 
 impl<S> Env<S> {
@@ -191,7 +193,7 @@ impl<S> Env<S> {
             tty: Default::default(),
             variables: Default::default(),
             any: Default::default(),
-            system: SharedSystem::new(system),
+            system: Rc::new(Concurrent::new(system)),
         }
     }
 
@@ -217,7 +219,7 @@ impl<S> Env<S> {
             tty: self.tty,
             variables: self.variables.clone(),
             any: self.any.clone(),
-            system: SharedSystem::new(system),
+            system: Rc::new(Concurrent::new(system)),
         }
     }
 }
@@ -268,7 +270,7 @@ impl<S> Env<S> {
     /// Before the function returns, it passes the results to
     /// [`TrapSet::catch_signal`] so the trap set can remember the signals
     /// caught to be handled later.
-    pub async fn wait_for_signals(&mut self) -> Rc<[signal::Number]> {
+    pub async fn wait_for_signals(&mut self) -> Rc<SignalList> {
         let result = self.system.wait_for_signals().await;
         for signal in result.iter().copied() {
             self.traps.catch_signal(signal);
@@ -289,24 +291,30 @@ impl<S> Env<S> {
     /// This function is similar to
     /// [`wait_for_signals`](Self::wait_for_signals) but does not wait for
     /// signals to be caught. Instead, it only checks if any signals have been
-    /// caught but not yet consumed in the [`SharedSystem`].
-    pub fn poll_signals(&mut self) -> Option<Rc<[signal::Number]>>
+    /// caught but not yet consumed in the [`SharedSystem`]. If no signals
+    /// have been caught, it returns `None`.
+    pub fn poll_signals(&mut self) -> Option<Rc<SignalList>>
     where
         S: Select + CaughtSignals + Clock,
     {
-        let system = self.system.clone();
+        let system = Rc::clone(&self.system);
 
         let mut future = std::pin::pin!(self.wait_for_signals());
-
         let mut context = Context::from_waker(Waker::noop());
+
+        // Check if the result is ready before peeking the system
         if let Poll::Ready(signals) = future.as_mut().poll(&mut context) {
             return Some(signals);
         }
 
-        system.select(true).ok();
+        // Peek to handle any pending signals
+        system.peek();
+
+        // Check again if the result is ready after peeking
         if let Poll::Ready(signals) = future.poll(&mut context) {
             return Some(signals);
         }
+
         None
     }
 
@@ -694,7 +702,7 @@ mod tests {
         }
 
         let result = env.poll_signals().unwrap();
-        assert_eq!(*result, [SIGCHLD]);
+        assert_eq!(result.as_slice(), [SIGCHLD]);
     }
 
     #[test]

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -436,7 +436,7 @@ impl<S> Env<S> {
         // We need to set the internal disposition before calling `wait` so we don't
         // miss any `SIGCHLD` that may arrive between `wait` and `wait_for_signal`.
         self.traps
-            .enable_internal_disposition_for_sigchld(&mut self.system)
+            .enable_internal_disposition_for_sigchld(&self.system)
             .await?;
 
         loop {
@@ -638,7 +638,7 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     SIGCHLD,
                     Action::Command("".into()),
                     Location::dummy(""),
@@ -664,7 +664,7 @@ mod tests {
         let mut env = Env::with_system(system.clone());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGCHLD,
                 Action::Command("".into()),
                 Location::dummy(""),

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -31,6 +31,14 @@
 //! [`RealSystem`] provides an implementation for them that interacts with
 //! the underlying system. [`VirtualSystem`] simulates a system for testing
 //! purposes.
+//!
+//! We assume that the shell process is single-threaded. This means that the
+//! shell process itself must not create threads, and all interactions with the
+//! system must be performed in the main thread. Using any items in this crate
+//! in a multi-threaded context is not supported and may cause undefined
+//! behavior. This prerequisite still applies even when a [`VirtualSystem`]
+//! simulates concurrent execution of multiple processes, which run as
+//! asynchronous tasks.
 
 use self::alias::AliasSet;
 use self::any::DataSet;

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -102,13 +102,13 @@ pub use unix_str as str;
 ///
 /// The shell execution environment consists of application-managed parts and
 /// system-managed parts. Application-managed parts are directly implemented in
-/// the `Env` instance. System-managed parts are managed by a [`SharedSystem`]
-/// that contains an instance of `S` that implements [`System`].
+/// the `Env` instance. System-managed parts are managed by a [`Concurrent`]
+/// wrapping a `System` instance.
 ///
 /// # Cloning
 ///
 /// `Env::clone` effectively clones the application-managed parts of the
-/// environment. Since [`SharedSystem`] is reference-counted, you will not get a
+/// environment. Since [`Concurrent`] is reference-counted, you will not get a
 /// deep copy of the system-managed parts. See also
 /// [`clone_with_system`](Self::clone_with_system).
 #[derive(Clone, Debug)]
@@ -171,8 +171,9 @@ impl<S> Env<S> {
     /// Creates a new environment with the given system.
     ///
     /// Members of the new environments are default-constructed except that:
+    /// - `main_pgid` is initialized as `system.getpgrp()`
     /// - `main_pid` is initialized as `system.getpid()`
-    /// - `system` is initialized as `SharedSystem::new(system)`
+    /// - `system` is initialized as `Rc::new(Concurrent::new(system))`
     #[must_use]
     pub fn with_system(system: S) -> Self
     where
@@ -266,7 +267,7 @@ impl<S> Env<S> {
     ///
     /// Returns an array of signals caught.
     ///
-    /// This function is a wrapper for [`SharedSystem::wait_for_signals`].
+    /// This function is a wrapper for [`Concurrent::wait_for_signals`].
     /// Before the function returns, it passes the results to
     /// [`TrapSet::catch_signal`] so the trap set can remember the signals
     /// caught to be handled later.
@@ -291,8 +292,8 @@ impl<S> Env<S> {
     /// This function is similar to
     /// [`wait_for_signals`](Self::wait_for_signals) but does not wait for
     /// signals to be caught. Instead, it only checks if any signals have been
-    /// caught but not yet consumed in the [`SharedSystem`]. If no signals
-    /// have been caught, it returns `None`.
+    /// caught but not yet consumed in the [`Concurrent`] instance. If no
+    /// signals have been caught, it returns `None`.
     pub fn poll_signals(&mut self) -> Option<Rc<SignalList>>
     where
         S: Select + CaughtSignals + Clock,

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -144,7 +144,7 @@ pub async fn replace_current_process<S: Exec + ShellPath + Signals + Sigmask + S
     args: Vec<Field>,
 ) -> std::result::Result<Infallible, ReplaceCurrentProcessError> {
     env.traps
-        .disable_internal_dispositions(&mut env.system)
+        .disable_internal_dispositions(&env.system)
         .await
         .ok();
 
@@ -153,7 +153,7 @@ pub async fn replace_current_process<S: Exec + ShellPath + Signals + Sigmask + S
     let Err(errno) = env.system.execve(path.as_c_str(), &args, &envs).await;
     env.exit_status = match errno {
         Errno::ENOEXEC => {
-            fall_back_on_sh(&mut env.system, path.clone(), args, envs).await;
+            fall_back_on_sh(&env.system, path.clone(), args, envs).await;
             ExitStatus::NOEXEC
         }
         Errno::ENOENT | Errno::ENOTDIR => ExitStatus::NOT_FOUND,
@@ -175,7 +175,7 @@ fn to_c_strings(s: Vec<Field>) -> Vec<CString> {
 
 /// Invokes the shell with the given arguments.
 async fn fall_back_on_sh<S: ShellPath + Exec>(
-    system: &mut S,
+    system: &S,
     mut script_path: CString,
     mut args: Vec<CString>,
     envs: Vec<CString>,

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -222,7 +222,7 @@ where
 
                 env.traps
                     .enter_subshell(
-                        &mut env.system,
+                        &env.system,
                         ignore_sigint_sigquit,
                         keep_internal_dispositions_for_stoppers,
                     )
@@ -405,7 +405,7 @@ mod tests {
         in_virtual_system(|mut env, _state| async move {
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     SIGCHLD,
                     Action::Command("echo foo".into()),
                     Location::dummy(""),
@@ -732,7 +732,7 @@ mod tests {
             parent_env.options.set(Monitor, On);
             parent_env
                 .traps
-                .enable_internal_dispositions_for_stoppers(&mut parent_env.system)
+                .enable_internal_dispositions_for_stoppers(&parent_env.system)
                 .await
                 .unwrap();
             stub_tty(&state);
@@ -762,7 +762,7 @@ mod tests {
             parent_env.options.set(Monitor, On);
             parent_env
                 .traps
-                .enable_internal_dispositions_for_stoppers(&mut parent_env.system)
+                .enable_internal_dispositions_for_stoppers(&parent_env.system)
                 .await
                 .unwrap();
             stub_tty(&state);

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -16,11 +16,9 @@
 
 //! API declarations and implementations for system-managed parts of the environment
 //!
-//! This module defines the [`System`] trait, which provides an interface to
-//! interact with the underlying system. It is a subtrait of various other traits
-//! that define specific functionalities, such as file system operations, process
-//! management, signal handling, and resource limit management. The following
-//! traits are included as subtraits of `System`:
+//! This module defines many traits that declare methods to interact with the
+//! underlying system, such as file system operations, process management,
+//! signal handling, and resource limit management:
 //!
 //! - [`CaughtSignals`]: Declares the `caught_signals` method for retrieving
 //!   caught signals.
@@ -82,20 +80,23 @@
 //! - [`resource::SetRlimit`]: Declares the `setrlimit` method for
 //!   setting resource limits.
 //!
-//! There are two main implementors of the `System` trait:
+//! There are two main implementors of these traits:
 //!
-//! - `RealSystem`: An implementation that interacts with the actual
+//! - [`RealSystem`]: An implementation that interacts with the actual
 //!   underlying system (see the [`real`] module).
-//! - `VirtualSystem`: An implementation that simulates system behavior
-//!   for testing purposes (see the [`virtual`] module).
+//! - [`VirtualSystem`]: An implementation that simulates system behavior for
+//!   testing purposes (see the [`virtual`] module).
 //!
-//! Additionally, there is the [`SharedSystem`] implementor that wraps
-//! another `System` instance to provide asynchronous methods.
+//! Additionally, [`Concurrent`] is a wrapper that extends the interface with
+//! asynchronous methods for concurrency.
+//! ([`SharedSystem`] is a former wrapper that provided similar functionality
+//! but is now deprecated in favor of `Concurrent`.)
 //!
-//! User code should generally depend only on specific subtraits of `System`
-//! rather than `System` itself. This allows for more modular and testable code.
-//! For example, code that only needs to write to file descriptors can depend
-//! on the `Write` trait alone.
+//! This module has a deprecated trait, [`System`], that combines all the traits
+//! above. To promote interface segregation, user code should generally depend
+//! only on specific traits that declare the methods it needs, rather than
+//! working with `System` directly. For example, code that only needs to write
+//! to file descriptors can depend on the `Write` trait alone.
 //!
 //! Some methods of these traits return [futures](std::future::Future), not
 //! because the underlying system calls are asynchronous, but to allow
@@ -165,13 +166,15 @@ use crate::trap::SignalSystem;
 use std::convert::Infallible;
 use std::fmt::Debug;
 
-/// API to the system-managed parts of the environment.
+/// Utility trait that aggregates all the traits in this module
 ///
 /// The `System` trait defines a collection of methods to access the underlying
-/// operating system from the shell as an application program. There are two
-/// substantial implementors for this trait: [`RealSystem`] and
-/// [`VirtualSystem`]. Another implementor is [`SharedSystem`], which wraps a
-/// `System` instance to extend the interface with asynchronous methods.
+/// operating system from the shell as an application program. See the
+/// [module-level documentation](self) for more details.
+///
+/// This trait is now deprecated in favor of depending on specific traits that
+/// declare the methods needed by the user code, which promotes interface
+/// segregation.
 #[deprecated(
     note = "use smaller, more specialized traits declared in the `system` module instead",
     since = "0.11.0"

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -18,10 +18,12 @@
 
 #[cfg(unix)]
 use super::real::RealSystem;
+use super::r#virtual::VirtualSystem;
 use super::{CaughtSignals, Clock, Errno, Fcntl, Read, Result, Select, Write};
 use crate::io::Fd;
+use crate::job::ProcessState;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
-use futures_util::poll;
+use futures_util::{pending, poll};
 use std::cell::{Cell, LazyCell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::future::poll_fn;
@@ -582,6 +584,76 @@ impl Concurrent<RealSystem> {
     }
 }
 
+impl Concurrent<VirtualSystem> {
+    /// Runs the given task with concurrency support.
+    ///
+    /// This function implements the main loop of the shell process. It runs the
+    /// given task while also calling [`select`](Self::select) to handle signals
+    /// and other events. The task is expected to perform I/O operations using
+    /// the methods of this `Concurrent` instance, so that it can yield when the
+    /// operations would block. The function returns the output of the task when
+    /// it completes.
+    ///
+    /// This is the `VirtualSystem` counterpart for the
+    /// [`run_sync`](Self::run_sync) method. To allow `VirtualSystem` to run
+    /// multiple tasks concurrently, this method is asynchronous and returns a
+    /// future that completes when the task finishes or the process is
+    /// terminated.
+    pub async fn run_virtual<F>(&self, task: F)
+    where
+        F: Future<Output = ()>,
+    {
+        let mut task = pin!(task);
+        while poll!(&mut task).is_pending() {
+            let state = self.inner.current_process().state();
+            match state {
+                ProcessState::Running => {
+                    // The process is running, but the task is not ready yet, so we need to wait
+                    // for it to become ready. Proceed to the `select` call below.
+                }
+                ProcessState::Halted(result) => {
+                    if result.is_stopped() {
+                        // The process is stopped while the task is still working.
+                        let terminated = self.inner.block_while_stopped().await;
+                        if !terminated {
+                            // The process has been resumed, so we can continue running the task.
+                            continue;
+                        }
+                    }
+                    // The process has been terminated, so we simply abort the task.
+                    return;
+                }
+            }
+
+            let mut select = pin!(self.select());
+            while poll!(&mut select).is_pending() {
+                let state = self.inner.current_process().state();
+                match state {
+                    ProcessState::Running => {
+                        // The process is running, but the select call is not ready yet, so we need
+                        // to wait for it to become ready. Here we propagate the pending state to
+                        // the caller to yield to other processes.
+                        pending!()
+                    }
+                    ProcessState::Halted(result) => {
+                        if result.is_stopped() {
+                            // The process is stopped while we are waiting for the select call.
+                            let terminated = self.inner.block_while_stopped().await;
+                            if !terminated {
+                                // The process has been resumed, so we can continue waiting
+                                // for the select call.
+                                continue;
+                            }
+                        }
+                        // The process has been terminated, so we simply abort the task.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
 mod delegates;
 mod rw_all;
 mod signal;
@@ -592,7 +664,7 @@ mod tests {
         Close as _, Disposition, Mode, OfdAccess, Open as _, OpenFlag, Pipe as _, SendSignal,
     };
     use super::*;
-    use crate::system::r#virtual::{PIPE_SIZE, SIGCHLD, SIGINT, SIGUSR2, VirtualSystem};
+    use crate::system::r#virtual::{PIPE_SIZE, SIGCHLD, SIGINT, SIGUSR2};
     use crate::test_helper::WakeFlag;
     use crate::trap::SignalSystem as _;
     use assert_matches::assert_matches;

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -376,8 +376,8 @@ where
     /// }
     /// ```
     ///
-    /// The [`run`](Self::run) method provides a convenient way to implement
-    /// such a main loop.
+    /// The [`run_real`](Self::run_real) and [`run_virtual`](Self::run_virtual)
+    /// methods provide a convenient way to implement such a main loop.
     ///
     /// The future returned by this method will be pending if and only if the
     /// future returned by the inner system's [`select`](Select::select) method
@@ -438,33 +438,6 @@ where
                 // Drop the list so that the next wait_for_signals call can create a new one.
                 state.signals = Weak::new();
             }
-        }
-    }
-
-    /// Runs the given task with concurrency support.
-    ///
-    /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Self::select) to handle signals
-    /// and other events. The task is expected to perform I/O operations using
-    /// the methods of this `Concurrent` instance, so that it can yield when the
-    /// operations would block. The function returns the output of the task when
-    /// it completes.
-    ///
-    /// The future returned by this method will be pending if and only if the
-    /// future returned by the internal system's [`select`](Select::select)
-    /// method is pending. For use with [`RealSystem`], the
-    /// [`run_sync`](Self::run_sync) method may be more convenient, which works
-    /// synchronously.
-    pub async fn run<F, T>(&self, task: F) -> T
-    where
-        F: Future<Output = T>,
-    {
-        let mut task = pin!(task);
-        loop {
-            if let Ready(result) = poll!(&mut task) {
-                return result;
-            }
-            self.select().await;
         }
     }
 }
@@ -567,17 +540,26 @@ impl Concurrent<RealSystem> {
     /// operations would block. The function returns the output of the task when
     /// it completes.
     ///
-    /// This method is a specialization of the more general [`run`](Self::run)
-    /// method for the case where the inner system is `RealSystem`. Since
-    /// [`RealSystem::select`] performs a real `select` system call that blocks
-    /// the entire process, this method synchronously returns the output of the
-    /// task.
-    pub fn run_sync<F, T>(&self, task: F) -> T
+    /// This method supports concurrency only inside the task. Other tasks
+    /// created outside the task will not be run concurrently.
+    /// This method blocks the current thread until the task completes, so it
+    /// should only be called in the main function of the shell process.
+    /// See the [`run_virtual`](Self::run_virtual) method for the
+    /// `VirtualSystem` counterpart.
+    pub fn run_real<F, T>(&self, task: F) -> T
     where
         F: Future<Output = T>,
     {
-        let future = pin!(self.run(task));
-        match future.poll(&mut Context::from_waker(Waker::noop())) {
+        let runner = pin!(async move {
+            let mut task = pin!(task);
+            loop {
+                if let Ready(result) = poll!(&mut task) {
+                    return result;
+                }
+                self.select().await;
+            }
+        });
+        match runner.poll(&mut Context::from_waker(Waker::noop())) {
             Ready(result) => result,
             Pending => unreachable!("`RealSystem::select` should never return `Pending`"),
         }
@@ -595,7 +577,7 @@ impl Concurrent<VirtualSystem> {
     /// it completes.
     ///
     /// This is the `VirtualSystem` counterpart for the
-    /// [`run_sync`](Self::run_sync) method. To allow `VirtualSystem` to run
+    /// [`run_real`](Self::run_real) method. To allow `VirtualSystem` to run
     /// multiple tasks concurrently, this method is asynchronous and returns a
     /// future that completes when the task finishes or the process is
     /// terminated.

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -16,6 +16,8 @@
 
 //! Items for concurrent task execution
 
+#[cfg(unix)]
+use super::real::RealSystem;
 use super::{CaughtSignals, Clock, Errno, Fcntl, Read, Result, Select, Write};
 use crate::io::Fd;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
@@ -23,6 +25,7 @@ use std::cell::{Cell, LazyCell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::future::poll_fn;
 use std::ops::{Deref, DerefMut};
+use std::pin::pin;
 use std::rc::{Rc, Weak};
 use std::task::Poll::{Pending, Ready};
 use std::task::{Context, Waker};
@@ -348,7 +351,7 @@ where
     /// ready. This method is similar to [`select`](Concurrent::select), but it
     /// does not block and returns immediately.
     pub fn peek(&self) {
-        let select = std::pin::pin!(self.select_impl(true));
+        let select = pin!(self.select_impl(true));
         let poll = select.poll(&mut Context::from_waker(Waker::noop()));
         debug_assert_eq!(poll, Ready(()), "peek should not block");
     }
@@ -369,6 +372,13 @@ where
     ///     concurrent.select().await;
     /// }
     /// ```
+    ///
+    /// The [`run`](Self::run) method provides a convenient way to implement
+    /// such a main loop.
+    ///
+    /// The future returned by this method will be pending if and only if the
+    /// future returned by the inner system's [`select`](Select::select) method
+    /// is pending.
     pub async fn select(&self) {
         self.select_impl(false).await;
     }
@@ -425,6 +435,49 @@ where
                 // Drop the list so that the next wait_for_signals call can create a new one.
                 state.signals = Weak::new();
             }
+        }
+    }
+
+    /// Runs the given task in the current process using an internal executor.
+    ///
+    /// This function implements the main loop of the shell process. It runs the
+    /// given task while also calling [`select`](Self::select) to handle signals
+    /// and other events. The task is expected to perform I/O operations using
+    /// the methods of this `Concurrent` instance, so that it can yield when the
+    /// operations would block. The function returns the output of the task when
+    /// it completes.
+    ///
+    /// The task is run on an internal executor ([`yash_executor::Executor`])
+    /// created for this method, which is separate from any executor that may be
+    /// used by the caller. This executor is not thread-safe, so the task must
+    /// not pass any [`Waker`]s provided by the task context to other threads.
+    ///
+    /// The future returned by this method will be pending if and only if the
+    /// future returned by the internal system's [`select`](Select::select)
+    /// method is pending. For use with [`RealSystem`], the
+    /// [`run_sync`](Self::run_sync) method may be more convenient, which works
+    /// synchronously.
+    pub async fn run<F, T>(&self, task: F) -> T
+    where
+        F: Future<Output = T>,
+    {
+        let executor = yash_executor::Executor::new();
+
+        // SAFETY: We never create new threads in the whole process, so wakers
+        // are never shared between threads.
+        let mut receiver = pin!(unsafe { executor.spawn(task) });
+
+        loop {
+            executor.run_until_stalled();
+
+            if let Ready(result) = receiver
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+            {
+                return result;
+            }
+
+            self.select().await;
         }
     }
 }
@@ -516,6 +569,39 @@ impl SignalList {
     }
 }
 
+#[cfg(unix)]
+impl Concurrent<RealSystem> {
+    /// Runs the given task in the current process using an internal executor.
+    ///
+    /// This function implements the main loop of the shell process. It runs the
+    /// given task while also calling [`select`](Self::select) to handle signals
+    /// and other events. The task is expected to perform I/O operations using
+    /// the methods of this `Concurrent` instance, so that it can yield when the
+    /// operations would block. The function returns the output of the task when
+    /// it completes.
+    ///
+    /// The task is run on an internal executor ([`yash_executor::Executor`])
+    /// created for this method, which is separate from any executor that may be
+    /// used by the caller. This executor is not thread-safe, so the task must
+    /// not pass any [`Waker`]s provided by the task context to other threads.
+    ///
+    /// This method is a specialization of the more general [`run`](Self::run)
+    /// method for the case where the inner system is `RealSystem`. Since
+    /// [`RealSystem::select`] performs a real `select` system call that blocks
+    /// the entire process, this method synchronously returns the output of the
+    /// task.
+    pub fn run_sync<F, T>(&self, task: F) -> T
+    where
+        F: Future<Output = T>,
+    {
+        let future = pin!(self.run(task));
+        match future.poll(&mut Context::from_waker(Waker::noop())) {
+            Ready(result) => result,
+            Pending => unreachable!("`RealSystem::select` should never return `Pending`"),
+        }
+    }
+}
+
 mod delegates;
 mod rw_all;
 mod signal;
@@ -531,7 +617,6 @@ mod tests {
     use crate::trap::SignalSystem as _;
     use assert_matches::assert_matches;
     use futures_util::FutureExt as _;
-    use std::pin::pin;
     use std::sync::Arc;
     use std::task::Poll::{Pending, Ready};
 

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -16,14 +16,9 @@
 
 //! Items for concurrent task execution
 
-#[cfg(unix)]
-use super::real::RealSystem;
-use super::r#virtual::VirtualSystem;
 use super::{CaughtSignals, Clock, Errno, Fcntl, Read, Result, Select, Write};
 use crate::io::Fd;
-use crate::job::ProcessState;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
-use futures_util::{pending, poll};
 use std::cell::{Cell, LazyCell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::future::poll_fn;
@@ -529,114 +524,8 @@ impl SignalList {
     }
 }
 
-#[cfg(unix)]
-impl Concurrent<RealSystem> {
-    /// Runs the given task with concurrency support.
-    ///
-    /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Self::select) to handle signals
-    /// and other events. The task is expected to perform I/O operations using
-    /// the methods of this `Concurrent` instance, so that it can yield when the
-    /// operations would block. The function returns the output of the task when
-    /// it completes.
-    ///
-    /// This method supports concurrency only inside the task. Other tasks
-    /// created outside the task will not be run concurrently.
-    /// This method blocks the current thread until the task completes, so it
-    /// should only be called in the main function of the shell process.
-    /// See the [`run_virtual`](Self::run_virtual) method for the
-    /// `VirtualSystem` counterpart.
-    pub fn run_real<F, T>(&self, task: F) -> T
-    where
-        F: Future<Output = T>,
-    {
-        let runner = pin!(async move {
-            let mut task = pin!(task);
-            loop {
-                if let Ready(result) = poll!(&mut task) {
-                    return result;
-                }
-                self.select().await;
-            }
-        });
-        match runner.poll(&mut Context::from_waker(Waker::noop())) {
-            Ready(result) => result,
-            Pending => unreachable!("`RealSystem::select` should never return `Pending`"),
-        }
-    }
-}
-
-impl Concurrent<VirtualSystem> {
-    /// Runs the given task with concurrency support.
-    ///
-    /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Self::select) to handle signals
-    /// and other events. The task is expected to perform I/O operations using
-    /// the methods of this `Concurrent` instance, so that it can yield when the
-    /// operations would block. The function returns the output of the task when
-    /// it completes.
-    ///
-    /// This is the `VirtualSystem` counterpart for the
-    /// [`run_real`](Self::run_real) method. To allow `VirtualSystem` to run
-    /// multiple tasks concurrently, this method is asynchronous and returns a
-    /// future that completes when the task finishes or the process is
-    /// terminated.
-    pub async fn run_virtual<F>(&self, task: F)
-    where
-        F: Future<Output = ()>,
-    {
-        let mut task = pin!(task);
-        while poll!(&mut task).is_pending() {
-            let state = self.inner.current_process().state();
-            match state {
-                ProcessState::Running => {
-                    // The process is running, but the task is not ready yet, so we need to wait
-                    // for it to become ready. Proceed to the `select` call below.
-                }
-                ProcessState::Halted(result) => {
-                    if result.is_stopped() {
-                        // The process is stopped while the task is still working.
-                        let terminated = self.inner.block_while_stopped().await;
-                        if !terminated {
-                            // The process has been resumed, so we can continue running the task.
-                            continue;
-                        }
-                    }
-                    // The process has been terminated, so we simply abort the task.
-                    return;
-                }
-            }
-
-            let mut select = pin!(self.select());
-            while poll!(&mut select).is_pending() {
-                let state = self.inner.current_process().state();
-                match state {
-                    ProcessState::Running => {
-                        // The process is running, but the select call is not ready yet, so we need
-                        // to wait for it to become ready. Here we propagate the pending state to
-                        // the caller to yield to other processes.
-                        pending!()
-                    }
-                    ProcessState::Halted(result) => {
-                        if result.is_stopped() {
-                            // The process is stopped while we are waiting for the select call.
-                            let terminated = self.inner.block_while_stopped().await;
-                            if !terminated {
-                                // The process has been resumed, so we can continue waiting
-                                // for the select call.
-                                continue;
-                            }
-                        }
-                        // The process has been terminated, so we simply abort the task.
-                        return;
-                    }
-                }
-            }
-        }
-    }
-}
-
 mod delegates;
+mod run;
 mod rw_all;
 mod signal;
 
@@ -646,7 +535,7 @@ mod tests {
         Close as _, Disposition, Mode, OfdAccess, Open as _, OpenFlag, Pipe as _, SendSignal,
     };
     use super::*;
-    use crate::system::r#virtual::{PIPE_SIZE, SIGCHLD, SIGINT, SIGUSR2};
+    use crate::system::r#virtual::{PIPE_SIZE, SIGCHLD, SIGINT, SIGUSR2, VirtualSystem};
     use crate::test_helper::WakeFlag;
     use crate::trap::SignalSystem as _;
     use assert_matches::assert_matches;

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -21,6 +21,7 @@ use super::real::RealSystem;
 use super::{CaughtSignals, Clock, Errno, Fcntl, Read, Result, Select, Write};
 use crate::io::Fd;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
+use futures_util::poll;
 use std::cell::{Cell, LazyCell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::future::poll_fn;
@@ -438,7 +439,7 @@ where
         }
     }
 
-    /// Runs the given task in the current process using an internal executor.
+    /// Runs the given task with concurrency support.
     ///
     /// This function implements the main loop of the shell process. It runs the
     /// given task while also calling [`select`](Self::select) to handle signals
@@ -446,11 +447,6 @@ where
     /// the methods of this `Concurrent` instance, so that it can yield when the
     /// operations would block. The function returns the output of the task when
     /// it completes.
-    ///
-    /// The task is run on an internal executor ([`yash_executor::Executor`])
-    /// created for this method, which is separate from any executor that may be
-    /// used by the caller. This executor is not thread-safe, so the task must
-    /// not pass any [`Waker`]s provided by the task context to other threads.
     ///
     /// The future returned by this method will be pending if and only if the
     /// future returned by the internal system's [`select`](Select::select)
@@ -461,22 +457,11 @@ where
     where
         F: Future<Output = T>,
     {
-        let executor = yash_executor::Executor::new();
-
-        // SAFETY: We never create new threads in the whole process, so wakers
-        // are never shared between threads.
-        let mut receiver = pin!(unsafe { executor.spawn(task) });
-
+        let mut task = pin!(task);
         loop {
-            executor.run_until_stalled();
-
-            if let Ready(result) = receiver
-                .as_mut()
-                .poll(&mut Context::from_waker(Waker::noop()))
-            {
+            if let Ready(result) = poll!(&mut task) {
                 return result;
             }
-
             self.select().await;
         }
     }
@@ -571,7 +556,7 @@ impl SignalList {
 
 #[cfg(unix)]
 impl Concurrent<RealSystem> {
-    /// Runs the given task in the current process using an internal executor.
+    /// Runs the given task with concurrency support.
     ///
     /// This function implements the main loop of the shell process. It runs the
     /// given task while also calling [`select`](Self::select) to handle signals
@@ -579,11 +564,6 @@ impl Concurrent<RealSystem> {
     /// the methods of this `Concurrent` instance, so that it can yield when the
     /// operations would block. The function returns the output of the task when
     /// it completes.
-    ///
-    /// The task is run on an internal executor ([`yash_executor::Executor`])
-    /// created for this method, which is separate from any executor that may be
-    /// used by the caller. This executor is not thread-safe, so the task must
-    /// not pass any [`Waker`]s provided by the task context to other threads.
     ///
     /// This method is a specialization of the more general [`run`](Self::run)
     /// method for the case where the inner system is `RealSystem`. Since

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -46,7 +46,7 @@ use std::time::{Duration, Instant};
 /// For system calls that do not block, such as [`Pipe`], the wrapper directly
 /// forwards the call to the inner system without any modification.
 ///
-/// This struct is designed to be used in an `Rc` to allow multiple tasks to
+/// This struct is designed to be used in an [`Rc`] to allow multiple tasks to
 /// share the same concurrent system. Some traits, such as [`Read`] and
 /// [`Write`], are implemented for `Rc<Concurrent<S>>` instead of
 /// `Concurrent<S>` to allow the methods to return futures that capture a clone
@@ -54,6 +54,44 @@ use std::time::{Duration, Instant};
 /// necessary because the futures need to access the internal state of the
 /// `Concurrent` system without capturing a reference to the original
 /// `Concurrent` struct, which may not live long enough.
+///
+/// The following example illustrates how multiple concurrent tasks are run in a
+/// single-threaded pool:
+///
+/// ```
+/// # use std::rc::Rc;
+/// # use yash_env::system::{Concurrent, Pipe as _, Read as _, Write as _};
+/// # use yash_env::VirtualSystem;
+/// # use futures_util::task::LocalSpawnExt as _;
+/// let system = Rc::new(Concurrent::new(VirtualSystem::new()));
+/// let system2 = system.clone();
+/// let system3 = system.clone();
+/// let (reader, writer) = system.pipe().unwrap();
+/// let mut executor = futures_executor::LocalPool::new();
+///
+/// // We add a task that tries to read from the pipe, but nothing has been
+/// // written to it, so the task is stalled.
+/// let read_task = executor.spawner().spawn_local_with_handle(async move {
+///     let mut buffer = [0; 1];
+///     system.read(reader, &mut buffer).await.unwrap();
+///     buffer[0]
+/// });
+/// executor.run_until_stalled();
+///
+/// // Let's add a task that writes to the pipe.
+/// executor.spawner().spawn_local(async move {
+///     system2.write_all(writer, &[123]).await.unwrap();
+/// });
+/// executor.run_until_stalled();
+///
+/// // The write task has written a byte to the pipe, but the read task is still
+/// // stalled. We need to wake it up by calling `select` or `peek`.
+/// system3.peek();
+///
+/// // Now the read task can proceed to the end.
+/// let number = executor.run_until(read_task.unwrap());
+/// assert_eq!(number, 123);
+/// ```
 ///
 /// [`Pipe`]: super::Pipe
 #[derive(Clone, Debug, Default)]

--- a/yash-env/src/system/concurrency/run.rs
+++ b/yash-env/src/system/concurrency/run.rs
@@ -1,0 +1,135 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Methods for running tasks with concurrency
+
+#[cfg(unix)]
+use super::super::real::RealSystem;
+use super::super::r#virtual::VirtualSystem;
+use super::Concurrent;
+use crate::job::ProcessState;
+use futures_util::{pending, poll};
+use std::pin::pin;
+
+#[cfg(unix)]
+impl Concurrent<RealSystem> {
+    /// Runs the given task with concurrency support.
+    ///
+    /// This function implements the main loop of the shell process. It runs the
+    /// given task while also calling [`select`](Self::select) to handle signals
+    /// and other events. The task is expected to perform I/O operations using
+    /// the methods of this `Concurrent` instance, so that it can yield when the
+    /// operations would block. The function returns the output of the task when
+    /// it completes.
+    ///
+    /// This method supports concurrency only inside the task. Other tasks
+    /// created outside the task will not be run concurrently.
+    /// This method blocks the current thread until the task completes, so it
+    /// should only be called in the main function of the shell process.
+    /// See the [`run_virtual`](Self::run_virtual) method for the
+    /// `VirtualSystem` counterpart.
+    pub fn run_real<F, T>(&self, task: F) -> T
+    where
+        F: Future<Output = T>,
+    {
+        use std::task::Poll::{Pending, Ready};
+        use std::task::{Context, Waker};
+
+        let runner = pin!(async move {
+            let mut task = pin!(task);
+            loop {
+                if let Ready(result) = poll!(&mut task) {
+                    return result;
+                }
+                self.select().await;
+            }
+        });
+        match runner.poll(&mut Context::from_waker(Waker::noop())) {
+            Ready(result) => result,
+            Pending => unreachable!("`RealSystem::select` should never return `Pending`"),
+        }
+    }
+}
+
+impl Concurrent<VirtualSystem> {
+    /// Runs the given task with concurrency support.
+    ///
+    /// This function implements the main loop of the shell process. It runs the
+    /// given task while also calling [`select`](Self::select) to handle signals
+    /// and other events. The task is expected to perform I/O operations using
+    /// the methods of this `Concurrent` instance, so that it can yield when the
+    /// operations would block. The function returns the output of the task when
+    /// it completes.
+    ///
+    /// This is the `VirtualSystem` counterpart for the
+    /// [`run_real`](Self::run_real) method. To allow `VirtualSystem` to run
+    /// multiple tasks concurrently, this method is asynchronous and returns a
+    /// future that completes when the task finishes or the process is
+    /// terminated.
+    pub async fn run_virtual<F>(&self, task: F)
+    where
+        F: Future<Output = ()>,
+    {
+        let mut task = pin!(task);
+        while poll!(&mut task).is_pending() {
+            let state = self.inner.current_process().state();
+            match state {
+                ProcessState::Running => {
+                    // The process is running, but the task is not ready yet, so we need to wait
+                    // for it to become ready. Proceed to the `select` call below.
+                }
+                ProcessState::Halted(result) => {
+                    if result.is_stopped() {
+                        // The process is stopped while the task is still working.
+                        let terminated = self.inner.block_while_stopped().await;
+                        if !terminated {
+                            // The process has been resumed, so we can continue running the task.
+                            continue;
+                        }
+                    }
+                    // The process has been terminated, so we simply abort the task.
+                    return;
+                }
+            }
+
+            let mut select = pin!(self.select());
+            while poll!(&mut select).is_pending() {
+                let state = self.inner.current_process().state();
+                match state {
+                    ProcessState::Running => {
+                        // The process is running, but the select call is not ready yet, so we need
+                        // to wait for it to become ready. Here we propagate the pending state to
+                        // the caller to yield to other processes.
+                        pending!()
+                    }
+                    ProcessState::Halted(result) => {
+                        if result.is_stopped() {
+                            // The process is stopped while we are waiting for the select call.
+                            let terminated = self.inner.block_while_stopped().await;
+                            if !terminated {
+                                // The process has been resumed, so we can continue waiting
+                                // for the select call.
+                                continue;
+                            }
+                        }
+                        // The process has been terminated, so we simply abort the task.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/yash-env/src/system/concurrency/run.rs
+++ b/yash-env/src/system/concurrency/run.rs
@@ -133,3 +133,328 @@ impl Concurrent<VirtualSystem> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    mod real_system {
+        use super::*;
+        use std::cell::Cell;
+        use std::time::Duration;
+
+        #[test]
+        fn run_real_returns_task_output_immediately_if_ready_on_first_poll() {
+            let system = Concurrent::new(unsafe { RealSystem::new() });
+            let result = system.run_real(async { 42 });
+            assert_eq!(result, 42);
+        }
+
+        #[test]
+        fn run_real_keeps_polling_task_until_completion_when_task_yields_multiple_times() {
+            let system = Concurrent::new(unsafe { RealSystem::new() });
+            let progress = Cell::new(0);
+
+            let result = system.run_real(async {
+                progress.set(1);
+                system.sleep(Duration::from_millis(1)).await;
+                progress.set(2);
+                system.sleep(Duration::from_millis(1)).await;
+                progress.set(3);
+                42
+            });
+
+            assert_eq!(result, 42);
+            assert_eq!(progress.get(), 3);
+        }
+
+        #[test]
+        fn run_real_calls_select_between_task_polls_while_task_is_pending() {
+            let system = Concurrent::new(unsafe { RealSystem::new() });
+            let progress = Cell::new(0);
+
+            let result = system.run_real(async {
+                progress.set(1);
+                system.sleep(Duration::from_millis(1)).await;
+                progress.set(2);
+                7
+            });
+
+            assert_eq!(result, 7);
+            assert_eq!(progress.get(), 2);
+        }
+
+        #[test]
+        #[should_panic = "boom"]
+        fn run_real_propagates_task_panic_to_caller() {
+            let system = Concurrent::new(unsafe { RealSystem::new() });
+            system.run_real(async { panic!("boom") })
+        }
+    }
+
+    mod virtual_system {
+        use super::*;
+        use crate::semantics::ExitStatus;
+        use crate::system::r#virtual::{SIGCONT, SIGKILL, SIGSTOP};
+        use crate::system::{Exit as _, SendSignal as _};
+        use crate::test_helper::WakeFlag;
+        use futures_util::FutureExt as _;
+        use std::cell::Cell;
+        use std::rc::Rc;
+        use std::sync::Arc;
+        use std::task::Poll::{Pending, Ready};
+        use std::task::{Context, Waker};
+        use std::time::{Duration, Instant};
+
+        struct DropFlag(Rc<Cell<bool>>);
+
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        fn virtual_system_with_current_time() -> (Concurrent<VirtualSystem>, Instant) {
+            let inner = VirtualSystem::new();
+            let now = Instant::now();
+            inner.state.borrow_mut().now = Some(now);
+            (Concurrent::new(inner), now)
+        }
+
+        #[test]
+        fn run_virtual_returns_immediately_when_task_is_ready_on_first_poll() {
+            let system = Concurrent::new(VirtualSystem::new());
+            let completed = Cell::new(false);
+
+            let result = system
+                .run_virtual(async { completed.set(true) })
+                .now_or_never();
+
+            assert_eq!(result, Some(()));
+            assert!(completed.get());
+        }
+
+        #[test]
+        fn run_virtual_completes_normally_when_task_alternates_between_pending_and_ready() {
+            let (system, now) = virtual_system_with_current_time();
+            let progress = Rc::new(Cell::new(0));
+            let progress_2 = Rc::clone(&progress);
+            let mut future = pin!(system.run_virtual(async {
+                progress_2.set(1);
+                system.sleep(Duration::from_secs(1)).await;
+                progress_2.set(2);
+                system.sleep(Duration::from_secs(1)).await;
+                progress_2.set(3);
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert_eq!(progress.get(), 1);
+
+            system
+                .inner
+                .state
+                .borrow_mut()
+                .advance_time(now + Duration::from_secs(1));
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert_eq!(progress.get(), 2);
+
+            system
+                .inner
+                .state
+                .borrow_mut()
+                .advance_time(now + Duration::from_secs(2));
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert_eq!(progress.get(), 3);
+        }
+
+        #[test]
+        fn run_virtual_waits_on_select_while_process_is_running_and_task_is_pending() {
+            let (system, now) = virtual_system_with_current_time();
+            let completed = Rc::new(Cell::new(false));
+            let completed_2 = Rc::clone(&completed);
+            let mut future = pin!(system.run_virtual(async {
+                system.sleep(Duration::from_secs(1)).await;
+                completed_2.set(true);
+            }));
+
+            let wake_flag = Arc::new(WakeFlag::new());
+            let waker = Waker::from(Arc::clone(&wake_flag));
+            let mut context = Context::from_waker(&waker);
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!completed.get());
+            assert!(!wake_flag.is_woken());
+
+            system
+                .inner
+                .state
+                .borrow_mut()
+                .advance_time(now + Duration::from_secs(1));
+            assert!(wake_flag.is_woken());
+
+            let wake_flag = Arc::new(WakeFlag::new());
+            let waker = Waker::from(Arc::clone(&wake_flag));
+            let mut context = Context::from_waker(&waker);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(completed.get());
+            assert!(!wake_flag.is_woken());
+        }
+
+        #[test]
+        fn run_virtual_yields_pending_to_caller_while_waiting_on_pending_select_in_running_state() {
+            let (system, _now) = virtual_system_with_current_time();
+            let completed = Rc::new(Cell::new(false));
+            let completed_2 = Rc::clone(&completed);
+            let mut future = pin!(system.run_virtual(async {
+                system.sleep(Duration::from_secs(1)).await;
+                completed_2.set(true);
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!completed.get());
+        }
+
+        #[test]
+        fn run_virtual_aborts_task_when_process_is_already_terminated_before_entering_select() {
+            let system = Concurrent::new(VirtualSystem::new());
+            let dropped = Rc::new(Cell::new(false));
+            let dropped_2 = Rc::clone(&dropped);
+            let mut future = pin!(system.run_virtual(async {
+                let _drop_flag = DropFlag(dropped_2);
+                system.exit(ExitStatus(42)).await;
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(dropped.get());
+        }
+
+        #[test]
+        fn run_virtual_blocks_while_stopped_before_select_and_resumes_task_when_process_is_continued()
+         {
+            let system = Concurrent::new(VirtualSystem::new());
+            let completed = Rc::new(Cell::new(false));
+            let mut future = pin!(system.run_virtual(async {
+                system.raise(SIGSTOP).await.unwrap();
+                completed.set(true);
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert_eq!(
+                system.inner.current_process().state(),
+                ProcessState::stopped(SIGSTOP),
+            );
+            assert!(!completed.get());
+
+            _ = system.inner.current_process_mut().raise_signal(SIGCONT);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(completed.get());
+        }
+
+        #[test]
+        fn run_virtual_blocks_while_stopped_before_select_and_aborts_when_process_terminates() {
+            let system = Concurrent::new(VirtualSystem::new());
+            let dropped = Rc::new(Cell::new(false));
+            let dropped_2 = Rc::clone(&dropped);
+            let mut future = pin!(system.run_virtual(async {
+                let _drop_flag = DropFlag(dropped_2);
+                system.raise(SIGSTOP).await.unwrap();
+                unreachable!("task should be aborted while stopped");
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!dropped.get());
+
+            _ = system.inner.current_process_mut().raise_signal(SIGKILL);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(dropped.get());
+        }
+
+        #[test]
+        fn run_virtual_blocks_while_stopped_during_pending_select_and_continues_waiting_after_resume()
+         {
+            let (system, now) = virtual_system_with_current_time();
+            let completed = Rc::new(Cell::new(false));
+            let completed_2 = Rc::clone(&completed);
+            let mut future = pin!(system.run_virtual(async {
+                system.sleep(Duration::from_secs(1)).await;
+                completed_2.set(true);
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+
+            _ = system
+                .inner
+                .current_process_mut()
+                .set_state(ProcessState::stopped(SIGSTOP));
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!completed.get());
+
+            system
+                .inner
+                .state
+                .borrow_mut()
+                .advance_time(now + Duration::from_secs(1));
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!completed.get());
+
+            _ = system
+                .inner
+                .current_process_mut()
+                .set_state(ProcessState::Running);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(completed.get());
+        }
+
+        #[test]
+        fn run_virtual_blocks_while_stopped_during_pending_select_and_aborts_when_terminated() {
+            let (system, _now) = virtual_system_with_current_time();
+            let dropped = Rc::new(Cell::new(false));
+            let mut future = pin!(system.run_virtual(async {
+                let _drop_flag = DropFlag(Rc::clone(&dropped));
+                system.sleep(Duration::from_secs(1)).await;
+                unreachable!("task should be aborted while sleeping");
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+
+            _ = system
+                .inner
+                .current_process_mut()
+                .set_state(ProcessState::stopped(SIGSTOP));
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!dropped.get());
+
+            _ = system.inner.current_process_mut().raise_signal(SIGKILL);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(dropped.get());
+        }
+
+        #[test]
+        fn run_virtual_aborts_immediately_when_process_becomes_terminated_while_waiting_on_pending_select()
+         {
+            let (system, _now) = virtual_system_with_current_time();
+            let dropped = Rc::new(Cell::new(false));
+            let mut future = pin!(system.run_virtual(async {
+                let _drop_flag = DropFlag(Rc::clone(&dropped));
+                system.sleep(Duration::from_secs(1)).await;
+                unreachable!("task should be aborted while sleeping");
+            }));
+
+            let mut context = Context::from_waker(Waker::noop());
+            assert_eq!(future.as_mut().poll(&mut context), Pending);
+            assert!(!dropped.get());
+
+            _ = system.inner.current_process_mut().raise_signal(SIGKILL);
+            assert_eq!(future.as_mut().poll(&mut context), Ready(()));
+            assert!(dropped.get());
+        }
+    }
+}

--- a/yash-env/src/system/future.rs
+++ b/yash-env/src/system/future.rs
@@ -29,11 +29,11 @@ use std::task::{Context, Poll};
 /// allocation if the future is already known to be ready.
 ///
 /// This type does not have a lifetime parameter, so the contained future must
-/// have a `'static` lifetime. This is because `FlexFuture` is also used in
+/// have a `'static` lifetime. ~~This is because `FlexFuture` is also used in
 /// [`SharedSystem`](super::SharedSystem), which performs dynamic lifetime
 /// checking to access its internal state guarded by a `RefCell`. Instead of
 /// borrowing the system, the future must share ownership of the system to keep
-/// it alive until the future is resolved.
+/// it alive until the future is resolved.~~
 #[deprecated(note = "FlexFuture is no longer used in this crate", since = "0.12.0")]
 pub enum FlexFuture<T> {
     /// Future that is already ready with a value

--- a/yash-env/src/system/io.rs
+++ b/yash-env/src/system/io.rs
@@ -164,9 +164,11 @@ pub trait Read {
     /// simulating blocking I/O in [virtual systems](super::virtual). In the
     /// [real system](super::real), this function does not work asynchronously
     /// and returns a ready `Future` with the result of the underlying system
-    /// call. See the [module-level documentation](super) for details. Use
-    /// [`SharedSystem::read_async`](super::SharedSystem::read_async) for
-    /// concurrent read operations in an `async` function context.
+    /// call. See the [module-level documentation](super) for details.
+    ///
+    /// The implementation for [`Rc<Concurrent<_>>`](super::Concurrent) provides
+    /// asynchronous reading by using non-blocking I/O, which allows concurrent
+    /// multitasking in `async` function contexts.
     fn read<'a>(
         &self,
         fd: Fd,
@@ -200,8 +202,13 @@ pub trait Write {
     /// In the [real system](super::real), this function does not work
     /// asynchronously and returns a ready `Future` with the result of the
     /// underlying system call. See the [module-level documentation](super) for
-    /// details. Use [`SharedSystem::write_all`](super::SharedSystem::write_all)
-    /// for concurrent write operations in an `async` function context.
+    /// details.
+    ///
+    /// The implementation for [`Rc<Concurrent<_>>`](super::Concurrent) provides
+    /// asynchronous writing by using non-blocking I/O, which allows concurrent
+    /// multitasking in `async` function contexts. Use
+    /// [`Concurrent::write_all`](super::Concurrent::write_all) to write the
+    /// entire buffer.
     fn write<'a>(
         &self,
         fd: Fd,

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -113,6 +113,9 @@ use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::compiler_fence;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
 use std::time::Duration;
 use std::time::Instant;
 use yash_executor::Executor;
@@ -1006,7 +1009,10 @@ impl Fork for RealSystem {
             unsafe { executor.spawn_pinned(task) }
             loop {
                 executor.run_until_stalled();
-                system.select(false).ok();
+
+                let select_future = std::pin::pin!(system.select());
+                let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
+                debug_assert_eq!(poll, Poll::Ready(()));
             }
         }))
     }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -109,17 +109,13 @@ use std::num::NonZero;
 use std::ops::RangeInclusive;
 use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::io::IntoRawFd;
-use std::pin::{Pin, pin};
 use std::ptr::NonNull;
+use std::rc::Rc;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::compiler_fence;
-use std::task::Context;
-use std::task::Poll;
-use std::task::Waker;
 use std::time::Duration;
 use std::time::Instant;
-use yash_executor::Executor;
 
 trait ErrnoIfM1: PartialEq + Sized {
     const MINUS_1: Self;
@@ -999,42 +995,10 @@ impl Fork for RealSystem {
 
         // Child process
         Ok(Box::new(|env, task| {
-            let system = env.system.clone();
-            run_loop(&system, task(env))
+            let system = Rc::clone(&env.system);
+            match system.run_sync(task(env)) {}
         }))
     }
-}
-
-/// Runs the task in the current process using [`Executor`].
-///
-/// This function implements the main loop of the shell process. It runs the
-/// given task while also calling [`select`](super::Concurrent::select) to
-/// handle signals and other events. The task is expected to call `exit` when it
-/// finishes, so this function never returns.
-///
-/// The task must not spawn any thread because the executor is not thread-safe.
-pub fn run_loop<F>(system: &super::Concurrent<RealSystem>, task: F) -> !
-where
-    F: Future<Output = Infallible>,
-{
-    fn inner(
-        system: &super::Concurrent<RealSystem>,
-        task: Pin<Box<dyn Future<Output = ()> + '_>>,
-    ) -> ! {
-        let executor = Executor::new();
-        // SAFETY: We never create new threads in the whole process, so wakers are
-        // never shared between threads.
-        unsafe { executor.spawn_pinned(task) }
-        loop {
-            executor.run_until_stalled();
-
-            let select_future = pin!(system.select());
-            let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
-            debug_assert_eq!(poll, Poll::Ready(()));
-        }
-    }
-
-    inner(system, Box::pin(async move { match task.await {} }))
 }
 
 impl Wait for RealSystem {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -109,6 +109,7 @@ use std::num::NonZero;
 use std::ops::RangeInclusive;
 use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::io::IntoRawFd;
+use std::pin::{Pin, pin};
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering;
@@ -999,23 +1000,41 @@ impl Fork for RealSystem {
         // Child process
         Ok(Box::new(|env, task| {
             let system = env.system.clone();
-            // Here we create a new executor to run the task. This makes sure that any
-            // other concurrent tasks in the parent process do not interfere with the
-            // child process.
-            let executor = Executor::new();
-            let task = Box::pin(async move { match task(env).await {} });
-            // SAFETY: We never create new threads in the whole process, so wakers are
-            // never shared between threads.
-            unsafe { executor.spawn_pinned(task) }
-            loop {
-                executor.run_until_stalled();
-
-                let select_future = std::pin::pin!(system.select());
-                let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
-                debug_assert_eq!(poll, Poll::Ready(()));
-            }
+            run_loop(&system, task(env))
         }))
     }
+}
+
+/// Runs the task in the current process using [`Executor`].
+///
+/// This function implements the main loop of the shell process. It runs the
+/// given task while also calling [`select`](super::Concurrent::select) to
+/// handle signals and other events. The task is expected to call `exit` when it
+/// finishes, so this function never returns.
+///
+/// The task must not spawn any thread because the executor is not thread-safe.
+pub fn run_loop<F>(system: &super::Concurrent<RealSystem>, task: F) -> !
+where
+    F: Future<Output = Infallible>,
+{
+    fn inner(
+        system: &super::Concurrent<RealSystem>,
+        task: Pin<Box<dyn Future<Output = ()> + '_>>,
+    ) -> ! {
+        let executor = Executor::new();
+        // SAFETY: We never create new threads in the whole process, so wakers are
+        // never shared between threads.
+        unsafe { executor.spawn_pinned(task) }
+        loop {
+            executor.run_until_stalled();
+
+            let select_future = pin!(system.select());
+            let poll = select_future.poll(&mut Context::from_waker(Waker::noop()));
+            debug_assert_eq!(poll, Poll::Ready(()));
+        }
+    }
+
+    inner(system, Box::pin(async move { match task.await {} }))
 }
 
 impl Wait for RealSystem {

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -996,7 +996,7 @@ impl Fork for RealSystem {
         // Child process
         Ok(Box::new(|env, task| {
             let system = Rc::clone(&env.system);
-            match system.run_sync(task(env)) {}
+            match system.run_real(task(env)) {}
         }))
     }
 }

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -19,10 +19,10 @@
 use super::Disposition;
 use super::Errno;
 use super::Result;
-#[cfg(doc)]
-use super::SharedSystem;
 use super::SigmaskOp;
 use super::signal;
+#[cfg(doc)]
+use super::{Concurrent, SharedSystem};
 use crate::io::Fd;
 use crate::system::{CaughtSignals, Clock, Sigaction, Sigmask, Signals};
 use std::cell::RefCell;
@@ -44,11 +44,9 @@ use std::time::Instant;
 pub trait Select: Signals {
     /// Waits for a next event.
     ///
-    /// This is a low-level function used internally by
-    /// [`SharedSystem::select`]. You should not call this function directly, or
-    /// you will disrupt the behavior of `SharedSystem`. The description below
-    /// applies if you want to do everything yourself without depending on
-    /// `SharedSystem`.
+    /// In a typical configuration, this trait is not used directly. Instead,
+    /// it is used by [`Concurrent`] and [`SharedSystem`] to implement
+    /// asynchronous I/O, signal handling, and timer functions.
     ///
     /// This function blocks the calling thread until one of the following
     /// condition is met:

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -380,6 +380,26 @@ impl<S> SharedSystem<S> {
         }
     }
 
+    /// Waits for a next event to occur.
+    ///
+    /// This function calls [`Select::select`] with arguments computed from the
+    /// current internal state of the `SharedSystem`. It will wake up tasks
+    /// waiting for the file descriptor to be ready in
+    /// [`read_async`](Self::read_async) and [`write_all`](Self::write_all) or
+    /// for a signal to be caught in [`wait_for_signal`](Self::wait_for_signal).
+    /// If no tasks are woken for FDs or signals and `poll` is false, this
+    /// function simulates blocking by returning `Pending` from the returned
+    /// future until the first task waiting for a specific time point is woken.
+    ///
+    /// This function may wake up a task even if the condition it is expecting
+    /// has not yet been met.
+    pub async fn select_async(&self) -> Result<()>
+    where
+        S: Select + CaughtSignals + Clock,
+    {
+        SelectSystem::select(&self.0, false).await
+    }
+
     /// Creates a new child process.
     ///
     /// See [`Fork::new_child_process`] for details.

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -148,14 +148,7 @@ use std::time::Instant;
 /// assert_eq!(number, 123);
 /// ```
 ///
-/// If there is a child process in the [`VirtualSystem`], you should call
-/// [`SystemState::select_all`](super::virtual::SystemState::select_all) in
-/// addition to [`SharedSystem::select`] so that the child process task is woken
-/// up when needed.
-/// (TBD code example)
-///
 /// [`System`]: crate::system::System
-/// [`VirtualSystem`]: crate::system::virtual::VirtualSystem
 #[derive(Debug)]
 pub struct SharedSystem<S>(pub(super) Rc<RefCell<SelectSystem<S>>>);
 
@@ -387,9 +380,9 @@ impl<S> SharedSystem<S> {
     /// waiting for the file descriptor to be ready in
     /// [`read_async`](Self::read_async) and [`write_all`](Self::write_all) or
     /// for a signal to be caught in [`wait_for_signal`](Self::wait_for_signal).
-    /// If no tasks are woken for FDs or signals and `poll` is false, this
-    /// function simulates blocking by returning `Pending` from the returned
-    /// future until the first task waiting for a specific time point is woken.
+    /// If no tasks are woken for FDs or signals, this function simulates
+    /// blocking by returning `Pending` from the returned future until the first
+    /// task waiting for a specific time point is woken.
     ///
     /// This function may wake up a task even if the condition it is expecting
     /// has not yet been met.

--- a/yash-env/src/system/signal.rs
+++ b/yash-env/src/system/signal.rs
@@ -17,7 +17,7 @@
 //! Signal-related functionality for the system module
 
 #[cfg(doc)]
-use super::SharedSystem;
+use super::{Concurrent, SharedSystem};
 use super::{Pid, Result};
 pub use crate::signal::{Name, Number, RawNumber};
 use std::borrow::Cow;
@@ -460,10 +460,9 @@ pub enum SigmaskOp {
 pub trait Sigmask: Signals {
     /// Gets and/or sets the signal blocking mask.
     ///
-    /// This is a low-level function used internally by [`SharedSystem`]. You
-    /// should not call this function directly, or you will disrupt the behavior
-    /// of `SharedSystem`. The description below applies if you want to do
-    /// everything yourself without depending on `SharedSystem`.
+    /// This trait is usually not used directly. Instead, it is used by
+    /// [`Concurrent`] and [`SharedSystem`] to configure signal handling
+    /// behavior of the process.
     ///
     /// This is a thin wrapper around the [`sigprocmask` system
     /// call](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_sigmask.html).
@@ -517,12 +516,6 @@ pub enum Disposition {
 pub trait GetSigaction: Signals {
     /// Gets the disposition for a signal.
     ///
-    /// This is a low-level function used internally by
-    /// [`SharedSystem`]. You should not call this function directly, or you
-    /// will leave the `SharedSystem` instance in an inconsistent state. The
-    /// description below applies if you want to do everything yourself without
-    /// depending on `SharedSystem`.
-    ///
     /// This is an abstract wrapper around the [`sigaction` system
     /// call](https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaction.html).
     /// This function returns the current disposition if successful.
@@ -543,11 +536,9 @@ impl<S: GetSigaction> GetSigaction for Rc<S> {
 pub trait Sigaction: GetSigaction {
     /// Gets and sets the disposition for a signal.
     ///
-    /// This is a low-level function used internally by [`SharedSystem`]. You
-    /// should not call this function directly, or you will leave the
-    /// `SharedSystem` instance in an inconsistent state. The description below
-    /// applies if you want to do everything yourself without depending on
-    /// `SharedSystem`.
+    /// This trait is usually not used directly. Instead, it is used by
+    /// [`Concurrent`] and [`SharedSystem`] to configure signal handling
+    /// behavior of the process.
     ///
     /// This is an abstract wrapper around the [`sigaction` system
     /// call](https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaction.html).
@@ -577,11 +568,9 @@ impl<S: Sigaction> Sigaction for Rc<S> {
 pub trait CaughtSignals: Signals {
     /// Returns signals this process has caught, if any.
     ///
-    /// This is a low-level function used internally by
-    /// [`SharedSystem::select`]. You should not call this function directly, or
-    /// you will disrupt the behavior of `SharedSystem`. The description below
-    /// applies if you want to do everything yourself without depending on
-    /// `SharedSystem`.
+    /// This trait is usually not used directly. Instead, it is used by
+    /// [`Concurrent`] and [`SharedSystem`] to collect signals caught by the
+    /// process.
     ///
     /// Implementors of this trait usually also implement [`Sigaction`] to allow
     /// setting which signals are caught.

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -154,11 +154,9 @@ use std::future::pending;
 use std::future::poll_fn;
 use std::future::ready;
 use std::io::SeekFrom;
-use std::ops::DerefMut as _;
 use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::Context;
 use std::task::Poll;
 use std::task::Waker;
 use std::time::Duration;
@@ -372,6 +370,28 @@ impl VirtualSystem {
                     }
                     Poll::Pending
                 }
+            }
+        })
+        .await
+    }
+
+    /// Blocks the calling thread while the current process is stopped.
+    ///
+    /// Returns `true` if the process has terminated, or `false` if it has resumed.
+    /// **Panics** if the process is not found in the system state.
+    pub(crate) async fn block_while_stopped(&self) -> bool {
+        let waker = Rc::new(Cell::new(None));
+
+        poll_fn(|cx| {
+            let mut process = self.current_process_mut();
+            match process.state() {
+                ProcessState::Running => Poll::Ready(false),
+                ProcessState::Halted(process_result) if process_result.is_stopped() => {
+                    waker.set(Some(cx.waker().clone()));
+                    process.wake_on_resumption(Rc::downgrade(&waker));
+                    Poll::Pending
+                }
+                ProcessState::Halted(_) => Poll::Ready(true),
             }
         })
         .await
@@ -1152,18 +1172,14 @@ impl Fork for VirtualSystem {
         Ok(Box::new(move |parent_env, task| {
             let system = VirtualSystem { state, process_id };
             let mut child_env = parent_env.clone_with_system(system.clone());
+            let concurrent = Rc::clone(&child_env.system);
 
-            let run_task_and_set_exit_status = Box::pin(async move {
-                let runner = ProcessRunner {
-                    task: task(&mut child_env),
-                    system,
-                    waker: Rc::new(Cell::new(None)),
-                };
-                runner.await;
-            });
-
+            let task_runner = async move {
+                let task = async move { match task(&mut child_env).await {} };
+                concurrent.run_virtual(task).await
+            };
             executor
-                .spawn(run_task_and_set_exit_status)
+                .spawn(Box::pin(task_runner))
                 .expect("the executor failed to start the child process task");
 
             process_id
@@ -1517,51 +1533,6 @@ pub trait Executor: Debug {
         &self,
         task: Pin<Box<dyn Future<Output = ()>>>,
     ) -> std::result::Result<(), Box<dyn std::error::Error>>;
-}
-
-/// Concurrent task that manages the execution of a process.
-///
-/// This struct is a helper for [`VirtualSystem::new_child_process`].
-/// It basically runs the given task, but pauses or cancels it depending on
-/// the state of the process.
-struct ProcessRunner<'a> {
-    task: Pin<Box<dyn Future<Output = Infallible> + 'a>>,
-    system: VirtualSystem,
-
-    /// Waker that is woken up when the process is resumed.
-    waker: Rc<Cell<Option<Waker>>>,
-}
-
-impl Future for ProcessRunner<'_> {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        let this = self.deref_mut();
-
-        let process_state = this.system.current_process().state;
-        if process_state == ProcessState::Running {
-            // Let the task make progress
-            let poll = this.task.as_mut().poll(cx);
-            match poll {
-                // unreachable: Poll::Ready(_) => todo!(),
-                Poll::Pending => (),
-            }
-        }
-
-        let mut process = this.system.current_process_mut();
-        match process.state {
-            ProcessState::Running => Poll::Pending,
-            ProcessState::Halted(result) => {
-                if result.is_stopped() {
-                    this.waker.set(Some(cx.waker().clone()));
-                    process.wake_on_resumption(Rc::downgrade(&this.waker));
-                    Poll::Pending
-                } else {
-                    Poll::Ready(())
-                }
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1153,11 +1153,6 @@ impl Fork for VirtualSystem {
             let system = VirtualSystem { state, process_id };
             let mut child_env = parent_env.clone_with_system(system.clone());
 
-            {
-                let mut process = system.current_process_mut();
-                process.selector = Rc::downgrade(&child_env.system.0);
-            }
-
             let run_task_and_set_exit_status = Box::pin(async move {
                 let runner = ProcessRunner {
                     task: task(&mut child_env),
@@ -2888,7 +2883,7 @@ mod tests {
         system.sigaction(SIGCHLD, Disposition::Catch).unwrap();
 
         let child_process = system.new_child_process().unwrap();
-
+        let system2 = system.clone();
         let mut env = Env::with_system(system);
         let _pid = child_process(
             &mut env,
@@ -2896,7 +2891,7 @@ mod tests {
         );
         executor.run_until_stalled();
 
-        assert_eq!(env.system.caught_signals(), [SIGCHLD]);
+        assert_eq!(system2.current_process().caught_signals, [SIGCHLD]);
     }
 
     #[test]
@@ -2987,7 +2982,7 @@ mod tests {
         system.sigaction(SIGCHLD, Disposition::Catch).unwrap();
 
         let child_process = system.new_child_process().unwrap();
-
+        let system2 = system.clone();
         let mut env = Env::with_system(system);
         let _pid = child_process(
             &mut env,
@@ -2995,7 +2990,7 @@ mod tests {
         );
         executor.run_until_stalled();
 
-        assert_eq!(env.system.caught_signals(), [SIGCHLD]);
+        assert_eq!(system2.current_process().caught_signals, [SIGCHLD]);
     }
 
     #[test]

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1444,6 +1444,16 @@ impl SystemState {
     ///
     /// The `RefCell` must not have been borrowed, or this function will panic
     /// with a double borrow.
+    ///
+    /// # Deprecation
+    ///
+    /// This function is deprecated because it is no longer necessary. Virtual
+    /// processes are now automatically woken up when they are ready to make
+    /// progress, so there is no need to manually call `select` on them.
+    #[deprecated(
+        note = "you no longer need to call this function manually",
+        since = "0.13.0"
+    )]
     pub fn select_all(this: &RefCell<Self>) {
         use std::task::{Context, Poll, Waker};
         let mut selectors = Vec::new();
@@ -1456,7 +1466,6 @@ impl SystemState {
         // dropping the borrow for `this`
         let mut context = Context::from_waker(Waker::noop());
         for selector in selectors {
-            // TODO merge advances of `now` performed by each select
             let mut future = std::pin::pin!(SelectSystem::select(&selector, false));
             if let Poll::Ready(result) = future.as_mut().poll(&mut context) {
                 result.ok();

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -22,9 +22,8 @@ use crate::Env;
 use crate::system::r#virtual::{Executor, FileBody, Inode, SystemState, VirtualSystem};
 use assert_matches::assert_matches;
 use futures_executor::LocalSpawner;
-use futures_util::FutureExt as _;
 use futures_util::task::LocalSpawnExt as _;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::str::from_utf8;
@@ -46,16 +45,17 @@ impl Executor for LocalExecutor {
 ///
 /// This function creates a [`VirtualSystem`] and installs a
 /// [`yash_executor::Spawner`] in it as an [`Executor`]. The argument function
-/// `f` is called with an [`Env`] with the virtual system. The executor loop is
-/// run until the task returned by `f` completes, and the result is returned.
+/// `task` is called with an [`Env`] with the virtual system. The executor loop
+/// is run until the future returned by `task` completes, and the result is
+/// returned.
 ///
-/// Function `f` is called with two arguments: the [`Env`] and a shared
+/// Function `task` is called with two arguments: the [`Env`] and a shared
 /// reference to the system state. The system state can be used to interact
-/// with the virtual system, e.g. to create files or concurrent tasks.
+/// with the virtual system, e.g. to create files or inspect the process state.
 ///
 /// This function is useful for testing asynchronous code that spawns tasks
 /// that need to be run concurrently with the main task.
-pub fn in_virtual_system<F, Fut, T>(f: F) -> T
+pub fn in_virtual_system<F, Fut, T>(task: F) -> T
 where
     F: FnOnce(Env<VirtualSystem>, Rc<RefCell<SystemState>>) -> Fut,
     Fut: Future<Output = T> + 'static,
@@ -67,36 +67,24 @@ where
     state.borrow_mut().executor = Some(Rc::new(global_executor.spawner()));
 
     let env = Env::with_system(system);
-    let selector = env.system.clone();
-    let task = f(env, Rc::clone(&state));
+    let concurrent = env.system.clone();
+    let task = task(env, Rc::clone(&state));
 
-    // Wrap the task in a loop that performs `select` to drive the executor
-    // until the task completes. This simulates the main loop of the shell
-    // process.
-    let task = async move {
-        let local_executor = yash_executor::Executor::new();
-        // SAFETY: Actually this is not safe if the task creates a thread and
-        // a waker from the executor is used in the thread. However, the shell
-        // process must be single-threaded to work correctly, so we assume the
-        // task does not create threads.
-        let mut result_future = unsafe { local_executor.spawn(task) };
-        loop {
-            local_executor.run_until_stalled();
-            if let Some(result) = (&mut result_future).now_or_never() {
-                return result;
-            }
-            selector.select().await;
-        }
+    let result = Rc::new(Cell::new(None));
+    let result_passer = Rc::clone(&result);
+    let runner = async move {
+        let run_task_and_set_result = async move { result_passer.set(Some(task.await)) };
+        concurrent.run_virtual(run_task_and_set_result).await
     };
 
-    // SAFETY: The same as above.
-    let mut task = unsafe { global_executor.spawn(task) };
+    // SAFETY: Actually this is not safe if the task creates a thread and a waker from the executor
+    // is used in the thread. However, the shell process must be single-threaded to work correctly,
+    // so we assume the task does not create threads.
+    unsafe { global_executor.spawn_pinned(Box::pin(runner)) };
 
-    // The outer, global executor allows the task to spawn child processes that
-    // are run concurrently with the main task.
     loop {
         global_executor.run_until_stalled();
-        if let Some(result) = (&mut task).now_or_never() {
+        if let Some(result) = result.take() {
             return result;
         }
 

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -82,7 +82,6 @@ where
             }
         }
         shared_system.select(false).unwrap();
-        SystemState::select_all(&state);
     }
 }
 

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -105,7 +105,7 @@ where
             if let Some(result) = (&mut result_future).now_or_never() {
                 return result;
             }
-            selector.select_async().await.ok();
+            selector.select().await;
         }
     };
 

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -42,26 +42,6 @@ impl Executor for LocalExecutor {
     }
 }
 
-/// Allows `Spawner` to be used as an `Executor` in the virtual system.
-///
-/// Remember that `yash_executor::Spawner` is for single-threaded processes.
-/// It is not safe to use it in a multi-threaded context, e.g. by spawning a
-/// task that creates threads and uses wakers from the executor in those
-/// threads.
-impl<'a> Executor for yash_executor::Spawner<'a> {
-    fn spawn(
-        &self,
-        task: Pin<Box<dyn Future<Output = ()>>>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        // SAFETY: Actually this is not safe if the task creates a thread and
-        // a waker from the executor is used in the thread. However, the shell
-        // process must be single-threaded to work correctly, so we assume the
-        // task does not create threads.
-        (unsafe { self.spawn_pinned(task) })
-            .map_err(|_| "failed to spawn task: the executor has been dropped".into())
-    }
-}
-
 /// Runs an asynchronous function in a virtual system with an executor.
 ///
 /// This function creates a [`VirtualSystem`] and installs a

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -92,6 +92,11 @@ where
         if let Some(next_wake_time) = state.scheduled_wakers.next_wake_time() {
             state.advance_time(next_wake_time);
         }
+        assert_ne!(
+            global_executor.wake_count(),
+            0,
+            "deadlock detected: at least one task should be woken up to make progress"
+        );
     }
 }
 

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -62,12 +62,12 @@ impl<'a> Executor for yash_executor::Spawner<'a> {
     }
 }
 
-/// Runs an asynchronous function in a virtual system with a local executor.
+/// Runs an asynchronous function in a virtual system with an executor.
 ///
-/// This function creates a [`VirtualSystem`] and installs a [`LocalExecutor`]
-/// in it. The argument function `f` is called with an [`Env`] with the virtual
-/// system. The executor is run until the task returned by `f` completes, and
-/// the result is returned.
+/// This function creates a [`VirtualSystem`] and installs a
+/// [`yash_executor::Spawner`] in it as an [`Executor`]. The argument function
+/// `f` is called with an [`Env`] with the virtual system. The executor loop is
+/// run until the task returned by `f` completes, and the result is returned.
 ///
 /// Function `f` is called with two arguments: the [`Env`] and a shared
 /// reference to the system state. The system state can be used to interact

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -42,6 +42,26 @@ impl Executor for LocalExecutor {
     }
 }
 
+/// Allows `Spawner` to be used as an `Executor` in the virtual system.
+///
+/// Remember that `yash_executor::Spawner` is for single-threaded processes.
+/// It is not safe to use it in a multi-threaded context, e.g. by spawning a
+/// task that creates threads and uses wakers from the executor in those
+/// threads.
+impl<'a> Executor for yash_executor::Spawner<'a> {
+    fn spawn(
+        &self,
+        task: Pin<Box<dyn Future<Output = ()>>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // SAFETY: Actually this is not safe if the task creates a thread and
+        // a waker from the executor is used in the thread. However, the shell
+        // process must be single-threaded to work correctly, so we assume the
+        // task does not create threads.
+        (unsafe { self.spawn_pinned(task) })
+            .map_err(|_| "failed to spawn task: the executor has been dropped".into())
+    }
+}
+
 /// Runs an asynchronous function in a virtual system with a local executor.
 ///
 /// This function creates a [`VirtualSystem`] and installs a [`LocalExecutor`]
@@ -63,25 +83,47 @@ where
 {
     let system = VirtualSystem::new();
     let state = Rc::clone(&system.state);
-    let mut executor = futures_executor::LocalPool::new();
-    state.borrow_mut().executor = Some(Rc::new(LocalExecutor(executor.spawner())));
+    let global_executor = yash_executor::Executor::new();
+    state.borrow_mut().executor = Some(Rc::new(global_executor.spawner()));
 
     let env = Env::with_system(system);
-    let shared_system = env.system.clone();
+    let selector = env.system.clone();
     let task = f(env, Rc::clone(&state));
-    let mut task = executor.spawner().spawn_local_with_handle(task).unwrap();
+
+    // Wrap the task in a loop that performs `select` to drive the executor
+    // until the task completes. This simulates the main loop of the shell
+    // process.
+    let task = async move {
+        let local_executor = yash_executor::Executor::new();
+        // SAFETY: Actually this is not safe if the task creates a thread and
+        // a waker from the executor is used in the thread. However, the shell
+        // process must be single-threaded to work correctly, so we assume the
+        // task does not create threads.
+        let mut result_future = unsafe { local_executor.spawn(task) };
+        loop {
+            local_executor.run_until_stalled();
+            if let Some(result) = (&mut result_future).now_or_never() {
+                return result;
+            }
+            selector.select_async().await.ok();
+        }
+    };
+
+    // SAFETY: The same as above.
+    let mut task = unsafe { global_executor.spawn(task) };
+
+    // The outer, global executor allows the task to spawn child processes that
+    // are run concurrently with the main task.
     loop {
+        global_executor.run_until_stalled();
         if let Some(result) = (&mut task).now_or_never() {
             return result;
         }
-        executor.run_until_stalled();
-        {
-            let mut state = state.borrow_mut();
-            if let Some(next_wake_time) = state.scheduled_wakers.next_wake_time() {
-                state.advance_time(next_wake_time);
-            }
+
+        let mut state = state.borrow_mut();
+        if let Some(next_wake_time) = state.scheduled_wakers.next_wake_time() {
+            state.advance_time(next_wake_time);
         }
-        shared_system.select(false).unwrap();
     }
 }
 

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -1109,7 +1109,7 @@ mod tests {
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1148,7 +1148,7 @@ mod tests {
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1187,7 +1187,7 @@ mod tests {
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -206,7 +206,7 @@ impl TrapSet {
     /// but also for all other conditions.
     pub async fn set_action<S: SignalSystem, C: Into<Condition>>(
         &mut self,
-        system: &mut S,
+        system: &S,
         cond: C,
         action: Action,
         origin: Location,
@@ -218,7 +218,7 @@ impl TrapSet {
 
     async fn set_action_impl<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
         cond: Condition,
         action: Action,
         origin: Location,
@@ -299,7 +299,7 @@ impl TrapSet {
     /// dispositions.
     pub async fn enter_subshell<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
         ignore_sigint_sigquit: bool,
         keep_internal_dispositions_for_stoppers: bool,
     ) {
@@ -379,7 +379,7 @@ impl TrapSet {
         &mut self,
         signal: signal::Number,
         disposition: Disposition,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         let entry = self.traps.entry(Condition::Signal(signal));
         GrandState::set_internal_disposition(system, entry, disposition).await
@@ -396,7 +396,7 @@ impl TrapSet {
     /// second call to the function will be a no-op.
     pub async fn enable_internal_disposition_for_sigchld<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGCHLD, Disposition::Catch, system)
             .await
@@ -412,7 +412,7 @@ impl TrapSet {
     /// second call to the function will be a no-op.
     pub async fn enable_internal_dispositions_for_terminators<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGINT, Disposition::Catch, system)
             .await?;
@@ -432,7 +432,7 @@ impl TrapSet {
     /// second call to the function will be a no-op.
     pub async fn enable_internal_dispositions_for_stoppers<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGTSTP, Disposition::Ignore, system)
             .await?;
@@ -445,7 +445,7 @@ impl TrapSet {
     /// Uninstalls the internal dispositions for `SIGINT`, `SIGTERM`, and `SIGQUIT`.
     pub async fn disable_internal_dispositions_for_terminators<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGINT, Disposition::Default, system)
             .await?;
@@ -458,7 +458,7 @@ impl TrapSet {
     /// Uninstalls the internal dispositions for `SIGTSTP`, `SIGTTIN`, and `SIGTTOU`.
     pub async fn disable_internal_dispositions_for_stoppers<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGTSTP, Disposition::Default, system)
             .await?;
@@ -475,7 +475,7 @@ impl TrapSet {
     /// Dispositions for any existing user-defined traps are not affected.
     pub async fn disable_internal_dispositions<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
     ) -> Result<(), Errno> {
         self.set_internal_disposition(S::SIGCHLD, Disposition::Default, system)
             .await?;
@@ -643,17 +643,11 @@ mod tests {
 
     #[test]
     fn setting_trap_for_two_signals() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         let result = trap_set
-            .set_action(
-                &mut system,
-                SIGUSR1,
-                Action::Ignore,
-                origin_1.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR1, Action::Ignore, origin_1.clone(), false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -661,13 +655,7 @@ mod tests {
         let command = Action::Command("echo".into());
         let origin_2 = Location::dummy("bar");
         let result = trap_set
-            .set_action(
-                &mut system,
-                SIGUSR2,
-                command.clone(),
-                origin_2.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR2, command.clone(), origin_2.clone(), false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -700,11 +688,11 @@ mod tests {
 
     #[test]
     fn setting_trap_for_sigkill() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin = Location::dummy("origin");
         let result = trap_set
-            .set_action(&mut system, SIGKILL, Action::Ignore, origin, false)
+            .set_action(&system, SIGKILL, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::SIGKILL));
@@ -714,11 +702,11 @@ mod tests {
 
     #[test]
     fn setting_trap_for_sigstop() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin = Location::dummy("origin");
         let result = trap_set
-            .set_action(&mut system, SIGSTOP, Action::Ignore, origin, false)
+            .set_action(&system, SIGSTOP, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::SIGSTOP));
@@ -759,17 +747,17 @@ mod tests {
 
     #[test]
     fn peeking_state_with_parent_state() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin = Location::dummy("foo");
         let command = Action::Command("echo".into());
         trap_set
-            .set_action(&mut system, SIGUSR1, command.clone(), origin.clone(), false)
+            .set_action(&system, SIGUSR1, command.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
 
@@ -786,30 +774,18 @@ mod tests {
 
     #[test]
     fn basic_iteration() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR1,
-                Action::Ignore,
-                origin_1.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR1, Action::Ignore, origin_1.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let command = Action::Command("echo".into());
         let origin_2 = Location::dummy("bar");
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR2,
-                command.clone(),
-                origin_2.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR2, command.clone(), origin_2.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -830,35 +806,23 @@ mod tests {
 
     #[test]
     fn iteration_after_entering_subshell() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR1,
-                Action::Ignore,
-                origin_1.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR1, Action::Ignore, origin_1.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let command = Action::Command("echo".into());
         let origin_2 = Location::dummy("bar");
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR2,
-                command.clone(),
-                origin_2.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR2, command.clone(), origin_2.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
 
@@ -879,29 +843,23 @@ mod tests {
 
     #[test]
     fn iteration_after_setting_trap_in_subshell() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         let command = Action::Command("echo".into());
         trap_set
-            .set_action(&mut system, SIGUSR1, command, origin_1, false)
+            .set_action(&system, SIGUSR1, command, origin_1, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         let origin_2 = Location::dummy("bar");
         let command = Action::Command("ls".into());
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR2,
-                command.clone(),
-                origin_2.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR2, command.clone(), origin_2.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -922,18 +880,18 @@ mod tests {
 
     #[test]
     fn entering_subshell_resets_command_traps() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGCHLD, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGCHLD, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -956,17 +914,17 @@ mod tests {
 
     #[test]
     fn entering_subshell_keeps_ignore_traps() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGCHLD, Action::Ignore, origin.clone(), false)
+            .set_action(&system, SIGCHLD, Action::Ignore, origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -985,23 +943,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigchld() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGCHLD, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGCHLD, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1024,23 +982,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigint() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGINT, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGINT, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1063,23 +1021,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigterm() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTERM, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGTERM, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1102,23 +1060,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigquit() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGQUIT, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGQUIT, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1141,23 +1099,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigtstp() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTSTP, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGTSTP, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1180,23 +1138,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigttin() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTTIN, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGTTIN, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1219,23 +1177,23 @@ mod tests {
 
     #[test]
     fn entering_subshell_with_internal_disposition_for_sigttou() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let action = Action::Command("".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTTOU, action.clone(), origin.clone(), false)
+            .set_action(&system, SIGTTOU, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         assert_eq!(
@@ -1258,37 +1216,31 @@ mod tests {
 
     #[test]
     fn setting_trap_after_entering_subshell_clears_parent_states() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         let command = Action::Command("echo 1".into());
         trap_set
-            .set_action(&mut system, SIGUSR1, command, origin_1, false)
+            .set_action(&system, SIGUSR1, command, origin_1, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let origin_2 = Location::dummy("bar");
         let command = Action::Command("echo 2".into());
         trap_set
-            .set_action(&mut system, SIGUSR2, command, origin_2, false)
+            .set_action(&system, SIGUSR2, command, origin_2, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
 
         let command = Action::Command("echo 9".into());
         let origin_3 = Location::dummy("qux");
         trap_set
-            .set_action(
-                &mut system,
-                SIGUSR1,
-                command.clone(),
-                origin_3.clone(),
-                false,
-            )
+            .set_action(&system, SIGUSR1, command.clone(), origin_3.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1321,28 +1273,28 @@ mod tests {
 
     #[test]
     fn entering_nested_subshell_clears_parent_states() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let origin_1 = Location::dummy("foo");
         let command = Action::Command("echo 1".into());
         trap_set
-            .set_action(&mut system, SIGUSR1, command, origin_1, false)
+            .set_action(&system, SIGUSR1, command, origin_1, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let origin_2 = Location::dummy("bar");
         let command = Action::Command("echo 2".into());
         trap_set
-            .set_action(&mut system, SIGUSR2, command, origin_2, false)
+            .set_action(&system, SIGUSR2, command, origin_2, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
         trap_set
-            .enter_subshell(&mut system, false, false)
+            .enter_subshell(&system, false, false)
             .now_or_never()
             .unwrap();
 
@@ -1377,7 +1329,7 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     SIGINT,
                     Action::Command("".into()),
                     Location::dummy(""),
@@ -1386,7 +1338,7 @@ mod tests {
                 .await
                 .unwrap();
             env.system.kill(env.main_pid, Some(SIGINT)).await.unwrap();
-            env.traps.enter_subshell(&mut env.system, true, false).await;
+            env.traps.enter_subshell(&env.system, true, false).await;
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
@@ -1400,7 +1352,7 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     SIGQUIT,
                     Action::Command("".into()),
                     Location::dummy(""),
@@ -1409,7 +1361,7 @@ mod tests {
                 .await
                 .unwrap();
             env.system.kill(env.main_pid, Some(SIGQUIT)).await.unwrap();
-            env.traps.enter_subshell(&mut env.system, true, false).await;
+            env.traps.enter_subshell(&env.system, true, false).await;
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
@@ -1420,10 +1372,10 @@ mod tests {
 
     #[test]
     fn ignoring_sigint_and_sigquit_on_entering_subshell_without_action_set() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enter_subshell(&mut system, true, false)
+            .enter_subshell(&system, true, false)
             .now_or_never()
             .unwrap();
         assert_eq!(system.0.borrow()[&SIGINT], Disposition::Ignore);
@@ -1436,7 +1388,7 @@ mod tests {
             for signal in [SIGTSTP, SIGTTIN, SIGTTOU] {
                 env.traps
                     .set_action(
-                        &mut env.system,
+                        &env.system,
                         signal,
                         Action::Command("".into()),
                         Location::dummy(""),
@@ -1446,13 +1398,13 @@ mod tests {
                     .unwrap();
             }
             env.traps
-                .enable_internal_dispositions_for_stoppers(&mut env.system)
+                .enable_internal_dispositions_for_stoppers(&env.system)
                 .await
                 .unwrap();
             for signal in [SIGTSTP, SIGTTIN, SIGTTOU] {
                 env.system.kill(env.main_pid, Some(signal)).await.unwrap();
             }
-            env.traps.enter_subshell(&mut env.system, false, true).await;
+            env.traps.enter_subshell(&env.system, false, true).await;
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
@@ -1469,7 +1421,7 @@ mod tests {
             for signal in [SIGTSTP, SIGTTIN, SIGTTOU] {
                 env.traps
                     .set_action(
-                        &mut env.system,
+                        &env.system,
                         signal,
                         Action::Command("".into()),
                         Location::dummy(""),
@@ -1478,7 +1430,7 @@ mod tests {
                     .await
                     .unwrap();
             }
-            env.traps.enter_subshell(&mut env.system, false, true).await;
+            env.traps.enter_subshell(&env.system, false, true).await;
 
             let state = state.borrow();
             let process = &state.processes[&env.main_pid];
@@ -1490,19 +1442,19 @@ mod tests {
 
     #[test]
     fn catching_signal() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let command = Action::Command("echo INT".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGINT, command, origin, false)
+            .set_action(&system, SIGINT, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let command = Action::Command("echo TERM".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTERM, command, origin, false)
+            .set_action(&system, SIGTERM, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1518,12 +1470,12 @@ mod tests {
 
     #[test]
     fn taking_signal_if_caught() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         let command = Action::Command("echo INT".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGINT, command, origin, false)
+            .set_action(&system, SIGINT, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1542,28 +1494,28 @@ mod tests {
 
     #[test]
     fn taking_caught_signal() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         assert_eq!(trap_set.take_caught_signal(), None);
 
         let command = Action::Command("echo INT".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGINT, command, origin, false)
+            .set_action(&system, SIGINT, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let command = Action::Command("echo TERM".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGTERM, command, origin, false)
+            .set_action(&system, SIGTERM, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let command = Action::Command("echo USR1".into());
         let origin = Location::dummy("origin");
         trap_set
-            .set_action(&mut system, SIGUSR1, command, origin, false)
+            .set_action(&system, SIGUSR1, command, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1601,10 +1553,10 @@ mod tests {
 
     #[test]
     fn enabling_internal_disposition_for_sigchld() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1613,10 +1565,10 @@ mod tests {
 
     #[test]
     fn enabling_internal_dispositions_for_terminators() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1627,10 +1579,10 @@ mod tests {
 
     #[test]
     fn enabling_internal_dispositions_for_stoppers() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1641,25 +1593,25 @@ mod tests {
 
     #[test]
     fn disabling_internal_dispositions_for_initially_defaulted_signals() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1686,22 +1638,22 @@ mod tests {
         ignore_signals(&mut system);
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1720,37 +1672,37 @@ mod tests {
         ignore_signals(&mut system);
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1769,7 +1721,7 @@ mod tests {
         ignore_signals(&mut system);
         let mut trap_set = TrapSet::default();
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1784,55 +1736,55 @@ mod tests {
 
     #[test]
     fn reenabling_internal_dispositions() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1847,16 +1799,16 @@ mod tests {
 
     #[test]
     fn setting_trap_to_ignore_after_enabling_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         let origin = Location::dummy("origin");
         let result = trap_set
-            .set_action(&mut system, SIGCHLD, Action::Ignore, origin, false)
+            .set_action(&system, SIGCHLD, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1869,17 +1821,17 @@ mod tests {
         ignore_signals(&mut system);
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1887,7 +1839,7 @@ mod tests {
         for signal in [SIGCHLD, SIGINT] {
             let origin = Location::dummy("origin");
             let result = trap_set
-                .set_action(&mut system, signal, Action::Default, origin, false)
+                .set_action(&system, signal, Action::Default, origin, false)
                 .now_or_never()
                 .unwrap();
             assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -1896,7 +1848,7 @@ mod tests {
         for signal in [SIGTERM, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU] {
             let origin = Location::dummy("origin");
             let result = trap_set
-                .set_action(&mut system, signal, Action::Default, origin, false)
+                .set_action(&system, signal, Action::Default, origin, false)
                 .now_or_never()
                 .unwrap();
             assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -1910,17 +1862,17 @@ mod tests {
         ignore_signals(&mut system);
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_stoppers(&mut system)
+            .enable_internal_dispositions_for_stoppers(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1928,7 +1880,7 @@ mod tests {
         for signal in [SIGCHLD, SIGINT] {
             let origin = Location::dummy("origin");
             let result = trap_set
-                .set_action(&mut system, signal, Action::Ignore, origin.clone(), true)
+                .set_action(&system, signal, Action::Ignore, origin.clone(), true)
                 .now_or_never()
                 .unwrap();
             assert_eq!(result, Ok(()));
@@ -1948,7 +1900,7 @@ mod tests {
         for signal in [SIGTERM, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU] {
             let origin = Location::dummy("origin");
             let result = trap_set
-                .set_action(&mut system, signal, Action::Ignore, origin.clone(), true)
+                .set_action(&system, signal, Action::Ignore, origin.clone(), true)
                 .now_or_never()
                 .unwrap();
             assert_eq!(result, Ok(()));
@@ -1971,28 +1923,28 @@ mod tests {
     fn disabling_internal_disposition_with_ignore_trap() {
         let signals = [SIGCHLD, SIGINT, SIGTERM, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU];
 
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut trap_set = TrapSet::default();
         trap_set
-            .enable_internal_disposition_for_sigchld(&mut system)
+            .enable_internal_disposition_for_sigchld(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         trap_set
-            .enable_internal_dispositions_for_terminators(&mut system)
+            .enable_internal_dispositions_for_terminators(&system)
             .now_or_never()
             .unwrap()
             .unwrap();
         let origin = Location::dummy("origin");
         for signal in signals {
             trap_set
-                .set_action(&mut system, signal, Action::Ignore, origin.clone(), false)
+                .set_action(&system, signal, Action::Ignore, origin.clone(), false)
                 .now_or_never()
                 .unwrap()
                 .unwrap();
         }
         trap_set
-            .disable_internal_dispositions(&mut system)
+            .disable_internal_dispositions(&system)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -42,9 +42,9 @@ use self::state::{EnterSubshellOption, GrandState};
 use crate::Env;
 use crate::signal;
 use crate::source::Location;
-use crate::system::{Disposition, Errno, Signals};
 #[cfg(doc)]
-use crate::system::{SharedSystem, System};
+use crate::system::Concurrent;
+use crate::system::{Disposition, Errno, Signals};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::pin::Pin;
@@ -388,8 +388,8 @@ impl TrapSet {
     /// Installs the internal disposition for `SIGCHLD`.
     ///
     /// You should install the internal disposition for `SIGCHLD` by using this
-    /// function before waiting for `SIGCHLD` with [`crate::system::Wait::wait`] and
-    /// [`SharedSystem::wait_for_signal`]. The disposition allows catching
+    /// function before waiting for `SIGCHLD` with [`crate::system::Wait::wait`]
+    /// and [`Concurrent::wait_for_signals`]. The disposition allows catching
     /// `SIGCHLD`.
     ///
     /// This function remembers that the disposition has been installed, so a

--- a/yash-env/src/trap/state.rs
+++ b/yash-env/src/trap/state.rs
@@ -212,7 +212,7 @@ impl GrandState {
 
     /// Updates the entry with the new action.
     pub async fn set_action<S: SignalSystem>(
-        system: &mut S,
+        system: &S,
         entry: Entry<'_, Condition, GrandState>,
         action: Action,
         origin: Location,
@@ -292,7 +292,7 @@ impl GrandState {
     /// The condition of the given entry must be a signal, or this function
     /// panics.
     pub async fn set_internal_disposition<S: SignalSystem>(
-        system: &mut S,
+        system: &S,
         entry: Entry<'_, Condition, GrandState>,
         disposition: Disposition,
     ) -> Result<(), Errno> {
@@ -337,7 +337,7 @@ impl GrandState {
     /// `option`.
     pub async fn enter_subshell<S: SignalSystem>(
         &mut self,
-        system: &mut S,
+        system: &S,
         cond: Condition,
         option: EnterSubshellOption,
     ) -> Result<(), Errno> {
@@ -393,7 +393,7 @@ impl GrandState {
     ///
     /// This function panics if the condition is not a signal.
     pub async fn ignore<S: SignalSystem>(
-        system: &mut S,
+        system: &S,
         vacant: VacantEntry<'_, Condition, GrandState>,
     ) -> Result<(), Errno> {
         let signal = match *vacant.key() {
@@ -580,12 +580,12 @@ mod tests {
 
     #[test]
     fn insertion_with_occupied_entry() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -625,15 +625,14 @@ mod tests {
 
     #[test]
     fn setting_trap_to_ignore_without_override_ignore() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
 
-        let result =
-            GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), false)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGCHLD.into()].current_state(),
@@ -649,15 +648,14 @@ mod tests {
 
     #[test]
     fn setting_trap_to_ignore_with_override_ignore() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
 
-        let result =
-            GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), true)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), true)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGCHLD.into()].current_state(),
@@ -673,16 +671,15 @@ mod tests {
 
     #[test]
     fn setting_trap_to_command() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let action = Action::Command("echo".into());
         let origin = Location::dummy("origin");
 
-        let result =
-            GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGCHLD.into()].current_state(),
@@ -698,21 +695,20 @@ mod tests {
 
     #[test]
     fn setting_trap_to_default() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("foo");
-        GrandState::set_action(&mut system, entry, Action::Ignore, origin, false)
+        GrandState::set_action(&system, entry, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
 
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("bar");
-        let result =
-            GrandState::set_action(&mut system, entry, Action::Default, origin.clone(), false)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, Action::Default, origin.clone(), false)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGCHLD.into()].current_state(),
@@ -728,12 +724,12 @@ mod tests {
 
     #[test]
     fn resetting_trap_from_ignore_no_override() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         system.0.borrow_mut().insert(SIGCHLD, Disposition::Ignore);
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("foo");
-        let result = GrandState::set_action(&mut system, entry, Action::Ignore, origin, false)
+        let result = GrandState::set_action(&system, entry, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -741,7 +737,7 @@ mod tests {
         // Idempotence
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("bar");
-        let result = GrandState::set_action(&mut system, entry, Action::Ignore, origin, false)
+        let result = GrandState::set_action(&system, entry, Action::Ignore, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -760,15 +756,14 @@ mod tests {
 
     #[test]
     fn resetting_trap_from_ignore_override() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         system.0.borrow_mut().insert(SIGCHLD, Disposition::Ignore);
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
-        let result =
-            GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), true)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), true)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGCHLD.into()].current_state(),
@@ -784,11 +779,11 @@ mod tests {
 
     #[test]
     fn internal_disposition_ignore() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
 
-        let result = GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        let result = GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -810,11 +805,11 @@ mod tests {
 
     #[test]
     fn internal_disposition_catch() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
 
-        let result = GrandState::set_internal_disposition(&mut system, entry, Disposition::Catch)
+        let result = GrandState::set_internal_disposition(&system, entry, Disposition::Catch)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -836,17 +831,17 @@ mod tests {
 
     #[test]
     fn action_ignore_and_internal_disposition_catch() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
-        GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false)
+        GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let entry = map.entry(SIGCHLD.into());
 
-        let result = GrandState::set_internal_disposition(&mut system, entry, Disposition::Catch)
+        let result = GrandState::set_internal_disposition(&system, entry, Disposition::Catch)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -868,18 +863,18 @@ mod tests {
 
     #[test]
     fn action_catch_and_internal_disposition_ignore() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGCHLD.into());
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let entry = map.entry(SIGCHLD.into());
 
-        let result = GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        let result = GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -901,10 +896,10 @@ mod tests {
 
     #[test]
     fn set_internal_disposition_for_initially_defaulted_signal_then_allow_override() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let entry = map.entry(SIGTTOU.into());
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -912,10 +907,9 @@ mod tests {
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
 
-        let result =
-            GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
-                .now_or_never()
-                .unwrap();
+        let result = GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&SIGTTOU.into()].internal_disposition(),
@@ -935,12 +929,12 @@ mod tests {
 
     #[test]
     fn set_internal_disposition_for_initially_ignored_signal_then_reject_override() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         system.0.borrow_mut().insert(SIGTTOU, Disposition::Ignore);
         let mut map = BTreeMap::new();
         let cond = SIGTTOU.into();
         let entry = map.entry(cond);
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -948,7 +942,7 @@ mod tests {
         let origin = Location::dummy("origin");
         let action = Action::Command("echo".into());
 
-        let result = GrandState::set_action(&mut system, entry, action, origin, false)
+        let result = GrandState::set_action(&system, entry, action, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -967,10 +961,10 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_internal_disposition_keeping_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
-        GrandState::set_internal_disposition(&mut system, map.entry(cond), Disposition::Catch)
+        GrandState::set_internal_disposition(&system, map.entry(cond), Disposition::Catch)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -978,11 +972,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::KeepInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::KeepInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1001,11 +991,11 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_internal_disposition_clearing_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
         let entry = map.entry(cond);
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Catch)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Catch)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1013,11 +1003,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::ClearInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::ClearInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1036,12 +1022,12 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_ignore_and_no_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
-        GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false)
+        GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1049,11 +1035,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::KeepInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::KeepInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1072,17 +1054,17 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_ignore_clearing_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
-        GrandState::set_action(&mut system, entry, Action::Ignore, origin.clone(), false)
+        GrandState::set_action(&system, entry, Action::Ignore, origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let entry = map.entry(cond);
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Catch)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Catch)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1090,11 +1072,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::ClearInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::ClearInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1113,13 +1091,13 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_command_and_no_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1127,11 +1105,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::ClearInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::ClearInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1157,18 +1131,18 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_command_keeping_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGTSTP.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let entry = map.entry(cond);
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1176,11 +1150,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::KeepInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::KeepInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1206,18 +1176,18 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_command_clearing_internal_disposition() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGTSTP.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let entry = map.entry(cond);
-        GrandState::set_internal_disposition(&mut system, entry, Disposition::Ignore)
+        GrandState::set_internal_disposition(&system, entry, Disposition::Ignore)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1225,11 +1195,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::ClearInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::ClearInternalDisposition)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1255,13 +1221,13 @@ mod tests {
 
     #[test]
     fn enter_subshell_with_command_ignoring() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1269,7 +1235,7 @@ mod tests {
         let result = map
             .get_mut(&cond)
             .unwrap()
-            .enter_subshell(&mut system, cond, EnterSubshellOption::Ignore)
+            .enter_subshell(&system, cond, EnterSubshellOption::Ignore)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1295,15 +1261,13 @@ mod tests {
 
     #[test]
     fn ignoring_initially_defaulted_signal() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let vacant = assert_matches!(entry, Entry::Vacant(vacant) => vacant);
 
-        let result = GrandState::ignore(&mut system, vacant)
-            .now_or_never()
-            .unwrap();
+        let result = GrandState::ignore(&system, vacant).now_or_never().unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&cond].current_state(),
@@ -1319,7 +1283,7 @@ mod tests {
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        let result = GrandState::set_action(&mut system, entry, action, origin, false)
+        let result = GrandState::set_action(&system, entry, action, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(()));
@@ -1327,16 +1291,14 @@ mod tests {
 
     #[test]
     fn ignoring_initially_ignored_signal() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         system.0.borrow_mut().insert(SIGQUIT, Disposition::Ignore);
         let mut map = BTreeMap::new();
         let cond = SIGQUIT.into();
         let entry = map.entry(cond);
         let vacant = assert_matches!(entry, Entry::Vacant(vacant) => vacant);
 
-        let result = GrandState::ignore(&mut system, vacant)
-            .now_or_never()
-            .unwrap();
+        let result = GrandState::ignore(&system, vacant).now_or_never().unwrap();
         assert_eq!(result, Ok(()));
         assert_eq!(
             map[&cond].current_state(),
@@ -1352,7 +1314,7 @@ mod tests {
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        let result = GrandState::set_action(&mut system, entry, action, origin, false)
+        let result = GrandState::set_action(&system, entry, action, origin, false)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(SetActionError::InitiallyIgnored));
@@ -1360,23 +1322,19 @@ mod tests {
 
     #[test]
     fn clearing_parent_setting() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGCHLD.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action, origin, false)
+        GrandState::set_action(&system, entry, action, origin, false)
             .now_or_never()
             .unwrap()
             .unwrap();
         let state = map.get_mut(&cond).unwrap();
         state
-            .enter_subshell(
-                &mut system,
-                cond,
-                EnterSubshellOption::ClearInternalDisposition,
-            )
+            .enter_subshell(&system, cond, EnterSubshellOption::ClearInternalDisposition)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1395,13 +1353,13 @@ mod tests {
 
     #[test]
     fn marking_as_caught_and_handling() {
-        let mut system = DummySystem::default();
+        let system = DummySystem::default();
         let mut map = BTreeMap::new();
         let cond = SIGUSR1.into();
         let entry = map.entry(cond);
         let origin = Location::dummy("foo");
         let action = Action::Command("echo".into());
-        GrandState::set_action(&mut system, entry, action.clone(), origin.clone(), false)
+        GrandState::set_action(&system, entry, action.clone(), origin.clone(), false)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/yash-prompt/src/lib.rs
+++ b/yash-prompt/src/lib.rs
@@ -45,7 +45,7 @@
 //! use std::cell::RefCell;
 //! use std::ops::ControlFlow::Continue;
 //! use yash_env::Env;
-//! use yash_env::input::FdReader;
+//! use yash_env::input::FdReader2;
 //! use yash_env::io::Fd;
 //! use yash_env::parser::Config;
 //! use yash_env::semantics::ExitStatus;
@@ -61,7 +61,7 @@
 //!     Box::pin(async move { expand_text(env, text).await.ok() })
 //! })));
 //!
-//! let reader = FdReader::new(Fd::STDIN, env.system.clone());
+//! let reader = FdReader2::new(Fd::STDIN, env.system.clone());
 //! let mut ref_env = RefCell::new(&mut env);
 //! let input = Box::new(Prompter::new(reader, &ref_env));
 //! let mut config = Config::with_input(input);

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -106,7 +106,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGUSR1,
                 Action::Command("echo USR1".into()),
                 Location::dummy(""),

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -213,7 +213,7 @@ mod tests {
             Box::pin(async move {
                 env.traps
                     .set_action(
-                        &mut env.system,
+                        &env.system,
                         yash_env::trap::Condition::Exit,
                         yash_env::trap::Action::Command("echo exiting".into()),
                         Location::dummy(""),

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -337,7 +337,7 @@ mod tests {
     fn ignore_sigttin(env: &mut Env<VirtualSystem>) {
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 VirtualSystem::SIGTTIN,
                 yash_env::trap::Action::Ignore,
                 Location::dummy(""),

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -133,7 +133,10 @@ where
     env.inner.system.close(writer).ok();
 
     // Read the output from the subshell
-    let result = env.inner.system.read_all(reader).await.unwrap_or_default();
+    // (In case of an error, we will use whatever we have read so far and ignore the error,
+    // just like bash does.)
+    let mut result = Vec::new();
+    env.inner.system.read_all_to(reader, &mut result).await.ok();
     env.inner.system.close(reader).ok();
 
     // Wait for the subshell

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -133,14 +133,7 @@ where
     env.inner.system.close(writer).ok();
 
     // Read the output from the subshell
-    let mut result = Vec::new();
-    let mut buffer = [0; 4096];
-    while let Ok(count) = env.inner.system.read_async(reader, &mut buffer).await {
-        if count == 0 {
-            break;
-        }
-        result.extend(&buffer[..count]);
-    }
+    let result = env.inner.system.read_all(reader).await.unwrap_or_default();
     env.inner.system.close(reader).ok();
 
     // Wait for the subshell

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -268,7 +268,7 @@ impl FdSpec {
         }
     }
 
-    fn close<S: Close>(self, system: &mut S) {
+    fn close<S: Close>(self, system: &S) {
         match self {
             FdSpec::Owned(fd) => {
                 let _ = system.close(fd);
@@ -560,7 +560,7 @@ where
     if let Some(fd) = fd_spec.as_fd() {
         if fd != target_fd {
             let dup_result = env.system.dup2(fd, target_fd);
-            fd_spec.close(&mut env.system);
+            fd_spec.close(&env.system);
             match dup_result {
                 Ok(new_fd) => assert_eq!(new_fd, target_fd),
                 Err(errno) => {

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -430,7 +430,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGUSR1,
                 Action::Command("echo USR1".into()),
                 Location::dummy(""),

--- a/yash-semantics/src/tests.rs
+++ b/yash-semantics/src/tests.rs
@@ -210,7 +210,7 @@ where
     {
         let mut buffer = [0; 1024];
         loop {
-            let count = env.system.read_async(Fd::STDIN, &mut buffer).await?;
+            let count = env.system.read(Fd::STDIN, &mut buffer).await?;
             if count == 0 {
                 break Ok(());
             }

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -82,7 +82,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("echo exit trap executed".into()),
                 Location::dummy(""),
@@ -114,7 +114,7 @@ mod tests {
         );
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("check".into()),
                 Location::dummy(""),
@@ -132,7 +132,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("return -n 123".into()),
                 Location::dummy(""),
@@ -155,7 +155,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("echo $?; echo $?".into()),
                 Location::dummy(""),
@@ -176,7 +176,7 @@ mod tests {
         env.builtins.insert("return", return_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("return -n 53; return".into()),
                 Location::dummy(""),
@@ -197,7 +197,7 @@ mod tests {
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("exit 31".into()),
                 Location::dummy(""),
@@ -218,7 +218,7 @@ mod tests {
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 Condition::Exit,
                 Action::Command("echo; exit".into()),
                 Location::dummy(""),

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -130,7 +130,7 @@ mod tests {
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGINT,
                 Action::Command("echo trapped".into()),
                 Location::dummy(""),
@@ -229,7 +229,7 @@ mod tests {
         );
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGINT,
                 Action::Command("check".into()),
                 Location::dummy(""),
@@ -261,7 +261,7 @@ mod tests {
         for signal in [SIGUSR1, SIGUSR2] {
             env.traps
                 .set_action(
-                    &mut env.system,
+                    &env.system,
                     signal,
                     Action::Command("echo $?; echo $?".into()),
                     Location::dummy(""),
@@ -288,7 +288,7 @@ mod tests {
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGUSR1,
                 Action::Command("echo; exit 56".into()),
                 Location::dummy(""),
@@ -312,7 +312,7 @@ mod tests {
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
-                &mut env.system,
+                &env.system,
                 SIGUSR1,
                 Action::Command("echo; exit".into()),
                 Location::dummy(""),

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -287,7 +287,7 @@ pub async fn finish<S: Runtime + 'static>(env: &mut Env<S>, xtrace: Option<XTrac
 }
 
 /// Convenience function for [finish]ing and
-/// [print](yash_env::SharedSystem::print_error)ing an (optional) `XTrace`.
+/// [print](yash_env::system::Concurrent::print_error)ing an (optional) `XTrace`.
 pub async fn print<S, X>(env: &mut Env<S>, xtrace: X)
 where
     S: Runtime + 'static,


### PR DESCRIPTION
## Description

This PR addresses part of #740.
The type of `Env::<S>::system` field is changed from `SharedSystem<S>` to `Rc<Concurrent<S>>`. It provides cleaner API and allows `VirtualSystem` to simulate system interaction more accurately.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a concurrency-aware input reader for more consistent stdin and init-file behavior.
  * New runtime helpers to drive tasks reliably in real and virtual execution modes.

* **Maintenance & Internal Refactor**
  * Streamlined system/concurrency model and unified signal/trap handling for more predictable behavior.
  * Consolidated async task execution for steadier child-process and shell task runs.

* **Documentation**
  * Updated changelog and docs to reflect the concurrency model, API adjustments, and deprecations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->