### PR TITLE
Implement blocking read/write operations in virtual system

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -44,6 +44,8 @@ A _private dependency_ is used internally and not visible to downstream users.
       performs a read operation.
     - `poll_write`: Polls for the file descriptor to be ready for writing and
       performs a write operation.
+    - `poll_write_full`: Calls `poll_write` repeatedly to write the entire buffer
+      to a pipe (FIFO).
 - The new module `waker` has been added containing the `WakerSet` and
   `ScheduledWakerQueue` structs for storing and activating wakers.
 - The read and write operations of the `system::virtual::VirtualSystem`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -205,6 +205,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 - When a blocking write to a FIFO or pipe with a buffer larger than `PIPE_BUF`
   is interrupted by a signal after some bytes have already been written, the
   write operation now returns the count of bytes written rather than `EINTR`.
+- `system::real::RealSystem::read` and `system::real::RealSystem::write` no
+  longer silently retry on `Errno::EINTR`. When the underlying system call
+  is interrupted by a signal, the error is now returned to the caller directly.
+  Callers are responsible for handling `EINTR` (e.g., by retrying the operation
+  or propagating the error).
 - `system::virtual::VirtualSystem::select` now correctly sends SIGCHLD to the
   parent process when temporarily changing the signal mask causes the process
   state to change.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -196,6 +196,13 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Fixed
 
