### PR TITLE
Move `cargo build --release` to do-release.sh

### DIFF
--- a/check-release-build.sh
+++ b/check-release-build.sh
@@ -1,19 +1,19 @@
 set -Ceux
 
 # Make sure the crates can be built with all combinations of features.
-# We're performing release builds here to make sure that the release build
+# We're performing release checks here to make sure that the release build
 # doesn't break due to any missing dependencies or similar issues.
-# Other check scripts only perform debug builds, so they won't catch such issues.
-cargo build --release --package 'yash-arith' --all-targets
-cargo build --release --package 'yash-builtin' --all-targets --no-default-features
-cargo build --release --package 'yash-builtin' --all-targets --no-default-features --features yash-semantics
-cargo build --release --package 'yash-cli' --all-targets
-cargo build --release --package 'yash-env' --all-targets --no-default-features
-cargo build --release --package 'yash-env' --all-targets --no-default-features --features test-helper
-cargo build --release --package 'yash-env' --all-targets --no-default-features --features yash-executor
-cargo build --release --package 'yash-executor' --all-targets
-cargo build --release --package 'yash-fnmatch' --all-targets
-cargo build --release --package 'yash-prompt' --all-targets
-cargo build --release --package 'yash-quote' --all-targets
-cargo build --release --package 'yash-semantics' --all-targets
-cargo build --release --package 'yash-syntax' --all-targets
+# Other check scripts only perform debug checks, so they won't catch such issues.
+cargo check --release --package 'yash-arith' --all-targets
+cargo check --release --package 'yash-builtin' --all-targets --no-default-features
+cargo check --release --package 'yash-builtin' --all-targets --no-default-features --features yash-semantics
+cargo check --release --package 'yash-cli' --all-targets
+cargo check --release --package 'yash-env' --all-targets --no-default-features
+cargo check --release --package 'yash-env' --all-targets --no-default-features --features test-helper
+cargo check --release --package 'yash-env' --all-targets --no-default-features --features yash-executor
+cargo check --release --package 'yash-executor' --all-targets
+cargo check --release --package 'yash-fnmatch' --all-targets
+cargo check --release --package 'yash-prompt' --all-targets
+cargo check --release --package 'yash-quote' --all-targets
+cargo check --release --package 'yash-semantics' --all-targets
+cargo check --release --package 'yash-syntax' --all-targets

--- a/do-release.sh
+++ b/do-release.sh
@@ -89,6 +89,11 @@ fi
 ./check-semver.sh
 for package do
     ./check-release-readiness.sh "$package"
+
+    # check-release-build.sh already performs `cargo check --release` but we
+    # also do `cargo build --release` just in case there are any issues that
+    # only manifest during the build step.
+    cargo build --release --package "$package" --all-targets --all-features
 done
 
 # Confirm the release


### PR DESCRIPTION
The full release builds take a long time, but it is quite rare for any error that cannot be caught by `cargo check --release` to occur in the build step. So we can save a lot of time during development by only doing the full release builds in do-release.sh, which is only run when actually performing a release.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release validation process with faster verification checks
  * Enhanced pre-release build validation to improve release reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->