### PR TITLE
Deprecate SharedSystem

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -180,6 +180,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Deprecated
 
+- `system::SharedSystem`: This struct is now deprecated in favor of the new
+  `system::Concurrent` struct, which provides better support for concurrent
+  execution of blocking operations in virtual systems.
 - `system::virtual::SystemState::select_all`: This method is no longer necessary
   because virtual processes are now automatically woken up when they are ready
   to make progress.

--- a/yash-env/src/input/fd_reader.rs
+++ b/yash-env/src/input/fd_reader.rs
@@ -19,6 +19,7 @@
 use super::{Context, Input, Result};
 use crate::io::Fd;
 use crate::option::State;
+#[allow(deprecated)]
 use crate::system::{Fcntl, Read, SharedSystem, Write};
 use std::cell::Cell;
 use std::rc::Rc;
@@ -42,6 +43,7 @@ pub struct FdReader<S> {
     /// File descriptor to read from
     fd: Fd,
     /// System to interact with the FD
+    #[allow(deprecated)]
     system: SharedSystem<S>,
     /// Whether lines read are echoed to stderr
     echo: Option<Rc<Cell<State>>>,
@@ -53,6 +55,7 @@ impl<S> FdReader<S> {
     /// The `fd` argument is the file descriptor to read from. It should be
     /// readable, have the close-on-exec flag set, and remain open for the
     /// lifetime of the `FdReader` instance.
+    #[allow(deprecated)]
     pub fn new(fd: Fd, system: SharedSystem<S>) -> Self {
         let echo = None;
         FdReader { fd, system, echo }
@@ -147,6 +150,7 @@ mod tests {
     #[test]
     fn empty_reader() {
         let system = VirtualSystem::new();
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
 
@@ -166,6 +170,7 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"echo ok\n");
         }
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
 
@@ -191,6 +196,7 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"#!/bin/sh\necho ok\nexit");
         }
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
 
@@ -228,6 +234,7 @@ mod tests {
             let file = Rc::new(Inode::new("echo file\n").into());
             state.file_system.save("/foo", file).unwrap();
         }
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let path = c"/foo";
         let fd = system
@@ -260,6 +267,7 @@ mod tests {
     fn reader_error() {
         let system = VirtualSystem::new();
         system.current_process_mut().close_fd(Fd::STDIN);
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
 
@@ -280,6 +288,7 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"one\ntwo");
         }
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
         #[allow(deprecated)]
@@ -305,6 +314,7 @@ mod tests {
             let file = state.file_system.get("/dev/stdin").unwrap();
             file.borrow_mut().body = FileBody::new(*b"one\ntwo");
         }
+        #[allow(deprecated)]
         let system = SharedSystem::new(system);
         let mut reader = FdReader::new(Fd::STDIN, system);
         #[allow(deprecated)]

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -71,6 +71,7 @@ use self::system::OfdAccess;
 use self::system::Open;
 use self::system::OpenFlag;
 use self::system::Select;
+#[allow(deprecated)]
 pub use self::system::SharedSystem;
 use self::system::Sigaction;
 use self::system::Sigmask;

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -142,6 +142,7 @@ use self::resource::{GetRlimit, LimitPair, Resource, SetRlimit};
 pub use self::select::Select;
 use self::select::SelectSystem;
 use self::select::SignalStatus;
+#[allow(deprecated)]
 pub use self::shared::SharedSystem;
 pub use self::signal::{
     CaughtSignals, Disposition, GetSigaction, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals,

--- a/yash-env/src/system/shared.rs
+++ b/yash-env/src/system/shared.rs
@@ -149,9 +149,11 @@ use std::time::Instant;
 /// ```
 ///
 /// [`System`]: crate::system::System
+#[deprecated(since = "0.13.0", note = "use `Concurrent` instead")]
 #[derive(Debug)]
 pub struct SharedSystem<S>(pub(super) Rc<RefCell<SelectSystem<S>>>);
 
+#[allow(deprecated)]
 impl<S> SharedSystem<S> {
     /// Creates a new shared system.
     pub fn new(system: S) -> Self {
@@ -404,6 +406,7 @@ impl<S> SharedSystem<S> {
     }
 }
 
+#[allow(deprecated)]
 impl<S> Clone for SharedSystem<S> {
     fn clone(&self) -> Self {
         SharedSystem(self.0.clone())
@@ -411,6 +414,7 @@ impl<S> Clone for SharedSystem<S> {
 }
 
 /// Delegates `Fstat` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Fstat> Fstat for SharedSystem<T> {
     type Stat = T::Stat;
 
@@ -423,6 +427,7 @@ impl<T: Fstat> Fstat for SharedSystem<T> {
 }
 
 /// Delegates `IsExecutableFile` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: IsExecutableFile> IsExecutableFile for SharedSystem<T> {
     fn is_executable_file(&self, path: &CStr) -> bool {
         self.0.borrow().is_executable_file(path)
@@ -430,6 +435,7 @@ impl<T: IsExecutableFile> IsExecutableFile for SharedSystem<T> {
 }
 
 /// Delegates `Pipe` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Pipe> Pipe for SharedSystem<T> {
     fn pipe(&self) -> Result<(Fd, Fd)> {
         self.0.borrow().pipe()
@@ -437,6 +443,7 @@ impl<T: Pipe> Pipe for SharedSystem<T> {
 }
 
 /// Delegates `Dup` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Dup> Dup for SharedSystem<T> {
     fn dup(&self, from: Fd, to_min: Fd, flags: EnumSet<FdFlag>) -> Result<Fd> {
         self.0.borrow().dup(from, to_min, flags)
@@ -446,6 +453,7 @@ impl<T: Dup> Dup for SharedSystem<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: Open> Open for SharedSystem<T> {
     fn open(
         &self,
@@ -467,6 +475,7 @@ impl<T: Open> Open for SharedSystem<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: Close> Close for SharedSystem<T> {
     fn close(&self, fd: Fd) -> Result<()> {
         self.0.borrow().close(fd)
@@ -474,6 +483,7 @@ impl<T: Close> Close for SharedSystem<T> {
 }
 
 /// Delegates `Fcntl` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Fcntl> Fcntl for SharedSystem<T> {
     fn ofd_access(&self, fd: Fd) -> Result<OfdAccess> {
         self.0.borrow().ofd_access(fd)
@@ -490,6 +500,7 @@ impl<T: Fcntl> Fcntl for SharedSystem<T> {
 }
 
 /// Delegates `Read` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Read> Read for SharedSystem<T> {
     fn read<'a>(
         &self,
@@ -501,6 +512,7 @@ impl<T: Read> Read for SharedSystem<T> {
 }
 
 /// Delegates `Write` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Write> Write for SharedSystem<T> {
     fn write<'a>(
         &self,
@@ -512,6 +524,7 @@ impl<T: Write> Write for SharedSystem<T> {
 }
 
 /// Delegates `Seek` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Seek> Seek for SharedSystem<T> {
     fn lseek(&self, fd: Fd, position: SeekFrom) -> Result<u64> {
         self.0.borrow().lseek(fd, position)
@@ -519,6 +532,7 @@ impl<T: Seek> Seek for SharedSystem<T> {
 }
 
 /// Delegates `Umask` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Umask> Umask for SharedSystem<T> {
     fn umask(&self, new_mask: Mode) -> Mode {
         self.0.borrow().umask(new_mask)
@@ -526,6 +540,7 @@ impl<T: Umask> Umask for SharedSystem<T> {
 }
 
 /// Delegates `GetCwd` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: GetCwd> GetCwd for SharedSystem<T> {
     fn getcwd(&self) -> Result<PathBuf> {
         self.0.borrow().getcwd()
@@ -533,6 +548,7 @@ impl<T: GetCwd> GetCwd for SharedSystem<T> {
 }
 
 /// Delegates `Chdir` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Chdir> Chdir for SharedSystem<T> {
     fn chdir(&self, path: &CStr) -> Result<()> {
         self.0.borrow().chdir(path)
@@ -540,6 +556,7 @@ impl<T: Chdir> Chdir for SharedSystem<T> {
 }
 
 /// Delegates `Time` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Clock> Clock for SharedSystem<T> {
     fn now(&self) -> Instant {
         self.0.borrow().now()
@@ -547,6 +564,7 @@ impl<T: Clock> Clock for SharedSystem<T> {
 }
 
 /// Delegates `Times` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Times> Times for SharedSystem<T> {
     fn times(&self) -> Result<CpuTimes> {
         self.0.borrow().times()
@@ -554,6 +572,7 @@ impl<T: Times> Times for SharedSystem<T> {
 }
 
 /// Delegates `GetPid` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: GetPid> GetPid for SharedSystem<T> {
     fn getsid(&self, pid: Pid) -> Result<Pid> {
         self.0.borrow().getsid(pid)
@@ -573,6 +592,7 @@ impl<T: GetPid> GetPid for SharedSystem<T> {
 }
 
 /// Delegates `SetPgid` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: SetPgid> SetPgid for SharedSystem<T> {
     fn setpgid(&self, pid: Pid, pgid: Pid) -> Result<()> {
         self.0.borrow().setpgid(pid, pgid)
@@ -580,6 +600,7 @@ impl<T: SetPgid> SetPgid for SharedSystem<T> {
 }
 
 /// Delegates `Signals` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Signals> Signals for SharedSystem<T> {
     const SIGABRT: signal::Number = T::SIGABRT;
     const SIGALRM: signal::Number = T::SIGALRM;
@@ -634,6 +655,7 @@ impl<T: Signals> Signals for SharedSystem<T> {
 }
 
 /// Delegates `Sigmask` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Sigmask> Sigmask for SharedSystem<T> {
     fn sigmask(
         &self,
@@ -645,6 +667,7 @@ impl<T: Sigmask> Sigmask for SharedSystem<T> {
 }
 
 /// Delegates `GetSigaction` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Sigaction> GetSigaction for SharedSystem<T> {
     fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition> {
         self.0.borrow().get_sigaction(signal)
@@ -652,6 +675,7 @@ impl<T: Sigaction> GetSigaction for SharedSystem<T> {
 }
 
 /// Delegates `Sigaction` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Sigaction> Sigaction for SharedSystem<T> {
     fn sigaction(&self, signal: signal::Number, action: Disposition) -> Result<Disposition> {
         self.0.borrow().sigaction(signal, action)
@@ -659,6 +683,7 @@ impl<T: Sigaction> Sigaction for SharedSystem<T> {
 }
 
 /// Delegates `CaughtSignals` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: CaughtSignals> CaughtSignals for SharedSystem<T> {
     fn caught_signals(&self) -> Vec<signal::Number> {
         self.0.borrow().caught_signals()
@@ -666,6 +691,7 @@ impl<T: CaughtSignals> CaughtSignals for SharedSystem<T> {
 }
 
 /// Delegates `SendSignal` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: SendSignal> SendSignal for SharedSystem<T> {
     fn kill(
         &self,
@@ -680,6 +706,7 @@ impl<T: SendSignal> SendSignal for SharedSystem<T> {
 }
 
 /// Delegates `Select` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Select> Select for SharedSystem<T> {
     fn select<'a>(
         &self,
@@ -693,6 +720,7 @@ impl<T: Select> Select for SharedSystem<T> {
 }
 
 /// Delegates `Isatty` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Isatty> Isatty for SharedSystem<T> {
     fn isatty(&self, fd: Fd) -> bool {
         self.0.borrow().isatty(fd)
@@ -700,6 +728,7 @@ impl<T: Isatty> Isatty for SharedSystem<T> {
 }
 
 /// Delegates `TcGetPgrp` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: TcGetPgrp> TcGetPgrp for SharedSystem<T> {
     fn tcgetpgrp(&self, fd: Fd) -> Result<Pid> {
         self.0.borrow().tcgetpgrp(fd)
@@ -707,6 +736,7 @@ impl<T: TcGetPgrp> TcGetPgrp for SharedSystem<T> {
 }
 
 /// Delegates `TcSetPgrp` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: TcSetPgrp> TcSetPgrp for SharedSystem<T> {
     fn tcsetpgrp(&self, fd: Fd, pgid: Pid) -> impl Future<Output = Result<()>> + use<T> {
         self.0.borrow().tcsetpgrp(fd, pgid)
@@ -714,6 +744,7 @@ impl<T: TcSetPgrp> TcSetPgrp for SharedSystem<T> {
 }
 
 /// Delegates `Wait` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Wait> Wait for SharedSystem<T> {
     fn wait(&self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {
         self.0.borrow().wait(target)
@@ -721,6 +752,7 @@ impl<T: Wait> Wait for SharedSystem<T> {
 }
 
 /// Delegates `Exec` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Exec> Exec for SharedSystem<T> {
     fn execve(
         &self,
@@ -733,6 +765,7 @@ impl<T: Exec> Exec for SharedSystem<T> {
 }
 
 /// Delegates `Exit` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Exit> Exit for SharedSystem<T> {
     fn exit(&self, exit_status: ExitStatus) -> impl Future<Output = Infallible> + use<T> {
         self.0.borrow().exit(exit_status)
@@ -740,6 +773,7 @@ impl<T: Exit> Exit for SharedSystem<T> {
 }
 
 /// Delegates `GetUid` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: GetUid> GetUid for SharedSystem<T> {
     fn getuid(&self) -> Uid {
         self.0.borrow().getuid()
@@ -756,6 +790,7 @@ impl<T: GetUid> GetUid for SharedSystem<T> {
 }
 
 /// Delegates `GetPw` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: GetPw> GetPw for SharedSystem<T> {
     fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>> {
         self.0.borrow().getpwnam_dir(name)
@@ -763,6 +798,7 @@ impl<T: GetPw> GetPw for SharedSystem<T> {
 }
 
 /// Delegates `Sysconf` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: Sysconf> Sysconf for SharedSystem<T> {
     fn confstr_path(&self) -> Result<UnixString> {
         self.0.borrow().confstr_path()
@@ -770,6 +806,7 @@ impl<T: Sysconf> Sysconf for SharedSystem<T> {
 }
 
 /// Delegates `ShellPath` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: ShellPath> ShellPath for SharedSystem<T> {
     fn shell_path(&self) -> CString {
         self.0.borrow().shell_path()
@@ -777,6 +814,7 @@ impl<T: ShellPath> ShellPath for SharedSystem<T> {
 }
 
 /// Delegates `GetRlimit` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: GetRlimit> GetRlimit for SharedSystem<T> {
     fn getrlimit(&self, resource: Resource) -> Result<LimitPair> {
         self.0.borrow().getrlimit(resource)
@@ -784,12 +822,14 @@ impl<T: GetRlimit> GetRlimit for SharedSystem<T> {
 }
 
 /// Delegates `SetRlimit` methods to the contained implementor.
+#[allow(deprecated)]
 impl<T: SetRlimit> SetRlimit for SharedSystem<T> {
     fn setrlimit(&self, resource: Resource, limits: LimitPair) -> Result<()> {
         self.0.borrow().setrlimit(resource, limits)
     }
 }
 
+#[allow(deprecated)]
 impl<S: Signals + Sigmask + Sigaction> SignalSystem for SharedSystem<S> {
     #[inline]
     fn get_disposition(&self, signal: signal::Number) -> Result<Disposition> {
@@ -808,6 +848,7 @@ impl<S: Signals + Sigmask + Sigaction> SignalSystem for SharedSystem<S> {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::super::r#virtual::PIPE_SIZE;
     use super::super::r#virtual::VirtualSystem;

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -102,7 +102,6 @@ use super::Read;
 use super::Result;
 use super::Seek;
 use super::Select;
-use super::SelectSystem;
 use super::SendSignal;
 use super::SetPgid;
 use super::SetRlimit;
@@ -1448,41 +1447,22 @@ impl SystemState {
         self.scheduled_wakers.wake(new_current_time);
     }
 
-    /// Performs [`select`](crate::system::SharedSystem::select) on all
-    /// processes in the system.
+    /// Does nothing.
     ///
-    /// Any errors are ignored.
+    /// This function is a no-op and is only provided for backward
+    /// compatibility. It is not necessary to call this function manually, as
+    /// virtual processes are now automatically woken up when they are ready to
+    /// make progress. If you have existing code that calls this function, you
+    /// can safely remove those calls.
     ///
-    /// The `RefCell` must not have been borrowed, or this function will panic
-    /// with a double borrow.
-    ///
-    /// # Deprecation
-    ///
-    /// This function is deprecated because it is no longer necessary. Virtual
-    /// processes are now automatically woken up when they are ready to make
-    /// progress, so there is no need to manually call `select` on them.
+    /// This function used to perform
+    /// [`select`](crate::system::SharedSystem::select) on all processes in the
+    /// system.
     #[deprecated(
         note = "you no longer need to call this function manually",
         since = "0.13.0"
     )]
-    pub fn select_all(this: &RefCell<Self>) {
-        use std::task::{Context, Poll, Waker};
-        let mut selectors = Vec::new();
-        for process in this.borrow().processes.values() {
-            if let Some(selector) = process.selector.upgrade() {
-                selectors.push(selector);
-            }
-        }
-        // To avoid double borrowing, SelectSystem::select must be called after
-        // dropping the borrow for `this`
-        let mut context = Context::from_waker(Waker::noop());
-        for selector in selectors {
-            let mut future = std::pin::pin!(SelectSystem::select(&selector, false));
-            if let Poll::Ready(result) = future.as_mut().poll(&mut context) {
-                result.ok();
-            }
-        }
-    }
+    pub fn select_all(_: &RefCell<Self>) {}
 
     /// Finds a child process to wait for.
     ///

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -21,7 +21,6 @@ use super::Gid;
 use super::Mode;
 use super::SigmaskOp;
 use super::Uid;
-use super::VirtualSystem;
 use super::WakerSet;
 use super::io::FdBody;
 use super::signal::{self, SignalEffect};
@@ -31,12 +30,10 @@ use crate::job::ProcessResult;
 use crate::job::ProcessState;
 use crate::path::Path;
 use crate::path::PathBuf;
-use crate::system::SelectSystem;
 use crate::system::resource::INFINITY;
 use crate::system::resource::LimitPair;
 use crate::system::resource::Resource;
 use std::cell::Cell;
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -116,13 +113,6 @@ pub struct Process {
     /// Limits for system resources
     pub(crate) resource_limits: HashMap<Resource, LimitPair>,
 
-    /// Weak reference to the `SelectSystem` for this process
-    ///
-    /// This weak reference is empty for the initial process of a
-    /// `VirtualSystem`.  When a new child process is created, a weak reference
-    /// to the `SelectSystem` for the child is set.
-    pub(crate) selector: Weak<RefCell<SelectSystem<VirtualSystem>>>,
-
     /// Copy of arguments passed to [`execve`](crate::System::execve)
     pub(crate) last_exec: Option<(CString, Vec<CString>, Vec<CString>)>,
 }
@@ -168,7 +158,6 @@ impl Process {
             caught_signals: Vec::new(),
             signal_wakers: WakerSet::new(),
             resource_limits: HashMap::new(),
-            selector: Weak::new(),
             last_exec: None,
         }
     }
@@ -609,6 +598,7 @@ mod tests {
     use enumset::EnumSet;
     use futures_util::FutureExt;
     use futures_util::task::LocalSpawnExt;
+    use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::future::poll_fn;
     use std::rc::Rc;


### PR DESCRIPTION
## Description

Deprecates SharedSystem in favor of Concurrent.

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecated**
  * `SharedSystem` is now deprecated in favor of `Concurrent` for improved support of concurrent execution in virtual systems.

* **Improvements**
  * Virtual processes are now automatically woken when ready, eliminating the need for manual polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->