### PR TITLE
Fix release build error in yash-env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -869,7 +869,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
 yash-builtin = { path = "yash-builtin", version = "0.16.0" }
-yash-env = { path = "yash-env", version = "0.13.0" }
+yash-env = { path = "yash-env", version = "0.13.1" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.11.0" }

--- a/check-extra.sh
+++ b/check-extra.sh
@@ -18,21 +18,21 @@ RUSTFLAGS='-D unused_crate_dependencies' cargo check --package 'yash-builtin' --
 RUSTFLAGS='-D unused_crate_dependencies' cargo check --package 'yash-builtin' --no-default-features --features yash-semantics
 
 # Make sure the crates can be built with all combinations of features.
-cargo build --package 'yash-arith' --all-targets
-cargo build --package 'yash-builtin' --all-targets
-cargo build --package 'yash-builtin' --all-targets --no-default-features
-cargo build --package 'yash-builtin' --all-targets --no-default-features --features yash-semantics
-cargo build --package 'yash-cli' --all-targets
-cargo build --package 'yash-env' --all-targets
-cargo build --package 'yash-env' --all-targets --no-default-features
-cargo build --package 'yash-env' --all-targets --no-default-features --features test-helper
-cargo build --package 'yash-env-test-helper' --all-targets
-cargo build --package 'yash-executor' --all-targets
-cargo build --package 'yash-fnmatch' --all-targets
-cargo build --package 'yash-prompt' --all-targets
-cargo build --package 'yash-quote' --all-targets
-cargo build --package 'yash-semantics' --all-targets
-cargo build --package 'yash-syntax' --all-targets
+cargo build --release --package 'yash-arith' --all-targets
+cargo build --release --package 'yash-builtin' --all-targets
+cargo build --release --package 'yash-builtin' --all-targets --no-default-features
+cargo build --release --package 'yash-builtin' --all-targets --no-default-features --features yash-semantics
+cargo build --release --package 'yash-cli' --all-targets
+cargo build --release --package 'yash-env' --all-targets
+cargo build --release --package 'yash-env' --all-targets --no-default-features
+cargo build --release --package 'yash-env' --all-targets --no-default-features --features test-helper
+cargo build --release --package 'yash-env-test-helper' --all-targets
+cargo build --release --package 'yash-executor' --all-targets
+cargo build --release --package 'yash-fnmatch' --all-targets
+cargo build --release --package 'yash-prompt' --all-targets
+cargo build --release --package 'yash-quote' --all-targets
+cargo build --release --package 'yash-semantics' --all-targets
+cargo build --release --package 'yash-syntax' --all-targets
 
 # Test with non-default feature configurations.
 #cargo test --package 'yash-arith' -- $quiet

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.16.1] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.13.0 → 0.13.1
+
 ## [0.16.0] - 2026-04-29
 
 ### Changed
@@ -662,6 +669,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.16.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.16.1
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.16.0
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.14.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,7 +9,7 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.6] - 2026-04-29
+## [3.0.7] - Unreleased
 
 ### Changed
 
@@ -320,7 +320,7 @@ later.
 
 - Initial release of the shell
 
-[3.0.6]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.6
+[3.0.7]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.7
 [3.0.5]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.5
 [3.0.4]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.4
 [3.0.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.3

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.13.1] - Unreleased
+
+### Fixed
+
+- Fixed the misconfiguration that prevented the crate from building in the
+  release profile. This bug was introduced in 0.13.0.
+
 ## [0.13.0] - 2026-04-29
 
 ### Added
@@ -1070,6 +1077,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env` crate
 
+[0.13.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.1
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.0
 [0.12.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.12.1
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.12.0

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,8 +13,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Fixed
 
-- Fixed the misconfiguration that prevented the crate from building in the
-  release profile. This bug was introduced in 0.13.0.
+- Fixed a bug where debug-only validation code was called in non-debug builds,
+  preventing the crate from building in the release profile. This bug was
+  introduced in 0.13.0.
 
 ## [0.13.0] - 2026-04-29
 

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/src/waker/queue.rs
+++ b/yash-env/src/waker/queue.rs
@@ -80,6 +80,8 @@ impl ScheduledWakerQueue {
     pub fn clear(&mut self) {
         self.wakers_by_time.clear();
         self.waker_to_time.clear();
+
+        #[cfg(debug_assertions)]
         self.validate();
     }
 
@@ -155,7 +157,9 @@ impl ScheduledWakerQueue {
             }
         };
 
+        #[cfg(debug_assertions)]
         self.validate();
+
         pushed
     }
 
@@ -202,7 +206,10 @@ impl ScheduledWakerQueue {
             self.waker_to_time.remove(waker_entry);
             self.wakers_by_time.pop_first();
         }
+
+        #[cfg(debug_assertions)]
         self.validate();
+
         next_wake_time
     }
 
@@ -224,6 +231,8 @@ impl ScheduledWakerQueue {
                 waker.wake();
             }
         }
+
+        #[cfg(debug_assertions)]
         self.validate();
     }
 

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.11.1] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.13.0 → 0.13.1
+
 ## [0.11.0] - 2026-04-29
 
 ### Changed
@@ -159,6 +166,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.11.1]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.11.1
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.11.0
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.10.0
 [0.9.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.9.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.1] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.13.0 → 0.13.1
+
 ## [0.15.0] - 2026-04-29
 
 ### Changed
@@ -453,6 +460,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.13.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.20.1] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.13.0 → 0.13.1
+
 ## [0.20.0] - 2026-04-29
 
 ### Changed
@@ -646,6 +653,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.20.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.20.1
 [0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.20.0
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.19.0
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.18.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"


### PR DESCRIPTION
## Description

Yash-env 0.13.0 had a bug where it does not build in the release profile. This PR fixes it and modifies the test script to catch similar issues in the future.

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a build-blocking misconfiguration in the release profile.

* **Chores**
  * Updated version numbers across multiple crates: yash-env (0.13.1), yash-builtin (0.16.1), yash-prompt (0.11.1), yash-semantics (0.15.1), and yash-syntax (0.20.1).
  * Updated dependencies to use latest versions.
  * Modified build script to use release builds for feature combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->