### PR TITLE
Reenable ignored tests

### DIFF
--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -631,7 +631,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "the new VirtualSystem::select behavior does not fit well with in_virtual_system"]
     fn process_group_id_of_job_controlled_pipeline() {
         fn stub_builtin(
             env: &mut Env<VirtualSystem>,

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -132,7 +132,6 @@ mod tests {
         });
     }
 
-    #[ignore = "non-blocking I/O on pipes is under reconstruction and this test currently causes a deadlock"]
     #[test]
     fn simple_command_returns_command_substitution_exit_status_from_redirection() {
         in_virtual_system(|mut env, _state| async move {
@@ -143,7 +142,6 @@ mod tests {
         });
     }
 
-    #[ignore = "non-blocking I/O on pipes is under reconstruction and this test currently causes a deadlock"]
     #[test]
     fn simple_command_handles_redirection_error_with_absent_target() {
         in_virtual_system(|mut env, _state| async move {


### PR DESCRIPTION
The three test cases mentioned in #761 now pass successfully. It seems they have been passing since the merge of #762. This commit re-enables them.
