### PR TITLE
Align panic messages with precondition style

### DIFF
--- a/.agents/skills/commit-message/SKILL.md
+++ b/.agents/skills/commit-message/SKILL.md
@@ -64,7 +64,9 @@ Produce:
 
 ## Output Format
 
-Unless the user asks for a different convention, provide:
+Unless the user asks for a different convention, always present the primary suggested commit message in a fenced `text` code block so it can be pasted directly into a commit editor.
+
+Use this structure:
 
 ```text
 <subject>
@@ -74,7 +76,7 @@ Unless the user asks for a different convention, provide:
 
 Keep the subject at 72 characters or fewer, preferably 50 or fewer, and wrap each body line at 72 characters.
 
-If useful, also provide 2 to 3 alternative subject lines with different emphasis, such as user-visible behavior, subsystem, or bug fix framing.
+If useful, also provide 2 to 3 alternative subject lines with different emphasis, such as user-visible behavior, subsystem, or bug fix framing. The alternatives can be outside the code block.
 
 ## Heuristics
 

--- a/yash-arith/CHANGELOG.md
+++ b/yash-arith/CHANGELOG.md
@@ -13,6 +13,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Revised some panic messages to be more informative.
 - Public dependency versions
     - Rust 1.65.0 → 1.87.0
 

--- a/yash-arith/src/eval.rs
+++ b/yash-arith/src/eval.rs
@@ -339,7 +339,9 @@ pub fn eval<'a, E: Env>(
     ast: &[Ast<'a>],
     env: &mut E,
 ) -> Result<Term<'a>, Error<E::GetVariableError, E::AssignVariableError>> {
-    let (root, children) = ast.split_last().expect("evaluating an empty expression");
+    let (root, children) = ast
+        .split_last()
+        .expect("the expression should not be empty");
     match root {
         Ast::Term(term) => Ok(term.clone()),
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Revised some panic messages to be more informative.
 - Public dependency versions:
     - yash-env 0.12.0 → 0.13.0
     - yash-semantics (optional) 0.14.0 → 0.15.0

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -208,7 +208,11 @@ where
     S: Fstat + GetCwd + IsExecutableFile + Sysconf + 'static,
 {
     if env.params.categories.contains(Category::Keyword) {
-        let IsKeyword(is_keyword) = env.env.any.get().expect("IsKeyword not found in env.any");
+        let IsKeyword(is_keyword) = env
+            .env
+            .any
+            .get()
+            .expect("`IsKeyword` should be in `env.any`");
         if is_keyword(env.env, &name.value) {
             return Ok(Categorization::Keyword);
         }

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -126,7 +126,7 @@ where
 
         Target::Function(function) => {
             let RunFunction(run_function) =
-                env.any.get().expect("RunFunction not found in env.any");
+                env.any.get().expect("`RunFunction` should be in `env.any`");
             let divert = run_function(env, function, fields, None).await;
             crate::Result::with_exit_status_and_divert(env.exit_status, divert)
         }

--- a/yash-builtin/src/eval.rs
+++ b/yash-builtin/src/eval.rs
@@ -70,7 +70,7 @@ where
     let RunReadEvalLoop(run_read_eval_loop) = *env
         .any
         .get()
-        .expect("`eval` built-in requires `RunReadEvalLoop` in `Env::any`");
+        .expect("`RunReadEvalLoop` should be in `env.any`");
     let mut config = Config::with_input(Box::new(Memory::new(&command.value)));
     config.source = Some(Rc::new(Source::Eval {
         original: command.origin,

--- a/yash-builtin/src/read/input.rs
+++ b/yash-builtin/src/read/input.rs
@@ -208,10 +208,7 @@ where
     }
 
     // Obtain the prompt string
-    let GetPrompt(get_prompt) = *env
-        .any
-        .get()
-        .expect("reading input requires `GetPrompt` in `Env::any`");
+    let GetPrompt(get_prompt) = *env.any.get().expect("`GetPrompt` should be in `env.any`");
     let mut context = yash_env::input::Context::default();
     context.set_is_first_line(false);
     let prompt = get_prompt(env, &context).await;

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -157,7 +157,7 @@ where
 
     match syntax::parse(args) {
         Ok(Command::PrintVariables) => {
-            let IsName(is_name) = env.any.get().expect("IsName not found in env.any");
+            let IsName(is_name) = env.any.get().expect("`IsName` should be in `env.any`");
             let mut vars: Vec<_> = env
                 .variables
                 .iter(Global)

--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -61,7 +61,7 @@ impl Command {
             .any
             .get::<RunReadEvalLoop<S>>()
             .cloned()
-            .expect("`source` built-in requires `RunReadEvalLoop` in `Env::any`");
+            .expect("`RunReadEvalLoop` should be in `env.any`");
         let system = env.system.clone();
         let ref_env = RefCell::new(&mut *env);
         let input = Box::new(Echo::new(FdReader2::new(fd, system), &ref_env));

--- a/yash-builtin/src/typeset/set_functions.rs
+++ b/yash-builtin/src/typeset/set_functions.rs
@@ -37,12 +37,14 @@ impl SetFunctions {
                             Ok(Some(mut function)) => {
                                 Rc::make_mut(&mut function).read_only_location =
                                     Some(name.origin.clone());
-                                functions
-                                    .define(function)
-                                    // The define function fails only when the set has a read-only
-                                    // function with the same name. This is impossible because we
-                                    // have just unset the function.
-                                    .expect("unreachable error case");
+                                let define_result = functions.define(function);
+                                // The define function fails only when the set has a read-only
+                                // function with the same name. This is impossible because we have
+                                // just unset the function.
+                                debug_assert!(
+                                    define_result.is_ok(),
+                                    "the function should be defined successfully: {define_result:?}"
+                                );
                             }
                         }
                     }

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -67,7 +67,7 @@ where
     let RunSignalTrapIfCaught(run_trap_if_caught) = *env
         .any
         .get()
-        .expect("`wait` built-in requires `RunSignalTrapIfCaught` in `Env::any`");
+        .expect("`RunSignalTrapIfCaught` should be in `env.any`");
 
     // We need to install the internal disposition before calling `wait` so we
     // don't miss any `SIGCHLD` that may arrive between `wait` and

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -175,6 +175,7 @@ A _private dependency_ is used internally and not visible to downstream users.
   simulates the execution of shell processes driven by
   `system::Concurrent::run_real`. It now also uses `yash_executor::Executor`
   as the executor instead of `futures_executor::LocalPool`.
+- Revised some panic messages to be more informative.
 - Private dependency versions:
     - derive_more 2.0.1 → 2.1.0
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -838,7 +838,7 @@ impl Clock for VirtualSystem {
         self.state
             .borrow()
             .now
-            .expect("SystemState::now not assigned")
+            .expect("`SystemState::now` should be assigned")
     }
 }
 
@@ -961,7 +961,7 @@ impl Sigmask for VirtualSystem {
             let process = state
                 .processes
                 .get_mut(&self.process_id)
-                .expect("current process not found");
+                .expect("the current process should be in the system state");
 
             if let Some(old_mask) = old_mask {
                 old_mask.clear();

--- a/yash-env/src/system/virtual/select.rs
+++ b/yash-env/src/system/virtual/select.rs
@@ -53,7 +53,7 @@ impl Select for VirtualSystem {
                 let proc = state
                     .processes
                     .get_mut(&this.process_id)
-                    .expect("current process not found");
+                    .expect("the current process should be in the system state");
 
                 let old_caught_signals = proc.caught_signals.len();
 
@@ -81,7 +81,7 @@ impl Select for VirtualSystem {
                     None | Some(Duration::ZERO) => None,
                     Some(timeout) => {
                         let now = state.now;
-                        let now = now.expect("current time unspecified; cannot compute deadline");
+                        let now = now.expect("the current time should be set in the system state");
                         Some(now + timeout)
                     }
                 };
@@ -96,7 +96,7 @@ impl Select for VirtualSystem {
                 let proc = state
                     .processes
                     .get_mut(&this.process_id)
-                    .expect("current process not found");
+                    .expect("the current process should be in the system state");
 
                 // If the process is currently suspended, do nothing until resumed
                 if let ProcessState::Halted(reason) = proc.state() {
@@ -147,7 +147,7 @@ impl Select for VirtualSystem {
                     None => timeout == Some(Duration::ZERO),
                     Some(deadline) => {
                         let now = state.now;
-                        let now = now.expect("current time unspecified; cannot check timeout");
+                        let now = now.expect("the current time should be set in the system state");
                         now >= deadline
                     }
                 };
@@ -183,7 +183,7 @@ impl Select for VirtualSystem {
                 let proc = state
                     .processes
                     .get_mut(&this.process_id)
-                    .expect("current process not found");
+                    .expect("the current process should be in the system state");
                 let result = proc.block_signals(SigmaskOp::Set, &old_mask);
                 if result.process_state_changed {
                     let ppid = proc.ppid;

--- a/yash-env/src/variable.rs
+++ b/yash-env/src/variable.rs
@@ -288,7 +288,7 @@ impl VariableSet {
         contexts
             .iter()
             .rposition(|context| matches!(context, Context::Regular { .. }))
-            .expect("base context has gone")
+            .expect("the stack should have at least one regular context")
     }
 
     /// Computes the index of the context that matches the specified scope.
@@ -685,7 +685,7 @@ impl VariableSet {
                 Context::Regular { positional_params } => Some(positional_params),
                 Context::Volatile => None,
             })
-            .expect("base context has gone")
+            .expect("the stack should have at least one regular context")
     }
 
     /// Returns a mutable reference to the positional parameters.
@@ -703,7 +703,7 @@ impl VariableSet {
                 Context::Regular { positional_params } => Some(positional_params),
                 Context::Volatile => None,
             })
-            .expect("base context has gone")
+            .expect("the stack should have at least one regular context")
     }
 
     fn push_context_impl(&mut self, context: Context) {
@@ -712,7 +712,11 @@ impl VariableSet {
 
     fn pop_context_impl(&mut self) {
         debug_assert!(!self.contexts.is_empty());
-        assert_ne!(self.contexts.len(), 1, "cannot pop the base context");
+        assert_ne!(
+            self.contexts.len(),
+            1,
+            "the base context should not be popped"
+        );
         self.contexts.pop();
         self.all_variables.retain(|_, stack| {
             stack.pop_if(|vic| {
@@ -1256,7 +1260,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot pop the base context")]
+    #[should_panic(expected = "the base context should not be popped")]
     fn cannot_pop_base_context() {
         let mut variables = VariableSet::new();
         variables.pop_context_impl();

--- a/yash-executor/CHANGELOG.md
+++ b/yash-executor/CHANGELOG.md
@@ -13,6 +13,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Revised some panic messages to be more informative.
 - Public dependency versions:
     - Rust 1.65.0 → 1.87.0
 

--- a/yash-executor/src/task.rs
+++ b/yash-executor/src/task.rs
@@ -34,12 +34,16 @@ impl Task<'_> {
     /// If `self.executor` has been dropped or the task is polled recursively,
     /// this method panics.
     pub fn poll(self: &Rc<Self>) -> bool {
-        assert_ne!(self.executor.strong_count(), 0, "executor has been dropped");
+        assert_ne!(
+            self.executor.strong_count(),
+            0,
+            "the executor should not be dropped"
+        );
 
         let mut future_or_none = self
             .future
             .try_borrow_mut()
-            .expect("future polled recursively");
+            .expect("`Future` should not be polled recursively");
         let Some(future) = future_or_none.as_mut() else {
             return true;
         };
@@ -117,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "executor has been dropped"]
+    #[should_panic = "the executor should not be dropped"]
     fn polling_without_executor_panics() {
         let task = Rc::new(Task {
             executor: Weak::new(),
@@ -165,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "future polled recursively"]
+    #[should_panic = "`Future` should not be polled recursively"]
     fn recursive_poll_panics() {
         let executor = Rc::default();
         let task = Rc::new(Task {

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -13,6 +13,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Revised some panic messages to be more informative.
 - Public dependency versions:
     - yash-env 0.12.0 → 0.13.0
 - Private dependency versions:

--- a/yash-prompt/src/expand_posix.rs
+++ b/yash-prompt/src/expand_posix.rs
@@ -115,10 +115,7 @@ where
         replace_exclamation_marks(&mut text.0);
     }
 
-    let ExpandText(expand_text) = *env
-        .any
-        .get()
-        .expect("`yash-prompt::expand_posix` requires `ExpandText` in `Env::any`");
+    let ExpandText(expand_text) = *env.any.get().expect("`ExpandText` should be in `env.any`");
     match expand_text(env, &text).await {
         Some((expansion, _exit_status)) => expansion,
         None => text.to_string(),

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Revised some panic messages to be more informative.
 - Public dependency versions:
     - yash-env 0.12.0 → 0.13.0
 

--- a/yash-syntax/src/parser/from_str.rs
+++ b/yash-syntax/src/parser/from_str.rs
@@ -32,7 +32,7 @@ use std::str::FromStr;
 fn unwrap_ready<F: Future>(f: F) -> <F as Future>::Output {
     use futures_util::future::FutureExt;
     f.now_or_never()
-        .expect("Expected Ready but received Pending")
+        .expect("the lexer should not block when reading from a string")
 }
 
 /// Returns an error if the parser has a remaining token.

--- a/yash-syntax/src/parser/lex/heredoc.rs
+++ b/yash-syntax/src/parser/lex/heredoc.rs
@@ -106,7 +106,7 @@ impl Lexer<'_> {
         here_doc
             .content
             .set(Text(content))
-            .expect("here-doc content must be read just once");
+            .expect("here-doc content should not be read more than once");
         Ok(())
     }
 }

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -42,7 +42,7 @@ pub trait Unquote {
         let mut unquoted = String::new();
         let is_quoted = self
             .write_unquoted(&mut unquoted)
-            .expect("`write_unquoted` should not fail");
+            .expect("`write_unquoted` should not fail when writing to a `String`");
         (unquoted, is_quoted)
     }
 }


### PR DESCRIPTION
## Description

Rewrite expect/assert panic messages across multiple crates to use the
Rust "expect as precondition" style (focused on what should hold) [1],
instead of terse "not found"/"unreachable" phrasing.
    
This makes invariant violations easier to understand in panic output,
adds useful context for debugging, and avoids repeating source-error
wording. The change also updates panic-string tests and adds matching
CHANGELOG.md notes in affected crates.
    
[1]: https://doc.rust-lang.org/std/error/index.html#common-message-styles

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined and enhanced error messages across all modules to be more informative, consistent, and user-friendly, providing clearer feedback when issues occur.
  * Improved error handling in built-in commands for better user experience.

* **Documentation**
  * Updated changelogs across all modules to document message clarity and consistency improvements.
  * Enhanced commit message skill documentation with improved formatting and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->