### PR TITLE
Abstracting `Concurrent`'s interface

### DIFF
--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -51,6 +51,7 @@ use yash_env::option::Option::Monitor;
 use yash_env::option::State::Off;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Errno, Fcntl, Isatty, SendSignal, Signals, Write};
 
 // Some definitions in this module are shared with the `fg` built-in.

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -28,6 +28,7 @@ use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 #[cfg(doc)]
 use yash_env::stack::Stack;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Chdir, Errno, Fcntl, Isatty, Write};
 
 /// Error invoking the underlying system call
@@ -83,9 +84,9 @@ pub fn failure_message<S: Isatty>(
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`failure_message`] and prints it
-/// with [`Concurrent::print_error`].
+/// with [`WriteAll::print_error`].
 ///
-/// [`Concurrent::print_error`]: yash_env::system::Concurrent::print_error
+/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
 pub async fn report_failure<S>(
     env: &mut Env<S>,
     operand: Option<&Field>,

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -22,6 +22,7 @@ use yash_env::Env;
 use yash_env::io::Fd;
 use yash_env::path::Path;
 use yash_env::source::pretty::{Report, ReportType};
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Errno, Fcntl, Isatty, Write};
 
 impl Origin {

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -21,6 +21,7 @@
 
 use yash_env::Env;
 use yash_env::io::Fd;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Fcntl, Isatty, Write};
 
 pub mod report;

--- a/yash-builtin/src/common/report.rs
+++ b/yash-builtin/src/common/report.rs
@@ -28,6 +28,7 @@ use yash_env::source::pretty::{
 };
 #[cfg(doc)]
 use yash_env::stack::Stack;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Fcntl, Isatty, Write};
 
 /// Convenience function for constructing an error report and a divert value.
@@ -47,11 +48,11 @@ use yash_env::system::{Fcntl, Isatty, Write};
 /// in a built-in. This ensures that the message contains the built-in name
 /// in a unified format.
 ///
-/// Use [`Concurrent::print_error`] to print the returned message and
+/// Use [`WriteAll::print_error`] to print the returned message and
 /// [`crate::Result::with_exit_status_and_divert`] to return the divert value
 /// along with an exit status.
 ///
-/// [`Concurrent::print_error`]: yash_env::system::Concurrent::print_error
+/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
 #[must_use = "returned message should be printed"]
 pub fn prepare_report_message_and_divert<'e, 'r, S>(
     env: &'e Env<S>,
@@ -115,6 +116,7 @@ where
 /// # use yash_env::builtin::Result;
 /// # use yash_env::semantics::ExitStatus;
 /// # use yash_env::source::pretty::{Report, ReportType, Snippet};
+/// # use yash_env::system::concurrency::WriteAll as _;
 /// # async {
 /// # let mut env = yash_env::Env::new_virtual();
 /// # let mut report = Report::new();

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -46,6 +46,7 @@ use yash_env::option::State::Off;
 use yash_env::semantics::Divert::Interrupt;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{
     Close, Dup, Fcntl, Isatty, Open, SendSignal, Sigaction, Sigmask, Signals, TcSetPgrp, Wait,
     Write,

--- a/yash-builtin/src/getopts.rs
+++ b/yash-builtin/src/getopts.rs
@@ -35,6 +35,7 @@ use std::num::NonZeroUsize;
 use yash_env::Env;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Fcntl, Isatty, Write};
 use yash_env::variable::OPTIND;
 

--- a/yash-builtin/src/read/input.rs
+++ b/yash-builtin/src/read/input.rs
@@ -23,6 +23,7 @@ use yash_env::prompt::GetPrompt;
 use yash_env::semantics::expansion::attr::AttrChar;
 use yash_env::semantics::expansion::attr::Origin;
 use yash_env::source::pretty::{Report, ReportType};
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Errno, Fcntl, Isatty, Read, Write};
 
 /// Error reading from the standard input

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -23,11 +23,10 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Span, SpanRole, add_span};
-#[cfg(doc)]
-use yash_env::system::Concurrent;
 use yash_env::system::Fcntl;
 use yash_env::system::Isatty;
 use yash_env::system::Write;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::variable::Scope::Global;
 
 /// Error returned by [`unset_variables`].
@@ -157,7 +156,9 @@ where
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`unset_variables_error_message`]
-/// and prints it with [`Concurrent::print_error`].
+/// and prints it with [`WriteAll::print_error`].
+///
+/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
 #[deprecated(
     note = "use `merge_reports` and `report_failure` directly",
     since = "0.11.0"
@@ -292,7 +293,9 @@ where
 /// Prints an error message to the standard error.
 ///
 /// This function constructs a message with [`unset_functions_error_message`]
