### PR TITLE
Generalize Env::system to hold any system type

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -114,6 +114,7 @@
 			"subtrait",
 			"subtraits",
 			"supertrait",
+			"supertraits",
 			"sysconf",
 			"tcgetpgrp",
 			"tcsetpgrp",

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -23,6 +23,14 @@ A _private dependency_ is used internally and not visible to downstream users.
     - yash-env 0.13.0 → 0.14.0
     - yash-semantics (optional) 0.15.0 → 0.16.0
 
+### Removed
+
+- The following formerly deprecated functions have been removed:
+    - `unset::semantics::report_functions_error`
+    - `unset::semantics::report_variables_error`
+    - `unset::semantics::unset_functions_error_message`
+    - `unset::semantics::unset_variables_error_message`
+
 ## [0.16.0] - 2026-04-29
 
 ### Changed

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,12 +13,92 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
-- The type parameter bound `S: yash_env::system::concurrency::RunLoop` has been
-  added to the following items:
-    - `iter`
-    - `command::main`
+- The `iter` function now requires
+  `S: std::clone::Clone + yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  in addition to the existing bounds on `S`.
+- The following functions now require the bound
+  `S: yash_env::system::Isatty + yash_env::system::concurrency::WriteAll` instead of
+  `S: yash_env::system::Isatty + yash_env::system::Fcntl + yash_env::system::Write`:
+    - `alias::main`
+    - `break::main`
+    - `cd::assign::set_oldpwd`
+    - `cd::assign::set_pwd`
+    - `cd::chdir::report_failure`
+    - `cd::print::print_path`
+    - `common::output`
+    - `common::report::report`
+    - `common::report::report_failure`
+    - `common::report::report_error`
+    - `common::report::report_simple`
+    - `common::report::report_simple_failure`
+    - `common::report::report_simple_error`
+    - `common::report::syntax_error`
+    - `continue::main`
+    - `exit::main`
+    - `export::main`
+    - `getopts::main`
+    - `readonly::main`
+    - `return::main`
+    - `shift::main`
+    - `source::syntax::Error::report`
+    - `typeset::main`
+    - `unalias::main`
+    - `unset::main`
+- Likewise, the bound `S: yash_env::system::Fcntl + yash_env::system::Write` has
+  been replaced with `S: yash_env::system::WriteAll` for the following functions
+  while other bounds remain unchanged:
+    - `bg::main`
+    - `cd::main`
+    - `command::Identify::execute`
+    - `eval::main`
+    - `jobs::main`
+    - `kill::Command::execute`
+    - `kill::main`
+    - `kill::print::execute`
+    - `kill::send::execute`
+    - `pwd::main`
+    - `read::input::read`
+    - `read::main`
+    - `times::main`
+    - `type::main`
+    - `ulimit::main`
+    - `umask::main`
+- In the following functions, the bound
+  `S: yash_env::system::Fcntl + yash_env::system::Write` has been removed and the bound
+  `S: yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  has been added while other bounds remain unchanged:
+    - `exec::main`
+    - `set::main`
+- In the following functions, the bound
+  `S: yash_env::system::Fcntl + yash_env::system::Write` has been removed and the bound
+  `S: std::clone::Clone + yash_env::system::concurrency::WriteAll`
+  has been added while other bounds remain unchanged:
+    - `source::Command::execute`
+    - `source::main`
+- In the following functions, the bound
+  `S: yash_env::system::Fcntl + yash_env::system::Write` has been removed and the bound
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  has been added:
     - `command::Command::execute`
     - `command::Invoke::execute`
+    - `command::main`
+    - `fg::main`
+- The `trap::Command::execute` function now requires the bound
+  `S: yash_env::trap::SignalSystem` instead of
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask`.
+- The `trap::main` function now requires the bound
+  `S: yash_env::system::Isatty + yash_env::trap::SignalSystem + yash_env::system::concurrency::WriteAll`
+  instead of
+  `S: yash_env::system::Fcntl + yash_env::system::Isatty + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Write`.
+- The `wait::core::wait_for_any_job_or_trap` and `wait::status::wait_while_running`
+  functions now require the bound
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::Wait + yash_env::trap::SignalSystem + 'static`
+  instead of
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Wait + 'static`.
+- The `wait::main` and `wait::Command::execute` functions now require the bound
+  `S: yash_env::system::Isatty + yash_env::system::concurrency::WaitForSignals + yash_env::system::Wait + yash_env::trap::SignalSystem + 'static`
+  instead of
+  `S: yash_env::system::Fcntl + yash_env::system::Isatty + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Wait + yash_env::system::Write + 'static`.
 - Public dependency versions:
     - yash-env 0.13.0 → 0.14.0
     - yash-semantics (optional) 0.15.0 → 0.16.0

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -30,7 +30,8 @@ use crate::common::syntax::parse_arguments;
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Parsed command line arguments
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -45,7 +46,7 @@ pub mod semantics;
 /// Entry point for executing the `alias` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     let mode = Mode::with_env(env);
     // TODO support options

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -51,8 +51,8 @@ use yash_env::option::Option::Monitor;
 use yash_env::option::State::Off;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Errno, Fcntl, Isatty, SendSignal, Signals, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Errno, Isatty, SendSignal, Signals};
 
 // Some definitions in this module are shared with the `fg` built-in.
 
@@ -116,7 +116,7 @@ impl<'a> From<&'a OperandError> for Report<'a> {
 /// This function panics if there is no job at the specified index.
 async fn resume_job_by_index<S>(env: &mut Env<S>, index: usize) -> Result<(), ResumeError>
 where
