### PR TITLE
Deprecate yash_env::test_helper::LocalExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,20 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.13.2] - Unreleased
+
+### Added
+
+- The `system::virtual::Executor` trait is now implemented for
+  `futures_executor::LocalSpawner`, allowing it to be used as an executor for
+  the virtual system in tests that use the `test-helper` feature.
+
+### Deprecated
+
+- The `test_helper::LocalExecutor` struct is now deprecated in favor of using
+  `futures_executor::LocalSpawner` directly as the executor for the virtual
+  system in tests.
+
 ## [0.13.1] - 2026-04-30
 
 ### Fixed
@@ -1078,6 +1092,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-env` crate
 
+[0.13.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.2
 [0.13.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.1
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.0
 [0.12.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.12.1

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1607,17 +1607,6 @@ mod tests {
     use std::task::Context;
     use std::task::Poll::{Pending, Ready};
 
-    impl Executor for futures_executor::LocalSpawner {
-        fn spawn(
-            &self,
-            task: Pin<Box<dyn Future<Output = ()>>>,
-        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-            use futures_util::task::LocalSpawnExt;
-            self.spawn_local(task)
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-        }
-    }
-
     #[test]
     fn fstatat_non_existent_file() {
         let system = VirtualSystem::new();

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -28,10 +28,25 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::str::from_utf8;
 
+/// This implementation is provided only when the `test-helper` feature is enabled.
+impl Executor for LocalSpawner {
+    fn spawn(
+        &self,
+        task: Pin<Box<dyn Future<Output = ()>>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(self.spawn_local(task)?)
+    }
+}
+
 /// Adapter for [`LocalSpawner`] to [`Executor`]
+#[deprecated(
+    since = "0.13.2",
+    note = "LocalSpawner can be used directly as an Executor, so this adapter is no longer needed"
+)]
 #[derive(Clone, Debug)]
 pub struct LocalExecutor(pub LocalSpawner);
 
+#[allow(deprecated)]
 impl Executor for LocalExecutor {
     fn spawn(
         &self,

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -160,7 +160,6 @@ mod tests {
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::Inode;
     use yash_env::system::r#virtual::SystemState;
-    use yash_env::test_helper::LocalExecutor;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
     use yash_env::test_helper::in_virtual_system;
@@ -201,7 +200,7 @@ mod tests {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut executor = futures_executor::LocalPool::new();
-        state.borrow_mut().executor = Some(Rc::new(LocalExecutor(executor.spawner())));
+        state.borrow_mut().executor = Some(Rc::new(executor.spawner()));
         let mut env = Env::with_system(system);
         env.builtins.insert("echo", echo_builtin());
 


### PR DESCRIPTION
## Description

The yash-env crate now provides a direct implementation of the yash_env::system::virtual::Executor trait for futures_executor::LocalSpawner, so that it can be used directly as the executor. The LocalExecutor adapter struct is now deprecated, as it is no longer necessary.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [ ] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [ ] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [ ] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [ ] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [ ] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)