-/// and prints it with [`Concurrent::print_error`].
+/// and prints it with [`WriteAll::print_error`].
+///
+/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
 #[deprecated(
     note = "use `merge_reports` and `report_failure` directly",
     since = "0.11.0"

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -35,6 +35,7 @@ use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::option::{Interactive, On};
 use yash_env::semantics::{Divert, ExitStatus, exit_or_raise};
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::resource::GetRlimit;
 use yash_env::system::{
     Chdir, Disposition, Errno, Fcntl, GetCwd, GetUid, Isatty, Sigaction, Signals, Sysconf,

--- a/yash-cli/src/startup/init_file.rs
+++ b/yash-cli/src/startup/init_file.rs
@@ -40,6 +40,7 @@ use yash_env::option::Option::Interactive;
 use yash_env::option::State::Off;
 use yash_env::parser::Config;
 use yash_env::stack::Frame;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{
     Close, Dup, Errno, Fcntl, GetUid, Isatty, Mode, OfdAccess, Open, OpenFlag, Write,
 };

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -32,6 +32,8 @@ A _private dependency_ is used internally and not visible to downstream users.
       specified duration.
     - `WaitForSignals`: A trait for providing the `wait_for_signals` method,
       which waits for signals to be delivered to the process.
+    - `Select`: A trait for providing the `select` method, which waits for
+      events on file descriptors and signals.
     - `RunLoop`: A trait for providing a common interface to call
       `Concurrent`'s runner methods from different contexts (e.g., real vs
       virtual systems). This trait is now implemented for `RealSystem` and
@@ -60,6 +62,8 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `sleep` (`system::concurrency::Sleep`)
     - `sleep_until` (`system::concurrency::Sleep`)
     - `wait_for_signals` (`system::concurrency::WaitForSignals`)
+    - `peek` (`system::concurrency::Select`)
+    - `select` (`system::concurrency::Select`)
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -24,6 +24,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   items:
     - `Concurrent`: A wrapper around a `System` implementation that provides
       asynchronous methods for concurrency.
+    - `ReadAll`: A trait for providing the `read_all_to` method, which reads
+      from a file descriptor until EOF and appends the data to a buffer.
     - `RunLoop`: A trait for providing a common interface to call
       `Concurrent`'s runner methods from different contexts (e.g., real vs
       virtual systems). This trait is now implemented for `RealSystem` and
@@ -42,6 +44,11 @@ A _private dependency_ is used internally and not visible to downstream users.
   the `subshell::Subshell` struct and
   `semantics::command::run_external_utility_in_subshell` function. For the
   `Subshell` struct, the bound `S: 'static` has also been added.
+- The following methods of `system::Concurrent`, which were inherent methods,
+  are now provided as trait implementations. You may have to import the
+  corresponding traits to use these methods:
+    - `read_all_to` (`system::concurrency::ReadAll`)
+    - `read_all` (`system::concurrency::ReadAll`)
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -26,6 +26,8 @@ A _private dependency_ is used internally and not visible to downstream users.
       asynchronous methods for concurrency.
     - `ReadAll`: A trait for providing the `read_all_to` method, which reads
       from a file descriptor until EOF and appends the data to a buffer.
+    - `WriteAll`: A trait for providing the `write_all` method, which writes
+      all data to a file descriptor.
     - `RunLoop`: A trait for providing a common interface to call
       `Concurrent`'s runner methods from different contexts (e.g., real vs
       virtual systems). This trait is now implemented for `RealSystem` and
@@ -49,6 +51,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   corresponding traits to use these methods:
     - `read_all_to` (`system::concurrency::ReadAll`)
     - `read_all` (`system::concurrency::ReadAll`)
+    - `write_all` (`system::concurrency::WriteAll`)
+    - `print_error` (`system::concurrency::WriteAll`)
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -28,6 +28,8 @@ A _private dependency_ is used internally and not visible to downstream users.
       from a file descriptor until EOF and appends the data to a buffer.
     - `WriteAll`: A trait for providing the `write_all` method, which writes
       all data to a file descriptor.
+    - `Sleep`: A trait for providing the `sleep` method, which sleeps for a
+      specified duration.
     - `RunLoop`: A trait for providing a common interface to call
       `Concurrent`'s runner methods from different contexts (e.g., real vs
       virtual systems). This trait is now implemented for `RealSystem` and
@@ -53,6 +55,8 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `read_all` (`system::concurrency::ReadAll`)
     - `write_all` (`system::concurrency::WriteAll`)
     - `print_error` (`system::concurrency::WriteAll`)
+    - `sleep` (`system::concurrency::Sleep`)
+    - `sleep_until` (`system::concurrency::Sleep`)
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -30,6 +30,8 @@ A _private dependency_ is used internally and not visible to downstream users.
       all data to a file descriptor.
     - `Sleep`: A trait for providing the `sleep` method, which sleeps for a
       specified duration.
+    - `WaitForSignals`: A trait for providing the `wait_for_signals` method,
+      which waits for signals to be delivered to the process.
     - `RunLoop`: A trait for providing a common interface to call
       `Concurrent`'s runner methods from different contexts (e.g., real vs
       virtual systems). This trait is now implemented for `RealSystem` and
@@ -57,6 +59,7 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `print_error` (`system::concurrency::WriteAll`)
     - `sleep` (`system::concurrency::Sleep`)
     - `sleep_until` (`system::concurrency::Sleep`)
+    - `wait_for_signals` (`system::concurrency::WaitForSignals`)
 
 ### Deprecated
 

--- a/yash-env/src/input/echo.rs
+++ b/yash-env/src/input/echo.rs
@@ -20,6 +20,7 @@ use super::{Context, Input, Result};
 use crate::Env;
 use crate::option::Option::Verbose;
 use crate::option::State::On;
+use crate::system::concurrency::WriteAll as _;
 use crate::system::{Fcntl, Write};
 use std::cell::RefCell;
 

