### PR TITLE
Add yash_env::subshell::Config and deprecate Subshell

### DIFF
--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -213,7 +213,6 @@ mod tests {
     use yash_env::option::Option::Interactive;
     use yash_env::option::State::On;
     use yash_env::subshell::Config;
-    use yash_env::subshell::JobControl;
     use yash_env::system::Concurrent;
     use yash_env::system::GetPid as _;
     use yash_env::system::TcGetPgrp as _;
@@ -229,12 +228,6 @@ mod tests {
         env.system.kill(target, Some(SIGSTOP)).await.unwrap();
     }
 
-    fn foreground_config() -> Config {
-        let mut config = Config::new();
-        config.job_control = Some(JobControl::Foreground);
-        config
-    }
-
     #[test]
     fn resume_job_by_index_resumes_job_in_foreground() {
         in_virtual_system(|mut env, state| async move {
@@ -242,7 +235,7 @@ mod tests {
             env.options.set(Monitor, On);
             let reached = Rc::new(Cell::new(false));
             let reached2 = Rc::clone(&reached);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async move |env, _| {
                     suspend(env).await;
 
@@ -271,7 +264,7 @@ mod tests {
             env.options.set(Monitor, On);
             let reached = Rc::new(Cell::new(false));
             let reached2 = Rc::clone(&reached);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async move |env, _| {
                     suspend(env).await;
                     reached2.set(true);
@@ -294,7 +287,7 @@ mod tests {
     fn resume_job_by_index_prints_job_name() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| suspend(env).await)
                 .await
                 .unwrap();
@@ -315,7 +308,7 @@ mod tests {
     fn resume_job_by_index_returns_after_job_exits() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     env.exit_status = ExitStatus(42);
@@ -342,7 +335,7 @@ mod tests {
     fn resume_job_by_index_returns_after_job_suspends() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;
@@ -371,7 +364,7 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             stub_tty(&state);
             env.options.set(Monitor, On);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| suspend(env).await)
                 .await
                 .unwrap();
@@ -449,7 +442,7 @@ mod tests {
             stub_tty(&state);
             env.options.set(Monitor, On);
             // previous job
-            let (pid1, subshell_result_1) = foreground_config()
+            let (pid1, subshell_result_1) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     unreachable!("previous job should not be resumed");
@@ -462,7 +455,7 @@ mod tests {
             job.state = subshell_result_1.into();
             env.jobs.add(job);
             // current job
-            let (pid2, subshell_result_2) = foreground_config()
+            let (pid2, subshell_result_2) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| suspend(env).await)
                 .await
                 .unwrap();
@@ -503,7 +496,7 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
             // previous job
-            let (pid1, subshell_result_1) = foreground_config()
+            let (pid1, subshell_result_1) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| suspend(env).await)
                 .await
                 .unwrap();
@@ -514,7 +507,7 @@ mod tests {
             job.name = "previous job".to_string();
             let index1 = env.jobs.add(job);
             // current job
-            let (pid2, subshell_result_2) = foreground_config()
+            let (pid2, subshell_result_2) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     unreachable!("current job should not be resumed");
@@ -564,7 +557,7 @@ mod tests {
         in_virtual_system(|mut env, _| async move {
             env.options.set(Monitor, On);
             env.exit_status = ExitStatus(42);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;
@@ -590,7 +583,7 @@ mod tests {
             env.options.set(Interactive, On);
             env.options.set(Monitor, On);
             env.exit_status = ExitStatus(42);
-            let (pid, subshell_result) = foreground_config()
+            let (pid, subshell_result) = Config::foreground()
                 .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -212,8 +212,8 @@ mod tests {
     use yash_env::job::ProcessResult;
     use yash_env::option::Option::Interactive;
     use yash_env::option::State::On;
+    use yash_env::subshell::Config;
     use yash_env::subshell::JobControl;
-    use yash_env::subshell::Subshell;
     use yash_env::system::Concurrent;
     use yash_env::system::GetPid as _;
     use yash_env::system::TcGetPgrp as _;
@@ -229,6 +229,12 @@ mod tests {
         env.system.kill(target, Some(SIGSTOP)).await.unwrap();
     }
 
+    fn foreground_config() -> Config {
+        let mut config = Config::new();
+        config.job_control = Some(JobControl::Foreground);
+        config
+    }
+
     #[test]
     fn resume_job_by_index_resumes_job_in_foreground() {
         in_virtual_system(|mut env, state| async move {
@@ -236,8 +242,8 @@ mod tests {
             env.options.set(Monitor, On);
             let reached = Rc::new(Cell::new(false));
             let reached2 = Rc::clone(&reached);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async move |env, _| {
                     suspend(env).await;
 
                     // When resumed, the subshell should be in the foreground.
@@ -245,9 +251,8 @@ mod tests {
                     assert_eq!(env.system.tcgetpgrp(tty).unwrap(), env.system.getpid());
                     reached2.set(true);
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -266,14 +271,13 @@ mod tests {
             env.options.set(Monitor, On);
             let reached = Rc::new(Cell::new(false));
             let reached2 = Rc::clone(&reached);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async move |env, _| {
                     suspend(env).await;
                     reached2.set(true);
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -290,9 +294,10 @@ mod tests {
     fn resume_job_by_index_prints_job_name() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let subshell =
-                Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| suspend(env).await)
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -310,14 +315,13 @@ mod tests {
     fn resume_job_by_index_returns_after_job_exits() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     env.exit_status = ExitStatus(42);
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -338,15 +342,14 @@ mod tests {
     fn resume_job_by_index_returns_after_job_suspends() {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;
                     unreachable!("child process should not be resumed twice");
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -368,9 +371,10 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             stub_tty(&state);
             env.options.set(Monitor, On);
-            let subshell =
-                Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| suspend(env).await)
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -445,23 +449,23 @@ mod tests {
             stub_tty(&state);
             env.options.set(Monitor, On);
             // previous job
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid1, subshell_result_1) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     unreachable!("previous job should not be resumed");
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result_1, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
             job.state = subshell_result_1.into();
             env.jobs.add(job);
             // current job
-            let subshell =
-                Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
+            let (pid2, subshell_result_2) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| suspend(env).await)
+                .await
+                .unwrap();
             assert_eq!(subshell_result_2, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
@@ -499,9 +503,10 @@ mod tests {
         in_virtual_system(|mut env, state| async move {
             env.options.set(Monitor, On);
             // previous job
-            let subshell =
-                Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-            let (pid1, subshell_result_1) = subshell.start_and_wait(&mut env).await.unwrap();
+            let (pid1, subshell_result_1) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| suspend(env).await)
+                .await
+                .unwrap();
             assert_eq!(subshell_result_1, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid1);
             job.job_controlled = true;
@@ -509,14 +514,13 @@ mod tests {
             job.name = "previous job".to_string();
             let index1 = env.jobs.add(job);
             // current job
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid2, subshell_result_2) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     unreachable!("current job should not be resumed");
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid2, subshell_result_2) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result_2, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid2);
             job.job_controlled = true;
@@ -560,15 +564,14 @@ mod tests {
         in_virtual_system(|mut env, _| async move {
             env.options.set(Monitor, On);
             env.exit_status = ExitStatus(42);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;
                     unreachable!("child process should not be resumed twice");
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;
@@ -587,15 +590,14 @@ mod tests {
             env.options.set(Interactive, On);
             env.options.set(Monitor, On);
             env.exit_status = ExitStatus(42);
-            let subshell = Subshell::new(|env, _| {
-                Box::pin(async move {
+            let (pid, subshell_result) = foreground_config()
+                .start_and_wait(&mut env, async |env, _| {
                     suspend(env).await;
                     suspend(env).await;
                     unreachable!("child process should not be resumed twice");
                 })
-            })
-            .job_control(JobControl::Foreground);
-            let (pid, subshell_result) = subshell.start_and_wait(&mut env).await.unwrap();
+                .await
+                .unwrap();
             assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
             let mut job = Job::new(pid);
             job.job_controlled = true;

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -53,6 +53,8 @@
 //!   [`RunSignalTrapIfCaught`](yash_env::trap::RunSignalTrapIfCaught) instance
 //!   to handle trapped signals while waiting for jobs.
 
+#![cfg_attr(test, recursion_limit = "256")]
+
 pub mod alias;
 pub mod bg;
 pub mod r#break;

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -161,8 +161,7 @@ mod tests {
     }
 
     async fn start_self_suspending_job(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
-        let config = Config::foreground();
-        let (pid, subshell_result) = config
+        let (pid, subshell_result) = Config::foreground()
             .start_and_wait(env, async |env, _| suspend(env).await)
             .await
             .unwrap();

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -142,7 +142,7 @@ mod tests {
     use std::task::Poll;
     use yash_env::job::{Job, ProcessResult};
     use yash_env::option::{Monitor, On};
-    use yash_env::subshell::{JobControl, Subshell};
+    use yash_env::subshell::{Config, JobControl};
     use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::{Concurrent, GetPid, SendSignal};
@@ -161,9 +161,12 @@ mod tests {
     }
 
     async fn start_self_suspending_job(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
-        let subshell =
-            Subshell::new(|env, _| Box::pin(suspend(env))).job_control(JobControl::Foreground);
-        let (pid, subshell_result) = subshell.start_and_wait(env).await.unwrap();
+        let mut config = Config::new();
+        config.job_control = Some(JobControl::Foreground);
+        let (pid, subshell_result) = config
+            .start_and_wait(env, async |env, _| suspend(env).await)
+            .await
+            .unwrap();
         assert_eq!(subshell_result, ProcessResult::Stopped(SIGSTOP));
         let mut job = Job::new(pid);
         job.job_controlled = true;

--- a/yash-builtin/src/wait.rs
+++ b/yash-builtin/src/wait.rs
@@ -142,7 +142,7 @@ mod tests {
     use std::task::Poll;
     use yash_env::job::{Job, ProcessResult};
     use yash_env::option::{Monitor, On};
-    use yash_env::subshell::{Config, JobControl};
+    use yash_env::subshell::Config;
     use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::system::r#virtual::VirtualSystem;
     use yash_env::system::{Concurrent, GetPid, SendSignal};
@@ -161,8 +161,7 @@ mod tests {
     }
 
     async fn start_self_suspending_job(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
-        let mut config = Config::new();
-        config.job_control = Some(JobControl::Foreground);
+        let config = Config::foreground();
         let (pid, subshell_result) = config
             .start_and_wait(env, async |env, _| suspend(env).await)
             .await

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -123,7 +123,7 @@ mod tests {
     use yash_env::job::ProcessState;
     use yash_env::semantics::ExitStatus;
     use yash_env::source::Location;
-    use yash_env::subshell::Subshell;
+    use yash_env::subshell::Config;
     use yash_env::system::Concurrent;
     use yash_env::system::SendSignal as _;
     use yash_env::system::r#virtual::{SIGSTOP, SIGTERM};
@@ -137,8 +137,10 @@ mod tests {
             stub_run_signal_trap_if_caught(&mut env);
 
             // Start a child process that never exits.
-            let subshell = Subshell::new(|_, _| Box::pin(pending()));
-            subshell.start(&mut env).await.unwrap();
+            Config::new()
+                .start(&mut env, async |_, _| pending().await)
+                .await
+                .unwrap();
 
             // The job is not finished, so the function keeps waiting.
             let future = pin!(wait_for_any_job_or_trap(&mut env));
@@ -152,8 +154,11 @@ mod tests {
             stub_run_signal_trap_if_caught(&mut env);
 
             // Start a child process that exits immediately.
-            let subshell = Subshell::new(|_, _| Box::pin(ready(())));
-            let pid = subshell.start(&mut env).await.unwrap().0;
+            let pid = Config::new()
+                .start(&mut env, async |_, _| ready(()).await)
+                .await
+                .unwrap()
+                .0;
             let index = env.jobs.add(Job::new(pid));
 
             // The job is finished, so the function returns immediately.
@@ -173,8 +178,11 @@ mod tests {
             stub_run_signal_trap_if_caught(&mut env);
 
             // Start a child process that never exits.
-            let subshell = Subshell::new(|_, _| Box::pin(pending()));
-            let pid = subshell.start(&mut env).await.unwrap().0;
+            let pid = Config::new()
+                .start(&mut env, async |_, _| pending().await)
+                .await
+                .unwrap()
+                .0;
             let index = env.jobs.add(Job::new(pid));
             // Suspend the child process.
             env.system.kill(pid, Some(SIGSTOP)).await.unwrap();
@@ -205,8 +213,10 @@ mod tests {
             };
 
             // Start a child process that never exits.
-            let subshell = Subshell::new(|_, _| Box::pin(pending()));
-            subshell.start(&mut env).await.unwrap();
+            Config::new()
+                .start(&mut env, async |_, _| pending().await)
+                .await
+                .unwrap();
 
             // Set a trap for SIGTERM.
             env.traps

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -45,6 +45,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `Env::run_in_child_process` method has been added as a convenient wrapper
   around `system::Fork::run_in_child_process` for running a task in a child
   process with the current environment state.
+- The `subshell::Config` struct has been added as a new API for creating and
+  starting subshells. It replaces the previous `Subshell` struct and provides a
+  more flexible and ergonomic way to configure subshells.
 - The `Default` trait is now implemented for `Env<S>` where
   `S: Default + system::GetPid`.
 
@@ -115,6 +118,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   `system::Concurrent::new_child_process` methods are now deprecated in favor of
   the new `run_in_child_process` method, which provides a more ergonomic way to
   create child processes.
+- The `subshell::Subshell` struct is now deprecated in favor of
+  `subshell::Config`.
 
 ### Removed
 

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -706,7 +706,7 @@ mod tests {
     use crate::io::MIN_INTERNAL_FD;
     use crate::job::Job;
     use crate::source::Location;
-    use crate::subshell::Subshell;
+    use crate::subshell::Config;
     use crate::system::Exit as _;
     use crate::system::r#virtual::Inode;
     use crate::system::r#virtual::SIGCHLD;
@@ -909,10 +909,12 @@ mod tests {
     #[test]
     fn start_and_wait_for_subshell() {
         in_virtual_system(|mut env, _state| async move {
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(42) })
-            });
-            let (pid, _) = subshell.start(&mut env).await.unwrap();
+            let (pid, _) = Config::new()
+                .start(&mut env, async |env, _job_control| {
+                    env.exit_status = ExitStatus(42)
+                })
+                .await
+                .unwrap();
             let result = env.wait_for_subshell(pid).await;
             assert_eq!(result, Ok((pid, ProcessState::exited(42))));
         });
@@ -921,10 +923,12 @@ mod tests {
     #[test]
     fn start_and_wait_for_subshell_with_job_list() {
         in_virtual_system(|mut env, _state| async move {
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(42) })
-            });
-            let (pid, _) = subshell.start(&mut env).await.unwrap();
+            let (pid, _) = Config::new()
+                .start(&mut env, async |env, _job_control| {
+                    env.exit_status = ExitStatus(42)
+                })
+                .await
+                .unwrap();
             let mut job = Job::new(pid);
             job.name = "my job".to_string();
             let job_index = env.jobs.add(job.clone());
@@ -963,27 +967,36 @@ mod tests {
 
         let [job_1, job_2, job_3] = executor.run_until(async {
             // Run a subshell.
-            let subshell_1 = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(12) })
-            });
-            let (pid_1, _) = subshell_1.start(&mut env).await.unwrap();
+            let (pid_1, _) = Config::new()
+                .start(&mut env, async |env, _job_control| {
+                    env.exit_status = ExitStatus(12)
+                })
+                .await
+                .unwrap();
 
             // Run another subshell.
-            let subshell_2 = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(35) })
-            });
-            let (pid_2, _) = subshell_2.start(&mut env).await.unwrap();
+            let (pid_2, _) = Config::new()
+                .start(&mut env, async |env, _job_control| {
+                    env.exit_status = ExitStatus(35)
+                })
+                .await
+                .unwrap();
 
             // This one will never finish.
-            let subshell_3 =
-                Subshell::new(|_env, _job_control| Box::pin(futures_util::future::pending()));
-            let (pid_3, _) = subshell_3.start(&mut env).await.unwrap();
+            let (pid_3, _) = Config::new()
+                .start(&mut env, async |_env, _job_control| {
+                    futures_util::future::pending().await
+                })
+                .await
+                .unwrap();
 
             // Yet another subshell. We don't make this into a job.
-            let subshell_4 = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(100) })
-            });
-            let (_pid_4, _) = subshell_4.start(&mut env).await.unwrap();
+            let (_pid_4, _) = Config::new()
+                .start(&mut env, async |env, _job_control| {
+                    env.exit_status = ExitStatus(100)
+                })
+                .await
+                .unwrap();
 
             // Create jobs.
             let job_1 = env.jobs.add(Job::new(pid_1));

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -26,7 +26,7 @@ use crate::job::add_job_if_suspended;
 use crate::semantics::{ExitStatus, Field, Result};
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
-use crate::subshell::{JobControl, Subshell};
+use crate::subshell::{Config, JobControl};
 use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
 use crate::system::{
@@ -282,16 +282,15 @@ where
     } else {
         String::new()
     };
-    let subshell = Subshell::new(move |env, _job_control| {
-        Box::pin(async move {
-            let location = args[0].origin.clone();
-            let Err(e) = replace_current_process(env, path, args).await;
-            handle_replace_current_process_error(env, e, location).await;
-        })
-    })
-    .job_control(JobControl::Foreground);
+    let mut config = Config::new();
+    config.job_control = Some(JobControl::Foreground);
+    let subshell_result = config.start_and_wait(env, async move |env, _job_control| {
+        let location = args[0].origin.clone();
+        let Err(e) = replace_current_process(env, path, args).await;
+        handle_replace_current_process_error(env, e, location).await;
+    });
 
-    match subshell.start_and_wait(env).await {
+    match subshell_result.await {
         Ok((pid, result)) => add_job_if_suspended(env, pid, result, || job_name),
         Err(errno) => {
             handle_start_subshell_error(env, StartSubshellError { utility, errno }).await;

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -282,12 +282,12 @@ where
     } else {
         String::new()
     };
-    let config = Config::foreground();
-    let subshell_result = config.start_and_wait(env, async move |env, _job_control| {
-        let location = args[0].origin.clone();
-        let Err(e) = replace_current_process(env, path, args).await;
-        handle_replace_current_process_error(env, e, location).await;
-    });
+    let subshell_result =
+        Config::foreground().start_and_wait(env, async move |env, _job_control| {
+            let location = args[0].origin.clone();
+            let Err(e) = replace_current_process(env, path, args).await;
+            handle_replace_current_process_error(env, e, location).await;
+        });
 
     match subshell_result.await {
         Ok((pid, result)) => add_job_if_suspended(env, pid, result, || job_name),

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -26,7 +26,7 @@ use crate::job::add_job_if_suspended;
 use crate::semantics::{ExitStatus, Field, Result};
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
-use crate::subshell::{Config, JobControl};
+use crate::subshell::Config;
 use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
 use crate::system::{
@@ -282,8 +282,7 @@ where
     } else {
         String::new()
     };
-    let mut config = Config::new();
-    config.job_control = Some(JobControl::Foreground);
+    let config = Config::foreground();
     let subshell_result = config.start_and_wait(env, async move |env, _job_control| {
         let location = args[0].origin.clone();
         let Err(e) = replace_current_process(env, path, args).await;

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -16,16 +16,17 @@
 
 //! Utility for starting subshells
 //!
-//! This module defines [`Subshell`], a builder for starting a subshell. It is
-//! [constructed](Subshell::new) with a function you want to run in a subshell.
-//! After configuring the builder with some options, you can
-//! [start](Subshell::start) the subshell.
-//!
-//! [`Subshell`] is implemented as a wrapper around
-//! [`Env::run_in_child_process`], which in turn uses
-//! [`Fork::run_in_child_process`]. You should prefer `Subshell` for the purpose
+//! This module defines [`Config`], a builder for starting a subshell. It is a
+//! collection of options for starting a subshell, and provides methods to start
+//! a subshell with the configured options. These methods are implemented as
+//! wrappers around [`Env::run_in_child_process`], which in turn uses
+//! [`Fork::run_in_child_process`]. You should prefer `Config` for the purpose
 //! of creating a subshell because it helps to arrange the child process
 //! properly.
+//!
+//! This module also defines a deprecated struct [`Subshell`] with a similar API
+//! to `Config` for backward compatibility. New code should use `Config` instead
+//! of `Subshell`.
 
 use crate::Env;
 use crate::job::Pid;
@@ -65,7 +66,8 @@ pub enum JobControl {
 
 /// Subshell builder
 ///
-/// See the [module documentation](self) for details.
+/// This is a helper for starting a subshell provided before [`Config`] was
+/// introduced. Use `Config` instead since it provides a better API.
 #[deprecated(
     note = "use `Config` for subshell configuration instead",
     since = "0.14.0"

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -21,9 +21,11 @@
 //! After configuring the builder with some options, you can
 //! [start](Subshell::start) the subshell.
 //!
-//! [`Subshell`] is implemented as a wrapper around [`Fork::new_child_process`].
-//! You should prefer `Subshell` for the purpose of creating a subshell because
-//! it helps to arrange the child process properly.
+//! [`Subshell`] is implemented as a wrapper around
+//! [`Env::run_in_child_process`], which in turn uses
+//! [`Fork::run_in_child_process`]. You should prefer `Subshell` for the purpose
+//! of creating a subshell because it helps to arrange the child process
+//! properly.
 
 use crate::Env;
 use crate::job::Pid;

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -66,6 +66,10 @@ pub enum JobControl {
 /// Subshell builder
 ///
 /// See the [module documentation](self) for details.
+#[deprecated(
+    note = "use `Config` for subshell configuration instead",
+    since = "0.14.0"
+)]
 #[must_use = "a subshell is not started unless you call `Subshell::start`"]
 pub struct Subshell<S, F> {
     task: F,
@@ -74,6 +78,7 @@ pub struct Subshell<S, F> {
     phantom_data: PhantomData<fn(&mut Env<S>)>,
 }
 
+#[allow(deprecated, reason = "for backward compatible API")]
 impl<S, F> std::fmt::Debug for Subshell<S, F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Subshell")
@@ -83,6 +88,7 @@ impl<S, F> std::fmt::Debug for Subshell<S, F> {
     }
 }
 
+#[allow(deprecated, reason = "for backward compatible API")]
 impl<S, F> Subshell<S, F>
 where
     S: Close
@@ -321,6 +327,7 @@ async fn restore_sigmask<S: Sigmask>(system: &S, mask: &[signal::Number]) -> Res
 mod config;
 pub use config::Config;
 
+#[allow(deprecated, reason = "for backward compatible API")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -31,10 +31,7 @@
 use crate::Env;
 use crate::job::Pid;
 use crate::job::ProcessResult;
-use crate::job::tcsetpgrp_with_block;
-use crate::semantics::exit_or_raise;
 use crate::signal;
-use crate::stack::Frame;
 use crate::system::Close;
 use crate::system::Dup;
 use crate::system::Errno;
@@ -169,6 +166,14 @@ where
         self
     }
 
+    fn into_config_and_task(self) -> (Config, F) {
+        let config = Config {
+            job_control: self.job_control,
+            ignores_sigint_sigquit: self.ignores_sigint_sigquit,
+        };
+        (config, self.task)
+    }
+
     /// Starts the subshell.
     ///
     /// This function creates a new child process that runs the task contained
@@ -191,81 +196,12 @@ where
     /// child process ID and the actual job control. Otherwise, it indicates the
     /// error.
     pub async fn start(self, env: &mut Env<S>) -> Result<(Pid, Option<JobControl>), Errno> {
-        // Do some preparation before starting a child process
-        let job_control = env.controls_jobs().then_some(self.job_control).flatten();
-        let tty = match job_control {
-            None | Some(JobControl::Background) => None,
-            // Open the tty in the parent process so we can reuse the FD for other jobs
-            Some(JobControl::Foreground) => env.get_tty().await.ok(),
-        };
-
-        let ignore_sigint_sigquit = self.ignores_sigint_sigquit && job_control.is_none();
-        let original_mask = if ignore_sigint_sigquit {
-            // Block SIGINT and SIGQUIT before forking the child process to
-            // prevent the child from being killed by those signals until the
-            // child starts ignoring them.
-            Some(block_sigint_sigquit(&env.system).await?)
-        } else {
-            None
-        };
-        let keep_internal_dispositions_for_stoppers = job_control.is_none();
-
-        // Define the child process task
-        const ME: Pid = Pid(0);
-        let task = move |mut child_env: Env<S>, ()| async move {
-            let env = &mut *child_env.push_frame(Frame::Subshell);
-
-            if let Some(job_control) = job_control {
-                if let Ok(()) = env.system.setpgid(ME, ME) {
-                    match job_control {
-                        JobControl::Background => (),
-                        JobControl::Foreground => {
-                            if let Some(tty) = tty {
-                                let pgid = env.system.getpgrp();
-                                tcsetpgrp_with_block(&env.system, tty, pgid).await.ok();
-                            }
-                        }
-                    }
-                }
-            }
-            env.jobs.disown_all();
-
-            env.traps
-                .enter_subshell(
-                    &env.system,
-                    ignore_sigint_sigquit,
-                    keep_internal_dispositions_for_stoppers,
-                )
-                .await;
-
-            (self.task)(env, job_control).await;
-            exit_or_raise(&env.system, env.exit_status).await
-        };
-
-        // Start the child
-        let (result, ()) = env.run_in_child_process((), task);
-
-        // Restore the original signal mask in the parent process. Need to do
-        // this before returning the error if the child process creation failed,
-        // to avoid leaving the parent process with an unexpected signal mask.
-        if let Some(mask) = original_mask {
-            restore_sigmask(&env.system, &mask).await.ok();
-        }
-
-        let child_pid = result?;
-
-        // The finishing
-        if job_control.is_some() {
-            // We should setpgid not only in the child but also in the parent to
-            // make sure the child is in a new process group before the parent
-            // returns from the start function.
-            let _ = env.system.setpgid(child_pid, ME);
-
-            // We don't tcsetpgrp in the parent. It would mess up the child
-            // which may have started another shell doing its own job control.
-        }
-
-        Ok((child_pid, job_control))
+        let (config, task) = self.into_config_and_task();
+        config
+            .start(env, async move |env, job_control| {
+                task(env, job_control).await
+            })
+            .await
     }
 
     /// Starts the subshell and waits for it to finish.
@@ -291,23 +227,12 @@ where
     where
         S: Wait,
     {
-        let (pid, job_control) = self.start(env).await?;
-        let result = loop {
-            let result = env.wait_for_subshell_to_halt(pid).await?.1;
-            if !result.is_stopped() || job_control.is_some() {
-                break result;
-            }
-        };
-
-        if job_control == Some(JobControl::Foreground) {
-            if let Some(tty) = env.tty {
-                tcsetpgrp_with_block(&env.system, tty, env.main_pgid)
-                    .await
-                    .ok();
-            }
-        }
-
-        Ok((pid, result))
+        let (config, task) = self.into_config_and_task();
+        config
+            .start_and_wait(env, async move |env, job_control| {
+                task(env, job_control).await
+            })
+            .await
     }
 }
 
@@ -338,6 +263,7 @@ mod tests {
     use crate::option::State::On;
     use crate::semantics::ExitStatus;
     use crate::source::Location;
+    use crate::stack::Frame;
     use crate::system::r#virtual::{Inode, SystemState, VirtualSystem};
     use crate::system::r#virtual::{SIGCHLD, SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
     use crate::system::{Concurrent, Disposition};

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -100,8 +100,8 @@ impl Config {
 
     /// Starts the subshell.
     ///
-    /// This function creates a new child process that runs the task contained
-    /// in this builder.
+    /// This function creates a new child process that runs the task provided as
+    /// an argument.
     ///
     /// Although this function is `async`, it does not wait for the child to
     /// finish, which means the parent and child processes will run

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -119,7 +119,14 @@ impl Config {
     /// child process ID and the actual job control status. Otherwise, it
     /// indicates the error.
     pub async fn start<S, F>(
-        &self,
+        // This method may be declared to take `self` by reference, but doing so
+        // would make the returned future capture `self` by reference, which
+        // demands the caller to keep the `Config` alive until the future is
+        // dropped. To allow code like below, we take `self` by value and
+        // implement `Clone` for `Config`.
+        //   let future = Config::new().start(...);
+        //   let result = future.await;
+        self,
         env: &mut Env<S>,
         task: F,
     ) -> Result<(Pid, Option<JobControl>), Errno>
@@ -238,7 +245,8 @@ impl Config {
     /// When a job-controlled subshell suspends, this function does not add it
     /// to `env.jobs`. You have to do it for yourself if necessary.
     pub async fn start_and_wait<S, F>(
-        &self,
+        // Why take `self` by value? See the comment in `start`.
+        self,
         env: &mut Env<S>,
         task: F,
     ) -> Result<(Pid, ProcessResult), Errno>

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -80,6 +80,21 @@ impl Config {
         Self::default()
     }
 
+    /// Creates a new `Config` with foreground job control.
+    ///
+    /// This is a convenient function to create a `Config` for a subshell that
+    /// should run in the foreground if job control is active. The returned
+    /// `Config` has [`job_control`](Self::job_control) set to
+    /// `Some(JobControl::Foreground)`, and the other fields set to their
+    /// default values.
+    #[must_use]
+    pub fn foreground() -> Self {
+        Self {
+            job_control: Some(JobControl::Foreground),
+            ..Self::default()
+        }
+    }
+
     /// Starts the subshell.
     ///
     /// This function creates a new child process that runs the task contained
@@ -466,11 +481,7 @@ mod tests {
             stub_tty(&state);
 
             let state_2 = Rc::clone(&state);
-            let config = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            };
-            let (child_pid, job_control) = config
+            let (child_pid, job_control) = Config::foreground()
                 .start(
                     &mut parent_env,
                     async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
@@ -499,16 +510,13 @@ mod tests {
             parent_env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let _ = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            }
-            .start(
-                &mut parent_env,
-                async move |_: &mut Env<Rc<Concurrent<VirtualSystem>>>, _| (),
-            )
-            .await
-            .unwrap();
+            let _ = Config::foreground()
+                .start(
+                    &mut parent_env,
+                    async move |_: &mut Env<Rc<Concurrent<VirtualSystem>>>, _| (),
+                )
+                .await
+                .unwrap();
             assert_matches!(parent_env.tty, Some(_));
         });
     }
@@ -522,11 +530,7 @@ mod tests {
             parent_env.options.set(Monitor, On);
 
             let state_2 = Rc::clone(&state);
-            let config = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            };
-            let (child_pid, job_control) = config
+            let (child_pid, job_control) = Config::foreground()
                 .start(
                     &mut parent_env,
                     async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
@@ -552,11 +556,7 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let config = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            };
-            let (child_pid, job_control) = config
+            let (child_pid, job_control) = Config::foreground()
                 .start(
                     &mut parent_env,
                     async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
@@ -587,11 +587,7 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let config = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            };
-            let (child_pid, job_control) = config
+            let (child_pid, job_control) = Config::foreground()
                 .start(
                     &mut parent_env,
                     async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
@@ -635,11 +631,7 @@ mod tests {
             env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let config = Config {
-                job_control: Some(JobControl::Foreground),
-                ..Config::new()
-            };
-            let (_pid, process_result) = config
+            let (_pid, process_result) = Config::foreground()
                 .start_and_wait(
                     &mut env,
                     async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -1,5 +1,5 @@
 // This file is part of yash, an extended POSIX shell.
-// Copyright (C) 2023 WATANABE Yuki
+// Copyright (C) 2026 WATANABE Yuki
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,151 +14,70 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Utility for starting subshells
-//!
-//! This module defines [`Subshell`], a builder for starting a subshell. It is
-//! [constructed](Subshell::new) with a function you want to run in a subshell.
-//! After configuring the builder with some options, you can
-//! [start](Subshell::start) the subshell.
-//!
-//! [`Subshell`] is implemented as a wrapper around
-//! [`Env::run_in_child_process`], which in turn uses
-//! [`Fork::run_in_child_process`]. You should prefer `Subshell` for the purpose
-//! of creating a subshell because it helps to arrange the child process
-//! properly.
+//! Subshell creation via [`Config`]
 
+use super::JobControl;
+use super::block_sigint_sigquit;
+use super::restore_sigmask;
 use crate::Env;
-use crate::job::Pid;
-use crate::job::ProcessResult;
 use crate::job::tcsetpgrp_with_block;
+use crate::job::{Pid, ProcessResult};
 use crate::semantics::exit_or_raise;
-use crate::signal;
 use crate::stack::Frame;
-use crate::system::Close;
-use crate::system::Dup;
-use crate::system::Errno;
-use crate::system::Exit;
-use crate::system::Fork;
-use crate::system::GetPid;
-use crate::system::Open;
-use crate::system::SendSignal;
-use crate::system::SetPgid;
-use crate::system::Sigaction;
-use crate::system::Sigmask;
-use crate::system::SigmaskOp;
-use crate::system::TcSetPgrp;
-use crate::system::Wait;
 use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
+use crate::system::{
+    Close, Dup, Errno, Exit, Fork, GetPid, Open, SendSignal, SetPgid, Sigaction, Sigmask,
+    TcSetPgrp, Wait,
+};
 use crate::trap::SignalSystem;
-use std::marker::PhantomData;
-use std::pin::Pin;
 
-/// Job state of a newly created subshell
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum JobControl {
-    /// The subshell becomes the foreground process group.
-    Foreground,
-    /// The subshell becomes a background process group.
-    Background,
-}
-
-/// Subshell builder
+/// Configuration for subshell creation
 ///
-/// See the [module documentation](self) for details.
-#[must_use = "a subshell is not started unless you call `Subshell::start`"]
-pub struct Subshell<S, F> {
-    task: F,
-    job_control: Option<JobControl>,
-    ignores_sigint_sigquit: bool,
-    phantom_data: PhantomData<fn(&mut Env<S>)>,
-}
-
-impl<S, F> std::fmt::Debug for Subshell<S, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Subshell")
-            .field("job_control", &self.job_control)
-            .field("ignores_sigint_sigquit", &self.ignores_sigint_sigquit)
-            .finish_non_exhaustive()
-    }
-}
-
-impl<S, F> Subshell<S, F>
-where
-    S: Close
-        + Dup
-        + Exit
-        + Fork
-        + GetPid
-        + Open
-        + SendSignal
-        + SetPgid
-        + SetRlimit
-        + Sigaction
-        + Sigmask
-        + SignalSystem
-        + TcSetPgrp
-        + WaitForSignals
-        + 'static,
-    F: for<'a> FnOnce(&'a mut Env<S>, Option<JobControl>) -> Pin<Box<dyn Future<Output = ()> + 'a>>
-        + 'static,
-    // TODO Revisit to simplify this function type when impl Future is allowed in return type
-{
-    /// Creates a new subshell builder with a task.
-    ///
-    /// The task will run in a subshell after it is started. The task takes two
-    /// arguments:
-    ///
-    /// 1. The environment in which the subshell runs, and
-    /// 2. Job control status for the subshell.
-    ///
-    /// If the task returns an `Err(Divert::...)`, it is handled as follows:
-    ///
-    /// - `Interrupt` and `Exit` with `Some(exit_status)` override the exit
-    ///   status in `Env`.
-    /// - Other `Divert` values are ignored.
-    pub fn new(task: F) -> Self {
-        Subshell {
-            task,
-            job_control: None,
-            ignores_sigint_sigquit: false,
-            phantom_data: PhantomData,
-        }
-    }
-
+/// This struct configures how a subshell is created.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct Config {
     /// Specifies disposition of the subshell with respect to job control.
     ///
-    /// If the argument is `None` (which is the default), the subshell runs in
+    /// If this value is `None` (which is the default), the subshell runs in
     /// the same process group as the parent process. If it is `Some(_)`, the
-    /// subshell becomes a new process group. For `JobControl::Foreground`, it
-    /// also brings itself to the foreground.
+    /// subshell becomes a new process group leader. For
+    /// `Some(JobControl::Foreground)`, it also brings itself to the foreground.
     ///
-    /// This parameter is ignored if the shell is not [controlling
-    /// jobs](Env::controls_jobs) when starting the subshell. You can tell the
-    /// actual job control status of the subshell by the second return value of
-    /// [`start`](Self::start) in the parent environment and the second argument
-    /// passed to the task in the subshell environment.
+    /// This parameter is ignored if the shell is not
+    /// [controlling jobs](Env::controls_jobs) when starting the subshell. You
+    /// can tell the actual job control status of the subshell by checking the
+    /// second return value of [`start`](Self::start) in the parent environment
+    /// and the second argument passed to the task in the subshell environment.
     ///
     /// If the parent process is a job-controlling interactive shell, but the
     /// subshell is not job-controlled, the subshell's signal dispositions for
-    /// SIGTSTP, SIGTTIN, and SIGTTOU are set to `Ignore`. This is to prevent
-    /// the subshell from being stopped by a job-stopping signal. Were the
-    /// subshell stopped, you could never resume it since it is not
+    /// `SIGTSTP`, `SIGTTIN`, and `SIGTTOU` are set to `Ignore`. This is to
+    /// prevent the subshell from being stopped by a job-stopping signal. Were
+    /// the subshell stopped, you could never resume it since it is not
     /// job-controlled.
-    pub fn job_control<J: Into<Option<JobControl>>>(mut self, job_control: J) -> Self {
-        self.job_control = job_control.into();
-        self
-    }
+    pub job_control: Option<JobControl>,
 
-    /// Makes the subshell ignore SIGINT and SIGQUIT.
+    /// If `true`, the subshell ignores `SIGINT` and `SIGQUIT`.
     ///
-    /// If `ignore` is true and the subshell is not job-controlled, the subshell
-    /// sets its signal dispositions for SIGINT and SIGQUIT to `Ignore`.
+    /// This parameter is for implementing the POSIX requirement that
+    /// asynchronous and-or lists ignore `SIGINT` and `SIGQUIT` if job control
+    /// is disabled. The value is passed to
+    /// [`TrapSet::enter_subshell`](crate::trap::TrapSet::enter_subshell) to
+    /// modify the signal dispositions for `SIGINT` and `SIGQUIT` in the
+    /// subshell.
     ///
-    /// The default is `false`.
-    pub fn ignore_sigint_sigquit(mut self, ignore: bool) -> Self {
-        self.ignores_sigint_sigquit = ignore;
-        self
+    /// This parameter has no effect if the subshell is job-controlled (see
+    /// [`job_control`](Self::job_control)). The default value is `false`.
+    pub ignores_sigint_sigquit: bool,
+}
+
+impl Config {
+    /// Creates a new `Config` with default settings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Starts the subshell.
@@ -168,21 +87,45 @@ where
     ///
     /// Although this function is `async`, it does not wait for the child to
     /// finish, which means the parent and child processes will run
-    /// concurrently. To wait for the child to finish, you need to call
-    /// [`Env::wait_for_subshell`] or [`Env::wait_for_subshell_to_finish`]. If
-    /// job control is active, you may want to add the process ID to `env.jobs`
-    /// before waiting.
+    /// concurrently. To wait for the child to change state, call
+    /// [`Env::wait_for_subshell`], [`Env::wait_for_subshell_to_halt`], or
+    /// [`Env::wait_for_subshell_to_finish`]. If job control is active, you may
+    /// want to add the process ID to [`Env::jobs`] before waiting. To start the
+    /// subshell and wait for it to finish at once, use
+    /// [`start_and_wait`](Self::start_and_wait).
     ///
     /// If you set [`job_control`](Self::job_control) to
-    /// `JobControl::Foreground`, this function opens `env.tty` by calling
-    /// [`Env::get_tty`]. The `tty` is used to change the foreground job to the
-    /// new subshell. However, `job_control` is effective only when the shell is
-    /// [controlling jobs](Env::controls_jobs).
+    /// `Some(JobControl::Foreground)`, this function opens [`Env::tty`] by
+    /// calling [`Env::get_tty`]. The `tty` is used to change the foreground job
+    /// to the new subshell. However, `job_control` is effective only when the
+    /// shell is [controlling jobs](Env::controls_jobs).
     ///
     /// If the subshell started successfully, the return value is a pair of the
-    /// child process ID and the actual job control. Otherwise, it indicates the
-    /// error.
-    pub async fn start(self, env: &mut Env<S>) -> Result<(Pid, Option<JobControl>), Errno> {
+    /// child process ID and the actual job control status. Otherwise, it
+    /// indicates the error.
+    pub async fn start<S, F>(
+        &self,
+        env: &mut Env<S>,
+        task: F,
+    ) -> Result<(Pid, Option<JobControl>), Errno>
+    where
+        S: Close
+            + Dup
+            + Exit
+            + Fork
+            + GetPid
+            + Open
+            + SendSignal
+            + SetPgid
+            + SetRlimit
+            + Sigaction
+            + Sigmask
+            + SignalSystem
+            + TcSetPgrp
+            + WaitForSignals
+            + 'static,
+        F: AsyncFnOnce(&mut Env<S>, Option<JobControl>) + 'static,
+    {
         // Do some preparation before starting a child process
         let job_control = env.controls_jobs().then_some(self.job_control).flatten();
         let tty = match job_control {
@@ -204,7 +147,7 @@ where
 
         // Define the child process task
         const ME: Pid = Pid(0);
-        let task = move |mut child_env: Env<S>, ()| async move {
+        let child_task = move |mut child_env: Env<S>, ()| async move {
             let env = &mut *child_env.push_frame(Frame::Subshell);
 
             if let Some(job_control) = job_control {
@@ -230,12 +173,12 @@ where
                 )
                 .await;
 
-            (self.task)(env, job_control).await;
+            task(env, job_control).await;
             exit_or_raise(&env.system, env.exit_status).await
         };
 
         // Start the child
-        let (result, ()) = env.run_in_child_process((), task);
+        let (result, ()) = env.run_in_child_process((), child_task);
 
         // Restore the original signal mask in the parent process. Need to do
         // this before returning the error if the child process creation failed,
@@ -279,11 +222,31 @@ where
     ///
     /// When a job-controlled subshell suspends, this function does not add it
     /// to `env.jobs`. You have to do it for yourself if necessary.
-    pub async fn start_and_wait(self, env: &mut Env<S>) -> Result<(Pid, ProcessResult), Errno>
+    pub async fn start_and_wait<S, F>(
+        &self,
+        env: &mut Env<S>,
+        task: F,
+    ) -> Result<(Pid, ProcessResult), Errno>
     where
-        S: Wait,
+        S: Close
+            + Dup
+            + Exit
+            + Fork
+            + GetPid
+            + Open
+            + SendSignal
+            + SetPgid
+            + SetRlimit
+            + Sigaction
+            + Sigmask
+            + SignalSystem
+            + TcSetPgrp
+            + Wait
+            + WaitForSignals
+            + 'static,
+        F: AsyncFnOnce(&mut Env<S>, Option<JobControl>) + 'static,
     {
-        let (pid, job_control) = self.start(env).await?;
+        let (pid, job_control) = self.start(env, task).await?;
         let result = loop {
             let result = env.wait_for_subshell_to_halt(pid).await?.1;
             if !result.is_stopped() || job_control.is_some() {
@@ -302,24 +265,6 @@ where
         Ok((pid, result))
     }
 }
-
-async fn block_sigint_sigquit<S: Sigmask>(system: &S) -> Result<Vec<signal::Number>, Errno> {
-    let mut old_mask = Vec::new();
-    system
-        .sigmask(
-            Some((SigmaskOp::Add, &[S::SIGINT, S::SIGQUIT])),
-            Some(&mut old_mask),
-        )
-        .await?;
-    Ok(old_mask)
-}
-
-async fn restore_sigmask<S: Sigmask>(system: &S, mask: &[signal::Number]) -> Result<(), Errno> {
-    system.sigmask(Some((SigmaskOp::Set, mask)), None).await
-}
-
-mod config;
-pub use config::Config;
 
 #[cfg(test)]
 mod tests {
@@ -349,42 +294,52 @@ mod tests {
     }
 
     #[test]
-    fn subshell_start_returns_child_process_id() {
+    fn start_returns_child_process_id() {
         in_virtual_system(|mut env, _state| async move {
             let parent_pid = env.main_pid;
             let child_pid = Rc::new(Cell::new(None));
             let child_pid_2 = Rc::clone(&child_pid);
-            let subshell = Subshell::new(
-                move |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
-                    Box::pin(async move {
+            let result = Config::new()
+                .start(
+                    &mut env,
+                    async move |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
                         child_pid_2.set(Some(env.system.getpid()));
                         assert_eq!(env.system.getppid(), parent_pid);
-                    })
-                },
-            );
-            let result = subshell.start(&mut env).await.unwrap().0;
+                    },
+                )
+                .await
+                .unwrap()
+                .0;
             env.wait_for_subshell(result).await.unwrap();
             assert_eq!(Some(result), child_pid.get());
         });
     }
 
     #[test]
-    fn subshell_start_failing() {
+    fn start_failing() {
         let mut executor = LocalPool::new();
         let env = &mut Env::new_virtual();
-        let subshell =
-            Subshell::new(|_env, _job_control| unreachable!("subshell not expected to run"));
-        let result = executor.run_until(subshell.start(env));
+        let result = executor.run_until(
+            Config::new().start(env, async |_env: &mut Env<_>, _job_control| {
+                unreachable!("subshell not expected to run")
+            }),
+        );
         assert_eq!(result, Err(Errno::ENOSYS));
     }
 
     #[test]
     fn stack_frame_in_subshell() {
         in_virtual_system(|mut env, _state| async move {
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async { assert_eq!(env.stack[..], [Frame::Subshell]) })
-            });
-            let pid = subshell.start(&mut env).await.unwrap().0;
+            let pid = Config::new()
+                .start(
+                    &mut env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        assert_eq!(env.stack[..], [Frame::Subshell])
+                    },
+                )
+                .await
+                .unwrap()
+                .0;
             assert_eq!(env.stack[..], []);
 
             env.wait_for_subshell(pid).await.unwrap();
@@ -395,10 +350,16 @@ mod tests {
     fn jobs_disowned_in_subshell() {
         in_virtual_system(|mut env, _state| async move {
             let index = env.jobs.add(Job::new(Pid(123)));
-            let subshell = Subshell::new(move |env, _job_control| {
-                Box::pin(async move { assert!(!env.jobs[index].is_owned) })
-            });
-            let pid = subshell.start(&mut env).await.unwrap().0;
+            let pid = Config::new()
+                .start(
+                    &mut env,
+                    async move |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        assert!(!env.jobs[index].is_owned)
+                    },
+                )
+                .await
+                .unwrap()
+                .0;
             env.wait_for_subshell(pid).await.unwrap();
 
             assert!(env.jobs[index].is_owned);
@@ -418,17 +379,21 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async {
-                    let (current, parent) = env.traps.get_state(SIGCHLD);
-                    assert_eq!(current.unwrap().action, Action::Default);
-                    assert_matches!(
-                        &parent.unwrap().action,
-                        Action::Command(body) => assert_eq!(&**body, "echo foo")
-                    );
-                })
-            });
-            let pid = subshell.start(&mut env).await.unwrap().0;
+            let pid = Config::new()
+                .start(
+                    &mut env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        let (current, parent) = env.traps.get_state(SIGCHLD);
+                        assert_eq!(current.unwrap().action, Action::Default);
+                        assert_matches!(
+                            &parent.unwrap().action,
+                            Action::Command(body) => assert_eq!(&**body, "echo foo")
+                        );
+                    },
+                )
+                .await
+                .unwrap()
+                .0;
             env.wait_for_subshell(pid).await.unwrap();
         });
     }
@@ -440,20 +405,18 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
-                    Box::pin(async move {
+            let (child_pid, job_control) = Config::new()
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
                         assert_eq!(state_2.borrow().foreground, None);
                         assert_eq!(job_control, None);
-                    })
-                },
-            )
-            .job_control(None)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, None);
             assert_eq!(state.borrow().processes[&child_pid].pgid, parent_pgid);
             assert_eq!(state.borrow().foreground, None);
@@ -470,20 +433,22 @@ mod tests {
             parent_env.options.set(Monitor, On);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
-                    Box::pin(async move {
+            let config = Config {
+                job_control: Some(JobControl::Background),
+                ..Config::new()
+            };
+            let (child_pid, job_control) = config
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
                         assert_eq!(state_2.borrow().foreground, None);
                         assert_eq!(job_control, Some(JobControl::Background));
-                    })
-                },
-            )
-            .job_control(JobControl::Background)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, Some(JobControl::Background));
             assert_eq!(state.borrow().processes[&child_pid].pgid, child_pid);
             assert_eq!(state.borrow().foreground, None);
@@ -501,20 +466,22 @@ mod tests {
             stub_tty(&state);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
-                    Box::pin(async move {
+            let config = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            };
+            let (child_pid, job_control) = config
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
                         assert_eq!(state_2.borrow().foreground, Some(child_pid));
                         assert_eq!(job_control, Some(JobControl::Foreground));
-                    })
-                },
-            )
-            .job_control(JobControl::Foreground)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, Some(JobControl::Foreground));
             assert_eq!(state.borrow().processes[&child_pid].pgid, child_pid);
             // The child may not yet have become the foreground job.
@@ -532,11 +499,16 @@ mod tests {
             parent_env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let _ = Subshell::new(move |_, _| Box::pin(std::future::ready(())))
-                .job_control(JobControl::Foreground)
-                .start(&mut parent_env)
-                .await
-                .unwrap();
+            let _ = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            }
+            .start(
+                &mut parent_env,
+                async move |_: &mut Env<Rc<Concurrent<VirtualSystem>>>, _| (),
+            )
+            .await
+            .unwrap();
             assert_matches!(parent_env.tty, Some(_));
         });
     }
@@ -550,19 +522,21 @@ mod tests {
             parent_env.options.set(Monitor, On);
 
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
-                    Box::pin(async move {
+            let config = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            };
+            let (child_pid, job_control) = config
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, child_pid);
                         assert_eq!(job_control, Some(JobControl::Foreground));
-                    })
-                },
-            )
-            .job_control(JobControl::Foreground)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, Some(JobControl::Foreground));
             assert_eq!(state.borrow().processes[&child_pid].pgid, child_pid);
 
@@ -578,19 +552,22 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
-                    Box::pin(async move {
+            let config = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            };
+            let (child_pid, job_control) = config
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
+                                _job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
                         assert_eq!(state_2.borrow().foreground, None);
-                    })
-                },
-            )
-            .job_control(JobControl::Foreground)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, None);
             assert_eq!(state.borrow().processes[&child_pid].pgid, parent_pgid);
             assert_eq!(state.borrow().foreground, None);
@@ -610,19 +587,22 @@ mod tests {
 
             let parent_pgid = state.borrow().processes[&parent_env.main_pid].pgid;
             let state_2 = Rc::clone(&state);
-            let (child_pid, job_control) = Subshell::new(
-                move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
-                    Box::pin(async move {
+            let config = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            };
+            let (child_pid, job_control) = config
+                .start(
+                    &mut parent_env,
+                    async move |child_env: &mut Env<Rc<Concurrent<VirtualSystem>>>,
+                                _job_control| {
                         let child_pid = child_env.system.getpid();
                         assert_eq!(state_2.borrow().processes[&child_pid].pgid, parent_pgid);
                         assert_eq!(state_2.borrow().foreground, None);
-                    })
-                },
-            )
-            .job_control(JobControl::Foreground)
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(job_control, None);
             assert_eq!(state.borrow().processes[&child_pid].pgid, parent_pgid);
             assert_eq!(state.borrow().foreground, None);
@@ -636,10 +616,15 @@ mod tests {
     #[test]
     fn wait_without_job_control() {
         in_virtual_system(|mut env, _state| async move {
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(42) })
-            });
-            let (_pid, process_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            let (_pid, process_result) = Config::new()
+                .start_and_wait(
+                    &mut env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        env.exit_status = ExitStatus(42)
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(process_result, ProcessResult::exited(42));
         });
     }
@@ -650,11 +635,19 @@ mod tests {
             env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let subshell = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .job_control(JobControl::Foreground);
-            let (_pid, process_result) = subshell.start_and_wait(&mut env).await.unwrap();
+            let config = Config {
+                job_control: Some(JobControl::Foreground),
+                ..Config::new()
+            };
+            let (_pid, process_result) = config
+                .start_and_wait(
+                    &mut env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        env.exit_status = ExitStatus(123)
+                    },
+                )
+                .await
+                .unwrap();
             assert_eq!(process_result, ProcessResult::exited(123));
             assert_eq!(state.borrow().foreground, Some(env.main_pgid));
         });
@@ -666,11 +659,16 @@ mod tests {
     #[test]
     fn sigint_sigquit_not_ignored_by_default() {
         in_virtual_system(|mut parent_env, state| async move {
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .job_control(JobControl::Background)
-            .start(&mut parent_env)
+            let (child_pid, _) = Config {
+                job_control: Some(JobControl::Background),
+                ..Config::new()
+            }
+            .start(
+                &mut parent_env,
+                async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    env.exit_status = ExitStatus(123)
+                },
+            )
             .await
             .unwrap();
             parent_env.wait_for_subshell(child_pid).await.unwrap();
@@ -685,12 +683,16 @@ mod tests {
     #[test]
     fn sigint_sigquit_ignored_in_uncontrolled_job() {
         in_virtual_system(|mut parent_env, state| async move {
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .job_control(JobControl::Background)
-            .ignore_sigint_sigquit(true)
-            .start(&mut parent_env)
+            let (child_pid, _) = Config {
+                job_control: Some(JobControl::Background),
+                ignores_sigint_sigquit: true,
+            }
+            .start(
+                &mut parent_env,
+                async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    env.exit_status = ExitStatus(123)
+                },
+            )
             .await
             .unwrap();
 
@@ -724,12 +726,16 @@ mod tests {
             parent_env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .job_control(JobControl::Background)
-            .ignore_sigint_sigquit(true)
-            .start(&mut parent_env)
+            let (child_pid, _) = Config {
+                job_control: Some(JobControl::Background),
+                ignores_sigint_sigquit: true,
+            }
+            .start(
+                &mut parent_env,
+                async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    env.exit_status = ExitStatus(123)
+                },
+            )
             .await
             .unwrap();
             parent_env.wait_for_subshell(child_pid).await.unwrap();
@@ -754,12 +760,15 @@ mod tests {
                 .unwrap();
             stub_tty(&state);
 
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+            let (child_pid, _) = Config::new()
+                .start(
+                    &mut parent_env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        env.exit_status = ExitStatus(123)
+                    },
+                )
+                .await
+                .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
             assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
@@ -784,11 +793,16 @@ mod tests {
                 .unwrap();
             stub_tty(&state);
 
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .job_control(JobControl::Background)
-            .start(&mut parent_env)
+            let (child_pid, _) = Config {
+                job_control: Some(JobControl::Background),
+                ..Config::new()
+            }
+            .start(
+                &mut parent_env,
+                async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                    env.exit_status = ExitStatus(123)
+                },
+            )
             .await
             .unwrap();
 
@@ -809,12 +823,15 @@ mod tests {
             parent_env.options.set(Interactive, On);
             stub_tty(&state);
 
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+            let (child_pid, _) = Config::new()
+                .start(
+                    &mut parent_env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        env.exit_status = ExitStatus(123)
+                    },
+                )
+                .await
+                .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
             assert_eq!(child_result, (child_pid, ProcessState::exited(123)));
@@ -834,12 +851,15 @@ mod tests {
             parent_env.options.set(Monitor, On);
             stub_tty(&state);
 
-            let (child_pid, _) = Subshell::new(|env, _job_control| {
-                Box::pin(async { env.exit_status = ExitStatus(123) })
-            })
-            .start(&mut parent_env)
-            .await
-            .unwrap();
+            let (child_pid, _) = Config::new()
+                .start(
+                    &mut parent_env,
+                    async |env: &mut Env<Rc<Concurrent<VirtualSystem>>>, _job_control| {
+                        env.exit_status = ExitStatus(123)
+                    },
+                )
+                .await
+                .unwrap();
 
             let child_result = parent_env.wait_for_subshell(child_pid).await.unwrap();
             assert_eq!(child_result, (child_pid, ProcessState::exited(123)));

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -147,7 +147,6 @@ impl Config {
             + Sigmask
             + SignalSystem
             + TcSetPgrp
-            + WaitForSignals
             + 'static,
         F: AsyncFnOnce(&mut Env<S>, Option<JobControl>) + 'static,
     {

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -34,7 +34,10 @@ use crate::trap::SignalSystem;
 
 /// Configuration for subshell creation
 ///
-/// This struct configures how a subshell is created.
+/// This struct configures how a subshell is created. An instance of `Config`
+/// can be created with [`new`](Self::new) or [`foreground`](Self::foreground),
+/// and modified by setting the fields. To start a subshell, call
+/// [`start`](Self::start) or [`start_and_wait`](Self::start_and_wait).
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct Config {

--- a/yash-prompt/src/lib.rs
+++ b/yash-prompt/src/lib.rs
@@ -77,6 +77,8 @@
 //! # }.now_or_never().unwrap();
 //! ```
 
+#![cfg_attr(test, recursion_limit = "256")]
+
 mod expand_posix;
 pub use expand_posix::ExpandText;
 pub use expand_posix::expand_posix;

--- a/yash-semantics/src/command/compound_command.rs
+++ b/yash-semantics/src/command/compound_command.rs
@@ -27,8 +27,6 @@ use yash_env::Env;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
-#[cfg(doc)]
-use yash_env::subshell::Subshell;
 use yash_syntax::syntax;
 use yash_syntax::syntax::Redir;
 
@@ -87,7 +85,7 @@ impl<S: Runtime + 'static> Command<S> for syntax::FullCompoundCommand {
 /// # Subshell
 ///
 /// A subshell is executed by running the contained list in a separate
-/// environment ([`Subshell`]).
+/// environment ([`yash_env::subshell`]).
 ///
 /// After the subshell has finished, [`Env::apply_errexit`] is called.
 ///

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -38,8 +38,7 @@ pub async fn execute<S: Runtime + 'static>(
     location: &Location,
 ) -> Result {
     let body_2 = Rc::clone(&body);
-    let config = Config::foreground();
-    let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
+    let subshell = Config::foreground().start_and_wait(env, async move |sub_env, _job_control| {
         subshell_main(sub_env, body_2).await
     });
     match subshell.await {

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -28,7 +28,6 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::Config;
-use yash_env::subshell::JobControl;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::List;
 
@@ -39,8 +38,7 @@ pub async fn execute<S: Runtime + 'static>(
     location: &Location,
 ) -> Result {
     let body_2 = Rc::clone(&body);
-    let mut config = Config::new();
-    config.job_control = Some(JobControl::Foreground);
+    let config = Config::foreground();
     let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
         subshell_main(sub_env, body_2).await
     });

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -27,8 +27,8 @@ use yash_env::job::add_job_if_suspended;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
+use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
-use yash_env::subshell::Subshell;
 use yash_syntax::source::Location;
 use yash_syntax::syntax::List;
 
@@ -39,9 +39,12 @@ pub async fn execute<S: Runtime + 'static>(
     location: &Location,
 ) -> Result {
     let body_2 = Rc::clone(&body);
-    let subshell = Subshell::new(|sub_env, _job_control| Box::pin(subshell_main(sub_env, body_2)));
-    let subshell = subshell.job_control(JobControl::Foreground);
-    match subshell.start_and_wait(env).await {
+    let mut config = Config::new();
+    config.job_control = Some(JobControl::Foreground);
+    let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
+        subshell_main(sub_env, body_2).await
+    });
+    match subshell.await {
         Ok((pid, result)) => {
             env.exit_status = add_job_if_suspended(env, pid, result, || body.to_string())?;
             env.apply_errexit()

--- a/yash-semantics/src/command/item.rs
+++ b/yash-semantics/src/command/item.rs
@@ -28,8 +28,8 @@ use yash_env::job::Job;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
+use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
-use yash_env::subshell::Subshell;
 use yash_env::system::{Close, Mode, OfdAccess, Open};
 use yash_syntax::source::Location;
 use yash_syntax::syntax;
@@ -71,13 +71,13 @@ async fn execute_async<S: Runtime + 'static>(
     async_flag: &Location,
 ) -> Result {
     let and_or_2 = Rc::clone(and_or);
-    let subshell = Subshell::new(|env_2, job_control| {
-        Box::pin(async move { async_body(env_2, job_control, &and_or_2).await })
+    let mut config = Config::new();
+    config.job_control = Some(JobControl::Background);
+    config.ignores_sigint_sigquit = true;
+    let subshell = config.start(env, async move |env_2, job_control| {
+        async_body(env_2, job_control, &and_or_2).await
     });
-    let subshell = subshell
-        .job_control(JobControl::Background)
-        .ignore_sigint_sigquit(true);
-    match subshell.start(env).await {
+    match subshell.await {
         Ok((pid, job_control)) => {
             // remember the process ID as a job
             let mut job = Job::new(pid);

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -125,8 +125,7 @@ async fn execute_job_controlled_pipeline<S: Runtime + 'static>(
     commands: &[Rc<syntax::Command>],
 ) -> Result {
     let commands_2 = commands.to_vec();
-    let config = Config::foreground();
-    let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
+    let subshell = Config::foreground().start_and_wait(env, async move |sub_env, _job_control| {
         let result = execute_multi_command_pipeline(sub_env, &commands_2).await;
         sub_env.apply_result(result);
         run_exit_trap(sub_env).await;

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -125,8 +125,7 @@ async fn execute_job_controlled_pipeline<S: Runtime + 'static>(
     commands: &[Rc<syntax::Command>],
 ) -> Result {
     let commands_2 = commands.to_vec();
-    let mut config = Config::new();
-    config.job_control = Some(JobControl::Foreground);
+    let config = Config::foreground();
     let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
         let result = execute_multi_command_pipeline(sub_env, &commands_2).await;
         sub_env.apply_result(result);

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -33,8 +33,8 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::stack::Frame;
+use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
-use yash_env::subshell::Subshell;
 use yash_env::system::concurrency::WriteAll;
 use yash_env::system::{Close, Dup, Errno, Isatty, Pipe};
 use yash_syntax::syntax;
@@ -125,16 +125,14 @@ async fn execute_job_controlled_pipeline<S: Runtime + 'static>(
     commands: &[Rc<syntax::Command>],
 ) -> Result {
     let commands_2 = commands.to_vec();
-    let subshell = Subshell::new(|sub_env, _job_control| {
-        Box::pin(async move {
-            let result = execute_multi_command_pipeline(sub_env, &commands_2).await;
-            sub_env.apply_result(result);
-            run_exit_trap(sub_env).await;
-        })
-    })
-    .job_control(JobControl::Foreground);
-
-    match subshell.start_and_wait(env).await {
+    let mut config = Config::new();
+    config.job_control = Some(JobControl::Foreground);
+    let subshell = config.start_and_wait(env, async move |sub_env, _job_control| {
+        let result = execute_multi_command_pipeline(sub_env, &commands_2).await;
+        sub_env.apply_result(result);
+        run_exit_trap(sub_env).await;
+    });
+    match subshell.await {
         Ok((pid, result)) => {
             env.exit_status = add_job_if_suspended(env, pid, result, || to_job_name(commands))?;
             Continue(())
@@ -168,14 +166,13 @@ async fn execute_multi_command_pipeline<S: Runtime + 'static>(
         shift_or_fail(env, &mut pipes, has_next).await?;
 
         let pipes = pipes;
-        let subshell = Subshell::new(move |env, _job_control| {
-            Box::pin(async move {
+        let start_result = Config::new()
+            .start(env, async move |env, _job_control| {
                 let result = connect_pipe_and_execute_command(env, pipes, command).await;
                 env.apply_result(result);
                 run_exit_trap(env).await;
             })
-        });
-        let start_result = subshell.start(env).await;
+            .await;
         pids.push(pid_or_fail(env, start_result).await?);
     }
 

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -31,8 +31,8 @@ use yash_env::job::add_job_if_suspended;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
+use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
-use yash_env::subshell::Subshell;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
 
@@ -46,29 +46,27 @@ pub async fn execute_absent_target<S: Runtime + 'static>(
     let redir_exit_status = if let Some(redir) = redirs.first() {
         let first_redir_location = redir.body.operand().location.clone();
         let redirs_2 = Rc::clone(redirs);
-        let subshell = Subshell::new(move |env, _job_control| {
-            Box::pin(async move {
-                let env = &mut RedirGuard::new(env);
-                let mut xtrace = XTrace::from_options(&env.options);
+        let mut config = Config::new();
+        config.job_control = Some(JobControl::Foreground);
+        let subshell = config.start_and_wait(env, async move |env, _job_control| {
+            let env = &mut RedirGuard::new(env);
+            let mut xtrace = XTrace::from_options(&env.options);
 
-                let redir_exit_status =
-                    match env.perform_redirs(redirs_2.iter(), xtrace.as_mut()).await {
-                        Ok(exit_status) => exit_status,
-                        Err(error) => {
-                            let result = error.handle(env).await;
-                            env.apply_result(result);
-                            return;
-                        }
-                    };
+            let redir_exit_status = match env.perform_redirs(redirs_2.iter(), xtrace.as_mut()).await
+            {
+                Ok(exit_status) => exit_status,
+                Err(error) => {
+                    let result = error.handle(env).await;
+                    env.apply_result(result);
+                    return;
+                }
+            };
 
-                print(env, xtrace).await;
+            print(env, xtrace).await;
 
-                env.exit_status = redir_exit_status.unwrap_or(exit_status);
-            })
-        })
-        .job_control(JobControl::Foreground);
-
-        match subshell.start_and_wait(env).await {
+            env.exit_status = redir_exit_status.unwrap_or(exit_status);
+        });
+        match subshell.await {
             Ok((pid, result)) => add_job_if_suspended(env, pid, result, || {
                 redirs
                     .iter()

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -32,7 +32,6 @@ use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::subshell::Config;
-use yash_env::subshell::JobControl;
 use yash_syntax::syntax::Assign;
 use yash_syntax::syntax::Redir;
 
@@ -46,8 +45,7 @@ pub async fn execute_absent_target<S: Runtime + 'static>(
     let redir_exit_status = if let Some(redir) = redirs.first() {
         let first_redir_location = redir.body.operand().location.clone();
         let redirs_2 = Rc::clone(redirs);
-        let mut config = Config::new();
-        config.job_control = Some(JobControl::Foreground);
+        let config = Config::foreground();
         let subshell = config.start_and_wait(env, async move |env, _job_control| {
             let env = &mut RedirGuard::new(env);
             let mut xtrace = XTrace::from_options(&env.options);

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -45,8 +45,7 @@ pub async fn execute_absent_target<S: Runtime + 'static>(
     let redir_exit_status = if let Some(redir) = redirs.first() {
         let first_redir_location = redir.body.operand().location.clone();
         let redirs_2 = Rc::clone(redirs);
-        let config = Config::foreground();
-        let subshell = config.start_and_wait(env, async move |env, _job_control| {
+        let subshell = Config::foreground().start_and_wait(env, async move |env, _job_control| {
             let env = &mut RedirGuard::new(env);
             let mut xtrace = XTrace::from_options(&env.options);
 

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -29,8 +29,8 @@ use crate::trap::run_exit_trap;
 use std::cell::RefCell;
 use yash_env::io::Fd;
 use yash_env::job::Pid;
+use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
-use yash_env::subshell::Subshell;
 use yash_env::system::concurrency::ReadAll;
 use yash_env::system::concurrency::WaitForSignals;
 use yash_env::system::{Close, Errno, Wait};
@@ -63,14 +63,13 @@ where
     };
 
     // Start a subshell to run the command
-    let subshell = Subshell::new(move |env, _job_control| {
-        Box::pin(async move {
+    let subshell_result = Config::new()
+        .start(env.inner, async move |env, _job_control| {
             let result = subshell_body(env, reader, writer, original, command).await;
             env.apply_result(result);
             run_exit_trap(env).await;
         })
-    });
-    let subshell_result = subshell.start(env.inner).await;
+        .await;
 
     expand_common(reader, writer, subshell_result, location, env).await
 }


### PR DESCRIPTION
## Description

This PR adds `yash_env::subshell::Config` as a new helper for starting subshells and deprecates the existing `yash_env::subshell::Subshell`. This resolves the following issues with `Subshell`:

- `Subshell` requires the task to be provided in a pinning box. An allocation is inevitable.
- `Subshell` has two type parameters that have to be resolved when it is constructed. This makes it difficult to infer the first parameter `S` from the type of the environment `Env<S>`, which is only provided when the `start` method is called.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified subshell creation/initialization across the codebase using a new configurable API; runtime behavior preserved.
* **Deprecated**
  * Legacy subshell construction marked deprecated in favor of the new configuration-based approach.
* **Documentation**
  * Changelog updated to document the new subshell configuration and deprecation.
* **Tests**
  * Unit tests updated to use the new subshell test harness.
* **Chores**
  * Test-only recursion limits increased for a couple crates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicant/yash-rs/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->