+- `system::virtual::VirtualSystem::read` and `system::virtual::VirtualSystem::write`
+  now return `Errno::EINTR` when a signal is caught while the operation is
+  blocking. Previously, these methods would block indefinitely, ignoring any
+  signals that were caught.
+- When a blocking write to a FIFO or pipe with a buffer larger than `PIPE_BUF`
+  is interrupted by a signal after some bytes have already been written, the
+  write operation now returns the count of bytes written rather than `EINTR`.
 - `system::virtual::VirtualSystem::select` now correctly sends SIGCHLD to the
   parent process when temporarily changing the signal mask causes the process
   state to change.

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -165,7 +165,7 @@ where
                 match this.inner.read(fd, buffer).await {
                     // EWOULDBLOCK is unreachable if it has the same value as EAGAIN.
                     #[allow(unreachable_patterns)]
-                    Err(Errno::EAGAIN | Errno::EWOULDBLOCK) => {
+                    Err(Errno::EAGAIN | Errno::EWOULDBLOCK | Errno::EINTR) => {
                         this.yield_for_read(fd, &waker).await
                     }
 
@@ -202,7 +202,7 @@ where
                 match this.inner.write(fd, buffer).await {
                     // EWOULDBLOCK is unreachable if it has the same value as EAGAIN.
                     #[allow(unreachable_patterns)]
-                    Err(Errno::EAGAIN | Errno::EWOULDBLOCK) => {
+                    Err(Errno::EAGAIN | Errno::EWOULDBLOCK | Errno::EINTR) => {
                         this.yield_for_write(fd, &waker).await
                     }
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -430,30 +430,24 @@ impl Fcntl for RealSystem {
 }
 
 impl Read for RealSystem {
+    /// Reads data from the file descriptor into the buffer.
     fn read<'a>(
         &self,
         fd: Fd,
         buffer: &'a mut [u8],
     ) -> impl Future<Output = Result<usize>> + use<'a> {
-        ready(loop {
-            let result =
-                unsafe { libc::read(fd.0, buffer.as_mut_ptr().cast(), buffer.len()) }.errno_if_m1();
-            if result != Err(Errno::EINTR) {
-                break result.map(|len| len.try_into().unwrap());
-            }
-        })
+        let result =
+            unsafe { libc::read(fd.0, buffer.as_mut_ptr().cast(), buffer.len()) }.errno_if_m1();
+        ready(result.map(|len| len.try_into().unwrap()))
     }
 }
 
 impl Write for RealSystem {
+    /// Writes data from the buffer to the file descriptor.
     fn write<'a>(&self, fd: Fd, buffer: &'a [u8]) -> impl Future<Output = Result<usize>> + use<'a> {
-        ready(loop {
-            let result =
-                unsafe { libc::write(fd.0, buffer.as_ptr().cast(), buffer.len()) }.errno_if_m1();
-            if result != Err(Errno::EINTR) {
-                break result.map(|len| len.try_into().unwrap());
-            }
-        })
+        let result =
+            unsafe { libc::write(fd.0, buffer.as_ptr().cast(), buffer.len()) }.errno_if_m1();
+        ready(result.map(|len| len.try_into().unwrap()))
     }
 }
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -755,7 +755,7 @@ impl Fcntl for VirtualSystem {
 }
 
 impl VirtualSystem {
-    /// Checks for newly caught signals and registers a signal waker if none found
+    /// Checks for newly caught signals and registers a signal waker if none found.
     ///
     /// Returns `true` if new signals have been caught since `initial_signal_count`,
     /// leaving the waker unregistered. Returns `false` and registers the waker for
@@ -813,14 +813,24 @@ impl Read for VirtualSystem {
 impl Write for VirtualSystem {
     /// Writes data from the buffer to the file descriptor.
     ///
-    /// For writes of at most [`PIPE_BUF`] bytes to a pipe or FIFO, this method
-    /// blocks until the entire buffer can be written atomically. For larger
-    /// writes, this method writes as many bytes as possible and blocks for more
-    /// space until the whole buffer is written.
+    /// For pipes (FIFOs) opened in blocking mode, if the write is at most
+    /// [`PIPE_BUF`] bytes, this method blocks until enough room is available
+    /// to write all bytes atomically. For larger writes, this method writes as
+    /// many bytes as fit on each pass and loops, blocking only when the pipe is
+    /// completely full, until the entire buffer has been written. The decision
+    /// to loop is encapsulated in
+    /// [`OpenFileDescription::poll_write_full`](OpenFileDescription::poll_write_full);
+    /// this method itself contains no file-type branching.
+    ///
+    /// For non-pipe file types or non-blocking mode, this method returns after
+    /// the first successful (possibly partial) write without looping.
     ///
     /// If a signal is caught while this method is blocking, it returns
     /// [`Errno::EINTR`] if no bytes have been written yet, or the count of
-    /// bytes written so far otherwise.
+    /// bytes written so far otherwise. The signal-precedence check runs at the
+    /// top of each poll iteration *before* any further write is attempted, so
+    /// when `Err(Errno::EINTR)` is returned no bytes have been transferred in
+    /// this call.
     fn write<'a>(&self, fd: Fd, buffer: &'a [u8]) -> impl Future<Output = Result<usize>> + use<'a> {
         let ofd = self.get_open_file_description(fd);
         let system = self.clone();
@@ -829,41 +839,32 @@ impl Write for VirtualSystem {
             let initial_signal_count = system.current_process().caught_signals_count;
             let mut bytes_written = 0usize;
             let waker: LazyCell<Rc<Cell<Option<Waker>>>> = LazyCell::default();
+            // Helper that maps the running byte count into the result returned
+            // when a signal interrupts the operation.
+            let interrupted = |bytes_written: usize| -> Poll<Result<usize>> {
+                Poll::Ready(if bytes_written > 0 {
+                    Ok(bytes_written)
+                } else {
+                    Err(Errno::EINTR)
+                })
+            };
             poll_fn(|context| {
-                loop {
-                    let remaining = &buffer[bytes_written..];
-                    if remaining.is_empty() {
-                        return Poll::Ready(Ok(bytes_written));
-                    }
-                    let get_waker = || {
-                        waker.set(Some(context.waker().clone()));
-                        Rc::downgrade(&waker)
-                    };
-                    match ofd.borrow_mut().poll_write(remaining, get_waker) {
-                        Poll::Ready(Ok(n)) => {
-                            bytes_written += n;
-                            // Continue the loop to write more bytes immediately
-                        }
-                        Poll::Ready(Err(e)) => {
-                            // Return bytes written so far if any, else propagate the error
-                            return Poll::Ready(if bytes_written > 0 {
-                                Ok(bytes_written)
-                            } else {
-                                Err(e)
-                            });
-                        }
-                        Poll::Pending => {
-                            if system.signal_interrupted(initial_signal_count, &waker, context) {
-                                return Poll::Ready(if bytes_written > 0 {
-                                    Ok(bytes_written)
-                                } else {
-                                    Err(Errno::EINTR)
-                                });
-                            }
-                            return Poll::Pending;
-                        }
-                    }
+                if system.current_process().caught_signals_count != initial_signal_count {
+                    return interrupted(bytes_written);
                 }
+                let get_waker = || {
+                    waker.set(Some(context.waker().clone()));
+                    Rc::downgrade(&waker)
+                };
+                let result =
+                    ofd.borrow_mut()
+                        .poll_write_full(buffer, &mut bytes_written, get_waker);
+                if result.is_pending()
+                    && system.signal_interrupted(initial_signal_count, &waker, context)
+                {
+                    return interrupted(bytes_written);
+                }
+                result
             })
             .await
         }
@@ -1901,6 +1902,200 @@ mod tests {
             system.current_process().caught_signals,
             [SIGINT],
             "SIGINT should be in the caught signals list"
+        );
+    }
+
+    #[test]
+    fn write_large_buffer_completes_fully_without_signal() {
+        // A large write in blocking mode (without a signal) must eventually
+        // transfer the entire buffer.  The pipe can hold PIPE_SIZE bytes at a
+        // time; the write fills it and blocks, a reader drains it, and the
+        // pattern repeats until all bytes are written.
+        let big_buf: Vec<u8> = (0..2 * PIPE_SIZE).map(|i| i as u8).collect();
+        let system = VirtualSystem::new();
+        let (reader, writer) = system.pipe().unwrap();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        let mut write_fut = pin!(system.write(writer, &big_buf));
+
+        // First poll: fills the pipe (PIPE_SIZE bytes), then blocks.
+        assert_eq!(write_fut.as_mut().poll(&mut context), Pending);
+
+        // Drain the pipe so the write can continue.
+        let mut read_buf = [0u8; PIPE_SIZE];
+        assert_eq!(
+            system.read(reader, &mut read_buf).now_or_never().unwrap(),
+            Ok(PIPE_SIZE)
+        );
+        assert_eq!(read_buf, big_buf[..PIPE_SIZE]);
+        assert!(
+            woken.is_woken(),
+            "draining the pipe should wake the write task"
+        );
+
+        // Second poll: writes the remaining bytes.
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(
+            write_fut.poll(&mut context),
+            Ready(Ok(2 * PIPE_SIZE)),
+            "large write without signal must complete the full buffer"
+        );
+
+        // The second half of the buffer must also be readable from the pipe.
+        let mut read_buf2 = [0u8; PIPE_SIZE];
+        assert_eq!(
+            system.read(reader, &mut read_buf2).now_or_never().unwrap(),
+            Ok(PIPE_SIZE)
+        );
+        assert_eq!(read_buf2, big_buf[PIPE_SIZE..]);
+    }
+
+    #[test]
+    fn write_returns_eintr_when_space_and_signal_arrive_simultaneously() {
+        // When a write is blocked on a full pipe, both the availability of
+        // space in the pipe and the delivery of a signal will wake the write
+        // task. In the current implementation, if both events occur before the
+        // next poll, the signal takes precedence and the write returns EINTR
+        // without writing any more bytes. This test verifies that behavior.
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (reader, writer) = system.pipe().unwrap();
+        // Fill the pipe so the next write blocks.
+        system
+            .write(writer, &[0u8; PIPE_SIZE])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        let mut write_fut = pin!(system.write(writer, &[1]));
+
+        // First poll: pipe is full, should be pending.
+        assert_eq!(write_fut.as_mut().poll(&mut context), Pending);
+
+        // Drain the pipe (space available, wakes the write task) and deliver a
+        // signal before the next poll — both events occur simultaneously.
+        let mut drain_buf = [0u8; PIPE_SIZE];
+        system
+            .read(reader, &mut drain_buf)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+        assert!(woken.is_woken(), "write task should have been woken");
+
+        // Second poll: even though space is available, the signal should interrupt.
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(
+            write_fut.as_mut().poll(&mut context),
+            Ready(Err(Errno::EINTR)),
+            "signal should interrupt write even when space is available"
+        );
+
+        // A fresh read on the now-drained pipe must block (return Pending)
+        // because the interrupted write left it empty: no bytes were
+        // transferred when EINTR was returned.
+        let mut probe_buf = [0u8; 1];
+        assert_eq!(
+            system.read(reader, &mut probe_buf).now_or_never(),
+            None,
+            "no bytes must be transferred when EINTR is returned"
+        );
+    }
+
+    #[test]
+    fn write_does_not_check_signals_before_first_block() {
+        // A signal caught *before* write is called must not cause the write to
+        // return EINTR if the operation never had to block. The signal-
+        // precedence policy only applies once the write has blocked at least
+        // once.
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (_reader, writer) = system.pipe().unwrap();
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+
+        let result = system.write(writer, &[42]).now_or_never().unwrap();
+        assert_eq!(
+            result,
+            Ok(1),
+            "write that does not block must succeed even with a pending signal"
+        );
+    }
+
+    #[test]
+    fn write_returns_partial_count_when_space_and_signal_arrive_simultaneously() {
+        // Verifies that when a large write has already written some bytes and then
+        // blocked, and both space becomes available and a signal is caught before
+        // the next poll, the write returns the byte count already written rather
+        // than continuing to write more.
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (reader, writer) = system.pipe().unwrap();
+
+        let big_buf: Vec<u8> = (0..2 * PIPE_SIZE).map(|i| i as u8).collect();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        let mut write_fut = pin!(system.write(writer, &big_buf));
+
+        // First poll: writes PIPE_SIZE bytes (filling the pipe), then blocks.
+        assert_eq!(write_fut.as_mut().poll(&mut context), Pending);
+
+        // Drain the pipe AND deliver a signal before the next poll.
+        let mut drain_buf = [0u8; PIPE_SIZE];
+        system
+            .read(reader, &mut drain_buf)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+        assert!(woken.is_woken(), "write task should have been woken");
+
+        // Second poll: the write should return the bytes written so far rather
+        // than continuing to write more.
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(
+            write_fut.poll(&mut context),
+            Ready(Ok(PIPE_SIZE)),
+            "signal should interrupt large write and return bytes written so far"
+        );
+    }
+
+    #[test]
+    fn write_to_non_blocking_pipe_does_not_block() {
+        // A write on a non-blocking FD must complete immediately and never return
+        // Pending, even when the buffer is larger than the pipe capacity.
+        let system = VirtualSystem::new();
+        let (_reader, writer) = system.pipe().unwrap();
+        system.get_and_set_nonblocking(writer, true).unwrap();
+
+        // Writing a buffer larger than the pipe capacity should return
+        // immediately with the number of bytes that fit.
+        let big_buf = vec![0u8; PIPE_SIZE * 2];
+        let result = system.write(writer, &big_buf).now_or_never();
+        assert_eq!(
+            result,
+            Some(Ok(PIPE_SIZE)),
+            "non-blocking write should return immediately with bytes that fit"
+        );
+
+        // A subsequent write to the now-full pipe should return EAGAIN immediately.
+        let result = system.write(writer, &[1]).now_or_never();
+        assert_eq!(
+            result,
+            Some(Err(Errno::EAGAIN)),
+            "non-blocking write to full pipe should return EAGAIN"
         );
     }
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -754,23 +754,56 @@ impl Fcntl for VirtualSystem {
     }
 }
 
+impl VirtualSystem {
+    /// Checks for newly caught signals and registers a signal waker if none found
+    ///
+    /// Returns `true` if new signals have been caught since `initial_signal_count`,
+    /// leaving the waker unregistered. Returns `false` and registers the waker for
+    /// future signal notifications otherwise.
+    fn signal_interrupted(
+        &self,
+        initial_signal_count: usize,
+        waker: &Rc<Cell<Option<Waker>>>,
+        context: &mut std::task::Context<'_>,
+    ) -> bool {
+        let mut proc = self.current_process_mut();
+        if proc.caught_signals_count != initial_signal_count {
+            return true;
+        }
+        waker.set(Some(context.waker().clone()));
+        proc.register_signal_waker(Rc::downgrade(waker));
+        false
+    }
+}
+
 impl Read for VirtualSystem {
     /// Reads data from the file descriptor into the buffer.
+    ///
+    /// If a signal is caught while this method is blocking for data, it returns
+    /// [`Errno::EINTR`].
     fn read<'a>(
         &self,
         fd: Fd,
         buffer: &'a mut [u8],
     ) -> impl Future<Output = Result<usize>> + use<'a> {
         let ofd = self.get_open_file_description(fd);
+        let system = self.clone();
         async move {
             let ofd = ofd?;
+            let initial_signal_count = system.current_process().caught_signals_count;
             let waker: LazyCell<Rc<Cell<Option<Waker>>>> = LazyCell::default();
             poll_fn(|context| {
                 let get_waker = || {
                     waker.set(Some(context.waker().clone()));
                     Rc::downgrade(&waker)
                 };
-                ofd.borrow_mut().poll_read(buffer, get_waker)
+                let result = ofd.borrow_mut().poll_read(buffer, get_waker);
+                if result.is_pending()
+                    && system.signal_interrupted(initial_signal_count, &waker, context)
+                {
+                    return Poll::Ready(Err(Errno::EINTR));
+                }
+                result
             })
             .await
         }
@@ -779,17 +812,58 @@ impl Read for VirtualSystem {
 
 impl Write for VirtualSystem {
     /// Writes data from the buffer to the file descriptor.
+    ///
+    /// For writes of at most [`PIPE_BUF`] bytes to a pipe or FIFO, this method
+    /// blocks until the entire buffer can be written atomically. For larger
+    /// writes, this method writes as many bytes as possible and blocks for more
+    /// space until the whole buffer is written.
+    ///
+    /// If a signal is caught while this method is blocking, it returns
+    /// [`Errno::EINTR`] if no bytes have been written yet, or the count of
+    /// bytes written so far otherwise.
     fn write<'a>(&self, fd: Fd, buffer: &'a [u8]) -> impl Future<Output = Result<usize>> + use<'a> {
         let ofd = self.get_open_file_description(fd);
+        let system = self.clone();
         async move {
             let ofd = ofd?;
+            let initial_signal_count = system.current_process().caught_signals_count;
+            let mut bytes_written = 0usize;
             let waker: LazyCell<Rc<Cell<Option<Waker>>>> = LazyCell::default();
             poll_fn(|context| {
-                let get_waker = || {
-                    waker.set(Some(context.waker().clone()));
-                    Rc::downgrade(&waker)
-                };
-                ofd.borrow_mut().poll_write(buffer, get_waker)
+                loop {
+                    let remaining = &buffer[bytes_written..];
+                    if remaining.is_empty() {
+                        return Poll::Ready(Ok(bytes_written));
+                    }
+                    let get_waker = || {
+                        waker.set(Some(context.waker().clone()));
+                        Rc::downgrade(&waker)
+                    };
+                    match ofd.borrow_mut().poll_write(remaining, get_waker) {
+                        Poll::Ready(Ok(n)) => {
+                            bytes_written += n;
+                            // Continue the loop to write more bytes immediately
+                        }
+                        Poll::Ready(Err(e)) => {
+                            // Return bytes written so far if any, else propagate the error
+                            return Poll::Ready(if bytes_written > 0 {
+                                Ok(bytes_written)
+                            } else {
+                                Err(e)
+                            });
+                        }
+                        Poll::Pending => {
+                            if system.signal_interrupted(initial_signal_count, &waker, context) {
+                                return Poll::Ready(if bytes_written > 0 {
+                                    Ok(bytes_written)
+                                } else {
+                                    Err(Errno::EINTR)
+                                });
+                            }
+                            return Poll::Pending;
+                        }
+                    }
+                }
             })
             .await
         }
@@ -1521,10 +1595,16 @@ mod tests {
     use crate::Env;
     use crate::job::ProcessResult;
     use crate::system::FileType;
+    use crate::system::r#virtual::PIPE_SIZE;
+    use crate::test_helper::WakeFlag;
     use assert_matches::assert_matches;
     use futures_executor::LocalPool;
     use futures_util::FutureExt as _;
     use std::future::pending;
+    use std::pin::pin;
+    use std::sync::Arc;
+    use std::task::Context;
+    use std::task::Poll::{Pending, Ready};
 
     impl Executor for futures_executor::LocalSpawner {
         fn spawn(
@@ -1686,6 +1766,142 @@ mod tests {
 
         let result = system.read(reader, &mut buffer).now_or_never().unwrap();
         assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn read_returns_eintr_when_interrupted_by_signal() {
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (reader, _writer) = system.pipe().unwrap();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+
+        let mut buffer = [0; 4];
+        let mut read_fut = pin!(system.read(reader, &mut buffer));
+
+        // First poll: no data, should be pending
+        assert_eq!(read_fut.as_mut().poll(&mut context), Pending);
+
+        // Deliver a signal
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+        assert!(woken.is_woken(), "signal should have woken the read task");
+
+        // Second poll: signal delivered, should return EINTR
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(read_fut.poll(&mut context), Ready(Err(Errno::EINTR)));
+    }
+
+    #[test]
+    fn read_does_not_return_eintr_if_data_available_despite_pending_signal() {
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (reader, writer) = system.pipe().unwrap();
+        // Write data before the signal
+        system
+            .write(writer, &[1, 2, 3])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        // Also deliver a signal
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+
+        let mut buffer = [0; 4];
+        let read_fut = pin!(system.read(reader, &mut buffer));
+        // Data is immediately available; should NOT return EINTR
+        assert_eq!(read_fut.poll(&mut context), Ready(Ok(3)));
+    }
+
+    #[test]
+    fn write_returns_eintr_when_interrupted_by_signal() {
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (_reader, writer) = system.pipe().unwrap();
+        // Fill the pipe to make the next write block
+        system
+            .write(writer, &[0u8; PIPE_SIZE])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+
+        let mut write_fut = pin!(system.write(writer, &[1]));
+
+        // First poll: no space, should be pending
+        assert_eq!(write_fut.as_mut().poll(&mut context), Pending);
+
+        // Deliver a signal
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+        assert!(woken.is_woken(), "signal should have woken the write task");
+
+        // Second poll: signal delivered, should return EINTR
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(write_fut.poll(&mut context), Ready(Err(Errno::EINTR)));
+    }
+
+    #[test]
+    fn write_returns_partial_count_when_interrupted_by_signal_after_partial_write() {
+        // Write a buffer larger than PIPE_SIZE (= 2 * PIPE_BUF) to a blocking
+        // pipe.  The pipe can hold PIPE_SIZE bytes; after those are written the
+        // write blocks waiting for room for the rest.  When a signal arrives
+        // during that blocking phase, the write must return the count of bytes
+        // already written rather than Err(EINTR).
+        let system = VirtualSystem::new();
+        system.sigaction(SIGINT, Disposition::Catch).unwrap();
+        let (reader, writer) = system.pipe().unwrap();
+
+        // A buffer larger than the pipe can hold: the write will fill the pipe
+        // and then block waiting for space.
+        let big_buf: Vec<u8> = (0..2 * PIPE_SIZE).map(|i| i as u8).collect();
+
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        let mut write_fut = pin!(system.write(writer, &big_buf));
+
+        // First poll: writes PIPE_SIZE bytes (filling the pipe), then blocks.
+        assert_eq!(write_fut.as_mut().poll(&mut context), Pending);
+
+        // A signal arrives while the write is blocking.
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+        assert!(woken.is_woken(), "signal should have woken the write task");
+
+        // Second poll: the write returns the bytes written so far, not EINTR.
+        let woken = Arc::new(WakeFlag::new());
+        let waker = std::task::Waker::from(woken.clone());
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(
+            write_fut.poll(&mut context),
+            Ready(Ok(PIPE_SIZE)),
+            "expected partial byte count written before the signal"
+        );
+
+        // The bytes already written should be available for reading.
+        let mut read_buf = [0u8; PIPE_SIZE];
+        assert_eq!(
+            system.read(reader, &mut read_buf).now_or_never().unwrap(),
+            Ok(PIPE_SIZE)
+        );
+        assert_eq!(read_buf, big_buf[..PIPE_SIZE]);
+
+        // The signal must have been recorded as caught.
+        assert_eq!(
+            system.current_process().caught_signals,
+            [SIGINT],
+            "SIGINT should be in the caught signals list"
+        );
     }
 
     #[test]

--- a/yash-env/src/system/virtual/file_body.rs
+++ b/yash-env/src/system/virtual/file_body.rs
@@ -375,6 +375,12 @@ impl FileBody {
     /// wake conditions and to allow it to be taken by the first condition that
     /// wakes the task.
     ///
+    /// For FIFO writes of at most [`PIPE_BUF`] bytes, the write is atomic:
+    /// either all bytes are written at once or the method blocks until enough
+    /// room is available. For larger writes, the method writes as many bytes as
+    /// fit in the pipe buffer and returns immediately; if no bytes fit (the
+    /// pipe is full), it blocks until at least one byte can be written.
+    ///
     /// The returned `Poll` indicates whether the write operation has completed
     /// or is still pending. If it is `Poll::Ready`, the contained `Result`
     /// indicates whether the write was successful and how many bytes were
@@ -865,7 +871,7 @@ mod tests {
     #[test]
     fn fifo_file_body_write_non_atomic_empty() {
         // When the write size exceeds PIPE_BUF, the FIFO has space for at least
-        // one byte, but there are readers that may read from the FIFO, the
+        // one byte, and there are readers that may read from the FIFO, the
         // write operation should succeed and write as much as possible.
         let mut body = FileBody::Fifo {
             content: VecDeque::from([0; PIPE_SIZE - 1]),

--- a/yash-env/src/system/virtual/io.rs
+++ b/yash-env/src/system/virtual/io.rs
@@ -17,6 +17,7 @@
 //! I/O within a virtual system.
 
 use super::super::Errno;
+use super::super::FileType;
 use super::FdFlag;
 use super::FileBody;
 use super::Inode;
@@ -282,6 +283,68 @@ impl OpenFileDescription {
         poll
     }
 
+    /// Drives a `write(2)`-equivalent loop on this open file description.
+    ///
+    /// This helper encapsulates the POSIX rule that a single blocking `write(2)`
+    /// call to a pipe must, in the absence of a signal, transfer the entire
+    /// buffer even when the buffer is larger than [`PIPE_BUF`]. For a blocking
+    /// FIFO it repeatedly calls [`poll_write`](Self::poll_write), advancing
+    /// `bytes_written` until either the buffer is exhausted (returns
+    /// `Ready(Ok(*bytes_written))`), no more bytes fit and the next call would
+    /// block (returns `Pending` after registering the waker), or an error is
+    /// reported (returns `Ready(Err(_))` if no bytes have been transferred yet,
+    /// or `Ready(Ok(*bytes_written))` otherwise).
+    ///
+    /// For non-FIFO files or non-blocking file descriptors it returns after a
+    /// single `poll_write` call without looping; this matches POSIX `write(2)`
+    /// semantics for those cases.
+    ///
+    /// `bytes_written` is updated in place so that the caller can resume the
+    /// operation across multiple polls without losing the running total when a
+    /// signal interrupts the operation. This function will panic if
+    /// `bytes_written` exceeds the length of `buffer`. `get_waker` has the same
+    /// contract as for [`poll_write`](Self::poll_write).
+    ///
+    /// [`PIPE_BUF`]: super::PIPE_BUF
+    pub fn poll_write_full<F>(
+        &mut self,
+        buffer: &[u8],
+        bytes_written: &mut usize,
+        mut get_waker: F,
+    ) -> Poll<Result<usize, Errno>>
+    where
+        F: FnMut() -> Weak<Cell<Option<Waker>>>,
+    {
+        // Whether to keep looping after a successful partial write. Only a
+        // blocking FIFO requires looping; everything else returns after the
+        // first successful poll_write call.
+        let loop_on_success =
+            !self.is_nonblocking && self.file.borrow().body.r#type() == FileType::Fifo;
+        loop {
+            let remaining = &buffer[*bytes_written..];
+            if remaining.is_empty() {
+                return Poll::Ready(Ok(*bytes_written));
+            }
+            match self.poll_write(remaining, &mut get_waker) {
+                Poll::Ready(Ok(n)) => {
+                    *bytes_written += n;
+                    if !loop_on_success || n == 0 {
+                        return Poll::Ready(Ok(*bytes_written));
+                    }
+                    // Blocking FIFO with bytes still remaining: try again.
+                }
+                Poll::Ready(Err(e)) => {
+                    return Poll::Ready(if *bytes_written > 0 {
+                        Ok(*bytes_written)
+                    } else {
+                        Err(e)
+                    });
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+
     /// Moves the file offset and returns the new offset.
     pub fn seek(&mut self, position: SeekFrom) -> Result<usize, Errno> {
         let len = match &self.file.borrow().body {
@@ -522,6 +585,93 @@ mod tests {
 
         let result = open_file.poll_write(&[9; 4], || unreachable!());
         assert_eq!(result, Poll::Ready(Ok(4)));
+    }
+
+    #[test]
+    fn poll_write_full_regular_file_returns_after_one_call() {
+        // For a regular file, poll_write_full must not loop. Even though
+        // FileBody::Regular always writes the whole buffer in one call, the
+        // helper must not branch on FIFO-specific logic.
+        let mut open_file = OpenFileDescription {
+            file: Rc::new(RefCell::new(Inode::new([]))),
+            offset: 0,
+            is_readable: false,
+            is_writable: true,
+            is_appending: false,
+            is_nonblocking: false,
+        };
+        let mut bytes_written = 0usize;
+        let buffer = [1, 2, 3, 4, 5];
+        let result = open_file.poll_write_full(&buffer, &mut bytes_written, || unreachable!());
+        assert_eq!(result, Poll::Ready(Ok(5)));
+        assert_eq!(bytes_written, 5);
+        assert_matches!(
+            &open_file.file.borrow().body,
+            FileBody::Regular { content, .. } => {
+                assert_eq!(content[..], [1, 2, 3, 4, 5]);
+            }
+        );
+    }
+
+    #[test]
+    fn poll_write_full_blocking_fifo_loops_until_full() {
+        // For a blocking FIFO, poll_write_full must keep calling poll_write
+        // until either the buffer is exhausted or no more bytes fit (returning
+        // Pending).
+        let fifo = Rc::new(RefCell::new(Inode {
+            body: FileBody::Fifo {
+                content: VecDeque::new(),
+                readers: 1,
+                writers: 1,
+                pending_open_wakers: WakerSet::new(),
+                pending_read_wakers: WakerSet::new(),
+                pending_write_wakers: WakerSet::new(),
+            },
+            permissions: Mode::default(),
+        }));
+        let mut open_file = OpenFileDescription::new(
+            fifo, /* offset */ 0, /* is_readable */ false, /* is_writable */ true,
+            /* is_appending */ false, /* is_nonblocking */ false,
+        );
+
+        // Write a buffer larger than the pipe capacity. The helper writes as
+        // much as fits (PIPE_SIZE bytes) and then returns Pending.
+        let buffer = [7u8; PIPE_SIZE + 1];
+        let waker_holder: Rc<Cell<Option<Waker>>> = Rc::new(Cell::new(Some(Waker::noop().clone())));
+        let mut bytes_written = 0usize;
+        let result =
+            open_file.poll_write_full(&buffer, &mut bytes_written, || Rc::downgrade(&waker_holder));
+        assert_eq!(result, Poll::Pending);
+        assert_eq!(bytes_written, PIPE_SIZE);
+    }
+
+    #[test]
+    fn poll_write_full_nonblocking_fifo_returns_after_one_chunk() {
+        // For a non-blocking FIFO, poll_write_full must not loop even if more
+        // bytes could be written across multiple poll_write calls.
+        let fifo = Rc::new(RefCell::new(Inode {
+            body: FileBody::Fifo {
+                content: VecDeque::new(),
+                readers: 1,
+                writers: 1,
+                pending_open_wakers: WakerSet::new(),
+                pending_read_wakers: WakerSet::new(),
+                pending_write_wakers: WakerSet::new(),
+            },
+            permissions: Mode::default(),
+        }));
+        let mut open_file = OpenFileDescription::new(
+            fifo, /* offset */ 0, /* is_readable */ false, /* is_writable */ true,
+            /* is_appending */ false, /* is_nonblocking */ true,
+        );
+
+        let buffer = [3u8; PIPE_SIZE * 2];
+        let mut bytes_written = 0usize;
+        let result = open_file.poll_write_full(&buffer, &mut bytes_written, || unreachable!());
+        // The first chunk fits entirely; the helper returns immediately rather
+        // than calling poll_write again (which would return EAGAIN).
+        assert_eq!(result, Poll::Ready(Ok(PIPE_SIZE)));
+        assert_eq!(bytes_written, PIPE_SIZE);
     }
 
     #[test]

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -102,6 +102,13 @@ pub struct Process {
     /// List of signals that have been delivered and caught
     pub(crate) caught_signals: Vec<signal::Number>,
 
+    /// Monotonically increasing count of signals that have been caught
+    ///
+    /// Unlike [`caught_signals`](Self::caught_signals), this counter is never
+    /// reset. It is incremented each time a signal is caught, regardless of
+    /// whether the signal has been consumed from `caught_signals`.
+    pub(crate) caught_signals_count: usize,
+
     /// Wakers of tasks waiting for signals to be delivered to this process
     ///
     /// When a signal is delivered to this process, all wakers in this set are
@@ -156,6 +163,7 @@ impl Process {
             blocked_signals: BTreeSet::new(),
             pending_signals: BTreeSet::new(),
             caught_signals: Vec::new(),
+            caught_signals_count: 0,
             signal_wakers: WakerSet::new(),
             resource_limits: HashMap::new(),
             last_exec: None,
@@ -507,6 +515,7 @@ impl Process {
             },
             Disposition::Catch => {
                 self.caught_signals.push(signal);
+                self.caught_signals_count += 1;
                 self.signal_wakers.wake_all();
                 SignalResult {
                     delivered: true,


### PR DESCRIPTION
This is a rework of #767 with a clean commit history, and resolves #729.

## Changes

- **Return EINTR on signal interruption (`VirtualSystem`)**: `VirtualSystem::read` and `VirtualSystem::write` now return `Errno::EINTR` when a signal is caught while blocking and no bytes have been transferred yet. If some bytes were already written before the signal arrived, the write returns the partial byte count instead of `EINTR`. A monotonically increasing `caught_signals_count` field on `Process` (never reset by `caught_signals()`) and a private `signal_interrupted` helper are used to detect new signals reliably between polls.

- **Non-atomic writes in blocking mode (`VirtualSystem`)**: The new helper `OpenFileDescription::poll_write_full` loops for blocking FIFOs, writing as many bytes as fit on each pass and returning `Pending` only when the pipe is completely full, until the whole buffer is consumed. `VirtualSystem::write` calls it once per poll_fn iteration and handles signal interruption around it.

- **Remove silent EINTR retry (`RealSystem`)**: `RealSystem::read` and `RealSystem::write` no longer loop on `EINTR`. The error is returned to the caller directly. `Concurrent<S>` is updated to treat `EINTR` the same as `EAGAIN`/`EWOULDBLOCK`, yielding once and retrying, so callers of `Concurrent` are not exposed to spurious `EINTR` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocking reads/writes now return EINTR on signal interruption; partial FIFO/pipe writes interrupted after progress report bytes written.
  * Concurrent I/O now treats signal interruptions consistently with readiness events.

* **New Features**
  * Added a polling helper to reliably complete full blocking FIFO/pipe writes and avoid silent retries.

* **Documentation**
  * Changelog and docs updated to describe the new EINTR semantics.

* **Tests**
  * Added unit tests for signal-interrupted read/write behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->