--- a/yash-env/src/input/ignore_eof.rs
+++ b/yash-env/src/input/ignore_eof.rs
@@ -20,6 +20,7 @@ use super::{Context, Input, Result};
 use crate::Env;
 use crate::io::Fd;
 use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off};
+use crate::system::concurrency::WriteAll as _;
 use crate::system::{Fcntl, Isatty, Write};
 use std::cell::RefCell;
 

--- a/yash-env/src/input/reporter.rs
+++ b/yash-env/src/input/reporter.rs
@@ -19,6 +19,7 @@ use crate::Env;
 use crate::io::Fd;
 use crate::job::fmt::Accumulator;
 use crate::option::{Interactive, Monitor, Off};
+use crate::system::concurrency::WriteAll as _;
 use crate::system::{Fcntl, Signals, Write};
 use std::cell::RefCell;
 

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -19,6 +19,7 @@
 use crate::Env;
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
+use crate::system::concurrency::WriteAll as _;
 use crate::system::{Close, Dup, Fcntl, FdFlag, Isatty, Write};
 use annotate_snippets::Renderer;
 use std::borrow::Cow;
@@ -101,7 +102,7 @@ where
 /// `env` allows it. The string will end with a newline.
 ///
 /// To print the returned string to the standard error, you can use
-/// [`Concurrent::print_error`](crate::system::Concurrent::print_error).
+/// [`WriteAll::print_error`](crate::system::concurrency::WriteAll::print_error).
 #[must_use]
 pub fn report_to_string<S: Isatty>(env: &Env<S>, report: &Report<'_>) -> String {
     let renderer = if env.should_print_error_in_color() {

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -81,6 +81,7 @@ use self::system::Signals;
 pub use self::system::System;
 use self::system::TcSetPgrp;
 use self::system::Wait;
+use self::system::concurrency::Select as _;
 use self::system::concurrency::WaitForSignals as _;
 #[cfg(unix)]
 pub use self::system::real::RealSystem;

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -81,6 +81,7 @@ use self::system::Signals;
 pub use self::system::System;
 use self::system::TcSetPgrp;
 use self::system::Wait;
+use self::system::concurrency::WaitForSignals as _;
 #[cfg(unix)]
 pub use self::system::real::RealSystem;
 pub use self::system::r#virtual::VirtualSystem;
@@ -268,7 +269,8 @@ impl<S> Env<S> {
     ///
     /// Returns an array of signals caught.
     ///
-    /// This function is a wrapper for [`Concurrent::wait_for_signals`].
+    /// This function is a wrapper for
+    /// [`WaitForSignals::wait_for_signals`](system::concurrency::WaitForSignals::wait_for_signals).
     /// Before the function returns, it passes the results to
     /// [`TrapSet::catch_signal`] so the trap set can remember the signals
     /// caught to be handled later.

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -20,9 +20,7 @@
 //! systems that enables concurrent execution of multiple possibly blocking I/O
 //! tasks on a single thread.
 
-use super::{
-    CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, Fork, Read, Result, Select, Write,
-};
+use super::{CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, Fork, Read, Result, Write};
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
@@ -41,13 +39,13 @@ use std::time::{Duration, Instant};
 /// This struct is used as a wrapper for systems for enabling concurrent
 /// execution of multiple possibly blocking I/O tasks on a single thread. The
 /// inner system is expected to implement the [`Read`], [`Write`], and
-/// [`Select`] traits with synchronous (blocking) behavior. This struct leaves
+/// [`super::Select`] traits with synchronous (blocking) behavior. This struct leaves
 /// [`Future`]s returned by I/O methods pending until the I/O operation is ready
 /// to avoid blocking the entire process. This allows you to start multiple I/O
 /// tasks and wait for them to complete concurrently on a single thread. This
 /// struct also provides methods for waiting for signals and waiting for a
 /// specified duration, which are represented as [`Future`]s as well. The
-/// [`select`](Self::select) method of this struct consolidates blocking
+/// [`select`](Select::select) method of this struct consolidates blocking
 /// behavior into a single system call so that the process can resume execution
 /// as soon as any of the specified events occurs.
 ///
@@ -69,6 +67,7 @@ use std::time::{Duration, Instant};
 /// ```
 /// # use std::rc::Rc;
 /// # use yash_env::system::{Concurrent, Pipe as _, Read as _, Write as _};
+/// # use yash_env::system::concurrency::Select as _;
 /// # use yash_env::system::concurrency::WriteAll as _;
 /// # use yash_env::VirtualSystem;
 /// # use futures_util::task::LocalSpawnExt as _;
@@ -179,7 +178,7 @@ impl<S> Concurrent<S> {
 /// the read operation. If the read operation would block (i.e., returns
 /// `EAGAIN` or `EWOULDBLOCK`), the method registers the current task's waker in
 /// the internal state so that it can be woken up by
-/// [`select`](Concurrent::select) when the file descriptor becomes ready for
+/// [`select`](Select::select) when the file descriptor becomes ready for
 /// reading.
 impl<S> Read for Rc<Concurrent<S>>
 where
@@ -216,7 +215,7 @@ where
 /// the write operation. If the write operation would block (i.e., returns
 /// `EAGAIN` or `EWOULDBLOCK`), the method registers the current task's waker in
 /// the internal state so that it can be woken up by
-/// [`select`](Concurrent::select) when the file descriptor becomes ready for
+/// [`select`](Select::select) when the file descriptor becomes ready for
 /// writing.
 impl<S> Write for Rc<Concurrent<S>>
 where
@@ -408,23 +407,28 @@ impl<S> WaitForSignals for Concurrent<S> {
     }
 }
 
-impl<S> Concurrent<S>
-where
-    S: CaughtSignals + Clock + Select,
-{
+/// Trait for peeking and waiting for pending concurrent events
+///
+/// This trait is different from the [`super::Select`] trait implemented by the
+/// inner system. The inner system's `select` method is expected to perform a
+/// single `select` system call with the specified file descriptors and timeout,
+/// and return the result of the system call. In contrast, the methods of this
+/// trait are designed to be used in the main loop of the process to handle all
+/// pending tasks and events. The `peek` method performs a `select` system call
+/// with a zero timeout to check for any ready events without blocking, while
+/// the `select` method performs a `select` system call with the appropriate
+/// file descriptors and timeout based on the current state of pending tasks,
+/// and returns a future that completes when any event becomes ready.
+pub trait Select {
     /// Peeks for any ready events without blocking.
     ///
     /// This method performs a `select` system call with the file descriptors
     /// and timeout of pending tasks, and wakes the tasks whose events are
-    /// ready. This method is similar to [`select`](Concurrent::select), but it
+    /// ready. This method is similar to [`select`](Self::select), but it
     /// does not block and returns immediately.
-    pub fn peek(&self) {
-        let select = pin!(self.select_impl(true));
-        let poll = select.poll(&mut Context::from_waker(Waker::noop()));
-        debug_assert_eq!(poll, Ready(()), "peek should not block");
-    }
+    fn peek(&self);
 
-    /// Waits for any of pending tasks to become ready.
+    /// Waits for any of the pending tasks to become ready.
     ///
     /// This method performs a `select` system call with the file descriptors
     /// and timeout of pending tasks, and wakes the tasks whose events are
@@ -445,12 +449,45 @@ where
     /// loop.
     ///
     /// The future returned by this method will be pending if and only if the
-    /// future returned by the inner system's [`select`](Select::select) method
-    /// is pending.
-    pub async fn select(&self) {
-        self.select_impl(false).await;
+    /// future returned by the inner system's
+    /// [`select`](super::Select::select) method is pending.
+    fn select(&self) -> impl Future<Output = ()> + use<'_, Self>;
+}
+
+impl<S> Select for Rc<S>
+where
+    S: Select,
+{
+    #[inline]
+    fn peek(&self) {
+        (self as &S).peek()
     }
 
+    #[inline]
+    fn select(&self) -> impl Future<Output = ()> + use<'_, S> {
+        (self as &S).select()
+    }
+}
+
+impl<S> Select for Concurrent<S>
+where
+    S: CaughtSignals + Clock + super::Select,
+{
+    fn peek(&self) {
+        let select = pin!(self.select_impl(true));
+        let poll = select.poll(&mut Context::from_waker(Waker::noop()));
+        debug_assert_eq!(poll, Ready(()), "peek should not block");
+    }
+
+    fn select(&self) -> impl Future<Output = ()> + use<'_, S> {
+        self.select_impl(false)
+    }
+}
+
+impl<S> Concurrent<S>
+where
+    S: CaughtSignals + Clock + super::Select,
+{
     #[allow(clippy::await_holding_refcell_ref)]
     async fn select_impl(&self, peek: bool) {
         // In this method, we keep the borrow of `state` across the `await` point. This is
@@ -650,10 +687,11 @@ pub trait RunLoop {
     /// Runs the given task with concurrency support.
     ///
     /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Concurrent::select) to handle
+    /// given task while also calling [`select`](Select::select) to handle
     /// signals and other events. The task is expected to perform I/O operations
-    /// using the methods of the given `Concurrent` instance, so that it can
-    /// yield when the operations would block.
+    /// using the methods of the given `Concurrent` instance like
+    /// [`ReadAll::read_all`] and [`WriteAll::write_all`], so that it can yield
+    /// when the operations would block.
     ///
     /// To allow an external executor to run multiple virtual processes (each
     /// with its own run loop) concurrently, this method is asynchronous and

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -636,6 +636,8 @@ mod run_virtual;
 mod rw_all;
 mod signal;
 
+pub use rw_all::ReadAll;
+
 #[cfg(test)]
 mod tests {
     use super::super::{

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -69,6 +69,7 @@ use std::time::{Duration, Instant};
 /// ```
 /// # use std::rc::Rc;
 /// # use yash_env::system::{Concurrent, Pipe as _, Read as _, Write as _};
+/// # use yash_env::system::concurrency::WriteAll as _;
 /// # use yash_env::VirtualSystem;
 /// # use futures_util::task::LocalSpawnExt as _;
 /// let system = Rc::new(Concurrent::new(VirtualSystem::new()));
@@ -637,6 +638,7 @@ mod rw_all;
 mod signal;
 
 pub use rw_all::ReadAll;
+pub use rw_all::WriteAll;
 
 #[cfg(test)]
 mod tests {

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -290,15 +290,41 @@ impl<S> Concurrent<S> {
     }
 }
 
-impl<S> Concurrent<S>
-where
-    S: Clock,
-{
+/// Trait for sleeping until a specified time or duration
+pub trait Sleep {
     /// Waits until the specified deadline.
     ///
     /// The returned future will be pending until the specified deadline is
     /// reached, at which point it will complete.
-    pub async fn sleep_until(&self, deadline: Instant) {
+    fn sleep_until(&self, deadline: Instant) -> impl Future<Output = ()>;
+
+    /// Waits for the specified duration to elapse.
+    ///
+    /// The returned future will be pending until the specified duration has
+    /// elapsed, at which point it will complete.
+    fn sleep(&self, duration: Duration) -> impl Future<Output = ()>;
+}
+
+impl<S> Sleep for Rc<S>
+where
+    S: Sleep,
+{
+    #[inline]
+    fn sleep_until(&self, deadline: Instant) -> impl Future<Output = ()> {
+        (self as &S).sleep_until(deadline)
+    }
+
+    #[inline]
+    fn sleep(&self, duration: Duration) -> impl Future<Output = ()> {
+        (self as &S).sleep(duration)
+    }
+}
+
+impl<S> Sleep for Concurrent<S>
+where
+    S: Clock,
+{
+    async fn sleep_until(&self, deadline: Instant) {
         let waker: LazyCell<Rc<Cell<Option<Waker>>>> = LazyCell::default();
         poll_fn(|context| {
             if self.inner.now() >= deadline {
@@ -315,11 +341,7 @@ where
         .await
     }
 
-    /// Waits for the specified duration to elapse.
-    ///
-    /// The returned future will be pending until the specified duration has
-    /// elapsed, at which point it will complete.
-    pub async fn sleep(&self, duration: Duration) {
+    async fn sleep(&self, duration: Duration) {
         let now = self.inner.now();
         let deadline = now + duration;
         self.sleep_until(deadline).await;

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -348,7 +348,8 @@ where
     }
 }
 
-impl<S> Concurrent<S> {
+/// Trait for waiting until caught signals become available
+pub trait WaitForSignals {
     /// Waits for signals to be caught.
     ///
     /// The returned future will be pending until any signal is caught, at which
@@ -364,7 +365,21 @@ impl<S> Concurrent<S> {
     /// method, so that the trap set can handle the signals properly.
     ///
     /// [`set_disposition`]: crate::trap::SignalSystem::set_disposition
-    pub async fn wait_for_signals(&self) -> Rc<SignalList> {
+    fn wait_for_signals(&self) -> impl Future<Output = Rc<SignalList>>;
+}
+
+impl<S> WaitForSignals for Rc<S>
+where
+    S: WaitForSignals,
+{
+    #[inline]
+    fn wait_for_signals(&self) -> impl Future<Output = Rc<SignalList>> {
+        (self as &S).wait_for_signals()
+    }
+}
+
+impl<S> WaitForSignals for Concurrent<S> {
+    async fn wait_for_signals(&self) -> Rc<SignalList> {
         let signals = {
             let mut state = self.state.borrow_mut();
             state.signals.upgrade().unwrap_or_else(|| {
@@ -543,10 +558,11 @@ impl<'a, S: Fcntl> Deref for TemporaryNonBlockingGuard<'a, S> {
 
 /// List of received signals
 ///
-/// This struct is returned by the [`Concurrent::wait_for_signals`] method to
-/// represent the list of signals that have been caught. This is a simple
-/// wrapper around `Vec<crate::signal::Number>` that is accessible through
-/// `Deref` and `DerefMut`.
+/// This struct is returned by the
+/// [`WaitForSignals::wait_for_signals`] method to represent the list of
+/// signals that have been caught. This is a simple wrapper around
+/// `Vec<crate::signal::Number>` that is accessible through `Deref` and
+/// `DerefMut`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignalList(OnceCell<Vec<crate::signal::Number>>);
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -342,13 +342,14 @@ where
 ///
 /// This implementation of `Sigmask` simply delegates to the inner system's
 /// `sigmask` method, which bypasses the internal state of `Concurrent` and may
-/// prevent the [`peek`](Concurrent::peek) and [`select`](Concurrent::select)
-/// methods from responding to received signals without race conditions. To
-/// ensure that the signal mask is configured in a way that allows `Concurrent`
-/// to respond to signals correctly, direct calls to `sigmask` should be
-/// avoided, and, if necessary, only used to temporarily change the signal mask
-/// for specific operations while ensuring that the original mask is restored
-/// afterward before a next call to `peek`, `select`, or `set_disposition`.
+/// prevent the [`peek`](super::Select::peek) and
+/// [`select`](super::Select::select) methods from responding to received
+/// signals without race conditions. To ensure that the signal mask is
+/// configured in a way that allows `Concurrent` to respond to signals
+/// correctly, direct calls to `sigmask` should be avoided, and, if necessary,
+/// only used to temporarily change the signal mask for specific operations
+/// while ensuring that the original mask is restored afterward before a next
+/// call to `peek`, `select`, or `set_disposition`.
 impl<S> Sigmask for Concurrent<S>
 where
     S: Sigmask,
@@ -377,14 +378,14 @@ where
 ///
 /// This implementation of `Sigaction` simply delegates to the inner system's
 /// `sigaction` method, which bypasses the internal state of `Concurrent` and
-/// may prevent the [`peek`](Concurrent::peek) and
-/// [`select`](Concurrent::select) methods from responding to received signals
-/// without race conditions. To ensure that signal dispositions are configured
-/// in a way that allows `Concurrent` to respond to signals correctly, direct
-/// calls to `sigaction` should be avoided, and, if necessary, only used to
-/// temporarily change the signal disposition for specific operations while
-/// ensuring that the original disposition is restored afterward before a next
-/// call to `peek`, `select`, or `set_disposition`.
+/// may prevent the [`peek`](super::Select::peek) and
+/// [`select`](super::Select::select) methods from responding to received
+/// signals without race conditions. To ensure that signal dispositions are
+/// configured in a way that allows `Concurrent` to respond to signals
+/// correctly, direct calls to `sigaction` should be avoided, and, if necessary,
+/// only used to temporarily change the signal disposition for specific
+/// operations while ensuring that the original disposition is restored
+/// afterward before a next call to `peek`, `select`, or `set_disposition`.
 ///
 /// The standard way to set a signal disposition to `Concurrent` is to use the
 /// `set_disposition` method provided by the [`SignalSystem`] trait, which

--- a/yash-env/src/system/concurrency/run_real.rs
+++ b/yash-env/src/system/concurrency/run_real.rs
@@ -21,6 +21,7 @@
 use super::super::real::RealSystem;
 use super::Concurrent;
 use super::RunLoop;
+use super::Select as _;
 use futures_util::poll;
 use std::pin::pin;
 
@@ -28,7 +29,7 @@ impl Concurrent<RealSystem> {
     /// Runs the given task with concurrency support.
     ///
     /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Self::select) to handle signals
+    /// given task while also calling [`select`](super::Select::select) to handle signals
     /// and other events. The task is expected to perform I/O operations using
     /// the methods of this `Concurrent` instance, so that it can yield when the
     /// operations would block. The function returns the output of the task when

--- a/yash-env/src/system/concurrency/run_real.rs
+++ b/yash-env/src/system/concurrency/run_real.rs
@@ -77,6 +77,7 @@ impl RunLoop for RealSystem {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Sleep as _;
     use super::*;
     use std::cell::Cell;
     use std::time::Duration;

--- a/yash-env/src/system/concurrency/run_virtual.rs
+++ b/yash-env/src/system/concurrency/run_virtual.rs
@@ -19,6 +19,7 @@
 use super::super::r#virtual::VirtualSystem;
 use super::Concurrent;
 use super::RunLoop;
+use super::Select as _;
 use crate::job::ProcessState;
 use futures_util::{pending, poll};
 use std::pin::pin;
@@ -27,7 +28,7 @@ impl Concurrent<VirtualSystem> {
     /// Runs the given task with concurrency support.
     ///
     /// This function implements the main loop of the shell process. It runs the
-    /// given task while also calling [`select`](Self::select) to handle signals
+    /// given task while also calling [`select`](super::Select::select) to handle signals
     /// and other events. The task is expected to perform I/O operations using
     /// the methods of this `Concurrent` instance, so that it can yield when the
     /// operations would block. The function returns when the task completes or

--- a/yash-env/src/system/concurrency/run_virtual.rs
+++ b/yash-env/src/system/concurrency/run_virtual.rs
@@ -110,6 +110,7 @@ impl RunLoop for VirtualSystem {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Sleep as _;
     use super::*;
     use crate::semantics::ExitStatus;
     use crate::system::r#virtual::{SIGCONT, SIGKILL, SIGSTOP};

--- a/yash-env/src/system/concurrency/rw_all.rs
+++ b/yash-env/src/system/concurrency/rw_all.rs
@@ -21,11 +21,10 @@ use crate::io::Fd;
 use crate::system::{Errno, Fcntl, Read, Write};
 use std::cell::LazyCell;
 use std::iter::repeat_n;
+use std::rc::Rc;
 
-impl<S> Concurrent<S>
-where
-    S: Fcntl + Read,
-{
+/// Trait for reading all data from a file descriptor until EOF is reached
+pub trait ReadAll {
     /// Reads from the file descriptor until EOF is reached, appending the data
     /// to the provided buffer.
     ///
@@ -34,7 +33,42 @@ where
     ///
     /// Use [`read_all`](Self::read_all) if you don't have an existing buffer to
     /// append to.
-    pub async fn read_all_to(&self, fd: Fd, buffer: &mut Vec<u8>) -> Result<(), Errno> {
+    fn read_all_to(&self, fd: Fd, buffer: &mut Vec<u8>) -> impl Future<Output = Result<(), Errno>>;
+
+    /// Reads from the file descriptor until EOF is reached, returning the
+    /// collected data as a `Vec<u8>`.
+    ///
+    /// This is a convenience method that allocates a buffer and calls
+    /// [`read_all_to`](Self::read_all_to).
+    fn read_all(&self, fd: Fd) -> impl Future<Output = Result<Vec<u8>, Errno>> {
+        async move {
+            let mut buffer = Vec::new();
+            self.read_all_to(fd, &mut buffer).await?;
+            Ok(buffer)
+        }
+    }
+}
+
+impl<S> ReadAll for Rc<S>
+where
+    S: ReadAll,
+{
+    #[inline]
+    fn read_all_to(&self, fd: Fd, buffer: &mut Vec<u8>) -> impl Future<Output = Result<(), Errno>> {
+        (self as &S).read_all_to(fd, buffer)
+    }
+
+    #[inline]
+    fn read_all(&self, fd: Fd) -> impl Future<Output = Result<Vec<u8>, Errno>> {
+        (self as &S).read_all(fd)
+    }
+}
+
+impl<S> ReadAll for Concurrent<S>
+where
+    S: Fcntl + Read,
+{
+    async fn read_all_to(&self, fd: Fd, buffer: &mut Vec<u8>) -> Result<(), Errno> {
         let this = TemporaryNonBlockingGuard::new(self, fd);
         let waker = LazyCell::default();
         let mut effective_length = buffer.len();
@@ -64,17 +98,6 @@ where
                 }
             }
         }
-    }
-
-    /// Reads from the file descriptor until EOF is reached, returning the
-    /// collected data as a `Vec<u8>`.
-    ///
-    /// This is a convenience method that allocates a buffer and calls
-    /// [`read_all_to`](Self::read_all_to).
-    pub async fn read_all(&self, fd: Fd) -> Result<Vec<u8>, Errno> {
-        let mut buffer = Vec::new();
-        self.read_all_to(fd, &mut buffer).await?;
-        Ok(buffer)
     }
 }
 

--- a/yash-env/src/system/concurrency/rw_all.rs
+++ b/yash-env/src/system/concurrency/rw_all.rs
@@ -171,6 +171,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::system::concurrency::Select as _;
     use crate::system::r#virtual::{PIPE_SIZE, VirtualSystem};
     use crate::system::{Close as _, Mode, OfdAccess, Open as _, OpenFlag, Pipe as _};
     use futures_util::FutureExt as _;

--- a/yash-env/src/system/concurrency/rw_all.rs
+++ b/yash-env/src/system/concurrency/rw_all.rs
@@ -101,10 +101,8 @@ where
     }
 }
 
-impl<S> Concurrent<S>
-where
-    S: Fcntl + Write,
-{
+/// Trait for writing all data to a file descriptor
+pub trait WriteAll {
     /// Writes all data from the provided buffer to the file descriptor.
     ///
     /// This method ensures that all data is written, even if multiple write
@@ -112,7 +110,37 @@ where
     ///
     /// If the data is empty, this method will return immediately without
     /// performing write operations.
-    pub async fn write_all(&self, fd: Fd, mut data: &[u8]) -> Result<(), Errno> {
+    fn write_all(&self, fd: Fd, data: &[u8]) -> impl Future<Output = Result<(), Errno>>;
+
+    /// Writes the given message to standard error.
+    ///
+    /// This is a convenience method that calls [`write_all`](Self::write_all)
+    /// with [`Fd::STDERR`].
+    fn print_error<T: AsRef<[u8]>>(&self, message: T) -> impl Future<Output = ()> {
+        async move { _ = self.write_all(Fd::STDERR, message.as_ref()).await }
+    }
+}
+
+impl<S> WriteAll for Rc<S>
+where
+    S: WriteAll,
+{
+    #[inline]
+    fn write_all(&self, fd: Fd, data: &[u8]) -> impl Future<Output = Result<(), Errno>> {
+        (self as &S).write_all(fd, data)
+    }
+
+    #[inline]
+    fn print_error<T: AsRef<[u8]>>(&self, message: T) -> impl Future<Output = ()> {
+        (self as &S).print_error(message)
+    }
+}
+
+impl<S> WriteAll for Concurrent<S>
+where
+    S: Fcntl + Write,
+{
+    async fn write_all(&self, fd: Fd, mut data: &[u8]) -> Result<(), Errno> {
         if data.is_empty() {
             return Ok(());
         }
@@ -137,15 +165,6 @@ where
                 Err(e) => return Err(e),
             }
         }
-    }
-
-    /// Writes the given message to standard error.
-    ///
-    /// This is a convenience method that calls [`write_all`](Self::write_all)
-    /// with [`Fd::STDERR`].
-    #[inline]
-    pub async fn print_error<T: AsRef<[u8]>>(&self, message: T) {
-        _ = self.write_all(Fd::STDERR, message.as_ref()).await
     }
 }
 

--- a/yash-env/src/system/concurrency/signal.rs
+++ b/yash-env/src/system/concurrency/signal.rs
@@ -43,7 +43,7 @@ where
     /// returns the old disposition.
     ///
     /// This implementation both updates the signal disposition and the signal
-    /// mask to ensure that the [`select`](Concurrent::select) method can
+    /// mask to ensure that the [`select`](super::Select::select) method can
     /// respond to received signals without race conditions. Specifically:
     ///
     /// - When setting the disposition to `Default` or `Ignore`, the signal is

--- a/yash-env/src/system/io.rs
+++ b/yash-env/src/system/io.rs
@@ -207,8 +207,8 @@ pub trait Write {
     /// The implementation for [`Rc<Concurrent<_>>`](super::Concurrent) provides
     /// asynchronous writing by using non-blocking I/O, which allows concurrent
     /// multitasking in `async` function contexts. Use
-    /// [`Concurrent::write_all`](super::Concurrent::write_all) to write the
-    /// entire buffer.
+    /// [`WriteAll::write_all`](super::concurrency::WriteAll::write_all) to
+    /// write the entire buffer.
     fn write<'a>(
         &self,
         fd: Fd,

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -28,6 +28,15 @@ use std::rc::Rc;
 use std::time::Duration;
 
 /// Trait for performing the `select` operation
+///
+/// This trait provides the `select` method, which represents the `select`
+/// system call. This trait is different from the
+/// [same-named trait in the `concurrency` submodule](super::concurrency::Select),
+/// which provides a higher-level interface for waiting on multiple events. The
+/// `Select` trait in this module is a lower-level interface that directly
+/// represents the behavior of the `select` system call. It is used by the
+/// `Select` trait in the `concurrency` submodule to implement its
+/// functionality.
 pub trait Select: Signals {
     /// Waits for a next event.
     ///
@@ -36,7 +45,7 @@ pub trait Select: Signals {
     /// handling, and timer functions.
     ///
     /// This function blocks the calling thread until one of the following
-    /// condition is met:
+    /// conditions is met:
     ///
     /// - An FD in `readers` becomes ready for reading.
     /// - An FD in `writers` becomes ready for writing.

--- a/yash-env/src/trap.rs
+++ b/yash-env/src/trap.rs
@@ -42,8 +42,6 @@ use self::state::{EnterSubshellOption, GrandState};
 use crate::Env;
 use crate::signal;
 use crate::source::Location;
-#[cfg(doc)]
-use crate::system::Concurrent;
 use crate::system::{Disposition, Errno, Signals};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
@@ -389,8 +387,9 @@ impl TrapSet {
     ///
     /// You should install the internal disposition for `SIGCHLD` by using this
     /// function before waiting for `SIGCHLD` with [`crate::system::Wait::wait`]
-    /// and [`Concurrent::wait_for_signals`]. The disposition allows catching
-    /// `SIGCHLD`.
+    /// and
+    /// [`WaitForSignals::wait_for_signals`](crate::system::concurrency::WaitForSignals::wait_for_signals).
+    /// The disposition allows catching `SIGCHLD`.
     ///
     /// This function remembers that the disposition has been installed, so a
     /// second call to the function will be a no-op.

--- a/yash-prompt/src/prompter.rs
+++ b/yash-prompt/src/prompter.rs
@@ -20,6 +20,7 @@ use super::expand_posix;
 use std::cell::RefCell;
 use yash_env::Env;
 use yash_env::input::{Context, Input, Result};
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Fcntl, Write};
 use yash_env::variable::{PS1, PS2, VariableSet};
 

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -29,6 +29,7 @@ use yash_env::semantics::Result;
 use yash_env::stack::Frame;
 #[cfg(doc)]
 use yash_env::subshell::Subshell;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_syntax::syntax;
 use yash_syntax::syntax::Redir;
 

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -30,6 +30,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Close, Mode, OfdAccess, Open};
 use yash_syntax::source::Location;
 use yash_syntax::syntax;

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -35,6 +35,7 @@ use yash_env::semantics::Result;
 use yash_env::stack::Frame;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Close, Dup, Errno, Fcntl, Isatty, Pipe, Write};
 use yash_syntax::syntax;
 

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -31,6 +31,7 @@ use yash_env::io::Fd;
 use yash_env::job::Pid;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
+use yash_env::system::concurrency::ReadAll as _;
 use yash_env::system::{
     Close, Dup as _, Errno, Fcntl, Pipe as _, Read, Sigaction, Sigmask, Signals, Wait,
 };

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -20,6 +20,7 @@ use super::ErrorCause;
 use yash_env::Env;
 use yash_env::io::Fd;
 use yash_env::path::Path;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Close, Errno, Fcntl, Open, Seek, Write};
 
 async fn fill_content<S>(env: &mut Env<S>, fd: Fd, content: &str) -> Result<(), Errno>

--- a/yash-semantics/src/tests.rs
+++ b/yash-semantics/src/tests.rs
@@ -34,6 +34,7 @@ use yash_env::system::Isatty;
 use yash_env::system::Read;
 use yash_env::system::SendSignal;
 use yash_env::system::Write;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::r#virtual::SIGSTOP;
 use yash_env::variable::Scope;
 

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -41,6 +41,7 @@ use yash_env::Env;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::semantics::Field;
+use yash_env::system::concurrency::WriteAll as _;
 use yash_env::variable::PS4;
 use yash_quote::quoted;
 use yash_syntax::syntax::Text;
@@ -287,7 +288,8 @@ pub async fn finish<S: Runtime + 'static>(env: &mut Env<S>, xtrace: Option<XTrac
 }
 
 /// Convenience function for [finish]ing and
-/// [print](yash_env::system::Concurrent::print_error)ing an (optional) `XTrace`.
+/// [print](yash_env::system::concurrency::WriteAll::print_error)ing an
+/// (optional) `XTrace`.
 pub async fn print<S, X>(env: &mut Env<S>, xtrace: X)
 where
     S: Runtime + 'static,


### PR DESCRIPTION
## Description

Resolves #781

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Concurrency operations reorganized around new traits—ReadAll, WriteAll, Sleep, WaitForSignals, and Select—replacing previous inherent method implementations. Updated documentation and imports throughout the codebase to reflect the new trait-based API.

* **Documentation**
  * Updated CHANGELOG documenting the API restructuring and trait exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->