-    S: Signals + SendSignal + Fcntl + Write,
+    S: Signals + SendSignal + WriteAll,
 {
     let mut job = env.jobs.get_mut(index).unwrap();
     if !job.is_owned {
@@ -153,7 +153,7 @@ where
 /// Resumes the job specified by the operand.
 async fn resume_job_by_id<S>(env: &mut Env<S>, job_id: &str) -> Result<(), OperandErrorKind>
 where
-    S: Signals + SendSignal + Fcntl + Write,
+    S: Signals + SendSignal + WriteAll,
 {
     let job_id = parse(job_id)?;
     let index = job_id.find(&env.jobs)?;
@@ -164,7 +164,7 @@ where
 /// Entry point of the `bg` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Signals + SendSignal + Fcntl + Isatty + Write,
+    S: Signals + SendSignal + Isatty + WriteAll,
 {
     let (options, operands) = match parse_arguments(&[], Mode::with_env(env), args) {
         Ok(result) => result,
@@ -204,12 +204,14 @@ where
 mod tests {
     use super::*;
     use futures_util::FutureExt as _;
+    use std::rc::Rc;
     use yash_env::VirtualSystem;
     use yash_env::job::Job;
     use yash_env::job::Pid;
     use yash_env::job::ProcessState;
     use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::Process;
     use yash_env::system::r#virtual::{SIGSTOP, SIGTSTP, SIGTTIN};
     use yash_env::test_helper::assert_stderr;
@@ -218,7 +220,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_sends_sigcont() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let pgid = Pid(123);
         let child_id = Pid(124);
         let orphan_id = Pid(456);
@@ -261,7 +263,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_prints_job_name() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let mut job = Job::new(Pid(123));
         job.job_controlled = true;
         job.name = "echo my job".into();
@@ -278,7 +280,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_sets_expected_state() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let pid = Pid(123);
         let mut job = Job::new(pid);
         job.job_controlled = true;
@@ -298,7 +300,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_makes_target_current_job() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let pgid = Pid(123);
         let orphan_id = Pid(456);
         let mut job = Job::new(pgid);
@@ -329,7 +331,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_sends_no_sigcont_to_dead_process() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let pid = Pid(123);
         let mut job = Job::new(pid);
         job.job_controlled = true;
@@ -359,7 +361,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_sets_last_async_pid() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let mut job = Job::new(Pid(123));
         job.job_controlled = true;
         job.state = ProcessState::exited(ExitStatus::SUCCESS);
@@ -394,7 +396,7 @@ mod tests {
     #[test]
     fn main_without_operands_resumes_current_job() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
         let pgid = Pid(100);
         let orphan_id = Pid(200);
@@ -433,7 +435,7 @@ mod tests {
     #[test]
     fn main_without_operands_fails_if_there_is_no_current_job() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
@@ -447,7 +449,7 @@ mod tests {
     #[test]
     fn main_with_operands_resumes_specified_jobs() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
         let pgid1 = Pid(100);
         let pgid2 = Pid(200);
@@ -498,7 +500,7 @@ mod tests {
         // function fails on the first operand, but it should try to handle the
         // remaining operands.
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
         let pgid = Pid(100);
         let mut job = Job::new(pgid);

--- a/yash-builtin/src/break.rs
+++ b/yash-builtin/src/break.rs
@@ -33,7 +33,8 @@ use crate::common::report::{report_error, report_simple_failure};
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 // pub mod display;
 pub mod semantics;
@@ -44,7 +45,7 @@ pub mod syntax;
 /// This function uses the [`syntax`] and [`semantics`] modules to execute the built-in.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(count) => match semantics::run(&env.stack, count) {

--- a/yash-builtin/src/cd.rs
+++ b/yash-builtin/src/cd.rs
@@ -28,7 +28,8 @@ use yash_env::path::PathBuf;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Footnote, FootnoteType, Report, ReportType};
-use yash_env::system::{Chdir, Errno, Fcntl, Fstat, GetCwd, Isatty, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Chdir, Errno, Fstat, GetCwd, Isatty};
 use yash_env::variable::PWD;
 
 /// Exit status when the built-in succeeds
@@ -101,7 +102,7 @@ fn get_pwd<S>(env: &Env<S>) -> String {
 /// corresponding exit status.
 async fn report_pwd_error<S>(env: &mut Env<S>, errno: Errno, ensure_pwd: bool) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let (r#type, exit_status) = if ensure_pwd {
         (ReportType::Error, EXIT_STATUS_STALE_PWD)
@@ -124,7 +125,7 @@ where
 /// This function uses functions in the submodules to execute the built-in.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Chdir + Fcntl + Fstat + GetCwd + Isatty + Write,
+    S: Chdir + Fstat + GetCwd + Isatty + WriteAll,
 {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,
@@ -167,13 +168,14 @@ mod tests {
     use futures_util::FutureExt as _;
     use std::rc::Rc;
     use yash_env::VirtualSystem;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
 
     #[test]
     fn report_pwd_error_with_ensure_pwd() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
 
         let result = report_pwd_error(&mut env, Errno::ENAMETOOLONG, true)
             .now_or_never()
@@ -189,7 +191,7 @@ mod tests {
     fn report_pwd_error_without_ensure_pwd() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
 
         let result = report_pwd_error(&mut env, Errno::ENAMETOOLONG, false)
             .now_or_never()

--- a/yash-builtin/src/cd/assign.rs
+++ b/yash-builtin/src/cd/assign.rs
@@ -22,7 +22,8 @@ use yash_env::Env;
 use yash_env::path::Path;
 use yash_env::path::PathBuf;
 use yash_env::source::pretty::{Report, ReportType, Snippet, Span, SpanRole};
-use yash_env::system::{Errno, Fcntl, GetCwd, Isatty, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Errno, GetCwd, Isatty};
 use yash_env::variable::AssignError;
 use yash_env::variable::OLDPWD;
 use yash_env::variable::PWD;
@@ -38,7 +39,7 @@ use yash_env::variable::Value::Scalar;
 /// the cd built-in.
 pub async fn set_oldpwd<S>(env: &mut Env<S>, value: String) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     set_variable(env, OLDPWD, value).await
 }
@@ -53,7 +54,7 @@ where
 /// the cd built-in.
 pub async fn set_pwd<S>(env: &mut Env<S>, path: PathBuf) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let value = path.into_unix_string().into_string().unwrap_or_default();
     set_variable(env, PWD, value).await
@@ -61,7 +62,7 @@ where
 
 async fn set_variable<S>(env: &mut Env<S>, name: &str, value: String) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let current_builtin = env.stack.current_builtin();
     let current_location = current_builtin.map(|builtin| builtin.name.origin.clone());
@@ -77,7 +78,7 @@ where
 /// Prints an error message for a read-only variable.
 async fn handle_assign_error<S>(env: &mut Env<S>, name: &str, error: AssignError) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Error;
@@ -118,13 +119,14 @@ mod tests {
     use yash_env::source::Location;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::{assert_stderr, assert_stdout};
 
     #[test]
     fn set_oldpwd_new() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
         let mut env = env.push_frame(Frame::Builtin(Builtin {
@@ -150,7 +152,7 @@ mod tests {
     fn set_oldpwd_overwrites_existing_variable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
         let mut env = env.push_frame(Frame::Builtin(Builtin {
@@ -179,7 +181,7 @@ mod tests {
     fn set_oldpwd_read_only_error() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("cd"),
             is_special: false,
@@ -205,7 +207,7 @@ mod tests {
     fn set_pwd_new() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
         let mut env = env.push_frame(Frame::Builtin(Builtin {
@@ -231,7 +233,7 @@ mod tests {
     fn set_pwd_overwrites_existing_variable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let cd = Field::dummy("cd");
         let location = cd.origin.clone();
         let mut env = env.push_frame(Frame::Builtin(Builtin {
@@ -260,7 +262,7 @@ mod tests {
     fn set_pwd_read_only_error() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let cd = Field::dummy("cd");
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: cd,

--- a/yash-builtin/src/cd/chdir.rs
+++ b/yash-builtin/src/cd/chdir.rs
@@ -28,8 +28,8 @@ use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 #[cfg(doc)]
 use yash_env::stack::Stack;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Chdir, Errno, Fcntl, Isatty, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Chdir, Errno, Isatty};
 
 /// Error invoking the underlying system call
 #[derive(Debug, Clone, Eq, Error, PartialEq)]
@@ -94,7 +94,7 @@ pub async fn report_failure<S>(
     error: &Error,
 ) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let (message, divert) = failure_message(env, operand, path, error);
     env.system.print_error(&message).await;

--- a/yash-builtin/src/cd/print.rs
+++ b/yash-builtin/src/cd/print.rs
@@ -22,8 +22,8 @@ use yash_env::Env;
 use yash_env::io::Fd;
 use yash_env::path::Path;
 use yash_env::source::pretty::{Report, ReportType};
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Errno, Fcntl, Isatty, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Errno, Isatty};
 
 impl Origin {
     /// Whether the built-in should print the target directory path.
@@ -39,7 +39,7 @@ impl Origin {
 /// Prints the new working directory path if needed.
 pub async fn print_path<S>(env: &mut Env<S>, path: &Path, origin: &Origin)
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     if !origin.should_print_path() {
         return;
@@ -57,7 +57,7 @@ where
 /// The message is only a warning because it does not affect the exit status.
 async fn handle_print_error<S>(env: &mut Env<S>, errno: Errno)
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Warning;

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -48,14 +48,15 @@ use enumset::EnumSet;
 use enumset::EnumSetType;
 use yash_env::Env;
 use yash_env::semantics::Field;
-use yash_env::system::concurrency::RunLoop;
+use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 #[cfg(all(doc, unix))]
 use yash_env::system::real::RealSystem;
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
-    Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetCwd, GetPid, IsExecutableFile, Isatty, Open,
-    SendSignal, SetPgid, ShellPath, Sigaction, Sigmask, Signals, Sysconf, TcSetPgrp, Wait, Write,
+    Close, Dup, Exec, Exit, Fork, Fstat, GetCwd, GetPid, IsExecutableFile, Isatty, Open,
+    SendSignal, SetPgid, ShellPath, Sigaction, Sigmask, Sysconf, TcSetPgrp, Wait,
 };
+use yash_env::trap::SignalSystem;
 
 /// Category of command name resolution
 ///
@@ -177,7 +178,6 @@ impl Command {
             + Dup
             + Exec
             + Exit
-            + Fcntl
             + Fork
             + Fstat
             + GetCwd
@@ -185,18 +185,18 @@ impl Command {
             + IsExecutableFile
             + Isatty
             + Open
-            + RunLoop
             + SendSignal
             + SetPgid
             + SetRlimit
             + ShellPath
             + Sigaction
             + Sigmask
-            + Signals
+            + SignalSystem
             + Sysconf
             + TcSetPgrp
             + Wait
-            + Write
+            + WaitForSignals
+            + WriteAll
             + 'static,
     {
         match self {
@@ -220,7 +220,6 @@ where
         + Dup
         + Exec
         + Exit
-        + Fcntl
         + Fork
         + Fstat
         + GetCwd
@@ -228,18 +227,18 @@ where
         + IsExecutableFile
         + Isatty
         + Open
-        + RunLoop
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + Sysconf
         + TcSetPgrp
         + Wait
-        + Write
+        + WaitForSignals
+        + WriteAll
         + 'static,
 {
     match syntax::parse(env, args) {

--- a/yash-builtin/src/command/identify.rs
+++ b/yash-builtin/src/command/identify.rs
@@ -34,7 +34,8 @@ use yash_env::semantics::Field;
 use yash_env::semantics::command::search::{Target, search};
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 use yash_env::str::UnixStr;
-use yash_env::system::{Fcntl, Fstat, GetCwd, IsExecutableFile, Isatty, Sysconf, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Fstat, GetCwd, IsExecutableFile, Isatty, Sysconf};
 use yash_quote::quoted;
 
 /// Result of [categorizing](categorize) a command
@@ -371,7 +372,7 @@ impl Identify {
     /// Performs the identifying semantics.
     pub async fn execute<S>(&self, env: &mut Env<S>) -> crate::Result
     where
-        S: Fcntl + Fstat + GetCwd + IsExecutableFile + Isatty + Sysconf + Write + 'static,
+        S: Fstat + GetCwd + IsExecutableFile + Isatty + Sysconf + WriteAll + 'static,
     {
         let (result, errors) = self.result(env);
 
@@ -399,6 +400,7 @@ mod tests {
     use yash_env::builtin::Builtin;
     use yash_env::function::Function;
     use yash_env::source::Location;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::function::FunctionBodyStub;
 
@@ -491,10 +493,12 @@ mod tests {
         let name = &Field::dummy("if");
         let env = &mut Env::new_virtual();
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_env, word| {
-                assert_eq!(word, "if");
-                true
-            })));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_env, word| {
+                    assert_eq!(word, "if");
+                    true
+                },
+            )));
         let params = &Search::default_for_identify();
         let env = &mut SearchEnv { env, params };
 
@@ -507,10 +511,12 @@ mod tests {
         let name = &Field::dummy("foo");
         let env = &mut Env::new_virtual();
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_env, word| {
-                assert_eq!(word, "foo");
-                false
-            })));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_env, word| {
+                    assert_eq!(word, "foo");
+                    false
+                },
+            )));
         let params = &Search::default_for_identify();
         let env = &mut SearchEnv { env, params };
 
@@ -543,7 +549,9 @@ mod tests {
         let alias = entry.0.clone();
         env.aliases.insert(entry);
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_, _| false)));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_, _| false,
+            )));
         let params = &Search::default_for_identify();
         let env = &mut SearchEnv { env, params };
 
@@ -556,7 +564,9 @@ mod tests {
         let name = &Field::dummy("a");
         let env = &mut Env::new_virtual();
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_, _| false)));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_, _| false,
+            )));
         let params = &Search::default_for_identify();
         let env = &mut SearchEnv { env, params };
 
@@ -575,7 +585,9 @@ mod tests {
             Location::dummy("a"),
         ));
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_, _| false)));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_, _| false,
+            )));
         let params = &mut Search::default_for_identify();
         params.categories.remove(Category::Alias);
         let env = &mut SearchEnv { env, params };
@@ -707,7 +719,9 @@ mod tests {
     fn identify_result_without_error() {
         let env = &mut Env::new_virtual();
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_, _| true)));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_, _| true,
+            )));
 
         let mut identify = Identify::default();
         let (result, errors) = identify.result(env);
@@ -734,9 +748,9 @@ mod tests {
     fn identify_result_with_error() {
         let env = &mut Env::new_virtual();
         env.any
-            .insert(Box::new(IsKeyword::<VirtualSystem>(|_, word| {
-                word == "if" || word == "fi"
-            })));
+            .insert(Box::new(IsKeyword::<Rc<Concurrent<VirtualSystem>>>(
+                |_, word| word == "if" || word == "fi",
+            )));
         let identify = Identify {
             names: Field::dummies(["if", "oops", "fi", "bar"]),
             ..Identify::default()

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -28,12 +28,13 @@ use yash_env::semantics::Field;
 use yash_env::semantics::command::RunFunction;
 use yash_env::semantics::command::run_external_utility_in_subshell;
 use yash_env::semantics::command::search::{Target, search};
-use yash_env::system::concurrency::RunLoop;
+use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
-    Close, Dup, Exec, Exit, Fcntl, Fork, GetPid, IsExecutableFile, Isatty, Open, SendSignal,
-    SetPgid, ShellPath, Sigaction, Sigmask, Signals, Sysconf, TcSetPgrp, Wait, Write,
+    Close, Dup, Exec, Exit, Fork, GetPid, IsExecutableFile, Isatty, Open, SendSignal, SetPgid,
+    ShellPath, Sigaction, Sigmask, Sysconf, TcSetPgrp, Wait,
 };
+use yash_env::trap::SignalSystem;
 
 impl Invoke {
     /// Execute the command
@@ -43,24 +44,23 @@ impl Invoke {
             + Dup
             + Exec
             + Exit
-            + Fcntl
             + Fork
             + GetPid
             + IsExecutableFile
             + Isatty
             + Open
-            + RunLoop
             + SendSignal
             + SetPgid
             + SetRlimit
             + ShellPath
             + Sigaction
             + Sigmask
-            + Signals
+            + SignalSystem
             + Sysconf
             + TcSetPgrp
             + Wait
-            + Write
+            + WaitForSignals
+            + WriteAll
             + 'static,
     {
         let Some(name) = self.fields.first() else {
@@ -98,22 +98,21 @@ where
         + Dup
         + Exec
         + Exit
-        + Fcntl
         + Fork
         + GetPid
         + Isatty
         + Open
-        + RunLoop
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + TcSetPgrp
         + Wait
-        + Write
+        + WaitForSignals
+        + WriteAll
         + 'static,
 {
     match target {
@@ -173,6 +172,7 @@ mod tests {
     use yash_env::function::{Function, FunctionBody, FunctionBodyObject};
     use yash_env::semantics::Field;
     use yash_env::source::Location;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
     use yash_semantics::Divert::Return;
@@ -211,7 +211,7 @@ mod tests {
     fn command_not_found() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins
             .insert("foo", Builtin::new(Special, |_, _| unreachable!()));
         let invoke = Invoke {
@@ -260,19 +260,20 @@ mod tests {
     #[test]
     fn invoking_function() {
         let mut env = Env::new_virtual();
-        env.any.insert(Box::new(RunFunction::<VirtualSystem>(
-            |env, function, fields, env_prep_hook| {
-                Box::pin(async move {
-                    yash_semantics::command::simple_command::execute_function_body(
-                        env,
-                        function,
-                        fields,
-                        env_prep_hook,
-                    )
-                    .await
-                })
-            },
-        )));
+        env.any
+            .insert(Box::new(RunFunction::<Rc<Concurrent<VirtualSystem>>>(
+                |env, function, fields, env_prep_hook| {
+                    Box::pin(async move {
+                        yash_semantics::command::simple_command::execute_function_body(
+                            env,
+                            function,
+                            fields,
+                            env_prep_hook,
+                        )
+                        .await
+                    })
+                },
+            )));
         env.builtins.insert(
             ":",
             Builtin::new(Special, |_, args| {

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -21,8 +21,8 @@
 
 use yash_env::Env;
 use yash_env::io::Fd;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 pub mod report;
 pub mod syntax;
@@ -36,7 +36,7 @@ pub mod syntax;
 /// errors that occur while printing the error message are ignored.
 pub async fn output<S>(env: &mut Env<S>, content: &str) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     match env.system.write_all(Fd::STDOUT, content.as_bytes()).await {
         Ok(_) => Default::default(),

--- a/yash-builtin/src/common/report.rs
+++ b/yash-builtin/src/common/report.rs
@@ -28,8 +28,8 @@ use yash_env::source::pretty::{
 };
 #[cfg(doc)]
 use yash_env::stack::Stack;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Convenience function for constructing an error report and a divert value.
 ///
@@ -134,10 +134,10 @@ pub async fn report<'a, S, R>(
     exit_status: ExitStatus,
 ) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
     R: Into<Report<'a>> + 'a,
 {
-    async fn inner<S: Isatty + Fcntl + Write>(
+    async fn inner<S: Isatty + WriteAll>(
         env: &mut Env<S>,
         report: Report<'_>,
         exit_status: ExitStatus,
@@ -155,7 +155,7 @@ where
 #[inline]
 pub async fn report_failure<'a, S, R>(env: &mut Env<S>, report: R) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
     R: Into<Report<'a>> + 'a,
 {
     self::report(env, report, ExitStatus::FAILURE).await
@@ -167,7 +167,7 @@ where
 #[inline]
 pub async fn report_error<'a, S, R>(env: &mut Env<S>, report: R) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
     R: Into<Report<'a>> + 'a,
 {
     self::report(env, report, ExitStatus::ERROR).await
@@ -188,7 +188,7 @@ pub async fn report_simple<S>(
     exit_status: ExitStatus,
 ) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Error;
@@ -201,7 +201,7 @@ where
 /// This is a simple shortcut for calling [`report_simple`] with [`ExitStatus::FAILURE`].
 pub async fn report_simple_failure<S>(env: &mut Env<S>, title: &str) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     report_simple(env, title, ExitStatus::FAILURE).await
 }
@@ -211,7 +211,7 @@ where
 /// This is a simple shortcut for calling [`report_simple`] with [`ExitStatus::ERROR`].
 pub async fn report_simple_error<S>(env: &mut Env<S>, title: &str) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     report_simple(env, title, ExitStatus::ERROR).await
 }
@@ -226,7 +226,7 @@ pub async fn syntax_error<S>(
     location: &Location,
 ) -> yash_env::builtin::Result
 where
-    S: Isatty + Fcntl + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Error;

--- a/yash-builtin/src/continue.rs
+++ b/yash-builtin/src/continue.rs
@@ -35,7 +35,8 @@ use crate::common::report::{report_error, report_simple_failure};
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 // pub mod display;
 pub mod semantics;
@@ -46,7 +47,7 @@ pub use super::r#break::syntax;
 /// This function uses the [`syntax`] and [`semantics`] modules to execute the built-in.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(count) => match semantics::run(&env.stack, count) {
@@ -72,6 +73,7 @@ mod tests {
     use yash_env::semantics::Field;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
 
@@ -85,7 +87,7 @@ mod tests {
     fn no_enclosing_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
             is_special: true,
@@ -107,7 +109,7 @@ mod tests {
     fn omitted_operand_with_one_enclosing_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
@@ -127,7 +129,7 @@ mod tests {
     fn omitted_operand_with_many_enclosing_loops() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
@@ -149,7 +151,7 @@ mod tests {
     fn explicit_operand_1_with_many_enclosing_loops() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
@@ -172,7 +174,7 @@ mod tests {
     fn explicit_operand_3_with_many_enclosing_loops() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
@@ -195,7 +197,7 @@ mod tests {
     fn explicit_operand_greater_than_number_of_loops() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Loop);
@@ -219,7 +221,7 @@ mod tests {
     fn explicit_operand_0() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
@@ -245,7 +247,7 @@ mod tests {
     fn explicit_operand_too_large() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
@@ -266,7 +268,7 @@ mod tests {
     fn too_many_operands() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),
@@ -289,7 +291,7 @@ mod tests {
     fn argument_separator() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Loop);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("continue"),

--- a/yash-builtin/src/eval.rs
+++ b/yash-builtin/src/eval.rs
@@ -38,7 +38,8 @@ use yash_env::parser::Config;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::{Field, RunReadEvalLoop};
 use yash_env::source::Source;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Entry point of the `eval` built-in execution
 ///
@@ -53,7 +54,7 @@ use yash_env::system::{Fcntl, Isatty, Write};
 /// found, the function **panics**.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write + 'static,
+    S: Isatty + WriteAll + 'static,
 {
     // TODO Support non-POSIX options
     let args = match parse_arguments(&[], Mode::with_env(env), args) {

--- a/yash-builtin/src/exec.rs
+++ b/yash-builtin/src/exec.rs
@@ -44,16 +44,16 @@ use yash_env::semantics::command::{ReplaceCurrentProcessError, replace_current_p
 use yash_env::semantics::{Divert::Abort, ExitStatus, Field};
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::{
-    Exec, Fcntl, IsExecutableFile, Isatty, ShellPath, Sigaction, Sigmask, Signals, Write,
-};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Exec, IsExecutableFile, Isatty, ShellPath, Sigaction, Sigmask};
+use yash_env::trap::SignalSystem;
 
 // TODO Split into syntax and semantics submodules
 
 /// Entry point for executing the `exec` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Exec + Fcntl + IsExecutableFile + Isatty + ShellPath + Sigmask + Sigaction + Signals + Write,
+    S: Exec + IsExecutableFile + Isatty + ShellPath + Sigmask + Sigaction + SignalSystem + WriteAll,
 {
     // TODO Support non-POSIX options
     let args = match parse_arguments(&[], Mode::with_env(env), args) {
@@ -135,8 +135,8 @@ mod tests {
     use yash_env::VirtualSystem;
     use yash_env::option::Option::Interactive;
     use yash_env::option::State::On;
-    use yash_env::system::Mode;
     use yash_env::system::r#virtual::{FileBody, Inode};
+    use yash_env::system::{Concurrent, Mode};
     use yash_env::variable::{PATH, Scope};
 
     fn dummy_file(is_native_executable: bool) -> Inode {
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn executes_external_utility_when_given_operand() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the external utility file
         system
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn accepts_double_hyphen_separator() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the external utility file
         system
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn passing_argument_to_external_utility() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the external utility file
         system
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn utility_name_with_slash() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the external utility file
         system
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn utility_not_found() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the external utility file
         system
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn utility_not_executable() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         // Prepare the file without executable permission
         let content = non_executable_file();
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn utility_not_executable_interactive_no_abort() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Interactive, On);
 
         // Prepare the file without executable permission

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -53,11 +53,12 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 // TODO Split into syntax and semantics submodules
 
-async fn operand_parse_error<S: Fcntl + Isatty + Write>(
+async fn operand_parse_error<S: Isatty + WriteAll>(
     env: &mut Env<S>,
     location: &Location,
     error: ParseIntError,
@@ -70,7 +71,7 @@ async fn operand_parse_error<S: Fcntl + Isatty + Write>(
 /// See the [module-level documentation](self) for details.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     // TODO Support non-POSIX options
     let args = match parse_arguments(&[], Mode::with_env(env), args) {
@@ -101,6 +102,7 @@ mod tests {
     use yash_env::VirtualSystem;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
 
     #[test]
@@ -138,7 +140,7 @@ mod tests {
     fn exit_with_negative_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
@@ -158,7 +160,7 @@ mod tests {
     fn exit_with_non_integer_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
@@ -178,7 +180,7 @@ mod tests {
     fn exit_with_too_large_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,
@@ -201,7 +203,7 @@ mod tests {
     fn exit_with_too_many_arguments() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("exit"),
             is_special: true,

--- a/yash-builtin/src/export.rs
+++ b/yash-builtin/src/export.rs
@@ -43,7 +43,8 @@ use crate::typeset::syntax::parse;
 use yash_env::Env;
 use yash_env::option::State::On;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// List of portable options applicable to the export built-in
 pub const PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
@@ -58,7 +59,7 @@ pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {
 /// Entry point of the export built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> yash_env::builtin::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match parse(PORTABLE_OPTIONS, args) {
         Ok((options, operands)) => match interpret(options, operands) {

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -46,11 +46,9 @@ use yash_env::option::State::Off;
 use yash_env::semantics::Divert::Interrupt;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{
-    Close, Dup, Fcntl, Isatty, Open, SendSignal, Sigaction, Sigmask, Signals, TcSetPgrp, Wait,
-    Write,
-};
+use yash_env::system::concurrency::{WaitForSignals, WriteAll};
+use yash_env::system::{Close, Dup, Isatty, Open, SendSignal, Sigaction, Sigmask, TcSetPgrp, Wait};
+use yash_env::trap::SignalSystem;
 
 /// Resumes the job at the specified index.
 ///
@@ -65,16 +63,16 @@ async fn resume_job_by_index<S>(
 where
     S: Close
         + Dup
-        + Fcntl
         + Isatty
         + Open
         + SendSignal
-        + Signals
+        + SignalSystem
         + Sigmask
         + Sigaction
         + TcSetPgrp
         + Wait
-        + Write,
+        + WaitForSignals
+        + WriteAll,
 {
     let tty = env.get_tty().await.ok();
 
@@ -137,16 +135,16 @@ async fn resume_job_by_id<S>(
 where
     S: Close
         + Dup
-        + Fcntl
         + Isatty
         + Open
         + SendSignal
-        + Signals
+        + SignalSystem
         + Sigmask
         + Sigaction
         + TcSetPgrp
         + Wait
-        + Write,
+        + WaitForSignals
+        + WriteAll,
 {
     let job_id = parse(job_id)?;
     let index = job_id.find(&env.jobs)?;
@@ -158,16 +156,16 @@ pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
     S: Close
         + Dup
-        + Fcntl
         + Isatty
         + Open
         + SendSignal
-        + Signals
+        + SignalSystem
         + Sigmask
         + Sigaction
         + TcSetPgrp
         + Wait
-        + Write,
+        + WaitForSignals
+        + WriteAll,
 {
     let (options, operands) = match parse_arguments(&[], Mode::with_env(env), args) {
         Ok(result) => result,
@@ -216,6 +214,7 @@ mod tests {
     use yash_env::option::State::On;
     use yash_env::subshell::JobControl;
     use yash_env::subshell::Subshell;
+    use yash_env::system::Concurrent;
     use yash_env::system::GetPid as _;
     use yash_env::system::TcGetPgrp as _;
     use yash_env::system::r#virtual::Process;
@@ -225,7 +224,7 @@ mod tests {
     use yash_env::test_helper::in_virtual_system;
     use yash_env::test_helper::stub_tty;
 
-    async fn suspend(env: &mut Env<VirtualSystem>) {
+    async fn suspend(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
         let target = env.system.getpid();
         env.system.kill(target, Some(SIGSTOP)).await.unwrap();
     }
@@ -388,7 +387,7 @@ mod tests {
     #[test]
     fn resume_job_by_index_sends_no_sigcont_to_dead_process() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
         let pid = Pid(123);
         let mut job = Job::new(pid);
@@ -484,7 +483,7 @@ mod tests {
     #[test]
     fn main_without_operands_fails_if_there_is_no_current_job() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
@@ -539,7 +538,7 @@ mod tests {
     #[test]
     fn main_with_operand_fails_if_jobs_is_not_found() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Monitor, On);
         let mut job = Job::new(Pid(123));
         job.job_controlled = true;

--- a/yash-builtin/src/getopts.rs
+++ b/yash-builtin/src/getopts.rs
@@ -35,8 +35,8 @@ use std::num::NonZeroUsize;
 use yash_env::Env;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::variable::OPTIND;
 
 pub mod model;
@@ -65,7 +65,7 @@ fn indexes_to_optind(arg_index: NonZeroUsize, char_index: NonZeroUsize) -> Strin
 /// Entry point of the getopts built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     // Parse arguments
     let operands = match parse_arguments(&[], Mode::with_env(env), args) {

--- a/yash-builtin/src/getopts/report.rs
+++ b/yash-builtin/src/getopts/report.rs
@@ -274,7 +274,7 @@ mod tests {
     }
 
     fn env_with_dummy_arg0_and_optarg() -> Env<VirtualSystem> {
-        let mut env = Env::new_virtual();
+        let mut env = Env::default();
         env.arg0 = "some/arg0".to_string();
         env.get_or_create_variable(OPTARG, Scope::Global)
             .assign("DUMMY", None)

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -36,7 +36,8 @@ use yash_env::semantics::Field;
 use yash_env::source::pretty::Report;
 use yash_env::source::pretty::ReportType;
 use yash_env::source::pretty::Snippet;
-use yash_env::system::{Fcntl, Isatty, Signals, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, Signals};
 
 // TODO Split into syntax and semantics submodules
 
@@ -60,7 +61,7 @@ fn find_error_report(error: FindError, operand: &Field) -> Report<'_> {
 /// Entry point for executing the `jobs` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Signals + Write,
+    S: Isatty + Signals + WriteAll,
 {
     let (options, operands) = match parse_arguments(OPTIONS, Mode::with_env(env), args) {
         Ok(result) => result,
@@ -136,6 +137,7 @@ mod tests {
     use yash_env::semantics::ExitStatus;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::r#virtual::{SIGINT, SIGQUIT, SIGSTOP, SIGTSTP};
     use yash_env::test_helper::assert_stderr;
@@ -145,7 +147,7 @@ mod tests {
     fn no_operands_no_jobs() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
@@ -155,7 +157,7 @@ mod tests {
     fn no_operands_some_jobs() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -228,7 +230,7 @@ mod tests {
     fn specifying_valid_job_ids() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -300,7 +302,7 @@ mod tests {
     fn specifying_job_ids_without_the_initial_percent() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(2));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -325,7 +327,7 @@ mod tests {
     fn specifying_job_ids_of_non_existing_jobs() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.jobs.add(Job::new(Pid(2)));
 
         let args = Field::dummies(["%2"]);
@@ -345,7 +347,7 @@ mod tests {
     fn specifying_ambiguous_job_id() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -372,7 +374,7 @@ mod tests {
     fn jobs_not_removed_in_case_of_error() {
         let system = VirtualSystem::new();
         system.current_process_mut().close_fd(Fd::STDOUT);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
 
         let mut job = Job::new(Pid(10));
         job.state = ProcessState::exited(0);
@@ -413,7 +415,7 @@ mod tests {
     fn state_changed_flag_not_cleared_in_case_of_error() {
         let system = VirtualSystem::new();
         system.current_process_mut().close_fd(Fd::STDOUT);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let i72 = env.jobs.add(Job::new(Pid(72)));
 
         let mut env = env.push_frame(Frame::Builtin(Builtin {
@@ -429,7 +431,7 @@ mod tests {
     fn l_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -455,7 +457,7 @@ mod tests {
     fn verbose_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -476,7 +478,7 @@ mod tests {
     fn p_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -495,7 +497,7 @@ mod tests {
     fn p_option_cancels_l_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);
@@ -514,7 +516,7 @@ mod tests {
     fn pgid_only_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.add(job);

--- a/yash-builtin/src/kill.rs
+++ b/yash-builtin/src/kill.rs
@@ -24,7 +24,8 @@ use crate::common::report::report_error;
 use yash_env::Env;
 use yash_env::semantics::Field;
 use yash_env::signal::RawNumber;
-use yash_env::system::{Fcntl, Isatty, SendSignal, Signals, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, SendSignal, Signals};
 
 /// Parsed command line arguments
 ///
@@ -79,7 +80,7 @@ impl Command {
     /// Executes the built-in.
     pub async fn execute<S>(&self, env: &mut Env<S>) -> crate::Result
     where
-        S: Fcntl + Isatty + SendSignal + Signals + Write,
+        S: Isatty + SendSignal + Signals + WriteAll,
     {
         match self {
             Self::Send {
@@ -96,7 +97,7 @@ impl Command {
 /// Entry point of the kill built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + SendSignal + Signals + Write,
+    S: Isatty + SendSignal + Signals + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(command) => command.execute(env).await,

--- a/yash-builtin/src/kill/print.rs
+++ b/yash-builtin/src/kill/print.rs
@@ -28,7 +28,8 @@ use yash_env::Env;
 use yash_env::semantics::{ExitStatus, Field};
 use yash_env::signal::{Number, RawNumber};
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::{Fcntl, Isatty, Signals, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, Signals};
 
 /// Returns an iterator over all supported signals.
 ///
@@ -150,7 +151,7 @@ pub fn print<'a, S: Signals>(
 /// Executes the `Print` command.
 pub async fn execute<S>(env: &mut Env<S>, signals: &[Field], verbose: bool) -> crate::Result
 where
-    S: Fcntl + Isatty + Signals + Write,
+    S: Isatty + Signals + WriteAll,
 {
     match print(&env.system, signals, verbose) {
         Ok(output) => crate::common::output(env, &output).await,

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -30,7 +30,8 @@ use yash_env::job::{JobList, id::FindError};
 use yash_env::semantics::Field;
 use yash_env::signal::{Number, RawNumber};
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::{Errno, Fcntl, Isatty, SendSignal, Signals, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Errno, Isatty, SendSignal, Signals};
 
 /// Error that may occur while [sending](send) a signal.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
@@ -161,7 +162,7 @@ pub async fn execute<S>(
     targets: &[Field],
 ) -> crate::Result
 where
-    S: Fcntl + Isatty + SendSignal + Signals + Write,
+    S: Isatty + SendSignal + Signals + WriteAll,
 {
     let signal_number = NonZero::new(signal).map(Number::from_raw_unchecked);
 
@@ -194,6 +195,7 @@ mod tests {
     use yash_env::job::Job;
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stderr;
 
@@ -283,7 +285,7 @@ mod tests {
         let system = VirtualSystem::new();
         let pid = system.process_id.to_string();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let result = execute(
             &mut env,
             -1,

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -96,13 +96,14 @@ use yash_env::builtin::Type::{Elective, Mandatory, Special, Substitutive};
 pub use yash_env::builtin::*;
 #[cfg(doc)]
 use yash_env::stack::{Frame, Stack};
-use yash_env::system::concurrency::RunLoop;
+use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::resource::{GetRlimit, SetRlimit};
 use yash_env::system::{
     Chdir, Clock, Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetCwd, GetPid, GetPw, GetUid,
     IsExecutableFile, Isatty, Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, Sigaction,
-    Sigmask, Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Umask, Wait, Write,
+    Sigmask, Sysconf, TcGetPgrp, TcSetPgrp, Times, Umask, Wait, Write,
 };
+use yash_env::trap::SignalSystem;
 
 /// Returns an iterator over all the implemented built-in utilities.
 ///
@@ -115,6 +116,7 @@ where
     // here for future extensibility.
     S: Chdir
         + Clock
+        + Clone
         + Close
         + Dup
         + Exec
@@ -132,7 +134,6 @@ where
         + Open
         + Pipe
         + Read
-        + RunLoop
         + Seek
         + SendSignal
         + SetPgid
@@ -140,14 +141,16 @@ where
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + Sysconf
         + TcGetPgrp
         + TcSetPgrp
         + Times
         + Umask
         + Wait
+        + WaitForSignals
         + Write
+        + WriteAll
         + 'static,
 {
     [
@@ -301,10 +304,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::rc::Rc;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
 
     #[test]
     fn iter_is_sorted() {
-        assert!(iter::<VirtualSystem>().is_sorted_by_key(|pair| pair.0));
+        assert!(iter::<Rc<Concurrent<VirtualSystem>>>().is_sorted_by_key(|pair| pair.0));
     }
 }

--- a/yash-builtin/src/pwd.rs
+++ b/yash-builtin/src/pwd.rs
@@ -29,7 +29,8 @@ use crate::common::report::{report_error, report_failure};
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Fstat, GetCwd, Isatty, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Fstat, GetCwd, Isatty};
 
 /// Choice of the behavior of the built-in
 #[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -55,7 +56,7 @@ pub mod syntax;
 /// This function uses the [`syntax`] and [`semantics`] modules to execute the built-in.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Fstat + GetCwd + Isatty + Write,
+    S: Fstat + GetCwd + Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(mode) => match semantics::compute(env, mode) {

--- a/yash-builtin/src/read.rs
+++ b/yash-builtin/src/read.rs
@@ -34,7 +34,8 @@ use crate::common::report::{merge_reports, report, report_simple};
 use yash_env::Env;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Read, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, Read};
 
 pub mod assigning;
 pub mod input;
@@ -85,7 +86,7 @@ pub struct Command {
 /// Entry point of the `read` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + Read + Write + 'static,
+    S: Isatty + Read + WriteAll + 'static,
 {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,

--- a/yash-builtin/src/read/input.rs
+++ b/yash-builtin/src/read/input.rs
@@ -23,8 +23,8 @@ use yash_env::prompt::GetPrompt;
 use yash_env::semantics::expansion::attr::AttrChar;
 use yash_env::semantics::expansion::attr::Origin;
 use yash_env::source::pretty::{Report, ReportType};
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Errno, Fcntl, Isatty, Read, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Errno, Isatty, Read};
 
 /// Error reading from the standard input
 ///
@@ -108,7 +108,7 @@ pub async fn read<S>(
     is_raw: bool,
 ) -> Result<(Vec<AttrChar>, bool), Error>
 where
-    S: Fcntl + Isatty + Read + Write + 'static,
+    S: Isatty + Read + WriteAll + 'static,
 {
     let mut result = Vec::new();
 
@@ -148,7 +148,7 @@ where
 /// If the input is not a valid UTF-8 sequence, this function returns an error.
 async fn read_char<S>(env: &mut Env<S>) -> Result<Option<char>, Error>
 where
-    S: Fcntl + Isatty + Read + Write,
+    S: Isatty + Read + WriteAll,
 {
     // Any character is at most 4 bytes in UTF-8.
     let mut buffer = [0; 4];
@@ -202,7 +202,7 @@ where
 /// **panics**.
 async fn print_prompt<S>(env: &mut Env<S>)
 where
-    S: Fcntl + Isatty + Write + 'static,
+    S: Isatty + WriteAll + 'static,
 {
     if !env.is_interactive() || !env.system.isatty(Fd::STDIN) {
         return;

--- a/yash-builtin/src/readonly.rs
+++ b/yash-builtin/src/readonly.rs
@@ -45,7 +45,8 @@ use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::option::State::On;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// List of portable options applicable to the readonly built-in
 pub const PORTABLE_OPTIONS: &[OptionSpec<'static>] = &[PRINT_OPTION];
@@ -62,7 +63,7 @@ pub const PRINT_CONTEXT: PrintContext<'static> = PrintContext {
 /// Entry point for executing the `readonly` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match parse(PORTABLE_OPTIONS, args) {
         Ok((options, operands)) => match interpret(options, operands) {

--- a/yash-builtin/src/return.rs
+++ b/yash-builtin/src/return.rs
@@ -47,7 +47,8 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 // TODO Split into syntax and semantics submodules
 
@@ -59,7 +60,7 @@ async fn operand_parse_error<S>(
     error: ParseIntError,
 ) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     syntax_error(env, &error.to_string(), location).await
 }
@@ -69,7 +70,7 @@ where
 /// See the [module-level documentation](self) for details.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let (options, operands) = match parse_arguments(OPTION_SPECS, Mode::with_env(env), args) {
         Ok(result) => result,
@@ -116,6 +117,7 @@ mod tests {
     use yash_env::semantics::ExitStatus;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
 
     #[test]
@@ -179,7 +181,7 @@ mod tests {
     fn return_with_negative_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
@@ -199,7 +201,7 @@ mod tests {
     fn exit_with_non_integer_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
@@ -219,7 +221,7 @@ mod tests {
     fn return_with_too_large_exit_status_operand() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
@@ -250,7 +252,7 @@ mod tests {
     fn return_with_too_many_operands() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,
@@ -270,7 +272,7 @@ mod tests {
     fn return_with_invalid_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("return"),
             is_special: true,

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -43,9 +43,9 @@ use yash_env::parser::IsName;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::stack::Frame::Subshell;
-use yash_env::system::{
-    Close, Dup, Fcntl, GetPid, Isatty, Open, Sigaction, Sigmask, Signals, TcSetPgrp, Write,
-};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Dup, GetPid, Isatty, Open, Sigaction, Sigmask, TcSetPgrp};
+use yash_env::trap::SignalSystem;
 use yash_env::variable::Scope::Global;
 
 /// Interpretation of command-line arguments that determine the behavior of the
@@ -77,7 +77,7 @@ pub mod syntax;
 /// depending on the `Interactive` and `Monitor` option states.
 async fn update_internal_dispositions_for_stoppers<S>(env: &mut Env<S>)
 where
-    S: Signals + Sigmask + Sigaction,
+    S: SignalSystem,
 {
     if env.options.get(Interactive) == State::On && env.options.get(Monitor) == State::On {
         env.traps
@@ -95,7 +95,7 @@ where
 /// option is enabled.
 async fn ensure_foreground<S>(env: &mut Env<S>)
 where
-    S: Open + Dup + Close + GetPid + Signals + Sigmask + Sigaction + TcSetPgrp,
+    S: Open + Dup + Close + GetPid + Sigmask + Sigaction + TcSetPgrp,
 {
     if env.options.get(Monitor) == State::On {
         env.ensure_foreground().await.ok();
@@ -108,7 +108,7 @@ async fn modify<S>(
     options: Vec<(yash_env::option::Option, State)>,
     positional_params: Option<Vec<Field>>,
 ) where
-    S: Open + Dup + Close + GetPid + Signals + Sigmask + Sigaction + TcSetPgrp,
+    S: Open + Dup + Close + GetPid + Sigaction + Sigmask + SignalSystem + TcSetPgrp,
 {
     // Modify options
     let mut monitor_changed = false;
@@ -143,14 +143,13 @@ where
     S: Open
         + Dup
         + Close
-        + Fcntl
         + GetPid
         + Isatty
-        + Signals
+        + SignalSystem
         + Sigmask
         + Sigaction
         + TcSetPgrp
-        + Write
+        + WriteAll
         + 'static,
 {
     use std::fmt::Write as _;
@@ -221,6 +220,7 @@ mod tests {
     use yash_env::option::Option::*;
     use yash_env::option::OptionSet;
     use yash_env::option::State::*;
+    use yash_env::system::Concurrent;
     use yash_env::system::Disposition;
     use yash_env::system::r#virtual::SIGTSTP;
     use yash_env::test_helper::assert_stderr;
@@ -234,11 +234,11 @@ mod tests {
     fn printing_variables() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.any
-            .insert(Box::new(IsName::<VirtualSystem>(|_env, name| {
-                yash_syntax::parser::lex::is_name(name)
-            })));
+            .insert(Box::new(IsName::<Rc<Concurrent<VirtualSystem>>>(
+                |_env, name| yash_syntax::parser::lex::is_name(name),
+            )));
         let mut var = env.variables.get_or_new("foo", Scope::Global);
         var.assign("value", None).unwrap();
         var.export(true);
@@ -261,7 +261,7 @@ mod tests {
     fn printing_options_human_readable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(AllExport, On);
         env.options.set(Unset, Off);
 
@@ -300,7 +300,7 @@ xtrace           off
     fn printing_options_machine_readable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Clobber, Off);
         env.options.set(Verbose, On);
         let options = env.options;
@@ -365,7 +365,7 @@ xtrace           off
     fn enabling_monitor_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         let args = Field::dummies(["-m"]);
 
@@ -383,7 +383,7 @@ xtrace           off
     fn disabling_monitor_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         let args = Field::dummies(["-m"]);
         _ = main(&mut env, args).now_or_never().unwrap();
@@ -403,7 +403,7 @@ xtrace           off
     fn internal_dispositions_not_enabled_for_stoppers_in_non_interactive_shell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["-m"]);
 
         let result = main(&mut env, args).now_or_never().unwrap();
@@ -420,7 +420,7 @@ xtrace           off
     fn internal_dispositions_not_enabled_for_stoppers_in_subshell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Subshell);
         env.options.set(Interactive, On);
         let args = Field::dummies(["-m"]);

--- a/yash-builtin/src/shift.rs
+++ b/yash-builtin/src/shift.rs
@@ -30,11 +30,12 @@ use yash_env::source::Location;
 use yash_env::source::pretty::{
     Footnote, FootnoteType, Report, ReportType, Snippet, Span, SpanRole, add_span,
 };
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     // TODO Support non-POSIX options
     let args = match parse_arguments(&[], Mode::with_env(env), args) {
@@ -134,6 +135,7 @@ mod tests {
     use yash_env::source::Location;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
 
     #[test]
@@ -211,7 +213,7 @@ mod tests {
     fn shifting_without_operand_without_params() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
@@ -235,7 +237,7 @@ mod tests {
     fn shifting_more_than_the_number_of_params() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,
@@ -262,7 +264,7 @@ mod tests {
     fn non_integral_operand_in_posix_mode() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         // TODO Enable POSIX mode
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
@@ -286,7 +288,7 @@ mod tests {
     fn too_many_operands() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("shift"),
             is_special: true,

--- a/yash-builtin/src/source.rs
+++ b/yash-builtin/src/source.rs
@@ -38,7 +38,8 @@ use yash_env::Env;
 #[cfg(doc)]
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::{Close, Dup, Fcntl, Isatty, Open, Read, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Dup, Isatty, Open, Read};
 
 mod semantics;
 pub mod syntax;
@@ -61,7 +62,7 @@ pub struct Command {
 /// Entry point of the `.` built-in execution
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Close + Dup + Fcntl + Isatty + Open + Read + Write + 'static,
+    S: Clone + Close + Dup + Isatty + Open + Read + WriteAll + 'static,
 {
     match syntax::parse(env, args) {
         Ok(command) => command.execute(env).await,

--- a/yash-builtin/src/source/semantics.rs
+++ b/yash-builtin/src/source/semantics.rs
@@ -33,9 +33,8 @@ use yash_env::semantics::{Divert, ExitStatus, Field, RunReadEvalLoop};
 use yash_env::source::Source;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 use yash_env::stack::Frame;
-use yash_env::system::{
-    Close, Dup, Errno, Fcntl, Isatty, Mode, OfdAccess, Open, OpenFlag, Read, Write,
-};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Dup, Errno, Isatty, Mode, OfdAccess, Open, OpenFlag, Read};
 use yash_env::variable::PATH;
 
 impl Command {
@@ -45,7 +44,7 @@ impl Command {
     /// to the standard error and returns `ExitStatus::FAILURE.into()`.
     pub async fn execute<S>(self, env: &mut Env<S>) -> crate::Result
     where
-        S: Close + Dup + Fcntl + Isatty + Open + Read + Write + 'static,
+        S: Clone + Close + Dup + Isatty + Open + Read + WriteAll + 'static,
     {
         let env = &mut *env.push_frame(Frame::DotScript);
 
@@ -153,7 +152,7 @@ async fn report_find_and_open_file_failure<S>(
     errno: Errno,
 ) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Error;
@@ -173,8 +172,8 @@ mod tests {
     use yash_env::VirtualSystem;
     use yash_env::io::MIN_INTERNAL_FD;
     use yash_env::path::Path;
-    use yash_env::system::FdFlag;
     use yash_env::system::r#virtual::Inode;
+    use yash_env::system::{Concurrent, FdFlag};
     use yash_env::variable::Scope;
 
     fn system_with_file<P: AsRef<Path>, C: Into<Vec<u8>>>(path: P, content: C) -> VirtualSystem {
@@ -274,10 +273,11 @@ mod tests {
     #[test]
     fn fd_is_closed_after_execute() {
         let system = system_with_file("/foo/file", "");
-        let mut env = Env::with_system(system.clone());
-        env.any.insert(Box::new(RunReadEvalLoop::<VirtualSystem>(
-            |_env, _lexer| Box::pin(async { ControlFlow::Continue(()) }),
-        )));
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        env.any
+            .insert(Box::new(RunReadEvalLoop::<Rc<Concurrent<VirtualSystem>>>(
+                |_env, _lexer| Box::pin(async { ControlFlow::Continue(()) }),
+            )));
         let command = Command {
             file: Field::dummy("/foo/file"),
             params: vec![],

--- a/yash-builtin/src/source/syntax.rs
+++ b/yash-builtin/src/source/syntax.rs
@@ -25,7 +25,8 @@ use thiserror::Error;
 use yash_env::Env;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Report, ReportType};
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Error in parsing command line arguments
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -59,7 +60,7 @@ impl Error {
     #[inline(always)]
     pub async fn report<S>(&self, env: &mut Env<S>) -> crate::Result
     where
-        S: Fcntl + Isatty + Write,
+        S: Isatty + WriteAll,
     {
         report_error(env, self).await
     }

--- a/yash-builtin/src/times.rs
+++ b/yash-builtin/src/times.rs
@@ -26,7 +26,8 @@ use crate::common::report::report_error;
 use crate::common::report::report_simple_failure;
 use yash_env::Env;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Times, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, Times};
 
 mod format;
 mod syntax;
@@ -34,7 +35,7 @@ mod syntax;
 /// Entry point of the `times` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Times + Fcntl + Isatty + Write,
+    S: Times + Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(()) => match env.system.times() {

--- a/yash-builtin/src/trap.rs
+++ b/yash-builtin/src/trap.rs
@@ -39,7 +39,8 @@ use yash_env::option::State::On;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
-use yash_env::system::{Fcntl, Isatty, Sigaction, Sigmask, Signals, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
 use yash_env::trap::SetActionError;
@@ -225,7 +226,7 @@ impl Command {
     /// output. On failure, returns a non-empty list of errors.
     pub async fn execute<S>(self, env: &mut Env<S>) -> Result<String, Vec<Error>>
     where
-        S: Signals + Sigmask + Sigaction,
+        S: SignalSystem,
     {
         match self {
             Self::PrintAll { include_default } => Ok(display_all_traps(
@@ -274,7 +275,7 @@ impl Command {
 /// Entry point for executing the `trap` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + Signals + Sigmask + Sigaction + Write,
+    S: Isatty + SignalSystem + WriteAll,
 {
     let (options, operands) = match parse_arguments(syntax::OPTION_SPECS, Mode::with_env(env), args)
     {
@@ -325,8 +326,8 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
-    use yash_env::system::Disposition;
     use yash_env::system::r#virtual::{SIGINT, SIGPIPE, SIGUSR1, SIGUSR2};
+    use yash_env::system::{Concurrent, Disposition};
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
 
@@ -335,7 +336,7 @@ mod tests {
         let system = VirtualSystem::new();
         let pid = system.process_id;
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["", "USR1"]);
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -348,7 +349,7 @@ mod tests {
         let system = VirtualSystem::new();
         let pid = system.process_id;
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "USR2"]);
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -361,7 +362,7 @@ mod tests {
         let system = VirtualSystem::new();
         let pid = system.process_id;
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["-", "PIPE"]);
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -373,7 +374,7 @@ mod tests {
     fn printing_no_trap() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -384,7 +385,7 @@ mod tests {
     fn printing_some_trap() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "INT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
 
@@ -397,7 +398,7 @@ mod tests {
     fn printing_some_traps() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "EXIT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["echo t", "TERM"]);
@@ -416,7 +417,7 @@ mod tests {
         system
             .current_process_mut()
             .set_disposition(SIGINT, Disposition::Ignore);
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
 
         let result = main(&mut env, vec![]).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
@@ -429,7 +430,7 @@ mod tests {
     fn printing_specified_traps() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "EXIT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["echo t", "TERM"]);
@@ -449,7 +450,7 @@ mod tests {
         let system = VirtualSystem::new();
         system.current_process_mut().close_fd(Fd::STDOUT);
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
@@ -470,7 +471,7 @@ mod tests {
     fn unknown_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
@@ -488,7 +489,7 @@ mod tests {
     fn missing_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
@@ -508,7 +509,7 @@ mod tests {
         system
             .current_process_mut()
             .set_disposition(SIGINT, Disposition::Ignore);
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
@@ -530,7 +531,7 @@ mod tests {
         system
             .current_process_mut()
             .set_disposition(SIGINT, Disposition::Ignore);
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.options.set(Interactive, On);
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
@@ -551,7 +552,7 @@ mod tests {
     fn trying_to_trap_sigkill() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut env = env.push_frame(Frame::Builtin(Builtin {
             name: Field::dummy("trap"),
             is_special: true,
@@ -571,7 +572,7 @@ mod tests {
     fn printing_traps_in_subshell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "INT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["", "TERM"]);
@@ -592,7 +593,7 @@ mod tests {
     fn printing_traps_after_setting_in_subshell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let args = Field::dummies(["echo", "INT"]);
         let _ = main(&mut env, args).now_or_never().unwrap();
         let args = Field::dummies(["", "TERM"]);

--- a/yash-builtin/src/type.rs
+++ b/yash-builtin/src/type.rs
@@ -31,7 +31,8 @@ use crate::common::syntax::parse_arguments;
 use yash_env::Env;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
-use yash_env::system::{Fcntl, Fstat, GetCwd, IsExecutableFile, Isatty, Sysconf, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Fstat, GetCwd, IsExecutableFile, Isatty, Sysconf};
 
 const OPTION_SPECS: &[OptionSpec] = &[
     // TODO: Non-standard options
@@ -63,7 +64,7 @@ fn parse<S>(env: &mut Env<S>, args: Vec<Field>) -> Result<Identify, crate::comma
 /// Entry point of the `type` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Fstat + GetCwd + IsExecutableFile + Isatty + Sysconf + Write + 'static,
+    S: Fstat + GetCwd + IsExecutableFile + Isatty + Sysconf + WriteAll + 'static,
 {
     match parse(env, args) {
         Ok(identify) => identify.execute(env).await,

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -41,7 +41,8 @@ use yash_env::option::State;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet, Span, SpanRole, add_span};
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::variable::{Value, Variable};
 
 mod print_functions;
@@ -451,7 +452,7 @@ impl<'a> From<&'a ExecuteError> for Report<'a> {
 /// Entry point of the typeset built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> yash_env::builtin::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match syntax::parse(syntax::ALL_OPTIONS, args) {
         Ok((options, operands)) => match syntax::interpret(options, operands) {

--- a/yash-builtin/src/ulimit.rs
+++ b/yash-builtin/src/ulimit.rs
@@ -30,8 +30,9 @@ use crate::common::output;
 use crate::common::report::{report_error, report_simple_failure};
 use yash_env::Env;
 use yash_env::semantics::Field;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::system::resource::{GetRlimit, Limit, Resource, SetRlimit};
-use yash_env::system::{Errno, Fcntl, Isatty, Write};
+use yash_env::system::{Errno, Isatty};
 
 /// Type of limit to show
 ///
@@ -134,7 +135,7 @@ impl Command {
 /// This is the main entry point for the `ulimit` built-in.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: GetRlimit + SetRlimit + Fcntl + Isatty + Write,
+    S: GetRlimit + SetRlimit + Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(command) => match command.execute(env).await {

--- a/yash-builtin/src/umask.rs
+++ b/yash-builtin/src/umask.rs
@@ -25,7 +25,8 @@ use crate::common::output;
 use crate::common::report::report_error;
 use yash_env::Env;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Mode, Umask, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Isatty, Mode, Umask};
 
 pub mod eval;
 pub mod format;
@@ -93,7 +94,7 @@ impl Command {
 /// Entry point of the `umask` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Umask + Fcntl + Isatty + Write,
+    S: Umask + Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(command) => {

--- a/yash-builtin/src/unalias.rs
+++ b/yash-builtin/src/unalias.rs
@@ -25,7 +25,8 @@ use crate::common::report::report_error;
 use crate::common::report::report_failure;
 use yash_env::Env;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Parsed command arguments for the `unalias` built-in
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -42,7 +43,7 @@ pub mod syntax;
 /// Entry point for executing the `unalias` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match syntax::parse(env, args) {
         Ok(command) => {

--- a/yash-builtin/src/unset.rs
+++ b/yash-builtin/src/unset.rs
@@ -25,7 +25,8 @@ use crate::Result;
 use crate::common::report::{merge_reports, report_error, report_failure};
 use yash_env::Env;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Selection of what to unset
 #[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -56,7 +57,7 @@ pub mod syntax;
 /// Entry point of the `unset` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let command = match syntax::parse(env, args) {
         Ok(command) => command,

--- a/yash-builtin/src/unset/semantics.rs
+++ b/yash-builtin/src/unset/semantics.rs
@@ -16,17 +16,11 @@
 
 //! Defines the behavior of the unset built-in.
 
-use crate::common::report::prepare_report_message_and_divert;
 use thiserror::Error;
 use yash_env::Env;
-use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Span, SpanRole, add_span};
-use yash_env::system::Fcntl;
-use yash_env::system::Isatty;
-use yash_env::system::Write;
-use yash_env::system::concurrency::WriteAll as _;
 use yash_env::variable::Scope::Global;
 
 /// Error returned by [`unset_variables`].
@@ -110,72 +104,6 @@ pub fn unset_variables<'a, S>(
     errors
 }
 
-/// Creates a message that describes the errors.
-///
-/// See [`prepare_report_message_and_divert`] for the second return value.
-#[deprecated(
-    note = "use `merge_reports` and `prepare_report_message_and_divert` directly",
-    since = "0.11.0"
-)]
-#[must_use = "returned message should be printed"]
-pub fn unset_variables_error_message<S>(
-    env: &Env<S>,
-    errors: &[UnsetVariablesError],
-) -> (String, yash_env::semantics::Result)
-where
-    S: Fcntl + Isatty + Write,
-{
-    let mut report = Report::new();
-    report.r#type = ReportType::Error;
-    report.title = "cannot unset variable".into();
-    for error in errors {
-        add_span(
-            &error.name.origin.code,
-            Span {
-                range: error.name.origin.byte_range(),
-                role: SpanRole::Primary {
-                    label: error.to_string().into(),
-                },
-            },
-            &mut report.snippets,
-        );
-        add_span(
-            &error.read_only_location.code,
-            Span {
-                range: error.read_only_location.byte_range(),
-                role: SpanRole::Supplementary {
-                    label: format!("variable `{}` was made read-only here", error.name).into(),
-                },
-            },
-            &mut report.snippets,
-        );
-    }
-    prepare_report_message_and_divert(env, report)
-}
-
-/// Prints an error message to the standard error.
-///
-/// This function constructs a message with [`unset_variables_error_message`]
-/// and prints it with [`WriteAll::print_error`].
-///
-/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
-#[deprecated(
-    note = "use `merge_reports` and `report_failure` directly",
-    since = "0.11.0"
-)]
-pub async fn report_variables_error<S>(
-    env: &mut Env<S>,
-    errors: &[UnsetVariablesError<'_>],
-) -> crate::Result
-where
-    S: Fcntl + Isatty + Write,
-{
-    #[allow(deprecated, reason = "the caller and callee are both deprecated")]
-    let (message, divert) = unset_variables_error_message(env, errors);
-    env.system.print_error(&message).await;
-    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
-}
-
 /// Error returned by [`unset_functions`].
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 #[error("cannot unset read-only function `{name}`")]
@@ -245,72 +173,6 @@ pub fn unset_functions<'a, S>(
         }
     }
     errors
-}
-
-/// Creates a message that describes the errors.
-///
-/// See [`prepare_report_message_and_divert`] for the second return value.
-#[deprecated(
-    note = "use `merge_reports` and `prepare_report_message_and_divert` directly",
-    since = "0.11.0"
-)]
-#[must_use = "returned message should be printed"]
-pub fn unset_functions_error_message<S>(
-    env: &mut Env<S>,
-    errors: &[UnsetFunctionsError<'_>],
-) -> (String, yash_env::semantics::Result)
-where
-    S: Fcntl + Isatty + Write,
-{
-    let mut report = Report::new();
-    report.r#type = ReportType::Error;
-    report.title = "cannot unset function".into();
-    for error in errors {
-        add_span(
-            &error.name.origin.code,
-            Span {
-                range: error.name.origin.byte_range(),
-                role: SpanRole::Primary {
-                    label: error.to_string().into(),
-                },
-            },
-            &mut report.snippets,
-        );
-        add_span(
-            &error.read_only_location.code,
-            Span {
-                range: error.read_only_location.byte_range(),
-                role: SpanRole::Supplementary {
-                    label: format!("function `{}` was made read-only here", error.name).into(),
-                },
-            },
-            &mut report.snippets,
-        );
-    }
-    prepare_report_message_and_divert(env, report)
-}
-
-/// Prints an error message to the standard error.
-///
-/// This function constructs a message with [`unset_functions_error_message`]
-/// and prints it with [`WriteAll::print_error`].
-///
-/// [`WriteAll::print_error`]: yash_env::system::concurrency::WriteAll::print_error
-#[deprecated(
-    note = "use `merge_reports` and `report_failure` directly",
-    since = "0.11.0"
-)]
-pub async fn report_functions_error<S>(
-    env: &mut Env<S>,
-    errors: &[UnsetFunctionsError<'_>],
-) -> crate::Result
-where
-    S: Fcntl + Isatty + Write,
-{
-    #[allow(deprecated, reason = "the caller and callee are both deprecated")]
-    let (message, divert) = unset_functions_error_message(env, errors);
-    env.system.print_error(&message).await;
-    crate::Result::with_exit_status_and_divert(ExitStatus::FAILURE, divert)
 }
 
 #[cfg(test)]

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -100,7 +100,6 @@ impl Command {
     /// Executes the `wait` built-in.
     pub async fn execute<S>(self, env: &mut Env<S>) -> crate::Result
     where
-        // S: Fcntl + Isatty + Sigaction + Sigmask + Signals + Wait + Write + 'static,
         S: Isatty + SignalSystem + Wait + WaitForSignals + WriteAll + 'static,
     {
         // Resolve job specifications to indexes

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -35,7 +35,9 @@ use yash_env::job::Pid;
 use yash_env::option::State::Off;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::{Fcntl, Isatty, Sigaction, Sigmask, Signals, Wait, Write};
+use yash_env::system::concurrency::{WaitForSignals, WriteAll};
+use yash_env::system::{Isatty, Wait};
+use yash_env::trap::SignalSystem;
 
 /// Job specification (job ID or process ID)
 ///
@@ -69,7 +71,7 @@ impl Command {
     /// If `indexes` is empty, waits for all jobs.
     async fn await_jobs<S, I>(env: &mut Env<S>, indexes: I) -> Result<ExitStatus, core::Error>
     where
-        S: Signals + Sigmask + Sigaction + Wait + 'static,
+        S: SignalSystem + Wait + WaitForSignals + 'static,
         I: IntoIterator<Item = Option<usize>>,
     {
         // Currently, we ignore the job control option as required by POSIX.
@@ -98,7 +100,8 @@ impl Command {
     /// Executes the `wait` built-in.
     pub async fn execute<S>(self, env: &mut Env<S>) -> crate::Result
     where
-        S: Fcntl + Isatty + Sigaction + Sigmask + Signals + Wait + Write + 'static,
+        // S: Fcntl + Isatty + Sigaction + Sigmask + Signals + Wait + Write + 'static,
+        S: Isatty + SignalSystem + Wait + WaitForSignals + WriteAll + 'static,
     {
         // Resolve job specifications to indexes
         let jobs = self.jobs.into_iter();
@@ -123,7 +126,7 @@ impl Command {
 /// Entry point for executing the `wait` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Fcntl + Isatty + Sigaction + Sigmask + Signals + Wait + Write + 'static,
+    S: Isatty + SignalSystem + Wait + WaitForSignals + WriteAll + 'static,
 {
     match syntax::parse(env, args) {
         Ok(command) => command.execute(env).await,
@@ -136,14 +139,14 @@ mod tests {
     use super::*;
     use futures_util::poll;
     use std::pin::pin;
+    use std::rc::Rc;
     use std::task::Poll;
     use yash_env::job::{Job, ProcessResult};
     use yash_env::option::{Monitor, On};
     use yash_env::subshell::{JobControl, Subshell};
-    use yash_env::system::GetPid as _;
-    use yash_env::system::SendSignal as _;
     use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::{Concurrent, GetPid, SendSignal};
     use yash_env::test_helper::{in_virtual_system, stub_tty};
     use yash_env::trap::RunSignalTrapIfCaught;
 
@@ -153,12 +156,12 @@ mod tests {
         })));
     }
 
-    async fn suspend(env: &mut Env<VirtualSystem>) {
+    async fn suspend<S: GetPid + SendSignal>(env: &mut Env<S>) {
         let target = env.system.getpid();
         env.system.kill(target, Some(SIGSTOP)).await.unwrap();
     }
 
-    async fn start_self_suspending_job(env: &mut Env<VirtualSystem>) {
+    async fn start_self_suspending_job(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
         let subshell =
             Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
         let (pid, subshell_result) = subshell.start_and_wait(env).await.unwrap();

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -24,8 +24,9 @@ use thiserror::Error;
 use yash_env::Env;
 use yash_env::job::Pid;
 use yash_env::signal;
-use yash_env::system::{Errno, Sigaction, Sigmask, Signals, Wait};
-use yash_env::trap::RunSignalTrapIfCaught;
+use yash_env::system::concurrency::WaitForSignals;
+use yash_env::system::{Errno, Wait};
+use yash_env::trap::{RunSignalTrapIfCaught, SignalSystem};
 
 /// Errors that may occur while waiting for a job
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
@@ -62,7 +63,7 @@ pub enum Error {
 /// `Err(Error::NothingToWait)` immediately.
 pub async fn wait_for_any_job_or_trap<S>(env: &mut Env<S>) -> Result<(), Error>
 where
-    S: Signals + Sigmask + Sigaction + Wait + 'static,
+    S: SignalSystem + Wait + WaitForSignals + 'static,
 {
     let RunSignalTrapIfCaught(run_trap_if_caught) = *env
         .any
@@ -115,6 +116,7 @@ mod tests {
     use std::future::{pending, ready};
     use std::ops::ControlFlow::Continue;
     use std::pin::pin;
+    use std::rc::Rc;
     use std::task::Poll;
     use yash_env::VirtualSystem;
     use yash_env::job::Job;
@@ -122,6 +124,7 @@ mod tests {
     use yash_env::semantics::ExitStatus;
     use yash_env::source::Location;
     use yash_env::subshell::Subshell;
+    use yash_env::system::Concurrent;
     use yash_env::system::SendSignal as _;
     use yash_env::system::r#virtual::{SIGSTOP, SIGTERM};
     use yash_env::test_helper::in_virtual_system;
@@ -187,14 +190,14 @@ mod tests {
     #[test]
     fn trap() {
         in_virtual_system(|mut env, state| async move {
-            env.any
-                .insert(Box::new(RunSignalTrapIfCaught::<VirtualSystem>(
-                    |env, signal| {
-                        Box::pin(async move {
-                            yash_semantics::trap::run_trap_if_caught(env, signal).await
-                        })
-                    },
-                )));
+            type TestSystem = Rc<Concurrent<VirtualSystem>>;
+            env.any.insert(Box::new(RunSignalTrapIfCaught::<TestSystem>(
+                |env, signal| {
+                    Box::pin(
+                        async move { yash_semantics::trap::run_trap_if_caught(env, signal).await },
+                    )
+                },
+            )));
 
             let system = VirtualSystem {
                 state,

--- a/yash-builtin/src/wait/status.rs
+++ b/yash-builtin/src/wait/status.rs
@@ -34,7 +34,9 @@ use yash_env::job::ProcessResult;
 use yash_env::job::ProcessState;
 use yash_env::option::State;
 use yash_env::semantics::ExitStatus;
-use yash_env::system::{Sigaction, Sigmask, Signals, Wait};
+use yash_env::system::Wait;
+use yash_env::system::concurrency::WaitForSignals;
+use yash_env::trap::SignalSystem;
 
 /// Waits while the given job is running.
 ///
@@ -46,7 +48,7 @@ pub async fn wait_while_running<S>(
     job_status: &mut dyn FnMut(&mut JobList) -> ControlFlow<ExitStatus>,
 ) -> Result<ExitStatus, Error>
 where
-    S: Signals + Sigmask + Sigaction + Wait + 'static,
+    S: SignalSystem + Wait + WaitForSignals + 'static,
 {
     loop {
         if let ControlFlow::Break(exit_status) = job_status(&mut env.jobs) {

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -35,10 +35,10 @@ use yash_env::Env;
 use yash_env::RealSystem;
 use yash_env::option::{Interactive, On};
 use yash_env::semantics::{Divert, ExitStatus, exit_or_raise};
-use yash_env::system::concurrency::WriteAll as _;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::system::resource::GetRlimit;
 use yash_env::system::{
-    Chdir, Disposition, Errno, Fcntl, GetCwd, GetUid, Isatty, Sigaction as _, Signals as _,
+    Chdir, Concurrent, Disposition, Errno, GetCwd, GetUid, Isatty, Sigaction as _, Signals as _,
     Sysconf, TcGetPgrp, Times, Umask, Write,
 };
 use yash_semantics::trap::run_exit_trap;
@@ -46,7 +46,7 @@ use yash_semantics::{Runtime, interactive_read_eval_loop, read_eval_loop};
 
 async fn print_version<S>(env: &mut Env<S>)
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let version = env!("CARGO_PKG_VERSION");
     let result = yash_builtin::common::output(env, &format!("yash {version}\n")).await;
@@ -60,6 +60,7 @@ where
 async fn run_as_shell_process<S>(env: &mut Env<S>)
 where
     S: Chdir
+        + Clone
         + GetCwd
         + GetRlimit
         + GetUid
@@ -68,6 +69,7 @@ where
         + TcGetPgrp
         + Times
         + Umask
+        + Write
         + 'static,
 {
     // Parse the command-line arguments
@@ -140,19 +142,20 @@ pub fn main() -> ! {
     // SAFETY: This is the only instance of RealSystem we create in the whole
     // process.
     let system = unsafe { RealSystem::new() };
-    let mut env = Env::with_system(system);
 
     // Rust by default sets SIGPIPE to SIG_IGN, which is not desired.
     // As an imperfect workaround, we set SIGPIPE to SIG_DFL here.
     // TODO Use unix_sigpipe: https://github.com/rust-lang/rust/issues/97889
-    env.system
+    system
         .sigaction(RealSystem::SIGPIPE, Disposition::Default)
         .ok();
 
-    let system = Rc::clone(&env.system);
+    let system = Rc::new(Concurrent::new(system));
+    let runner = Rc::clone(&system);
     let task = async {
+        let mut env = Env::with_system(system);
         run_as_shell_process(&mut env).await;
         exit_or_raise(&env.system, env.exit_status).await
     };
-    system.run_real(task)
+    runner.run_real(task)
 }

--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -27,7 +27,7 @@ use yash_env::parser::IsName;
 use yash_env::prompt::GetPrompt;
 use yash_env::semantics::command::RunFunction;
 use yash_env::system::resource::GetRlimit;
-use yash_env::system::{Chdir, GetCwd, GetUid, Isatty, Sysconf, TcGetPgrp, Times, Umask};
+use yash_env::system::{Chdir, GetCwd, GetUid, Isatty, Sysconf, TcGetPgrp, Times, Umask, Write};
 use yash_env::trap::RunSignalTrapIfCaught;
 use yash_prompt::ExpandText;
 use yash_semantics::expansion::expand_text;
@@ -68,6 +68,7 @@ pub fn auto_interactive<S: Isatty>(system: &S, run: &Run) -> bool {
 pub async fn configure_environment<S>(env: &mut Env<S>, run: Run) -> Work
 where
     S: Chdir
+        + Clone
         + GetCwd
         + GetRlimit
         + GetUid
@@ -76,6 +77,7 @@ where
         + TcGetPgrp
         + Times
         + Umask
+        + Write
         + 'static,
 {
     // Apply the parsed options to the environment

--- a/yash-cli/src/startup/init_file.rs
+++ b/yash-cli/src/startup/init_file.rs
@@ -40,10 +40,8 @@ use yash_env::option::Option::Interactive;
 use yash_env::option::State::Off;
 use yash_env::parser::Config;
 use yash_env::stack::Frame;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{
-    Close, Dup, Errno, Fcntl, GetUid, Isatty, Mode, OfdAccess, Open, OpenFlag, Write,
-};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Dup, Errno, GetUid, Isatty, Mode, OfdAccess, Open, OpenFlag};
 use yash_env::variable::ENV;
 use yash_semantics::expansion::expand_text;
 use yash_semantics::read_eval_loop;
@@ -65,7 +63,7 @@ pub enum DefaultFilePathError {
 
 impl<S> Handle<S> for DefaultFilePathError
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     async fn handle(&self, env: &mut Env<S>) -> yash_semantics::Result {
         match self {
@@ -153,7 +151,7 @@ where
 /// If `path` is an empty string, the function returns immediately.
 pub async fn run_init_file<S>(env: &mut Env<S>, path: &str)
 where
-    S: Runtime + 'static,
+    S: Clone + Runtime + 'static,
 {
     if path.is_empty() {
         return;
@@ -216,7 +214,7 @@ where
 /// path are reported to the standard error.
 pub async fn run_rcfile<S>(env: &mut Env<S>, file: InitFile)
 where
-    S: GetUid + Runtime + 'static,
+    S: Clone + GetUid + Runtime + 'static,
 {
     match resolve_rcfile_path(env, file).await {
         Ok(path) => run_init_file(env, &path).await,
@@ -231,7 +229,7 @@ mod tests {
     use futures_util::FutureExt as _;
     use yash_env::VirtualSystem;
     use yash_env::option::State::On;
-    use yash_env::system::{Gid, Uid};
+    use yash_env::system::{Concurrent, Gid, Uid};
     use yash_env::variable::Scope::Global;
 
     #[test]
@@ -334,7 +332,7 @@ mod tests {
         let system = VirtualSystem::new();
         system.current_process_mut().set_uid(Uid(0));
         system.current_process_mut().set_euid(Uid(10));
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         let path = "/path/to/rcfile".to_string();
         let file = InitFile::File { path };
@@ -347,7 +345,7 @@ mod tests {
         let system = VirtualSystem::new();
         system.current_process_mut().set_gid(Gid(0));
         system.current_process_mut().set_egid(Gid(10));
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         let path = "/path/to/rcfile".to_string();
         let file = InitFile::File { path };

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -38,8 +38,9 @@ use yash_env::io::move_fd_internal;
 use yash_env::option::Option::Interactive;
 use yash_env::option::State::{Off, On};
 use yash_env::parser::Config;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::system::{
-    Close, Dup, Errno, Fcntl, Fstat, Isatty, Mode, OfdAccess, Open, OpenFlag, Read, Signals, Write,
+    Close, Dup, Errno, Fcntl, Fstat, Isatty, Mode, OfdAccess, Open, OpenFlag, Read, Signals,
 };
 use yash_prompt::Prompter;
 use yash_syntax::input::InputObject;
@@ -85,7 +86,7 @@ pub async fn prepare_input<'s, 'i, 'e, S>(
 ) -> Result<Lexer<'i>, PrepareInputError<'e>>
 where
     's: 'i + 'e,
-    S: Close + Dup + Fcntl + Fstat + Isatty + Open + Read + Signals + Write + 'static,
+    S: Clone + Close + Dup + Fcntl + Fstat + Isatty + Open + Read + Signals + WriteAll + 'static,
 {
     fn lexer_with_input_and_source<'a>(
         input: Box<dyn InputObject + 'a>,
@@ -159,7 +160,7 @@ where
 /// applied to the input object.
 fn prepare_fd_input<'i, S>(fd: Fd, ref_env: &'i RefCell<&mut Env<S>>) -> Box<dyn InputObject + 'i>
 where
-    S: Fcntl + Isatty + Read + Signals + Write + 'static,
+    S: Clone + Isatty + Read + Signals + WriteAll + 'static,
 {
     let env = ref_env.borrow();
     let system = env.system.clone();

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -62,7 +62,7 @@ A _private dependency_ is used internally and not visible to downstream users.
       `S: system::concurrency::WaitForSignals + system::concurrency::Select`.
     - The `Env::wait_for_subshell`, `Env::wait_for_subshell_to_halt`, and
       `Env::wait_for_subshell_to_finish` methods now require the trait bound
-      `S: system::SignalSystem + system::concurrency::WaitForSignals + system::concurrency::Wait`
+      `S: trap::SignalSystem + system::concurrency::WaitForSignals + system::Wait`
       instead of `S: system::Signals + system::Sigmask + system::Sigaction + system::Wait`.
     - The inherent methods of `subshell::Subshell` now additionally require the
       trait bound `S: trap::SignalSystem + 'static`.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -64,6 +64,12 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `wait_for_signals` (`system::concurrency::WaitForSignals`)
     - `peek` (`system::concurrency::Select`)
     - `select` (`system::concurrency::Select`)
+- The `input::FdReader2::new` function now takes a system of any type instead of
+  specifically an `Rc<Concurrent<S>>`. This allows `FdReader2` to be used with
+  any system that implements the necessary traits for reading from file
+  descriptors, rather than being limited to `Concurrent` systems. The
+  implementation of `input::Input` for `FdReader2` now only requires the system
+  to implement the `Read` trait.
 
 ### Deprecated
 
@@ -116,6 +122,9 @@ This version has been yanked due to an issue that prevents the crate from buildi
 
 ### Added
 
+- The `input::FdReader2` struct has been added as a replacement for the previous
+  `FdReader` struct. The new `FdReader2` struct is designed to work with the new
+  `Concurrent` system.
 - The `system::Stat` trait has been added to represent file metadata.
 - The `system::Fstat` trait now has the associated type `Stat` to represent
   the type of file metadata returned by `fstat` and `fstatat` methods.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -45,13 +45,51 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `Env::run_in_child_process` method has been added as a convenient wrapper
   around `system::Fork::run_in_child_process` for running a task in a child
   process with the current environment state.
+- The `Default` trait is now implemented for `Env<S>` where
+  `S: Default + system::GetPid`.
 
 ### Changed
 
-- The type parameter bound `S: system::concurrency::RunLoop` has been added to
-  the `subshell::Subshell` struct and
-  `semantics::command::run_external_utility_in_subshell` function. For the
-  `Subshell` struct, the bound `S: 'static` has also been added.
+- The `system` field of `Env` now holds an `S` instead of `Rc<Concurrent<S>>`.
+  This allows the environment to hold broader types of systems without being
+  tied to the `Concurrent` wrapper. The following changes have been made to
+  accommodate this:
+    - The `new_virtual` method is now implemented for
+      `Env<Rc<Concurrent<VirtualSystem>>>` instead of `Env<VirtualSystem>`.
+    - The `Env::wait_for_signal` and `Env::wait_for_signals` methods now require
+      the trait bound `S: system::concurrency::WaitForSignals`.
+    - The `Env::poll_signals` method now requires the trait bound
+      `S: system::concurrency::WaitForSignals + system::concurrency::Select`.
+    - The `Env::wait_for_subshell`, `Env::wait_for_subshell_to_halt`, and
+      `Env::wait_for_subshell_to_finish` methods now require the trait bound
+      `S: system::SignalSystem + system::concurrency::WaitForSignals + system::concurrency::Wait`
+      instead of `S: system::Signals + system::Sigmask + system::Sigaction + system::Wait`.
+    - The inherent methods of `subshell::Subshell` now additionally require the
+      trait bound `S: trap::SignalSystem + 'static`.
+    - The `io::print_report` and `io::print_error` functions now require the trait bound
+      `S: system::Isatty + system::concurrency::WriteAll` instead of
+      `S: system::Isatty + system::Fcntl + system::Write`
+    - The `semantics::command::replace_current_process` function now requires the trait bound
+      `S: system::Exec + system::ShellPath + trap::SignalSystem` instead of
+      `S: system::Exec + system::ShellPath + system::Sigmask + system::Sigaction`.
+    - The `semantics::command::run_external_utility_in_subshell` function now
+      additionally requires the trait bound
+      `S: system::concurrency::WaitForSignals + trap::SignalSystem`.
+    - The implementation of `input::Input` for `input::Echo` now requires the
+      trait bound `S: system::concurrency::WriteAll` instead of
+      `S: system::Fcntl + system::Write`.
+    - The implementation of `input::Input` for `input::IgnoreEof` now requires
+      the trait bound `S: system::Isatty + system::concurrency::WriteAll`
+      instead of `S: system::Isatty + system::Fcntl + system::Write`.
+    - The implementation of `input::Input` for `input::reporter::Reporter` now
+      requires the trait bound `S: system::Signals + system::concurrency::WriteAll`
+      instead of `S: system::Fcntl + system::Signals + system::Write`.
+    - The `system::ChildProcessStarter` and `system::ChildProcessTask` type
+      aliases now abstract functions that take `&mut Env<Rc<Concurrent<S>>>`
+      instead of `&mut Env<S>`.
+    - The `test_helper::in_virtual_system` function now provides an
+      `Env<Rc<Concurrent<VirtualSystem>>>` to the provided task instead of
+      `Env<VirtualSystem>`.
 - The following methods of `system::Concurrent`, which were inherent methods,
   are now provided as trait implementations. You may have to import the
   corresponding traits to use these methods:

--- a/yash-env/src/fork.rs
+++ b/yash-env/src/fork.rs
@@ -26,12 +26,10 @@ use crate::job::{JobList, Pid};
 use crate::option::OptionSet;
 use crate::semantics::ExitStatus;
 use crate::stack::Stack;
-use crate::system::Concurrent;
 use crate::trap::TrapSet;
 use crate::variable::VariableSet;
 use std::collections::HashMap;
 use std::mem::take;
-use std::rc::Rc;
 
 /// Subset of [`Env`] for optimizing child process creation
 ///
@@ -140,7 +138,7 @@ impl<S> ForkEnvState<S> {
     /// instance that was created in the parent process, so the child process
     /// will have the same environment as the parent.
     #[must_use]
-    pub fn into_env_with_system(self, system: Rc<Concurrent<S>>) -> Env<S> {
+    pub fn into_env_with_system(self, system: S) -> Env<S> {
         Env {
             aliases: self.aliases,
             arg0: self.arg0,

--- a/yash-env/src/input/echo.rs
+++ b/yash-env/src/input/echo.rs
@@ -20,8 +20,7 @@ use super::{Context, Input, Result};
 use crate::Env;
 use crate::option::Option::Verbose;
 use crate::option::State::On;
-use crate::system::concurrency::WriteAll as _;
-use crate::system::{Fcntl, Write};
+use crate::system::concurrency::WriteAll;
 use std::cell::RefCell;
 
 /// `Input` decorator that echoes the input.
@@ -61,7 +60,7 @@ impl<S, T: Clone> Clone for Echo<'_, '_, S, T> {
     }
 }
 
-impl<S: Fcntl + Write, T: Input> Input for Echo<'_, '_, S, T> {
+impl<S: WriteAll, T: Input> Input for Echo<'_, '_, S, T> {
     #[allow(
         clippy::await_holding_refcell_ref,
         reason = "other decorators, the parser, or the executor do not run concurrently with this method"
@@ -82,6 +81,7 @@ impl<S: Fcntl + Write, T: Input> Input for Echo<'_, '_, S, T> {
 mod tests {
     use super::super::Memory;
     use super::*;
+    use crate::system::Concurrent;
     use crate::system::r#virtual::VirtualSystem;
     use crate::test_helper::assert_stderr;
     use futures_util::FutureExt as _;
@@ -91,7 +91,7 @@ mod tests {
     fn verbose_off() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let ref_env = RefCell::new(&mut env);
         let memory = Memory::new("echo test\n");
         let mut echo = Echo::new(memory, &ref_env);
@@ -109,7 +109,7 @@ mod tests {
     fn verbose_on() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Verbose, On);
         let ref_env = RefCell::new(&mut env);
         let memory = Memory::new("echo test\nfoo");

--- a/yash-env/src/input/fd_reader_2.rs
+++ b/yash-env/src/input/fd_reader_2.rs
@@ -18,31 +18,31 @@
 
 use super::{Context, Input, Result};
 use crate::io::Fd;
-use crate::system::{Concurrent, Fcntl, Read};
-use std::rc::Rc;
+use crate::system::Read;
 use std::slice::from_mut;
 
 /// [Input function](Input) that reads from a file descriptor
 ///
-/// An instance of `FdReader2<S>` contains a `Rc<Concurrent<S>>` to read input
-/// from a file descriptor.
+/// An instance of `FdReader2<S>` contains a system of type `S` that is used to
+/// read from the file descriptor. The system must implement the `Read` trait to
+/// allow the reading operation.
 ///
-/// Although `FdReader2` implements `Clone`, it does not mean you can create and
-/// keep a copy of a `FdReader2` instance to replay the input later. Since both
-/// the original and clone share the same `Concurrent<S>`, reading a line from
-/// one instance will affect the next read from the other.
+/// Although `FdReader2` implements `Clone`, cloning an instance does not allow
+/// you to replay the input later. If the system is contained in `Rc`, for
+/// example, reading from one instance will affect subsequent reads from the
+/// other, since they share the same system and file descriptor.
 ///
 /// This struct is named `FdReader2` to distinguish it from `FdReader`, an older
 /// implementation that existed before the `Concurrent` system was implemented.
 /// The `FdReader` struct has been removed, but the name `FdReader2` is kept for
 /// backward compatibility.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[must_use = "FdReader2 does nothing unless used by a parser"]
 pub struct FdReader2<S> {
     /// File descriptor to read from
     fd: Fd,
     /// System to interact with the FD
-    system: Rc<Concurrent<S>>,
+    system: S,
 }
 
 impl<S> FdReader2<S> {
@@ -51,22 +51,12 @@ impl<S> FdReader2<S> {
     /// The `fd` argument is the file descriptor to read from. It should be
     /// readable, have the close-on-exec flag set, and remain open for the
     /// lifetime of the `FdReader2` instance.
-    pub fn new(fd: Fd, system: Rc<Concurrent<S>>) -> Self {
+    pub fn new(fd: Fd, system: S) -> Self {
         FdReader2 { fd, system }
     }
 }
 
-// Not derived automatically because S may not implement Clone
-impl<S> Clone for FdReader2<S> {
-    fn clone(&self) -> Self {
-        Self {
-            fd: self.fd,
-            system: self.system.clone(),
-        }
-    }
-}
-
-impl<S: Fcntl + Read> Input for FdReader2<S> {
+impl<S: Read> Input for FdReader2<S> {
     async fn next_line(&mut self, _context: &Context) -> Result {
         // TODO Read many bytes at once if seekable
 
@@ -100,6 +90,7 @@ impl<S: Fcntl + Read> Input for FdReader2<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::system::Concurrent;
     use crate::system::Errno;
     use crate::system::Mode;
     use crate::system::OfdAccess;
@@ -109,6 +100,7 @@ mod tests {
     use crate::system::r#virtual::Inode;
     use crate::system::r#virtual::VirtualSystem;
     use futures_util::FutureExt as _;
+    use std::rc::Rc;
 
     #[test]
     fn empty_reader() {

--- a/yash-env/src/input/ignore_eof.rs
+++ b/yash-env/src/input/ignore_eof.rs
@@ -20,8 +20,8 @@ use super::{Context, Input, Result};
 use crate::Env;
 use crate::io::Fd;
 use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off};
-use crate::system::concurrency::WriteAll as _;
-use crate::system::{Fcntl, Isatty, Write};
+use crate::system::Isatty;
+use crate::system::concurrency::WriteAll;
 use std::cell::RefCell;
 
 /// `Input` decorator that ignores EOF on a terminal
@@ -91,7 +91,7 @@ impl<S, T: Clone> Clone for IgnoreEof<'_, '_, S, T> {
     }
 }
 
-impl<S: Fcntl + Isatty + Write, T: Input> Input for IgnoreEof<'_, '_, S, T> {
+impl<S: Isatty + WriteAll, T: Input> Input for IgnoreEof<'_, '_, S, T> {
     #[allow(
         clippy::await_holding_refcell_ref,
         reason = "other decorators, the parser, or the executor do not run concurrently with this method"
@@ -124,8 +124,8 @@ mod tests {
     use super::super::Memory;
     use super::*;
     use crate::option::On;
-    use crate::system::Mode;
     use crate::system::r#virtual::{FdBody, FileBody, Inode, OpenFileDescription, VirtualSystem};
+    use crate::system::{Concurrent, Mode};
     use crate::test_helper::assert_stderr;
     use enumset::EnumSet;
     use futures_util::FutureExt as _;
@@ -205,7 +205,7 @@ mod tests {
     fn decorator_reads_from_inner_input() {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);
@@ -228,7 +228,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);
@@ -255,7 +255,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);
@@ -284,7 +284,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);
@@ -313,7 +313,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, Off);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);
@@ -340,7 +340,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_tty(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, Off);
         let ref_env = RefCell::new(&mut env);
@@ -367,7 +367,7 @@ mod tests {
         let mut system = VirtualSystem::new();
         set_stdin_to_regular_file(&mut system);
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Interactive, On);
         env.options.set(IgnoreEofOption, On);
         let ref_env = RefCell::new(&mut env);

--- a/yash-env/src/input/reporter.rs
+++ b/yash-env/src/input/reporter.rs
@@ -19,8 +19,8 @@ use crate::Env;
 use crate::io::Fd;
 use crate::job::fmt::Accumulator;
 use crate::option::{Interactive, Monitor, Off};
-use crate::system::concurrency::WriteAll as _;
-use crate::system::{Fcntl, Signals, Write};
+use crate::system::Signals;
+use crate::system::concurrency::WriteAll;
 use std::cell::RefCell;
 
 /// `Input` decorator that reports job status changes before reading a line
@@ -57,7 +57,7 @@ impl<S, T: Clone> Clone for Reporter<'_, '_, S, T> {
     }
 }
 
-impl<S: Fcntl + Signals + Write, T: Input> Input for Reporter<'_, '_, S, T> {
+impl<S: Signals + WriteAll, T: Input> Input for Reporter<'_, '_, S, T> {
     #[allow(
         clippy::await_holding_refcell_ref,
         reason = "other decorators, the parser, or the executor do not run concurrently with this method"
@@ -68,7 +68,7 @@ impl<S: Fcntl + Signals + Write, T: Input> Input for Reporter<'_, '_, S, T> {
     }
 }
 
-async fn report<S: Fcntl + Signals + Write>(env: &mut Env<S>) {
+async fn report<S: Signals + WriteAll>(env: &mut Env<S>) {
     if env.options.get(Interactive) == Off || env.options.get(Monitor) == Off {
         return;
     }
@@ -100,6 +100,7 @@ mod tests {
     use crate::VirtualSystem;
     use crate::job::{Job, Pid, ProcessState};
     use crate::option::On;
+    use crate::system::Concurrent;
     use crate::system::r#virtual::SystemState;
     use crate::test_helper::assert_stderr;
     use futures_util::FutureExt as _;
@@ -121,7 +122,7 @@ mod tests {
     fn reporter_shows_job_status_before_reading_input() {
         let system = VirtualSystem::new();
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.jobs.add({
             let mut job = Job::new(Pid(10));
             job.state_changed = true;
@@ -157,7 +158,7 @@ mod tests {
     fn all_jobs_with_changed_status_are_reported() {
         let system = VirtualSystem::new();
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.jobs.add({
             let mut job = Job::new(Pid(10));
             job.state_changed = true;
@@ -229,7 +230,7 @@ mod tests {
     fn no_report_if_not_interactive() {
         let system = VirtualSystem::new();
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.jobs.add({
             let mut job = Job::new(Pid(10));
             job.state_changed = true;
@@ -253,7 +254,7 @@ mod tests {
     fn no_report_if_not_monitor() {
         let system = VirtualSystem::new();
         let state = system.state.clone();
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.jobs.add({
             let mut job = Job::new(Pid(10));
             job.state_changed = true;

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -19,8 +19,8 @@
 use crate::Env;
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
-use crate::system::concurrency::WriteAll as _;
-use crate::system::{Close, Dup, Fcntl, FdFlag, Isatty, Write};
+use crate::system::concurrency::WriteAll;
+use crate::system::{Close, Dup, FdFlag, Isatty};
 use annotate_snippets::Renderer;
 use std::borrow::Cow;
 #[cfg(unix)]
@@ -102,7 +102,7 @@ where
 /// `env` allows it. The string will end with a newline.
 ///
 /// To print the returned string to the standard error, you can use
-/// [`WriteAll::print_error`](crate::system::concurrency::WriteAll::print_error).
+/// [`WriteAll::print_error`].
 #[must_use]
 pub fn report_to_string<S: Isatty>(env: &Env<S>, report: &Report<'_>) -> String {
     let renderer = if env.should_print_error_in_color() {
@@ -117,7 +117,7 @@ pub fn report_to_string<S: Isatty>(env: &Env<S>, report: &Report<'_>) -> String 
 ///
 /// This function converts the `report` into a string by using
 /// [`report_to_string`], and prints the result to the standard error.
-pub async fn print_report<S: Isatty + Fcntl + Write>(env: &mut Env<S>, report: &Report<'_>) {
+pub async fn print_report<S: Isatty + WriteAll>(env: &mut Env<S>, report: &Report<'_>) {
     let report_str = report_to_string(env, report);
     env.system.print_error(&report_str).await;
 }
@@ -126,7 +126,7 @@ pub async fn print_report<S: Isatty + Fcntl + Write>(env: &mut Env<S>, report: &
 ///
 /// This function constructs a temporary [`Report`] based on the given `title`,
 /// `label`, and `location`. The message is printed using [`print_report`].
-pub async fn print_error<S: Isatty + Fcntl + Write>(
+pub async fn print_error<S: Isatty + WriteAll>(
     env: &mut Env<S>,
     title: Cow<'_, str>,
     label: Cow<'_, str>,

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -22,15 +22,17 @@
 //! parts are implemented in pure Rust in this crate. Many application-managed
 //! parts like [function]s and [variable]s can be manipulated independently of
 //! interactions with the underlying system. System-managed parts, on the other
-//! hand, depend on the underlying system. Attributes like the working directory
+//! hand, reside in the underlying system. Attributes like the working directory
 //! and umask are managed by the system to be accessed only by interaction with
 //! the system interface.
 //!
 //! Traits declared in the [`system`] module define the interface to the
 //! system-managed parts of the environment.
-//! [`RealSystem`] provides an implementation for them that interacts with
-//! the underlying system. [`VirtualSystem`] simulates a system for testing
-//! purposes.
+//! [`RealSystem`] provides an implementation that interacts with the actual
+//! underlying system. [`VirtualSystem`] simulates a system in memory for
+//! testing purposes. [`Concurrent`] is a wrapper that adds support for
+//! concurrent execution of multiple tasks on top of any system that implements
+//! the required traits.
 //!
 //! We assume that the shell process is single-threaded. This means that the
 //! shell process itself must not create threads, and all interactions with the
@@ -57,8 +59,6 @@ use self::semantics::Divert;
 use self::semantics::ExitStatus;
 use self::stack::Frame;
 use self::stack::Stack;
-use self::system::CaughtSignals;
-use self::system::Clock;
 use self::system::Close;
 use self::system::Concurrent;
 use self::system::Dup;
@@ -72,7 +72,6 @@ use self::system::Mode;
 use self::system::OfdAccess;
 use self::system::Open;
 use self::system::OpenFlag;
-use self::system::Select;
 use self::system::Sigaction;
 use self::system::Sigmask;
 use self::system::SignalList;
@@ -81,11 +80,12 @@ use self::system::Signals;
 pub use self::system::System;
 use self::system::TcSetPgrp;
 use self::system::Wait;
-use self::system::concurrency::Select as _;
-use self::system::concurrency::WaitForSignals as _;
+use self::system::concurrency::Select;
+use self::system::concurrency::WaitForSignals;
 #[cfg(unix)]
 pub use self::system::real::RealSystem;
 pub use self::system::r#virtual::VirtualSystem;
+use self::trap::SignalSystem;
 use self::trap::TrapSet;
 use self::variable::PPID;
 use self::variable::Scope;
@@ -94,6 +94,7 @@ use self::variable::VariableSet;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::ControlFlow::{self, Break, Continue};
+use std::pin::pin;
 use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
@@ -103,17 +104,13 @@ pub use unix_str as str;
 
 /// Whole shell execution environment.
 ///
-/// The shell execution environment consists of application-managed parts and
-/// system-managed parts. Application-managed parts are directly implemented in
-/// the `Env` instance. System-managed parts are managed by a [`Concurrent`]
-/// wrapping a `System` instance.
+/// See the [module-level documentation](self) for details.
 ///
-/// # Cloning
-///
-/// `Env::clone` effectively clones the application-managed parts of the
-/// environment. Since [`Concurrent`] is reference-counted, you will not get a
-/// deep copy of the system-managed parts. See also
-/// [`clone_with_system`](Self::clone_with_system).
+/// This struct is typically instantiated as `Env<Rc<Concurrent<RealSystem>>>`
+/// in the actual shell, but it can be used with other system types for testing
+/// or other purposes. For example, `Env<VirtualSystem>` can be used for testing
+/// without concurrency, and `Env<Rc<Concurrent<VirtualSystem>>>` can be used
+/// for testing with concurrency.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Env<S> {
@@ -167,7 +164,7 @@ pub struct Env<S> {
     pub any: DataSet,
 
     /// Interface to the system-managed parts of the environment
-    pub system: Rc<Concurrent<S>>,
+    pub system: S,
 }
 
 impl<S> Env<S> {
@@ -176,7 +173,7 @@ impl<S> Env<S> {
     /// Members of the new environments are default-constructed except that:
     /// - `main_pgid` is initialized as `system.getpgrp()`
     /// - `main_pid` is initialized as `system.getpid()`
-    /// - `system` is initialized as `Rc::new(Concurrent::new(system))`
+    /// - `system` is initialized as the provided `system` instance
     #[must_use]
     pub fn with_system(system: S) -> Self
     where
@@ -197,7 +194,7 @@ impl<S> Env<S> {
             tty: Default::default(),
             variables: Default::default(),
             any: Default::default(),
-            system: Rc::new(Concurrent::new(system)),
+            system,
         }
     }
 
@@ -223,16 +220,32 @@ impl<S> Env<S> {
             tty: self.tty,
             variables: self.variables.clone(),
             any: self.any.clone(),
-            system: Rc::new(Concurrent::new(system)),
+            system,
         }
     }
 }
 
-impl Env<VirtualSystem> {
-    /// Creates a new environment with a default-constructed [`VirtualSystem`].
+impl<S> Default for Env<S>
+where
+    S: Default + GetPid,
+{
+    /// Creates a new environment with a default-constructed system.
+    ///
+    /// This is equivalent to `Env::with_system(S::default())`.
+    fn default() -> Self {
+        Self::with_system(S::default())
+    }
+}
+
+impl Env<Rc<Concurrent<VirtualSystem>>> {
+    /// Creates a new environment with a default-constructed [`VirtualSystem`]
+    /// wrapped in [`Concurrent`].
+    ///
+    /// This is equivalent to `Env::<Rc<Concurrent<VirtualSystem>>>::default()`,
+    /// but more explicit about the type of the system.
     #[must_use]
     pub fn new_virtual() -> Self {
-        Env::with_system(VirtualSystem::default())
+        Self::default()
     }
 }
 
@@ -270,12 +283,14 @@ impl<S> Env<S> {
     ///
     /// Returns an array of signals caught.
     ///
-    /// This function is a wrapper for
-    /// [`WaitForSignals::wait_for_signals`](system::concurrency::WaitForSignals::wait_for_signals).
+    /// This function is a wrapper for [`WaitForSignals::wait_for_signals`].
     /// Before the function returns, it passes the results to
     /// [`TrapSet::catch_signal`] so the trap set can remember the signals
     /// caught to be handled later.
-    pub async fn wait_for_signals(&mut self) -> Rc<SignalList> {
+    pub async fn wait_for_signals(&mut self) -> Rc<SignalList>
+    where
+        S: WaitForSignals,
+    {
         let result = self.system.wait_for_signals().await;
         for signal in result.iter().copied() {
             self.traps.catch_signal(signal);
@@ -287,7 +302,10 @@ impl<S> Env<S> {
     ///
     /// This function calls [`wait_for_signals`](Self::wait_for_signals)
     /// repeatedly until it returns results containing the specified `signal`.
-    pub async fn wait_for_signal(&mut self, signal: signal::Number) {
+    pub async fn wait_for_signal(&mut self, signal: signal::Number)
+    where
+        S: WaitForSignals,
+    {
         while !self.wait_for_signals().await.contains(&signal) {}
     }
 
@@ -296,31 +314,43 @@ impl<S> Env<S> {
     /// This function is similar to
     /// [`wait_for_signals`](Self::wait_for_signals) but does not wait for
     /// signals to be caught. Instead, it only checks if any signals have been
-    /// caught but not yet consumed in the [`Concurrent`] instance. If no
-    /// signals have been caught, it returns `None`.
+    /// caught but not yet consumed in the system. If no signals have been
+    /// caught, it returns `None`.
+    ///
+    /// Before the function returns, it passes the results to
+    /// [`TrapSet::catch_signal`] so the trap set can remember the signals
+    /// caught to be handled later.
     pub fn poll_signals(&mut self) -> Option<Rc<SignalList>>
     where
-        S: Select + CaughtSignals + Clock,
+        S: WaitForSignals + Select,
     {
-        let system = Rc::clone(&self.system);
+        fn poll<S: WaitForSignals + Select>(system: &S) -> Option<Rc<SignalList>> {
+            let mut future = pin!(system.wait_for_signals());
+            let mut context = Context::from_waker(Waker::noop());
 
-        let mut future = std::pin::pin!(self.wait_for_signals());
-        let mut context = Context::from_waker(Waker::noop());
+            // Check if the result is ready before peeking the system
+            if let Poll::Ready(signals) = future.as_mut().poll(&mut context) {
+                return Some(signals);
+            }
 
-        // Check if the result is ready before peeking the system
-        if let Poll::Ready(signals) = future.as_mut().poll(&mut context) {
-            return Some(signals);
+            // Peek to handle any pending signals
+            system.peek();
+
+            // Check again if the result is ready after peeking
+            if let Poll::Ready(signals) = future.poll(&mut context) {
+                return Some(signals);
+            }
+
+            None
         }
 
-        // Peek to handle any pending signals
-        system.peek();
-
-        // Check again if the result is ready after peeking
-        if let Poll::Ready(signals) = future.poll(&mut context) {
-            return Some(signals);
+        let signals = poll(&self.system);
+        if let Some(signals) = &signals {
+            for signal in signals.iter().copied() {
+                self.traps.catch_signal(signal);
+            }
         }
-
-        None
+        signals
     }
 
     /// Whether error messages should be printed in color
@@ -440,8 +470,7 @@ impl<S> Env<S> {
         child_task: F,
     ) -> (Result<Pid, Errno>, D)
     where
-        S: 'static,
-        Rc<Concurrent<S>>: Fork,
+        S: Fork + 'static,
         D: Clone + 'static,
         F: AsyncFnOnce(Self, D) + 'static,
     {
@@ -449,8 +478,8 @@ impl<S> Env<S> {
 
         let (pid_or_error, (state, shared_data)) = self.system.run_in_child_process(
             (state, shared_data),
-            |child_concurrent, (state, shared_data): (ForkEnvState<S>, D)| async move {
-                let child_env = state.into_env_with_system(child_concurrent);
+            |child_system, (state, shared_data): (ForkEnvState<S>, D)| async move {
+                let child_env = state.into_env_with_system(child_system);
                 child_task(child_env, shared_data).await
             },
         );
@@ -470,7 +499,7 @@ impl<S> Env<S> {
     /// - `pid`: the child whose process ID is `pid`
     /// - `-pgid`: any child in the process group whose process group ID is `pgid`
     ///
-    /// When [`self.system.wait`](system::Wait::wait) returned a new state of the
+    /// When [`self.system.wait`](Wait::wait) returned a new state of the
     /// target, it is sent to `self.jobs` ([`JobList::update_status`]) before
     /// being returned from this function.
     ///
@@ -482,7 +511,7 @@ impl<S> Env<S> {
     /// instead.
     pub async fn wait_for_subshell(&mut self, target: Pid) -> Result<(Pid, ProcessState), Errno>
     where
-        S: Signals + Sigmask + Sigaction + Wait,
+        S: SignalSystem + WaitForSignals + Wait,
     {
         // We need to set the internal disposition before calling `wait` so we don't
         // miss any `SIGCHLD` that may arrive between `wait` and `wait_for_signal`.
@@ -510,7 +539,7 @@ impl<S> Env<S> {
         target: Pid,
     ) -> Result<(Pid, ProcessResult), Errno>
     where
-        S: Signals + Sigmask + Sigaction + Wait,
+        S: SignalSystem + WaitForSignals + Wait,
     {
         loop {
             let (pid, state) = self.wait_for_subshell(target).await?;
@@ -532,7 +561,7 @@ impl<S> Env<S> {
         target: Pid,
     ) -> Result<(Pid, ExitStatus), Errno>
     where
-        S: Signals + Sigmask + Sigaction + Wait,
+        S: SignalSystem + WaitForSignals + Wait,
     {
         loop {
             let (pid, result) = self.wait_for_subshell_to_halt(target).await?;
@@ -544,7 +573,7 @@ impl<S> Env<S> {
 
     /// Applies all job status updates to jobs in `self.jobs`.
     ///
-    /// This function calls [`self.system.wait`](system::Wait::wait) repeatedly until
+    /// This function calls [`self.system.wait`](Wait::wait) repeatedly until
     /// all status updates available are applied to `self.jobs`
     /// ([`JobList::update_status`]).
     ///
@@ -558,9 +587,7 @@ impl<S> Env<S> {
             self.jobs.update_status(pid, state);
         }
     }
-}
 
-impl<S> Env<S> {
     /// Tests whether the current environment is an interactive shell.
     ///
     /// This function returns true if and only if:
@@ -716,9 +743,9 @@ mod tests {
         })
     }
 
-    fn poll_signals_env() -> (Env<VirtualSystem>, VirtualSystem) {
+    fn poll_signals_env() -> (Env<Rc<Concurrent<VirtualSystem>>>, VirtualSystem) {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.traps
             .set_action(
                 &env.system,
@@ -801,7 +828,7 @@ mod tests {
 
             let (result, shared_data) = env.run_in_child_process(
                 42_u32,
-                |child_env: Env<VirtualSystem>, data| async move {
+                |child_env: Env<Rc<Concurrent<VirtualSystem>>>, data| async move {
                     assert_eq!(data, 42);
                     child_seen_pid_2.set(Some(child_env.system.getpid()));
                     child_seen_ppid_2.set(Some(child_env.system.getppid()));
@@ -831,13 +858,15 @@ mod tests {
                 .assign("before", None)
                 .unwrap();
 
-            let (result, ()) =
-                env.run_in_child_process((), |child_env: Env<VirtualSystem>, ()| async move {
+            let (result, ()) = env.run_in_child_process(
+                (),
+                |child_env: Env<Rc<Concurrent<VirtualSystem>>>, ()| async move {
                     assert_eq!(child_env.arg0, "parent-shell");
                     assert_eq!(child_env.exit_status, ExitStatus(5));
                     assert_eq!(child_env.variables.get_scalar("PARENT"), Some("before"));
                     child_env.system.exit(ExitStatus(0)).await;
-                });
+                },
+            );
 
             let child_pid = result.unwrap();
             _ = env.wait_for_subshell(child_pid).await;
@@ -854,15 +883,17 @@ mod tests {
                 .assign("before", None)
                 .unwrap();
 
-            let (result, ()) =
-                env.run_in_child_process((), |mut child_env: Env<VirtualSystem>, ()| async move {
+            let (result, ()) = env.run_in_child_process(
+                (),
+                |mut child_env: Env<Rc<Concurrent<VirtualSystem>>>, ()| async move {
                     child_env
                         .variables
                         .get_or_new("PARENT", Scope::Global)
                         .assign("after", None)
                         .unwrap();
                     child_env.system.exit(ExitStatus(0)).await;
-                });
+                },
+            );
 
             let child_pid = result.unwrap();
             assert_eq!(
@@ -909,7 +940,7 @@ mod tests {
         let system = VirtualSystem::new();
         let mut executor = LocalPool::new();
         system.state.borrow_mut().executor = Some(Rc::new(executor.spawner()));
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         executor.run_until(async move {
             let result = env.wait_for_subshell(Pid::ALL).await;
             assert_eq!(result, Err(Errno::ECHILD));
@@ -928,7 +959,7 @@ mod tests {
         let mut executor = futures_executor::LocalPool::new();
         system.state.borrow_mut().executor = Some(Rc::new(executor.spawner()));
 
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
 
         let [job_1, job_2, job_3] = executor.run_until(async {
             // Run a subshell.

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -27,12 +27,13 @@ use crate::semantics::{ExitStatus, Field, Result};
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
 use crate::subshell::{JobControl, Subshell};
-use crate::system::concurrency::RunLoop;
+use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
 use crate::system::{
     Close, Dup, Errno, Exec, Exit, Fork, GetPid, Open, SendSignal, SetPgid, ShellPath, Sigaction,
-    Sigmask, Signals, TcSetPgrp, Wait,
+    Sigmask, TcSetPgrp, Wait,
 };
+use crate::trap::SignalSystem;
 use itertools::Itertools as _;
 use std::convert::Infallible;
 use std::ffi::CString;
@@ -139,7 +140,7 @@ pub struct ReplaceCurrentProcessError {
 ///
 /// This function is for implementing the simple command execution semantics and
 /// the `exec` built-in utility.
-pub async fn replace_current_process<S: Exec + ShellPath + Signals + Sigmask + Sigaction>(
+pub async fn replace_current_process<S: Exec + ShellPath + SignalSystem>(
     env: &mut Env<S>,
     path: CString,
     args: Vec<Field>,
@@ -262,16 +263,16 @@ where
         + Fork
         + GetPid
         + Open
-        + RunLoop
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + TcSetPgrp
         + Wait
+        + WaitForSignals
         + 'static,
 {
     let utility = args[0].clone();

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -44,11 +44,11 @@ use crate::system::SetPgid;
 use crate::system::Sigaction;
 use crate::system::Sigmask;
 use crate::system::SigmaskOp;
-use crate::system::Signals;
 use crate::system::TcSetPgrp;
 use crate::system::Wait;
-use crate::system::concurrency::RunLoop;
+use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
+use crate::trap::SignalSystem;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
@@ -89,14 +89,14 @@ where
         + Fork
         + GetPid
         + Open
-        + RunLoop
         + SendSignal
         + SetPgid
         + SetRlimit
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + TcSetPgrp
+        + WaitForSignals
         + 'static,
     F: for<'a> FnOnce(&'a mut Env<S>, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>>
         + 'static,
@@ -324,10 +324,9 @@ mod tests {
     use crate::option::State::On;
     use crate::semantics::ExitStatus;
     use crate::source::Location;
-    use crate::system::Disposition;
-    use crate::system::r#virtual::Inode;
-    use crate::system::r#virtual::SystemState;
+    use crate::system::r#virtual::{Inode, SystemState, VirtualSystem};
     use crate::system::r#virtual::{SIGCHLD, SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
+    use crate::system::{Concurrent, Disposition};
     use crate::test_helper::in_virtual_system;
     use crate::trap::Action;
     use assert_matches::assert_matches;
@@ -350,12 +349,14 @@ mod tests {
             let parent_pid = env.main_pid;
             let child_pid = Rc::new(Cell::new(None));
             let child_pid_2 = Rc::clone(&child_pid);
-            let subshell = Subshell::new(move |env, _job_control| {
-                Box::pin(async move {
-                    child_pid_2.set(Some(env.system.getpid()));
-                    assert_eq!(env.system.getppid(), parent_pid);
-                })
-            });
+            let subshell = Subshell::new(
+                move |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    Box::pin(async move {
+                        child_pid_2.set(Some(env.system.getpid()));
+                        assert_eq!(env.system.getppid(), parent_pid);
+                    })
+                },
+            );
             let result = subshell.start(&mut env).await.unwrap().0;
             env.wait_for_subshell(result).await.unwrap();
             assert_eq!(Some(result), child_pid.get());
@@ -434,14 +435,16 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
-                    assert_eq!(state_2.borrow().foreground, None);
-                    assert_eq!(job_control, None);
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
+                        assert_eq!(state_2.borrow().foreground, None);
+                        assert_eq!(job_control, None);
+                    })
+                },
+            )
             .job_control(None)
             .start(&mut parent_env)
             .await
@@ -462,14 +465,16 @@ mod tests {
             parent_env.options.set(Monitor, On);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
-                    assert_eq!(state_2.borrow().foreground, None);
-                    assert_eq!(job_control, Some(JobControl::Background));
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
+                        assert_eq!(state_2.borrow().foreground, None);
+                        assert_eq!(job_control, Some(JobControl::Background));
+                    })
+                },
+            )
             .job_control(JobControl::Background)
             .start(&mut parent_env)
             .await
@@ -491,14 +496,16 @@ mod tests {
             stub_tty(&state);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
-                    assert_eq!(state_2.borrow().foreground, Some(child_pid));
-                    assert_eq!(job_control, Some(JobControl::Foreground));
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
+                        assert_eq!(state_2.borrow().foreground, Some(child_pid));
+                        assert_eq!(job_control, Some(JobControl::Foreground));
+                    })
+                },
+            )
             .job_control(JobControl::Foreground)
             .start(&mut parent_env)
             .await
@@ -538,13 +545,15 @@ mod tests {
             parent_env.options.set(Monitor, On);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
-                    assert_eq!(job_control, Some(JobControl::Foreground));
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
+                        assert_eq!(job_control, Some(JobControl::Foreground));
+                    })
+                },
+            )
             .job_control(JobControl::Foreground)
             .start(&mut parent_env)
             .await
@@ -564,13 +573,15 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, _job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
-                    assert_eq!(state_2.borrow().foreground, None);
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
+                        assert_eq!(state_2.borrow().foreground, None);
+                    })
+                },
+            )
             .job_control(JobControl::Foreground)
             .start(&mut parent_env)
             .await
@@ -594,13 +605,15 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(move |child_env, _job_control| {
-                Box::pin(async move {
-                    let child_pid = child_env.system.getpid();
-                    assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
-                    assert_eq!(state_2.borrow().foreground, None);
-                })
-            })
+            let (child_pid, job_control) = Subshell::new(
+                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    Box::pin(async move {
+                        let child_pid = child_env.system.getpid();
+                        assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
+                        assert_eq!(state_2.borrow().foreground, None);
+                    })
+                },
+            )
             .job_control(JobControl::Foreground)
             .start(&mut parent_env)
             .await

--- a/yash-env/src/system/process.rs
+++ b/yash-env/src/system/process.rs
@@ -16,7 +16,7 @@
 
 //! Items related to process management
 
-use super::{ExitStatus, Result, Signals};
+use super::{Concurrent, ExitStatus, Result, Signals};
 use crate::Env;
 #[cfg(all(doc, unix))]
 use crate::RealSystem;
@@ -113,7 +113,8 @@ type PinFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 /// Note that the output type of the task is `Infallible`. This is to ensure
 /// that the task [exits](super::Exit::exit) cleanly or
 /// [kills](super::SendSignal::kill) itself with a signal.
-pub type ChildProcessTask<S> = Box<dyn for<'a> FnOnce(&'a mut Env<S>) -> PinFuture<'a, Infallible>>;
+pub type ChildProcessTask<S> =
+    Box<dyn for<'a> FnOnce(&'a mut Env<Rc<Concurrent<S>>>) -> PinFuture<'a, Infallible>>;
 
 /// Abstract function that starts a child process
 ///
@@ -137,7 +138,8 @@ pub type ChildProcessTask<S> = Box<dyn for<'a> FnOnce(&'a mut Env<S>) -> PinFutu
 /// This function only starts the child, which continues to run asynchronously
 /// after the function returns its PID. To wait for the child to finish and
 /// obtain its exit status, use [`wait`](Wait::wait).
-pub type ChildProcessStarter<S> = Box<dyn FnOnce(&mut Env<S>, ChildProcessTask<S>) -> Pid>;
+pub type ChildProcessStarter<S> =
+    Box<dyn FnOnce(&mut Env<Rc<Concurrent<S>>>, ChildProcessTask<S>) -> Pid>;
 
 /// Trait for spawning new processes
 pub trait Fork {

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -132,6 +132,7 @@ use crate::semantics::ExitStatus;
 use crate::str::UnixStr;
 use crate::str::UnixString;
 use crate::system::ChildProcessStarter;
+use crate::system::Concurrent;
 use crate::waker::ScheduledWakerQueue;
 use crate::waker::WakerSet;
 use enumset::EnumSet;
@@ -1301,7 +1302,7 @@ impl Fork for VirtualSystem {
         let state = Rc::clone(&self.state);
         Ok(Box::new(move |parent_env, task| {
             let system = VirtualSystem { state, process_id };
-            let mut child_env = parent_env.clone_with_system(system.clone());
+            let mut child_env = parent_env.clone_with_system(Rc::new(Concurrent::new(system)));
             let concurrent = Rc::clone(&child_env.system);
 
             let task_runner = async move {
@@ -3170,7 +3171,7 @@ mod tests {
         assert_eq!(state.processes.len(), 2);
         drop(state);
 
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let child_process = result.unwrap();
         let pid = child_process(
             &mut env,

--- a/yash-env/src/test_helper.rs
+++ b/yash-env/src/test_helper.rs
@@ -19,6 +19,7 @@
 //! This module is conditionally compiled when the `test-helper` feature is enabled.
 
 use crate::Env;
+use crate::system::Concurrent;
 use crate::system::r#virtual::{Executor, FileBody, Inode, SystemState, VirtualSystem};
 use assert_matches::assert_matches;
 use futures_executor::LocalSpawner;
@@ -72,7 +73,7 @@ impl Executor for LocalExecutor {
 /// that need to be run concurrently with the main task.
 pub fn in_virtual_system<F, Fut, T>(task: F) -> T
 where
-    F: FnOnce(Env<VirtualSystem>, Rc<RefCell<SystemState>>) -> Fut,
+    F: FnOnce(Env<Rc<Concurrent<VirtualSystem>>>, Rc<RefCell<SystemState>>) -> Fut,
     Fut: Future<Output = T> + 'static,
     T: 'static,
 {
@@ -81,8 +82,8 @@ where
     let global_executor = yash_executor::Executor::new();
     state.borrow_mut().executor = Some(Rc::new(global_executor.spawner()));
 
-    let env = Env::with_system(system);
-    let concurrent = env.system.clone();
+    let env = Env::with_system(Rc::new(Concurrent::new(system)));
+    let concurrent = Rc::clone(&env.system);
     let task = task(env, Rc::clone(&state));
 
     let result = Rc::new(Cell::new(None));

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -13,6 +13,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The implementation of `yash_env::input::Input` for `Prompter` now requires the
+  trait bound `S: yash_env::system::concurrency::WriteAll` instead of
+  `S: yash_env::system::Fcntl + yash_env::system::Write`.
 - Public dependency versions:
     - yash-env 0.13.0 → 0.14.0
     - yash-syntax 0.20.0 → 0.21.0

--- a/yash-prompt/src/lib.rs
+++ b/yash-prompt/src/lib.rs
@@ -44,12 +44,14 @@
 //! # async {
 //! use std::cell::RefCell;
 //! use std::ops::ControlFlow::Continue;
+//! use std::rc::Rc;
 //! use yash_env::Env;
 //! use yash_env::input::FdReader2;
 //! use yash_env::io::Fd;
 //! use yash_env::parser::Config;
 //! use yash_env::semantics::ExitStatus;
 //! use yash_env::source::Source;
+//! use yash_env::system::concurrency::Concurrent;
 //! use yash_env::system::r#virtual::VirtualSystem;
 //! use yash_prompt::{ExpandText, Prompter};
 //! use yash_semantics::expansion::expand_text;
@@ -57,7 +59,7 @@
 //! use yash_syntax::parser::lex::Lexer;
 //!
 //! let mut env = Env::new_virtual();
-//! env.any.insert(Box::new(ExpandText::<VirtualSystem>(|env, text| {
+//! env.any.insert(Box::new(ExpandText::<Rc<Concurrent<VirtualSystem>>>(|env, text| {
 //!     Box::pin(async move { expand_text(env, text).await.ok() })
 //! })));
 //!
@@ -88,6 +90,8 @@ pub use prompter::fetch_posix;
 #[cfg(test)]
 mod tests {
     use super::ExpandText;
+    use std::rc::Rc;
+    use yash_env::system::Concurrent;
     use yash_env::{Env, VirtualSystem};
     use yash_semantics::Runtime;
 
@@ -102,7 +106,7 @@ mod tests {
         env
     }
 
-    pub(crate) fn env_with_expand_text() -> Env<VirtualSystem> {
-        env_with_expand_text_and_system(VirtualSystem::new())
+    pub(crate) fn env_with_expand_text() -> Env<Rc<Concurrent<VirtualSystem>>> {
+        env_with_expand_text_and_system(Rc::new(Concurrent::new(VirtualSystem::new())))
     }
 }

--- a/yash-prompt/src/prompter.rs
+++ b/yash-prompt/src/prompter.rs
@@ -20,8 +20,7 @@ use super::expand_posix;
 use std::cell::RefCell;
 use yash_env::Env;
 use yash_env::input::{Context, Input, Result};
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Fcntl, Write};
+use yash_env::system::concurrency::WriteAll;
 use yash_env::variable::{PS1, PS2, VariableSet};
 
 /// [`Input`] decorator that shows a command prompt
@@ -65,7 +64,7 @@ impl<S, T: Clone> Clone for Prompter<'_, '_, S, T> {
 
 impl<S, T> Input for Prompter<'_, '_, S, T>
 where
-    S: Fcntl + Write + 'static,
+    S: WriteAll + 'static,
     T: Input,
 {
     #[allow(
@@ -80,7 +79,7 @@ where
 
 async fn print_prompt<S>(env: &mut Env<S>, context: &Context)
 where
-    S: Fcntl + Write + 'static,
+    S: WriteAll + 'static,
 {
     // Obtain the prompt string
     let prompt = fetch_posix(&env.variables, context);
@@ -116,6 +115,7 @@ mod tests {
     use futures_util::FutureExt as _;
     use std::rc::Rc;
     use yash_env::input::Memory;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SystemState;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stderr;
@@ -146,7 +146,7 @@ mod tests {
     fn prompter_shows_prompt_before_reading() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = env_with_expand_text_and_system(system);
+        let mut env = env_with_expand_text_and_system(Rc::new(Concurrent::new(system)));
         define_variable(&mut env, PS1, PS1_INITIAL_VALUE_NON_ROOT);
 
         struct InputMock(Rc<RefCell<SystemState>>);
@@ -175,7 +175,7 @@ mod tests {
     fn ps1_variable_defines_main_prompt() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = env_with_expand_text_and_system(system);
+        let mut env = env_with_expand_text_and_system(Rc::new(Concurrent::new(system)));
         define_variable(&mut env, PS1, "my_custom_prompt !! >");
         let ref_env = RefCell::new(&mut env);
         let mut prompter = Prompter::new(Memory::new(""), &ref_env);
@@ -193,7 +193,7 @@ mod tests {
     fn ps2_variable_defines_continuation_prompt() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = env_with_expand_text_and_system(system);
+        let mut env = env_with_expand_text_and_system(Rc::new(Concurrent::new(system)));
         define_variable(&mut env, PS2, "continuation ! >");
         let ref_env = RefCell::new(&mut env);
         let mut prompter = Prompter::new(Memory::new(""), &ref_env);
@@ -209,7 +209,7 @@ mod tests {
     fn parameter_expansion_in_prompt_string() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = env_with_expand_text_and_system(system);
+        let mut env = env_with_expand_text_and_system(Rc::new(Concurrent::new(system)));
         define_variable(&mut env, PS1, "$X $ ");
         define_variable(&mut env, "X", "foo");
         let ref_env = RefCell::new(&mut env);

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,12 +13,23 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
-- The `Runtime` trait now requires the `yash_env::system::concurrency::RunLoop`
-  trait as a supertrait.
-- The type parameter bound `S: yash_env::system::concurrency::RunLoop` has been
-  added to the following items:
-    - `impl<S> Runtime for S`
-    - `command::simple_command::start_external_utility_in_subshell_and_wait`
+- The `Runtime` trait now requires the `yash_env::system::concurrency::ReadAll`,
+  `yash_env::system::concurrency::Select`,
+  `yash_env::system::concurrency::WaitForSignals`,
+  `yash_env::system::concurrency::WriteAll`, and
+  `yash_env::trap::SignalSystem`
+  traits as supertraits, and no longer requires the
+  `yash_env::system::CaughtSignals`, `yash_env::system::Select`, and
+  `yash_env::system::Write` traits. The blanket implementation of `Runtime` has
+  been adjusted accordingly.
+- The type parameter bound
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  has been added to `command::simple_command::start_external_utility_in_subshell_and_wait`.
+- The implementation of the `Handle` trait for `yash_syntax::parser::Error`,
+  `expansion::Error`, and `redir::Error` now requires the trait bounds
+  `S: yash_env::system::concurrency::WriteAll + yash_env::system::Isatty`
+  instead of
+  `S: yash_env::system::Fcntl + yash_env::system::Write + yash_env::system::Isatty`.
 - Public dependency versions:
     - yash-env 0.13.0 → 0.14.0
     - yash-syntax 0.20.0 → 0.21.0

--- a/yash-semantics/src/command.rs
+++ b/yash-semantics/src/command.rs
@@ -87,12 +87,15 @@ impl<S: Runtime + 'static> Command<S> for syntax::List {
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use super::*;
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
     use futures_util::FutureExt as _;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stdout;
@@ -102,7 +105,7 @@ mod tests {
     #[test]
     fn command_handles_traps() {
         let system = VirtualSystem::new();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(

--- a/yash-semantics/src/command/and_or.rs
+++ b/yash-semantics/src/command/and_or.rs
@@ -98,6 +98,7 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stdout;
 
     #[test]
@@ -114,7 +115,7 @@ mod tests {
     fn true_and_true() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let list: AndOrList = "echo one && echo two".parse().unwrap();
 
@@ -138,7 +139,7 @@ mod tests {
     fn false_and_true() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 1 && echo !".parse().unwrap();
@@ -153,7 +154,7 @@ mod tests {
     fn true_and_true_and_true() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let list: AndOrList = "echo 1 && echo 2 && echo 3".parse().unwrap();
 
@@ -167,7 +168,7 @@ mod tests {
     fn true_and_false_and_true() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 0 && return -n 2 && echo !".parse().unwrap();
@@ -192,7 +193,7 @@ mod tests {
     fn true_or_false() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "echo + || return -n 100".parse().unwrap();
@@ -207,7 +208,7 @@ mod tests {
     fn false_or_true() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "{ echo one; return -n 1; } || { echo two; }"
@@ -224,7 +225,7 @@ mod tests {
     fn false_or_false() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "{ echo one; return -n 1; } || { echo two; return -n 2; }"
@@ -252,7 +253,7 @@ mod tests {
     fn false_or_true_or_false() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let list: AndOrList = "return -n 3 || echo + || return -n 4".parse().unwrap();
@@ -297,7 +298,7 @@ mod tests {
     #[test]
     fn stack_in_list() {
         fn stub_builtin_condition(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -309,7 +310,7 @@ mod tests {
             })
         }
         fn stub_builtin_no_condition(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -29,7 +29,6 @@ use yash_env::semantics::Result;
 use yash_env::stack::Frame;
 #[cfg(doc)]
 use yash_env::subshell::Subshell;
-use yash_env::system::concurrency::WriteAll as _;
 use yash_syntax::syntax;
 use yash_syntax::syntax::Redir;
 
@@ -171,6 +170,7 @@ mod tests {
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn stack_in_condition() {
         fn stub_builtin(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -205,7 +205,7 @@ mod tests {
     fn redirecting_compound_command() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: syntax::FullCompoundCommand = "{ echo 1; echo 2; } > /file".parse().unwrap();
         let result = command.execute(&mut env).now_or_never().unwrap();
@@ -223,7 +223,7 @@ mod tests {
     fn tracing_redirections() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(yash_env::option::Option::XTrace, On);
         let command: syntax::FullCompoundCommand = "{ echo X; } > /file < /file".parse().unwrap();
@@ -237,7 +237,7 @@ mod tests {
     fn redirection_error_prevents_command_execution() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: syntax::FullCompoundCommand =
             "{ echo not reached; } < /no/such/file".parse().unwrap();

--- a/yash-semantics/src/command/compound_command/case.rs
+++ b/yash-semantics/src/command/compound_command/case.rs
@@ -133,6 +133,7 @@ mod tests {
     use yash_env::option::Option::ErrExit;
     use yash_env::option::State::On;
     use yash_env::semantics::Divert;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SystemState;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
@@ -140,10 +141,10 @@ mod tests {
     use yash_env::variable::Scope;
     use yash_syntax::syntax::CompoundCommand;
 
-    fn fixture() -> (Env<VirtualSystem>, Rc<RefCell<SystemState>>) {
+    fn fixture() -> (Env<Rc<Concurrent<VirtualSystem>>>, Rc<RefCell<SystemState>>) {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         (env, state)

--- a/yash-semantics/src/command/compound_command/for_loop.rs
+++ b/yash-semantics/src/command/compound_command/for_loop.rs
@@ -129,6 +129,7 @@ mod tests {
     use yash_env::builtin::Builtin;
     use yash_env::option::Option::ErrExit;
     use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
     use yash_syntax::source::Location;
@@ -149,7 +150,7 @@ mod tests {
     fn without_words_with_one_positional_parameters() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.variables.positional_params_mut().values = vec!["foo".to_string()];
         let command: CompoundCommand = "for v do echo :$v:; done".parse().unwrap();
@@ -164,7 +165,7 @@ mod tests {
     fn without_words_with_many_positional_parameters() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.variables.positional_params_mut().values =
             vec!["1".to_string(), "2".to_string(), "three".to_string()];
@@ -180,7 +181,7 @@ mod tests {
     fn with_one_word() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for v in 1; do echo :$v:; done".parse().unwrap();
 
@@ -194,7 +195,7 @@ mod tests {
     fn with_many_words() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for v in baz bar foo; do echo +$v+; done".parse().unwrap();
 
@@ -209,7 +210,7 @@ mod tests {
     #[test]
     fn stack_frame_in_loop() {
         fn execute(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -234,7 +235,7 @@ mod tests {
     fn xtrace_of_for_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(yash_env::option::Option::XTrace, On);
         let command: CompoundCommand = r"for i in 1 \$ 3; do echo $i; done".parse().unwrap();
@@ -248,7 +249,7 @@ mod tests {
     fn return_from_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let command = "for i in 1; do return -n 5; return 2; echo X; done";
@@ -264,7 +265,7 @@ mod tests {
     fn break_for_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -282,7 +283,7 @@ mod tests {
     fn break_outer_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for i in 1 2 3; do echo a; break $n; echo b; done"
@@ -307,7 +308,7 @@ mod tests {
     fn continue_for_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -325,7 +326,7 @@ mod tests {
     fn continue_outer_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for i in 1 2 3; do echo a; continue $n; echo b; done"
@@ -350,7 +351,7 @@ mod tests {
     fn expansion_error_in_name() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for $() do echo unreached; done".parse().unwrap();
 
@@ -364,7 +365,7 @@ mod tests {
     fn errexit_with_expansion_error_in_name() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(ErrExit, On);
         let command: CompoundCommand = "for $() do echo unreached; done".parse().unwrap();
@@ -379,7 +380,7 @@ mod tests {
     fn expansion_error_in_words() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "for x in $(); do echo unreached; done".parse().unwrap();
 
@@ -393,7 +394,7 @@ mod tests {
     fn errexit_with_expansion_error_in_words() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(ErrExit, On);
         let command: CompoundCommand = "for x in $(); do echo unreached; done".parse().unwrap();
@@ -408,7 +409,7 @@ mod tests {
     fn assignment_error_with_read_only_variable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let mut var = env.variables.get_or_new("x", Scope::Global);
         var.assign("", None).unwrap();
@@ -425,7 +426,7 @@ mod tests {
     fn errexit_with_assignment_error_with_read_only_variable() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(ErrExit, On);
         let mut var = env.variables.get_or_new("x", Scope::Global);

--- a/yash-semantics/src/command/compound_command/if.rs
+++ b/yash-semantics/src/command/compound_command/if.rs
@@ -61,14 +61,15 @@ mod tests {
     use std::rc::Rc;
     use yash_env::VirtualSystem;
     use yash_env::semantics::Divert;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SystemState;
     use yash_env::test_helper::assert_stdout;
     use yash_syntax::syntax::CompoundCommand;
 
-    fn fixture() -> (Env<VirtualSystem>, Rc<RefCell<SystemState>>) {
+    fn fixture() -> (Env<Rc<Concurrent<VirtualSystem>>>, Rc<RefCell<SystemState>>) {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         (env, state)

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -80,6 +80,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stderr;
@@ -105,7 +106,7 @@ mod tests {
     #[test]
     fn divert_in_subshell() {
         fn exit_builtin(
-            _env: &mut Env<VirtualSystem>,
+            _env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<yash_env::semantics::Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -133,7 +134,7 @@ mod tests {
     fn error_starting_subshell() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let command: CompoundCommand = "(foo=bar; echo $foo; return -n 123)".parse().unwrap();
@@ -207,7 +208,7 @@ mod tests {
     #[test]
     fn exit_trap() {
         fn trap_builtin(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<yash_env::semantics::Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {

--- a/yash-semantics/src/command/compound_command/while_loop.rs
+++ b/yash-semantics/src/command/compound_command/while_loop.rs
@@ -115,16 +115,17 @@ mod tests {
     use yash_env::builtin::Builtin;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SystemState;
     use yash_env::test_helper::assert_stdout;
     use yash_env::variable::Scope;
     use yash_env::variable::Value;
     use yash_syntax::syntax::CompoundCommand;
 
-    fn fixture() -> (Env<VirtualSystem>, Rc<RefCell<SystemState>>) {
+    fn fixture() -> (Env<Rc<Concurrent<VirtualSystem>>>, Rc<RefCell<SystemState>>) {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         (env, state)
@@ -197,7 +198,7 @@ mod tests {
     #[test]
     fn stack_frame_in_while_loop() {
         fn execute(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -222,7 +223,7 @@ mod tests {
     fn break_while_loop_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -238,7 +239,7 @@ mod tests {
     fn break_while_loop_body() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -275,7 +276,7 @@ mod tests {
     fn break_outer_loop_of_while() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "while break $n; do echo 1; done".parse().unwrap();
@@ -298,7 +299,7 @@ mod tests {
     fn continue_while_loop_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
@@ -317,7 +318,7 @@ mod tests {
     fn continue_while_loop_body() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
@@ -360,7 +361,7 @@ mod tests {
     fn continue_outer_loop_of_while() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "while continue $n; do echo 1; done".parse().unwrap();
@@ -445,7 +446,7 @@ mod tests {
     #[test]
     fn stack_frame_in_until_loop() {
         fn execute(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -470,7 +471,7 @@ mod tests {
     fn break_until_loop_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -486,7 +487,7 @@ mod tests {
     fn break_until_loop_body() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.exit_status = ExitStatus(123);
@@ -519,7 +520,7 @@ mod tests {
     fn break_outer_loop_of_until() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("break", break_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "until ! break $n; do echo 1; done".parse().unwrap();
@@ -542,7 +543,7 @@ mod tests {
     fn continue_until_loop_condition() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
@@ -561,7 +562,7 @@ mod tests {
     fn continue_until_loop_body() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
@@ -604,7 +605,7 @@ mod tests {
     fn continue_outer_loop_of_until() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("continue", continue_builtin());
         env.builtins.insert("echo", echo_builtin());
         let command: CompoundCommand = "until continue $n; do echo 1; done".parse().unwrap();

--- a/yash-semantics/src/command/function_definition.rs
+++ b/yash-semantics/src/command/function_definition.rs
@@ -30,7 +30,8 @@ use yash_env::function::FunctionBody;
 use yash_env::function::FunctionBodyObject;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 use yash_syntax::source::pretty::{Report, ReportType, Snippet, Span, SpanRole, add_span};
 use yash_syntax::syntax;
 
@@ -108,7 +109,7 @@ async fn define_function<S: Runtime + 'static>(
 /// This function assumes `error.existing.read_only_location.is_some()`.
 async fn report_define_error<S>(env: &mut Env<S>, error: &DefineError<S>)
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let mut report = Report::new();
     report.r#type = ReportType::Error;
@@ -151,6 +152,7 @@ mod tests {
     use yash_env::option::On;
     use yash_env::option::Option::ErrExit;
     use yash_env::semantics::Divert;
+    use yash_env::system::Concurrent;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::function::FunctionBodyStub;
     use yash_syntax::source::Location;
@@ -208,7 +210,7 @@ mod tests {
     fn function_definition_read_only() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let function = Rc::new(Function {
             name: "foo".to_string(),
             body: FunctionBodyStub::rc_dyn(),

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -30,7 +30,6 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
-use yash_env::system::concurrency::WriteAll as _;
 use yash_env::system::{Close, Mode, OfdAccess, Open};
 use yash_syntax::source::Location;
 use yash_syntax::syntax;
@@ -157,6 +156,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::option::Option::{Interactive, Monitor};
     use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
     use yash_env::system::Signals as _;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::Inode;
@@ -202,7 +202,7 @@ mod tests {
         let state = Rc::clone(&system.state);
         let mut executor = futures_executor::LocalPool::new();
         state.borrow_mut().executor = Some(Rc::new(executor.spawner()));
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
 
         let and_or: syntax::AndOrList = "echo foo".parse().unwrap();
@@ -295,7 +295,7 @@ mod tests {
     fn item_execute_async_fail() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("return", return_builtin());
 
         let and_or: syntax::AndOrList = "return -n 42".parse().unwrap();
@@ -334,7 +334,7 @@ mod tests {
         })
     }
 
-    fn ignore_sigttin(env: &mut Env<VirtualSystem>) {
+    fn ignore_sigttin(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
         env.traps
             .set_action(
                 &env.system,

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -35,8 +35,8 @@ use yash_env::semantics::Result;
 use yash_env::stack::Frame;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Close, Dup, Errno, Fcntl, Isatty, Pipe, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Dup, Errno, Isatty, Pipe};
 use yash_syntax::syntax;
 
 /// Executes the pipeline.
@@ -201,7 +201,7 @@ async fn execute_multi_command_pipeline<S: Runtime + 'static>(
 
 async fn shift_or_fail<S>(env: &mut Env<S>, pipes: &mut PipeSet, has_next: bool) -> Result
 where
-    S: Close + Fcntl + Isatty + Pipe + Write,
+    S: Close + Isatty + Pipe + WriteAll,
 {
     match pipes.shift(env, has_next) {
         Ok(()) => Continue(()),
@@ -237,7 +237,7 @@ async fn pid_or_fail<S>(
     start_result: std::result::Result<(Pid, Option<JobControl>), Errno>,
 ) -> Result<Pid>
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     match start_result {
         Ok((pid, job_control)) => {
@@ -345,6 +345,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::option::Option::{ErrExit, Monitor};
     use yash_env::semantics::Field;
+    use yash_env::system::Concurrent;
     use yash_env::system::GetPid as _;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::SIGSTOP;
@@ -591,7 +592,7 @@ mod tests {
     #[test]
     fn stack_without_inversion() {
         fn stub_builtin(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -611,7 +612,7 @@ mod tests {
     #[test]
     fn stack_with_inversion() {
         fn stub_builtin(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -634,7 +635,7 @@ mod tests {
     #[test]
     fn process_group_id_of_job_controlled_pipeline() {
         fn stub_builtin(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             let pgid = env.system.getpgrp().0 as _;

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -109,6 +109,7 @@ mod tests {
     use std::str::from_utf8;
     use yash_env::VirtualSystem;
     use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::in_virtual_system;
@@ -157,7 +158,7 @@ mod tests {
     fn simple_command_handles_subshell_error_with_absent_target() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let command: syntax::SimpleCommand = ">/tmp/foo".parse().unwrap();
         let result = command.execute(&mut env).now_or_never().unwrap();
         assert_eq!(result, Break(Divert::Interrupt(Some(ExitStatus::ERROR))));
@@ -191,7 +192,7 @@ mod tests {
     fn simple_command_handles_assignment_error_with_absent_target() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut var = env.variables.get_or_new("a", Scope::Global);
         var.assign("", None).unwrap();
         var.make_read_only(Location::dummy("ROL"));

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -118,6 +118,7 @@ mod tests {
     use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::system::Errno;
     use yash_env::system::Mode;
     use yash_env::system::r#virtual::FileBody;
@@ -162,7 +163,7 @@ mod tests {
     fn simple_command_applies_redirections_to_builtin() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: syntax::SimpleCommand = "echo hello >/tmp/file".parse().unwrap();
         _ = command.execute(&mut env).now_or_never().unwrap();
@@ -178,7 +179,7 @@ mod tests {
     fn simple_command_by_default_reverts_redirections_to_builtin() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: syntax::SimpleCommand = "echo hello >/tmp/file".parse().unwrap();
         _ = command.execute(&mut env).now_or_never().unwrap();
@@ -192,7 +193,7 @@ mod tests {
     fn simple_command_retains_redirections_to_builtin_if_requested() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert(
             "exec",
@@ -220,7 +221,7 @@ mod tests {
     fn simple_command_skips_running_builtin_on_redirection_error() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let command: syntax::SimpleCommand = "echo X </no/such/file >/tmp/file".parse().unwrap();
 
@@ -236,8 +237,7 @@ mod tests {
 
     #[test]
     fn special_builtin_interrupts_on_redirection_error() {
-        let system = VirtualSystem::new();
-        let mut env = Env::with_system(system);
+        let mut env = Env::new_virtual();
         env.builtins.insert("return", return_builtin());
         let command: syntax::SimpleCommand = "return </no/such/file".parse().unwrap();
 
@@ -261,7 +261,7 @@ mod tests {
     fn substitutive_builtin_must_be_found_in_path_after_assignments() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         // Register `echo` as a substitutive built-in
         let mut echo_builtin = echo_builtin();
         echo_builtin.r#type = Substitutive;
@@ -320,7 +320,7 @@ mod tests {
     fn simple_command_assigns_temporarily_for_regular_builtin() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("local", local_builtin());
         let command: syntax::SimpleCommand = "v=42 local v".parse().unwrap();
         _ = command.execute(&mut env).now_or_never().unwrap();
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn simple_command_pushes_stack_frame_for_builtin() {
         fn builtin_main(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async {
@@ -343,7 +343,7 @@ mod tests {
             })
         }
         fn special_main(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async {
@@ -371,7 +371,7 @@ mod tests {
     fn xtrace_for_builtin() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.options.set(yash_env::option::XTrace, On);
         let command: syntax::SimpleCommand = "foo=bar echo hello >/dev/null".parse().unwrap();

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -34,12 +34,14 @@ use yash_env::semantics::Field;
 use yash_env::semantics::Result;
 use yash_env::semantics::command::ReplaceCurrentProcessError;
 use yash_env::semantics::command::run_external_utility_in_subshell;
-use yash_env::system::concurrency::RunLoop;
+use yash_env::system::concurrency::WaitForSignals;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
-    Close, Dup, Exec, Exit, Fcntl, Fork, GetPid, Isatty, Open, SendSignal, SetPgid, ShellPath,
-    Sigaction, Sigmask, Signals, TcSetPgrp, Wait, Write,
+    Close, Dup, Exec, Exit, Fork, GetPid, Isatty, Open, SendSignal, SetPgid, ShellPath, Sigaction,
+    Sigmask, TcSetPgrp, Wait,
 };
+use yash_env::trap::SignalSystem;
 use yash_env::variable::Context;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
@@ -109,22 +111,21 @@ where
         + Dup
         + Exec
         + Exit
-        + Fcntl
         + Fork
         + GetPid
         + Isatty
         + Open
-        + RunLoop
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + TcSetPgrp
         + Wait
-        + Write
+        + WaitForSignals
+        + WriteAll
         + 'static,
 {
     run_external_utility_in_subshell(

--- a/yash-semantics/src/command/simple_command/function.rs
+++ b/yash-semantics/src/command/simple_command/function.rs
@@ -109,6 +109,7 @@ mod tests {
     use yash_env::function::FunctionBodyObject;
     use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
@@ -116,7 +117,7 @@ mod tests {
     use yash_syntax::source::Location;
     use yash_syntax::syntax::SimpleCommand;
 
-    fn function_body_impl(src: &str) -> Rc<dyn FunctionBodyObject<VirtualSystem>> {
+    fn function_body_impl(src: &str) -> Rc<dyn FunctionBodyObject<Rc<Concurrent<VirtualSystem>>>> {
         Rc::new(BodyImpl(src.parse().unwrap()))
     }
 
@@ -141,7 +142,7 @@ mod tests {
     fn simple_command_applies_redirections_to_function() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let function = Function::new(
             "foo",
@@ -163,7 +164,7 @@ mod tests {
     fn simple_command_skips_running_function_on_redirection_error() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let function = Function::new(
             "foo",
@@ -219,7 +220,7 @@ mod tests {
     fn simple_command_passes_arguments_to_function() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let function = Function::new(
             "foo",
@@ -238,7 +239,7 @@ mod tests {
     fn simple_command_creates_temporary_context_executing_function() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("local", local_builtin());
         let function = Function::new(
@@ -258,7 +259,7 @@ mod tests {
     fn simple_command_performs_function_assignment_in_temporary_context() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let function = Function::new(
             "foo",
@@ -298,7 +299,7 @@ mod tests {
     fn xtrace_for_function() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let function = Function::new(
             "foo",
             function_body_impl("for i in; do :; done"),

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -31,10 +31,10 @@ use yash_env::io::Fd;
 use yash_env::job::Pid;
 use yash_env::subshell::JobControl;
 use yash_env::subshell::Subshell;
-use yash_env::system::concurrency::ReadAll as _;
-use yash_env::system::{
-    Close, Dup as _, Errno, Fcntl, Pipe as _, Read, Sigaction, Sigmask, Signals, Wait,
-};
+use yash_env::system::concurrency::ReadAll;
+use yash_env::system::concurrency::WaitForSignals;
+use yash_env::system::{Close, Errno, Wait};
+use yash_env::trap::SignalSystem;
 use yash_syntax::parser::lex::Lexer;
 use yash_syntax::source::Location;
 use yash_syntax::source::Source;
@@ -113,7 +113,7 @@ async fn expand_common<S>(
     env: &mut Env<'_, S>,
 ) -> Result<Phrase, Error>
 where
-    S: Close + Fcntl + Read + Sigaction + Signals + Sigmask + Wait,
+    S: Close + ReadAll + SignalSystem + Wait + WaitForSignals,
 {
     // See if the subshell has successfully started
     let pid = match subshell_result {

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -154,11 +154,13 @@ fn to_field(value: &str) -> Vec<AttrChar> {
 pub mod tests {
     use super::*;
     use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::variable::{IFS, Scope};
     use yash_syntax::syntax::{Switch, SwitchAction, SwitchCondition};
 
-    pub fn env_with_positional_params_and_ifs() -> yash_env::Env<VirtualSystem> {
+    pub fn env_with_positional_params_and_ifs() -> yash_env::Env<Rc<Concurrent<VirtualSystem>>> {
         let mut env = yash_env::Env::new_virtual();
         env.variables.positional_params_mut().values = vec!["a".to_string(), "c".to_string()];
         env.variables

--- a/yash-semantics/src/handle.rs
+++ b/yash-semantics/src/handle.rs
@@ -21,7 +21,8 @@ use std::ops::ControlFlow::{Break, Continue};
 use yash_env::Env;
 use yash_env::io::print_report;
 use yash_env::semantics::Divert;
-use yash_env::system::{Fcntl, Isatty, Write};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 use yash_syntax::source::Source;
 
 /// Error handler.
@@ -46,7 +47,7 @@ pub trait Handle<S> {
 /// exit statuses instead of `ExitStatus::ERROR`.
 impl<S> Handle<S> for yash_syntax::parser::Error
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     async fn handle(&self, env: &mut Env<S>) -> super::Result {
         print_report(env, &self.to_report()).await;
@@ -74,7 +75,7 @@ where
 /// [`ErrExit`]: yash_env::option::Option::ErrExit
 impl<S> Handle<S> for crate::expansion::Error
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     async fn handle(&self, env: &mut Env<S>) -> super::Result {
         print_report(env, &self.to_report()).await;
@@ -101,7 +102,7 @@ where
 /// interrupting accordingly.
 impl<S> Handle<S> for crate::redir::Error
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     async fn handle(&self, env: &mut Env<S>) -> super::Result {
         print_report(env, &self.to_report()).await;

--- a/yash-semantics/src/redir.rs
+++ b/yash-semantics/src/redir.rs
@@ -718,6 +718,7 @@ mod tests {
     use std::rc::Rc;
     use yash_env::Env;
     use yash_env::VirtualSystem;
+    use yash_env::system::Concurrent;
     use yash_env::system::Read as _;
     use yash_env::system::Write as _;
     use yash_env::system::resource::LimitPair;
@@ -725,12 +726,13 @@ mod tests {
     use yash_env::system::resource::SetRlimit as _;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::Inode;
+    use yash_env::system::r#virtual::SystemState;
     use yash_env::test_helper::in_virtual_system;
     use yash_env::waker::WakerSet;
     use yash_syntax::syntax::Text;
 
-    /// Returns a virtual system with a file descriptor limit.
-    fn system_with_nofile_limit() -> VirtualSystem {
+    /// Returns an environment with a virtual system with a file descriptor limit.
+    fn env_with_nofile_limit() -> (Env<Rc<Concurrent<VirtualSystem>>>, Rc<RefCell<SystemState>>) {
         let system = VirtualSystem::new();
         system
             .setrlimit(
@@ -741,17 +743,18 @@ mod tests {
                 },
             )
             .unwrap();
-        system
+        let state = Rc::clone(&system.state);
+        let env = Env::with_system(Rc::new(Concurrent::new(system)));
+        (env, state)
     }
 
     #[test]
     fn basic_file_in_redirection() {
-        let system = system_with_nofile_limit();
+        let (mut env, state) = env_with_nofile_limit();
         let file = Rc::new(RefCell::new(Inode::new([42, 123, 254])));
-        let mut state = system.state.borrow_mut();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", file).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
         let redir = "3< foo".parse().unwrap();
         let result = env
@@ -774,12 +777,11 @@ mod tests {
 
     #[test]
     fn moving_fd() {
-        let system = system_with_nofile_limit();
+        let (mut env, state) = env_with_nofile_limit();
         let file = Rc::new(RefCell::new(Inode::new([42, 123, 254])));
-        let mut state = system.state.borrow_mut();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", file).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
         let redir = "< foo".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -808,8 +810,8 @@ mod tests {
 
     #[test]
     fn saving_and_undoing_fd() {
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("file", Rc::default()).unwrap();
         state
             .file_system
@@ -818,7 +820,6 @@ mod tests {
             .borrow_mut()
             .body = FileBody::new([17]);
         drop(state);
-        let mut env = Env::with_system(system);
         let mut redir_env = RedirGuard::new(&mut env);
         let redir = "< file".parse().unwrap();
         redir_env
@@ -842,8 +843,8 @@ mod tests {
 
     #[test]
     fn preserving_fd() {
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("file", Rc::default()).unwrap();
         state
             .file_system
@@ -852,7 +853,6 @@ mod tests {
             .borrow_mut()
             .body = FileBody::new([17]);
         drop(state);
-        let mut env = Env::with_system(system);
         let mut redir_env = RedirGuard::new(&mut env);
         let redir = "< file".parse().unwrap();
         redir_env
@@ -882,11 +882,10 @@ mod tests {
 
     #[test]
     fn undoing_without_initial_fd() {
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("input", Rc::default()).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut redir_env = RedirGuard::new(&mut env);
         let redir = "4< input".parse().unwrap();
         redir_env
@@ -909,7 +908,7 @@ mod tests {
 
     #[test]
     fn unreadable_file() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "< no_such_file".parse().unwrap();
         let e = env
@@ -926,14 +925,13 @@ mod tests {
 
     #[test]
     fn multiple_redirections() {
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         let file = Rc::new(RefCell::new(Inode::new([100])));
         state.file_system.save("foo", file).unwrap();
         let file = Rc::new(RefCell::new(Inode::new([200])));
         state.file_system.save("bar", file).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
         env.perform_redir(&"< foo".parse().unwrap(), None)
             .now_or_never()
@@ -965,15 +963,14 @@ mod tests {
 
     #[test]
     fn later_redirection_wins() {
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         let file = Rc::new(RefCell::new(Inode::new([100])));
         state.file_system.save("foo", file).unwrap();
         let file = Rc::new(RefCell::new(Inode::new([200])));
         state.file_system.save("bar", file).unwrap();
         drop(state);
 
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
         env.perform_redir(&"< foo".parse().unwrap(), None)
             .now_or_never()
@@ -997,7 +994,7 @@ mod tests {
 
     #[test]
     fn target_with_cloexec() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let fd = env
             .system
             .open(
@@ -1073,7 +1070,7 @@ mod tests {
     #[test]
     fn xtrace_normal() {
         let mut xtrace = XTrace::new();
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         env.perform_redir(&"> foo${unset-&}".parse().unwrap(), Some(&mut xtrace))
             .now_or_never()
@@ -1090,7 +1087,7 @@ mod tests {
     #[test]
     fn xtrace_here_doc() {
         let mut xtrace = XTrace::new();
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
 
         let redir = Redir {
@@ -1125,7 +1122,7 @@ mod tests {
 
     #[test]
     fn file_in_closes_opened_file_on_error() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999</dev/stdin".parse().unwrap();
         let e = env
@@ -1151,9 +1148,7 @@ mod tests {
 
     #[test]
     fn file_out_creates_empty_file() {
-        let system = system_with_nofile_limit();
-        let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let (mut env, state) = env_with_nofile_limit();
         let mut env = RedirGuard::new(&mut env);
         let redir = "3> foo".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1176,11 +1171,10 @@ mod tests {
     #[test]
     fn file_out_truncates_existing_file() {
         let file = Rc::new(RefCell::new(Inode::new([42, 123, 254])));
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", Rc::clone(&file)).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3> foo".parse().unwrap();
@@ -1198,11 +1192,10 @@ mod tests {
     #[test]
     fn file_out_noclobber_with_regular_file() {
         let file = Rc::new(RefCell::new(Inode::new([42, 123, 254])));
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", Rc::clone(&file)).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         env.options.set(Clobber, Off);
         let mut env = RedirGuard::new(&mut env);
 
@@ -1238,11 +1231,10 @@ mod tests {
             permissions: Default::default(),
         };
         let file = Rc::new(RefCell::new(inode));
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", Rc::clone(&file)).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         env.options.set(Clobber, Off);
         let mut env = RedirGuard::new(&mut env);
 
@@ -1253,7 +1245,7 @@ mod tests {
 
     #[test]
     fn file_out_closes_opened_file_on_error() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999>foo".parse().unwrap();
         let e = env
@@ -1278,9 +1270,7 @@ mod tests {
 
     #[test]
     fn file_clobber_creates_empty_file() {
-        let system = system_with_nofile_limit();
-        let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let (mut env, state) = env_with_nofile_limit();
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3>| foo".parse().unwrap();
@@ -1304,11 +1294,10 @@ mod tests {
     #[test]
     fn file_clobber_by_default_truncates_existing_file() {
         let file = Rc::new(RefCell::new(Inode::new([42, 123, 254])));
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", Rc::clone(&file)).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3>| foo".parse().unwrap();
@@ -1327,7 +1316,7 @@ mod tests {
 
     #[test]
     fn file_clobber_closes_opened_file_on_error() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999>|foo".parse().unwrap();
         let e = env
@@ -1352,9 +1341,7 @@ mod tests {
 
     #[test]
     fn file_append_creates_empty_file() {
-        let system = system_with_nofile_limit();
-        let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let (mut env, state) = env_with_nofile_limit();
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3>> foo".parse().unwrap();
@@ -1378,11 +1365,10 @@ mod tests {
     #[test]
     fn file_append_appends_to_existing_file() {
         let file = Rc::new(RefCell::new(Inode::new(*b"one\n")));
-        let system = system_with_nofile_limit();
-        let mut state = system.state.borrow_mut();
+        let (mut env, state) = env_with_nofile_limit();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", Rc::clone(&file)).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
 
         let redir = ">> foo".parse().unwrap();
@@ -1404,7 +1390,7 @@ mod tests {
 
     #[test]
     fn file_append_closes_opened_file_on_error() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999>>foo".parse().unwrap();
         let e = env
@@ -1429,9 +1415,7 @@ mod tests {
 
     #[test]
     fn file_in_out_creates_empty_file() {
-        let system = system_with_nofile_limit();
-        let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let (mut env, state) = env_with_nofile_limit();
         let mut env = RedirGuard::new(&mut env);
         let redir = "3<> foo".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1453,12 +1437,11 @@ mod tests {
 
     #[test]
     fn file_in_out_leaves_existing_file_content() {
-        let system = system_with_nofile_limit();
+        let (mut env, state) = env_with_nofile_limit();
         let file = Rc::new(RefCell::new(Inode::new([132, 79, 210])));
-        let mut state = system.state.borrow_mut();
+        let mut state = state.borrow_mut();
         state.file_system.save("foo", file).unwrap();
         drop(state);
-        let mut env = Env::with_system(system);
         let mut env = RedirGuard::new(&mut env);
         let redir = "3<> foo".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1479,7 +1462,7 @@ mod tests {
 
     #[test]
     fn file_in_out_closes_opened_file_on_error() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999<>foo".parse().unwrap();
         let e = env
@@ -1505,8 +1488,7 @@ mod tests {
     #[test]
     fn fd_in_copies_fd() {
         for fd in [Fd(0), Fd(3)] {
-            let system = system_with_nofile_limit();
-            let state = Rc::clone(&system.state);
+            let (mut env, state) = env_with_nofile_limit();
             state
                 .borrow_mut()
                 .file_system
@@ -1514,7 +1496,6 @@ mod tests {
                 .unwrap()
                 .borrow_mut()
                 .body = FileBody::new([1, 2, 42]);
-            let mut env = Env::with_system(system);
             let mut env = RedirGuard::new(&mut env);
             let redir = "3<& 0".parse().unwrap();
             env.perform_redir(&redir, None)
@@ -1536,7 +1517,7 @@ mod tests {
 
     #[test]
     fn fd_in_closes_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "<& -".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1556,7 +1537,7 @@ mod tests {
 
     #[test]
     fn fd_in_rejects_unreadable_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "3>foo".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1576,7 +1557,7 @@ mod tests {
 
     #[test]
     fn fd_in_rejects_unopened_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3<&3".parse().unwrap();
@@ -1591,7 +1572,7 @@ mod tests {
 
     #[test]
     fn fd_in_rejects_fd_with_cloexec() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         env.system
             .fcntl_setfd(Fd(0), FdFlag::CloseOnExec.into())
             .unwrap();
@@ -1609,7 +1590,7 @@ mod tests {
 
     #[test]
     fn keep_target_fd_open_on_error_in_fd_in() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999<&0".parse().unwrap();
         let e = env
@@ -1636,9 +1617,7 @@ mod tests {
     #[test]
     fn fd_out_copies_fd() {
         for fd in [Fd(1), Fd(4)] {
-            let system = system_with_nofile_limit();
-            let state = Rc::clone(&system.state);
-            let mut env = Env::with_system(system);
+            let (mut env, state) = env_with_nofile_limit();
             let mut env = RedirGuard::new(&mut env);
             let redir = "4>& 1".parse().unwrap();
             env.perform_redir(&redir, None)
@@ -1661,7 +1640,7 @@ mod tests {
 
     #[test]
     fn fd_out_closes_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = ">& -".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1681,7 +1660,7 @@ mod tests {
 
     #[test]
     fn fd_out_rejects_unwritable_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "3</dev/stdin".parse().unwrap();
         env.perform_redir(&redir, None)
@@ -1701,7 +1680,7 @@ mod tests {
 
     #[test]
     fn fd_out_rejects_unopened_fd() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
 
         let redir = "3>&3".parse().unwrap();
@@ -1716,7 +1695,7 @@ mod tests {
 
     #[test]
     fn fd_out_rejects_fd_with_cloexec() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         env.system
             .fcntl_setfd(Fd(1), FdFlag::CloseOnExec.into())
             .unwrap();
@@ -1734,7 +1713,7 @@ mod tests {
 
     #[test]
     fn keep_target_fd_open_on_error_in_fd_out() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "999999999>&1".parse().unwrap();
         let e = env
@@ -1759,7 +1738,7 @@ mod tests {
 
     #[test]
     fn pipe_redirection_not_yet_implemented() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "3>>|4".parse().unwrap();
         let e = env
@@ -1774,7 +1753,7 @@ mod tests {
 
     #[test]
     fn here_string_not_yet_implemented() {
-        let mut env = Env::with_system(system_with_nofile_limit());
+        let mut env = env_with_nofile_limit().0;
         let mut env = RedirGuard::new(&mut env);
         let redir = "3<<< here".parse().unwrap();
         let e = env

--- a/yash-semantics/src/redir/here_doc.rs
+++ b/yash-semantics/src/redir/here_doc.rs
@@ -20,12 +20,12 @@ use super::ErrorCause;
 use yash_env::Env;
 use yash_env::io::Fd;
 use yash_env::path::Path;
-use yash_env::system::concurrency::WriteAll as _;
-use yash_env::system::{Close, Errno, Fcntl, Open, Seek, Write};
+use yash_env::system::concurrency::WriteAll;
+use yash_env::system::{Close, Errno, Open, Seek};
 
 async fn fill_content<S>(env: &mut Env<S>, fd: Fd, content: &str) -> Result<(), Errno>
 where
-    S: Fcntl + Seek + Write,
+    S: Seek + WriteAll,
 {
     env.system.write_all(fd, content.as_bytes()).await?;
     env.system.lseek(fd, std::io::SeekFrom::Start(0))?;
@@ -39,7 +39,7 @@ where
 /// from.
 pub(super) async fn open_fd<S>(env: &mut Env<S>, content: String) -> Result<Fd, ErrorCause>
 where
-    S: Close + Fcntl + Open + Seek + Write,
+    S: Close + Open + Seek + WriteAll,
 {
     // TODO Use a pipe for short content
     let fd = match env.system.open_tmpfile(Path::new("/tmp")) {

--- a/yash-semantics/src/runner.rs
+++ b/yash-semantics/src/runner.rs
@@ -214,6 +214,7 @@ mod tests {
     use yash_env::input::Memory;
     use yash_env::option::Option::Verbose;
     use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::SIGUSR1;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stderr;
@@ -238,7 +239,7 @@ mod tests {
     fn exit_status_in_out() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.exit_status = ExitStatus(42);
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
@@ -255,7 +256,7 @@ mod tests {
     fn executing_many_lines_of_code() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let mut lexer = Lexer::with_code("echo 1\necho 2\necho 3;");
         let ref_env = RefCell::new(&mut env);
@@ -270,7 +271,7 @@ mod tests {
         use yash_syntax::alias::{Alias, HashEntry};
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.aliases.insert(HashEntry(Rc::new(Alias {
             name: "echo".to_string(),
             replacement: "echo alias\necho ok".to_string(),
@@ -291,7 +292,7 @@ mod tests {
     fn verbose_option() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.options.set(Verbose, On);
         let ref_env = RefCell::new(&mut env);
         let input = Box::new(Echo::new(Memory::new("case _ in esac"), &ref_env));
@@ -310,7 +311,7 @@ mod tests {
         // the loop continues
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let mut lexer = Lexer::with_code("${X?}\necho $?\n");
         let ref_env = RefCell::new(&mut env);
@@ -328,7 +329,7 @@ mod tests {
         // interactive mode, the loop breaks
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.builtins.insert("return", return_builtin());
         let mut lexer = Lexer::with_code("return 123\necho $?\n");
@@ -347,7 +348,7 @@ mod tests {
         // the loop breaks
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let mut lexer = Lexer::with_code("${X?}\necho $?\n");
         let ref_env = RefCell::new(&mut env);
@@ -361,7 +362,7 @@ mod tests {
     fn handling_syntax_error() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut lexer = Lexer::with_code(";;");
         let ref_env = RefCell::new(&mut env);
         let result = read_eval_loop(&ref_env, &mut lexer).now_or_never().unwrap();
@@ -373,7 +374,7 @@ mod tests {
     fn syntax_error_aborts_non_interactive_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         let mut lexer = Lexer::with_code(";;\necho !");
         let ref_env = RefCell::new(&mut env);
@@ -387,7 +388,7 @@ mod tests {
     fn syntax_error_continues_interactive_loop() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         // The ";;" causes a syntax error, the following "(" is ignored, and the
         // loop continues with the command "echo $?" on the next line.
@@ -426,8 +427,9 @@ mod tests {
     #[test]
     fn running_traps_between_parsing_and_executing() {
         let system = VirtualSystem::new();
+        let pid = system.process_id;
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
@@ -443,7 +445,7 @@ mod tests {
         let _ = state
             .borrow_mut()
             .processes
-            .get_mut(&system.process_id)
+            .get_mut(&pid)
             .unwrap()
             .raise_signal(SIGUSR1);
         let mut lexer = Lexer::with_code("echo $?");

--- a/yash-semantics/src/runtime.rs
+++ b/yash-semantics/src/runtime.rs
@@ -17,13 +17,13 @@
 //! Definition of `Runtime`
 
 use std::fmt::Debug;
-use yash_env::system::concurrency::RunLoop;
+use yash_env::system::concurrency::{ReadAll, Select, WaitForSignals, WriteAll};
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
-    CaughtSignals, Clock, Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetPid, GetPw,
-    IsExecutableFile, Isatty, Open, Pipe, Read, Seek, Select, SendSignal, SetPgid, ShellPath,
-    Sigaction, Sigmask, Signals, TcSetPgrp, Wait, Write,
+    Clock, Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetPid, GetPw, IsExecutableFile, Isatty,
+    Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, Sigaction, Sigmask, TcSetPgrp, Wait,
 };
+use yash_env::trap::SignalSystem;
 
 /// Runtime environment for executing shell commands
 ///
@@ -34,8 +34,7 @@ use yash_env::system::{
 /// implementation. Therefore, this trait serves as a convenient shorthand to
 /// express the required capabilities.
 pub trait Runtime:
-    CaughtSignals
-    + Clock
+    Clock
     + Close
     + Debug
     + Dup
@@ -51,7 +50,7 @@ pub trait Runtime:
     + Open
     + Pipe
     + Read
-    + RunLoop
+    + ReadAll
     + Seek
     + Select
     + SendSignal
@@ -60,18 +59,18 @@ pub trait Runtime:
     + ShellPath
     + Sigaction
     + Sigmask
-    + Signals
+    + SignalSystem
     + TcSetPgrp
     + Wait
-    + Write
+    + WaitForSignals
+    + WriteAll
 {
 }
 
 /// Any type automatically implements `Runtime` if it implements all the
 /// supertraits of `Runtime`.
 impl<S> Runtime for S where
-    S: CaughtSignals
-        + Clock
+    S: Clock
         + Close
         + Debug
         + Dup
@@ -87,7 +86,7 @@ impl<S> Runtime for S where
         + Open
         + Pipe
         + Read
-        + RunLoop
+        + ReadAll
         + Seek
         + Select
         + SendSignal
@@ -96,9 +95,10 @@ impl<S> Runtime for S where
         + ShellPath
         + Sigaction
         + Sigmask
-        + Signals
+        + SignalSystem
         + TcSetPgrp
         + Wait
-        + Write
+        + WaitForSignals
+        + WriteAll
 {
 }

--- a/yash-semantics/src/tests.rs
+++ b/yash-semantics/src/tests.rs
@@ -29,12 +29,10 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::system::Errno;
-use yash_env::system::Fcntl;
 use yash_env::system::Isatty;
 use yash_env::system::Read;
 use yash_env::system::SendSignal;
-use yash_env::system::Write;
-use yash_env::system::concurrency::WriteAll as _;
+use yash_env::system::concurrency::WriteAll;
 use yash_env::system::r#virtual::SIGSTOP;
 use yash_env::variable::Scope;
 
@@ -134,7 +132,7 @@ fn local_builtin_main<S>(
     args: Vec<Field>,
 ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>>
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     Box::pin(async move {
         for Field { value, origin } in args {
@@ -165,7 +163,7 @@ where
 
 pub fn local_builtin<S>() -> Builtin<S>
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     let mut builtin = Builtin::new(Mandatory, local_builtin_main);
     builtin.is_declaration_utility = Some(true);
@@ -177,7 +175,7 @@ fn echo_builtin_main<S>(
     args: Vec<Field>,
 ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>>
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     Box::pin(async move {
         let fields = args.iter().map(|f| &f.value).format(" ");
@@ -193,7 +191,7 @@ where
 /// Returns a minimal implementation of the `echo` built-in.
 pub fn echo_builtin<S>() -> Builtin<S>
 where
-    S: Fcntl + Isatty + Write,
+    S: Isatty + WriteAll,
 {
     Builtin::new(Mandatory, echo_builtin_main)
 }
@@ -203,11 +201,11 @@ fn cat_builtin_main<S>(
     _args: Vec<Field>,
 ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>>
 where
-    S: Fcntl + Isatty + Read + Write,
+    S: Isatty + Read + WriteAll,
 {
     async fn inner<S>(env: &mut Env<S>) -> std::result::Result<(), Errno>
     where
-        S: Fcntl + Isatty + Read + Write,
+        S: Isatty + Read + WriteAll,
     {
         let mut buffer = [0; 1024];
         loop {
@@ -231,7 +229,7 @@ where
 /// Returns a minimal implementation of the `cat` built-in.
 pub fn cat_builtin<S>() -> Builtin<S>
 where
-    S: Fcntl + Isatty + Read + Write,
+    S: Isatty + Read + WriteAll,
 {
     Builtin::new(Mandatory, cat_builtin_main)
 }

--- a/yash-semantics/src/trap/exit.rs
+++ b/yash-semantics/src/trap/exit.rs
@@ -64,6 +64,7 @@ mod tests {
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
     use yash_env::stack::Frame;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::assert_stdout;
     use yash_syntax::source::Location;
@@ -78,7 +79,7 @@ mod tests {
     fn runs_exit_trap() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
@@ -99,7 +100,7 @@ mod tests {
     #[test]
     fn stack_frame_in_trap_action() {
         fn execute(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -151,7 +152,7 @@ mod tests {
     fn exit_status_inside_trap() {
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -118,15 +118,16 @@ mod tests {
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
     use yash_env::signal;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::r#virtual::{SIGINT, SIGTERM, SIGUSR1, SIGUSR2};
     use yash_env::test_helper::assert_stdout;
     use yash_env::trap::Action;
     use yash_syntax::source::Location;
 
-    fn signal_env() -> (Env<VirtualSystem>, VirtualSystem) {
+    fn signal_env() -> (Env<Rc<Concurrent<VirtualSystem>>>, VirtualSystem) {
         let system = VirtualSystem::default();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.builtins.insert("echo", echo_builtin());
         env.traps
             .set_action(
@@ -213,7 +214,7 @@ mod tests {
     #[test]
     fn stack_frame_in_trap_action() {
         fn execute(
-            env: &mut Env<VirtualSystem>,
+            env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
             _args: Vec<Field>,
         ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
             Box::pin(async move {
@@ -222,7 +223,7 @@ mod tests {
             })
         }
         let system = VirtualSystem::default();
-        let mut env = Env::with_system(system.clone());
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.builtins.insert(
             "check",
             Builtin::new(yash_env::builtin::Type::Mandatory, execute),

--- a/yash-semantics/src/xtrace.rs
+++ b/yash-semantics/src/xtrace.rs
@@ -41,7 +41,6 @@ use yash_env::Env;
 use yash_env::option::OptionSet;
 use yash_env::option::State;
 use yash_env::semantics::Field;
-use yash_env::system::concurrency::WriteAll as _;
 use yash_env::variable::PS4;
 use yash_quote::quoted;
 use yash_syntax::syntax::Text;
@@ -307,6 +306,8 @@ mod tests {
     use super::*;
     use crate::tests::echo_builtin;
     use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::system::Concurrent;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::test_helper::in_virtual_system;
     use yash_env::variable::Scope::Global;
@@ -322,7 +323,7 @@ mod tests {
         assert_eq!(xtrace.here_doc_contents, "");
     }
 
-    fn fixture() -> Env<VirtualSystem> {
+    fn fixture() -> Env<Rc<Concurrent<VirtualSystem>>> {
         let mut env = Env::new_virtual();
         env.variables
             .get_or_new(PS4, Global)


### PR DESCRIPTION
## Description

This is the fundamental changes for resolving #780. Changes the type of `Env::system` from `Rc<Concurrent<S>>` to `S` and fixes all the relevant code to retain the same behavior.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked system/concurrency and signal handling across the project to use higher‑level, concurrency-friendly interfaces.

* **Tests**
  * Updated test harnesses and fixtures to match the new concurrency/environment model.

* **Documentation**
  * Changelogs and docs updated to reflect API and trait-model changes.

* **Chores**
  * Added "supertraits" to the workspace spelling dictionary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicant/yash-rs/pull/785)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->