### PR TITLE
Use native signal sets in sigmask and select

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -103,6 +103,7 @@
 			"sigprocmask",
 			"SIGQUIT",
 			"SIGSEGV",
+			"sigset",
 			"SIGSTOP",
 			"SIGTERM",
 			"SIGTSTP",

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -106,6 +106,10 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `system::Select::select`
 - The `system::Select` trait now requires the `system::Sigmask` trait as a
   supertrait.
+- The `system::virtual::Process::blocked_signals` and
+  `system::virtual::Process::pending_signals` methods now return a reference to
+  `system::virtual::Sigset` instead of a reference to
+  `BTreeSet<signal::Number>`.
 - The `system::virtual::Process::block_signals` method now takes an iterator of
   signal numbers instead of a slice, allowing for more flexible ways to specify
   the signals to block (e.g., using a `HashSet` or other collection).

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -101,6 +101,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       `Env<VirtualSystem>`.
 - The `system::Sigmask` trait now has the associated type `Sigset`, which must
   be specified when implementing the trait.
+- The `system::Concurrent` struct now requires the inner system type `S` to
+  implement the `system::Sigmask` trait. The `S: system::Sigmask` bound has also
+  been added to relevant methods and trait implementations for `Concurrent`.
 - The following methods of `system::Concurrent`, which were inherent methods,
   are now provided as trait implementations. You may have to import the
   corresponding traits to use these methods:

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
+- The `system::Sigset` trait has been added to represent a set of signals,
+  abstracting the `sigset_t` type from POSIX.
+- The `system::real::Sigset` struct has been added as the concrete `Sigset`
+  implementation for the real system.
+- The `system::virtual::Sigset` struct has been added as the concrete `Sigset`
+  implementation for the virtual system.
 - The `run_in_child_process` method has been added to the `system::Fork` trait.
   It provides a new way to create child processes that is cleaner and more
   usable than the existing `new_child_process` method.
@@ -93,6 +99,8 @@ A _private dependency_ is used internally and not visible to downstream users.
     - The `test_helper::in_virtual_system` function now provides an
       `Env<Rc<Concurrent<VirtualSystem>>>` to the provided task instead of
       `Env<VirtualSystem>`.
+- The `system::Sigmask` trait now has the associated type `Sigset`, which must
+  be specified when implementing the trait.
 - The following methods of `system::Concurrent`, which were inherent methods,
   are now provided as trait implementations. You may have to import the
   corresponding traits to use these methods:

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -100,10 +100,20 @@ A _private dependency_ is used internally and not visible to downstream users.
       `Env<Rc<Concurrent<VirtualSystem>>>` to the provided task instead of
       `Env<VirtualSystem>`.
 - The `system::Sigmask` trait now has the associated type `Sigset`, which must
-  be specified when implementing the trait.
+  be specified when implementing the trait. The `Sigset` type is now used in
+  the signatures of the following methods to represent sets of signals:
+    - `system::Sigmask::sigmask`
+    - `system::Select::select`
+- The `system::Select` trait now requires the `system::Sigmask` trait as a
+  supertrait.
+- The `system::virtual::Process::block_signals` method now takes an iterator of
+  signal numbers instead of a slice, allowing for more flexible ways to specify
+  the signals to block (e.g., using a `HashSet` or other collection).
 - The `system::Concurrent` struct now requires the inner system type `S` to
-  implement the `system::Sigmask` trait. The `S: system::Sigmask` bound has also
-  been added to relevant methods and trait implementations for `Concurrent`.
+  implement the `system::Sigmask` trait, as it now internally contains a
+  `Sigset` to manage the signal mask for the select operation. The
+  `S: system::Sigmask` bound has also been added to relevant methods and
+  trait implementations for `Concurrent`.
 - The following methods of `system::Concurrent`, which were inherent methods,
   are now provided as trait implementations. You may have to import the
   corresponding traits to use these methods:

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -45,7 +45,7 @@ use crate::Env;
 use crate::io::Fd;
 use crate::semantics::{Divert, ExitStatus};
 use crate::signal;
-use crate::system::{Disposition, Sigaction, Sigmask, SigmaskOp, Signals, TcSetPgrp};
+use crate::system::{Disposition, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _, TcSetPgrp};
 use slab::Slab;
 use std::collections::HashMap;
 use std::iter::FusedIterator;
@@ -940,10 +940,13 @@ pub async fn tcsetpgrp_with_block<S>(system: &S, fd: Fd, pgid: Pid) -> crate::sy
 where
     S: Signals + Sigmask + TcSetPgrp + ?Sized,
 {
-    let mut old_mask = Vec::new();
+    let mut old_mask = S::Sigset::new();
 
     system
-        .sigmask(Some((SigmaskOp::Add, &[S::SIGTTOU])), Some(&mut old_mask))
+        .sigmask(
+            Some((SigmaskOp::Add, &S::Sigset::from_signals([S::SIGTTOU])?)),
+            Some(&mut old_mask),
+        )
         .await?;
 
     let result = system.tcsetpgrp(fd, pgid).await;
@@ -978,15 +981,14 @@ pub async fn tcsetpgrp_without_block<S>(system: &S, fd: Fd, pgid: Pid) -> crate:
 where
     S: Signals + Sigaction + Sigmask + TcSetPgrp + ?Sized,
 {
+    let sigttou = S::Sigset::from_signals([S::SIGTTOU])?;
+
     match system.sigaction(S::SIGTTOU, Disposition::Default) {
         Err(e) => Err(e),
         Ok(old_handling) => {
-            let mut old_mask = Vec::new();
+            let mut old_mask = S::Sigset::new();
             let result = match system
-                .sigmask(
-                    Some((SigmaskOp::Remove, &[S::SIGTTOU])),
-                    Some(&mut old_mask),
-                )
+                .sigmask(Some((SigmaskOp::Remove, &sigttou)), Some(&mut old_mask))
                 .await
             {
                 Err(e) => Err(e),

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -708,6 +708,7 @@ mod tests {
     use crate::source::Location;
     use crate::subshell::Config;
     use crate::system::Exit as _;
+    use crate::system::Sigset as _;
     use crate::system::r#virtual::Inode;
     use crate::system::r#virtual::SIGCHLD;
     use crate::test_helper::in_virtual_system;
@@ -733,7 +734,7 @@ mod tests {
             {
                 let mut state = state.borrow_mut();
                 let process = state.processes.get_mut(&env.main_pid).unwrap();
-                assert!(process.blocked_signals().contains(&SIGCHLD));
+                assert_eq!(process.blocked_signals().contains(SIGCHLD), Ok(true));
                 let _ = process.raise_signal(SIGCHLD);
             }
             env.wait_for_signal(SIGCHLD).await;
@@ -773,7 +774,7 @@ mod tests {
         {
             let mut state = system.state.borrow_mut();
             let process = state.processes.get_mut(&system.process_id).unwrap();
-            assert!(process.blocked_signals().contains(&SIGCHLD));
+            assert_eq!(process.blocked_signals().contains(SIGCHLD), Ok(true));
             let _ = process.raise_signal(SIGCHLD);
         }
 

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -21,7 +21,9 @@ use crate::signal;
 use crate::source::Location;
 use crate::system::resource::{LimitPair, Resource, SetRlimit};
 use crate::system::r#virtual::SignalEffect;
-use crate::system::{Disposition, Exit, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals};
+use crate::system::{
+    Disposition, Exit, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _,
+};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::ffi::c_int;
@@ -374,7 +376,10 @@ where
 
         // Unblock the signal
         system
-            .sigmask(Some((SigmaskOp::Remove, &[signal.1])), None)
+            .sigmask(
+                Some((SigmaskOp::Remove, &S::Sigset::from_signals([signal.1])?)),
+                None,
+            )
             .await?;
 
         // Send the signal to the current process

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -648,8 +648,11 @@ mod tests {
 
             let state = state.borrow();
             let parent_process = &state.processes[&parent_env.main_pid];
-            assert!(!parent_process.blocked_signals().contains(&SIGINT));
-            assert!(!parent_process.blocked_signals().contains(&SIGQUIT));
+            assert_eq!(parent_process.blocked_signals().contains(SIGINT), Ok(false));
+            assert_eq!(
+                parent_process.blocked_signals().contains(SIGQUIT),
+                Ok(false)
+            );
             let child_process = &state.processes[&child_pid];
             assert_eq!(child_process.disposition(SIGINT), Disposition::Ignore);
             assert_eq!(child_process.disposition(SIGQUIT), Disposition::Ignore);

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -31,7 +31,6 @@
 use crate::Env;
 use crate::job::Pid;
 use crate::job::ProcessResult;
-use crate::signal;
 use crate::system::Close;
 use crate::system::Dup;
 use crate::system::Errno;
@@ -44,6 +43,7 @@ use crate::system::SetPgid;
 use crate::system::Sigaction;
 use crate::system::Sigmask;
 use crate::system::SigmaskOp;
+use crate::system::Sigset as _;
 use crate::system::TcSetPgrp;
 use crate::system::Wait;
 use crate::system::concurrency::WaitForSignals;
@@ -236,18 +236,21 @@ where
     }
 }
 
-async fn block_sigint_sigquit<S: Sigmask>(system: &S) -> Result<Vec<signal::Number>, Errno> {
-    let mut old_mask = Vec::new();
+async fn block_sigint_sigquit<S: Sigmask>(system: &S) -> Result<S::Sigset, Errno> {
+    let mut old_mask = S::Sigset::new();
     system
         .sigmask(
-            Some((SigmaskOp::Add, &[S::SIGINT, S::SIGQUIT])),
+            Some((
+                SigmaskOp::Add,
+                &S::Sigset::from_signals([S::SIGINT, S::SIGQUIT])?,
+            )),
             Some(&mut old_mask),
         )
         .await?;
     Ok(old_mask)
 }
 
-async fn restore_sigmask<S: Sigmask>(system: &S, mask: &[signal::Number]) -> Result<(), Errno> {
+async fn restore_sigmask<S: Sigmask>(system: &S, mask: &S::Sigset) -> Result<(), Errno> {
     system.sigmask(Some((SigmaskOp::Set, mask)), None).await
 }
 

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -301,7 +301,7 @@ mod tests {
     use crate::source::Location;
     use crate::system::r#virtual::{Inode, SystemState, VirtualSystem};
     use crate::system::r#virtual::{SIGCHLD, SIGINT, SIGQUIT, SIGTSTP, SIGTTIN, SIGTTOU};
-    use crate::system::{Concurrent, Disposition};
+    use crate::system::{Concurrent, Disposition, Sigset as _};
     use crate::test_helper::in_virtual_system;
     use crate::trap::Action;
     use assert_matches::assert_matches;
@@ -714,8 +714,11 @@ mod tests {
 
             let state = state.borrow();
             let parent_process = &state.processes[&parent_env.main_pid];
-            assert!(!parent_process.blocked_signals().contains(&SIGINT));
-            assert!(!parent_process.blocked_signals().contains(&SIGQUIT));
+            assert_eq!(parent_process.blocked_signals().contains(SIGINT), Ok(false));
+            assert_eq!(
+                parent_process.blocked_signals().contains(SIGQUIT),
+                Ok(false)
+            );
             let child_process = &state.processes[&child_pid];
             assert_eq!(child_process.disposition(SIGINT), Disposition::Ignore);
             assert_eq!(child_process.disposition(SIGQUIT), Disposition::Ignore);

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -139,6 +139,7 @@ use self::resource::{GetRlimit, SetRlimit};
 pub use self::select::Select;
 pub use self::signal::{
     CaughtSignals, Disposition, GetSigaction, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals,
+    Sigset,
 };
 pub use self::sysconf::{ShellPath, Sysconf};
 pub use self::terminal::{Isatty, TcGetPgrp, TcSetPgrp};

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -107,12 +107,12 @@ use std::time::{Duration, Instant};
 #[derive(Clone, Debug, Default)]
 pub struct Concurrent<S: Sigmask> {
     inner: S,
-    state: RefCell<State>,
+    state: RefCell<State<S::Sigset>>,
 }
 
 /// Internal state for `Concurrent` system
 #[derive(Clone, Debug, Default)]
-struct State {
+struct State<S> {
     /// Wakers for tasks waiting for read readiness on each file descriptor
     reads: HashMap<Fd, WakerSet>,
     /// Wakers for tasks waiting for write readiness on each file descriptor
@@ -132,14 +132,15 @@ struct State {
     /// Signal mask for the `select` method
     ///
     /// This cache is initialized from the signal mask the shell inherited from
-    /// the parent shell and then updated by [`Concurrent::sigmask`] for use by
-    /// `select`. In particular, signals the shell wants to catch are removed
-    /// from this mask so they can interrupt `select`. The value is `None` until
-    /// the signal mask is first updated by [`Concurrent::sigmask`].
-    select_mask: Option<Vec<crate::signal::Number>>,
+    /// the parent shell and then updated by
+    /// [`Concurrent::update_sigmask_and_select_mask`] for use by `select`. In
+    /// particular, signals the shell wants to catch are removed from this mask
+    /// so they can interrupt `select`. The value is `None` until the signal
+    /// mask is first updated by `update_sigmask_and_select_mask`.
+    select_mask: Option<S>,
 }
 
-impl State {
+impl<S: Clone> State<S> {
     /// Creates a clone of the current state for use in a child process.
     ///
     /// This method is intended to be used when forking a new process, allowing
@@ -275,7 +276,7 @@ impl<S: Sigmask> Concurrent<S> {
         target: G,
     ) where
         F: FnOnce() -> Rc<Cell<Option<Waker>>>,
-        G: Fn(&mut State) -> &mut HashMap<Fd, WakerSet>,
+        G: Fn(&mut State<S::Sigset>) -> &mut HashMap<Fd, WakerSet>,
     {
         let mut first_time = true;
         poll_fn(|context| {
@@ -517,7 +518,7 @@ where
                 .map(|target| target.saturating_duration_since(self.inner.now()))
         };
         let signal_mask = (state.signals.strong_count() > 0)
-            .then(|| state.select_mask.as_deref())
+            .then(|| state.select_mask.as_ref())
             .flatten();
 
         // Perform the `select` call

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -313,7 +313,7 @@ pub trait Sleep {
 
 impl<S> Sleep for Rc<S>
 where
-    S: Sigmask + Sleep,
+    S: Sleep,
 {
     #[inline]
     fn sleep_until(&self, deadline: Instant) -> impl Future<Output = ()> {

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -20,7 +20,9 @@
 //! systems that enables concurrent execution of multiple possibly blocking I/O
 //! tasks on a single thread.
 
-use super::{CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, Fork, Read, Result, Write};
+use super::{
+    CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, Fork, Read, Result, Sigmask, Write,
+};
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
@@ -103,7 +105,7 @@ use std::time::{Duration, Instant};
 ///
 /// [`Pipe`]: super::Pipe
 #[derive(Clone, Debug, Default)]
-pub struct Concurrent<S> {
+pub struct Concurrent<S: Sigmask> {
     inner: S,
     state: RefCell<State>,
 }
@@ -162,7 +164,7 @@ impl State {
     }
 }
 
-impl<S> Concurrent<S> {
+impl<S: Sigmask> Concurrent<S> {
     /// Creates a new `Concurrent` system that wraps the given inner system.
     #[must_use]
     pub fn new(inner: S) -> Self {
@@ -182,7 +184,7 @@ impl<S> Concurrent<S> {
 /// reading.
 impl<S> Read for Rc<Concurrent<S>>
 where
-    S: Fcntl + Read,
+    S: Fcntl + Read + Sigmask,
 {
     fn read<'a>(
         &self,
@@ -221,7 +223,7 @@ where
 /// writing.
 impl<S> Write for Rc<Concurrent<S>>
 where
-    S: Fcntl + Write,
+    S: Fcntl + Write + Sigmask,
 {
     fn write<'a>(
         &self,
@@ -249,7 +251,7 @@ where
     }
 }
 
-impl<S> Concurrent<S> {
+impl<S: Sigmask> Concurrent<S> {
     async fn yield_for_read<F>(&self, fd: Fd, waker: &LazyCell<Rc<Cell<Option<Waker>>>, F>)
     where
         F: FnOnce() -> Rc<Cell<Option<Waker>>>,
@@ -310,7 +312,7 @@ pub trait Sleep {
 
 impl<S> Sleep for Rc<S>
 where
-    S: Sleep,
+    S: Sigmask + Sleep,
 {
     #[inline]
     fn sleep_until(&self, deadline: Instant) -> impl Future<Output = ()> {
@@ -325,7 +327,7 @@ where
 
 impl<S> Sleep for Concurrent<S>
 where
-    S: Clock,
+    S: Clock + Sigmask,
 {
     async fn sleep_until(&self, deadline: Instant) {
         let waker: LazyCell<Rc<Cell<Option<Waker>>>> = LazyCell::default();
@@ -381,7 +383,7 @@ where
     }
 }
 
-impl<S> WaitForSignals for Concurrent<S> {
+impl<S: Sigmask> WaitForSignals for Concurrent<S> {
     async fn wait_for_signals(&self) -> Rc<SignalList> {
         let signals = {
             let mut state = self.state.borrow_mut();
@@ -475,7 +477,7 @@ where
 
 impl<S> Select for Concurrent<S>
 where
-    S: CaughtSignals + Clock + super::Select,
+    S: CaughtSignals + Clock + super::Select + Sigmask,
 {
     fn peek(&self) {
         let select = pin!(self.select_impl(true));
@@ -490,7 +492,7 @@ where
 
 impl<S> Concurrent<S>
 where
-    S: CaughtSignals + Clock + super::Select,
+    S: CaughtSignals + Clock + super::Select + Sigmask,
 {
     #[allow(
         clippy::await_holding_refcell_ref,
@@ -565,13 +567,13 @@ fn wake_tasks_for_ready_fds(task_map: &mut HashMap<Fd, WakerSet>, ready_fds: &[F
 /// Guard for temporarily setting a file descriptor to non-blocking mode and
 /// restoring the original blocking mode when dropped
 #[derive(Debug)]
-struct TemporaryNonBlockingGuard<'a, S: Fcntl> {
+struct TemporaryNonBlockingGuard<'a, S: Fcntl + Sigmask> {
     system: &'a Concurrent<S>,
     fd: Fd,
     original_nonblocking: bool,
 }
 
-impl<'a, S: Fcntl> TemporaryNonBlockingGuard<'a, S> {
+impl<'a, S: Fcntl + Sigmask> TemporaryNonBlockingGuard<'a, S> {
     fn new(system: &'a Concurrent<S>, fd: Fd) -> Self {
         Self {
             system,
@@ -581,7 +583,7 @@ impl<'a, S: Fcntl> TemporaryNonBlockingGuard<'a, S> {
     }
 }
 
-impl<'a, S: Fcntl> Drop for TemporaryNonBlockingGuard<'a, S> {
+impl<'a, S: Fcntl + Sigmask> Drop for TemporaryNonBlockingGuard<'a, S> {
     fn drop(&mut self) {
         if !self.original_nonblocking {
             self.system
@@ -592,7 +594,7 @@ impl<'a, S: Fcntl> Drop for TemporaryNonBlockingGuard<'a, S> {
     }
 }
 
-impl<'a, S: Fcntl> Deref for TemporaryNonBlockingGuard<'a, S> {
+impl<'a, S: Fcntl + Sigmask> Deref for TemporaryNonBlockingGuard<'a, S> {
     type Target = Concurrent<S>;
 
     fn deref(&self) -> &Self::Target {
@@ -641,7 +643,7 @@ impl SignalList {
 
 impl<S> Fork for Rc<Concurrent<S>>
 where
-    S: Fork + RunLoop + Sized,
+    S: Fork + RunLoop + Sigmask + Sized,
 {
     /// Runs a task in a new child process.
     ///
@@ -710,7 +712,7 @@ pub trait RunLoop {
         task: F,
     ) -> impl Future<Output = ()> + use<'c, Self, F>
     where
-        Self: Sized,
+        Self: Sigmask + Sized,
         F: Future<Output = ()>;
 }
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -359,8 +359,8 @@ where
     #[inline]
     fn sigmask(
         &self,
-        op_and_signals: Option<(SigmaskOp, &[signal::Number])>,
-        old_mask: Option<&mut Vec<signal::Number>>,
+        op_and_signals: Option<(SigmaskOp, &Self::Sigset)>,
+        old_mask: Option<&mut Self::Sigset>,
     ) -> impl Future<Output = Result<()>> + use<S> {
         self.inner.sigmask(op_and_signals, old_mask)
     }

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -39,7 +39,7 @@ use unix_str::UnixString;
 
 impl<S> Fstat for Concurrent<S>
 where
-    S: Fstat,
+    S: Fstat + Sigmask,
 {
     type Stat = S::Stat;
 
@@ -63,7 +63,7 @@ where
 
 impl<S> IsExecutableFile for Concurrent<S>
 where
-    S: IsExecutableFile,
+    S: IsExecutableFile + Sigmask,
 {
     #[inline]
     fn is_executable_file(&self, path: &CStr) -> bool {
@@ -73,7 +73,7 @@ where
 
 impl<S> Pipe for Concurrent<S>
 where
-    S: Pipe,
+    S: Pipe + Sigmask,
 {
     #[inline]
     fn pipe(&self) -> Result<(Fd, Fd)> {
@@ -83,7 +83,7 @@ where
 
 impl<S> Dup for Concurrent<S>
 where
-    S: Dup,
+    S: Dup + Sigmask,
 {
     #[inline]
     fn dup(&self, from: Fd, to_min: Fd, flags: EnumSet<FdFlag>) -> Result<Fd> {
@@ -99,7 +99,7 @@ where
 /// This implementation does not (yet) support non-blocking open operations.
 impl<S> Open for Concurrent<S>
 where
-    S: Open,
+    S: Open + Sigmask,
 {
     #[inline]
     fn open(
@@ -130,7 +130,7 @@ where
 
 impl<S> Close for Concurrent<S>
 where
-    S: Close,
+    S: Close + Sigmask,
 {
     #[inline]
     fn close(&self, fd: Fd) -> Result<()> {
@@ -140,7 +140,7 @@ where
 
 impl<S> Fcntl for Concurrent<S>
 where
-    S: Fcntl,
+    S: Fcntl + Sigmask,
 {
     #[inline]
     fn ofd_access(&self, fd: Fd) -> Result<OfdAccess> {
@@ -165,7 +165,7 @@ where
 
 impl<S> Seek for Concurrent<S>
 where
-    S: Seek,
+    S: Seek + Sigmask,
 {
     #[inline]
     fn lseek(&self, fd: Fd, position: SeekFrom) -> Result<u64> {
@@ -175,7 +175,7 @@ where
 
 impl<S> Umask for Concurrent<S>
 where
-    S: Umask,
+    S: Sigmask + Umask,
 {
     #[inline]
     fn umask(&self, new_mask: Mode) -> Mode {
@@ -185,7 +185,7 @@ where
 
 impl<S> GetCwd for Concurrent<S>
 where
-    S: GetCwd,
+    S: GetCwd + Sigmask,
 {
     #[inline]
     fn getcwd(&self) -> Result<PathBuf> {
@@ -195,7 +195,7 @@ where
 
 impl<S> Chdir for Concurrent<S>
 where
-    S: Chdir,
+    S: Chdir + Sigmask,
 {
     #[inline]
     fn chdir(&self, path: &CStr) -> Result<()> {
@@ -205,7 +205,7 @@ where
 
 impl<S> Clock for Concurrent<S>
 where
-    S: Clock,
+    S: Clock + Sigmask,
 {
     #[inline]
     fn now(&self) -> Instant {
@@ -215,7 +215,7 @@ where
 
 impl<S> Times for Concurrent<S>
 where
-    S: Times,
+    S: Sigmask + Times,
 {
     #[inline]
     fn times(&self) -> Result<CpuTimes> {
@@ -225,7 +225,7 @@ where
 
 impl<S> GetPid for Concurrent<S>
 where
-    S: GetPid,
+    S: GetPid + Sigmask,
 {
     #[inline]
     fn getpid(&self) -> Pid {
@@ -247,7 +247,7 @@ where
 
 impl<S> SetPgid for Concurrent<S>
 where
-    S: SetPgid,
+    S: SetPgid + Sigmask,
 {
     #[inline]
     fn setpgid(&self, pid: Pid, pgid: Pid) -> Result<()> {
@@ -257,7 +257,7 @@ where
 
 impl<S> Signals for Concurrent<S>
 where
-    S: Signals,
+    S: Sigmask,
 {
     const SIGABRT: signal::Number = S::SIGABRT;
     const SIGALRM: signal::Number = S::SIGALRM;
@@ -368,7 +368,7 @@ where
 
 impl<S> GetSigaction for Concurrent<S>
 where
-    S: GetSigaction,
+    S: GetSigaction + Sigmask,
 {
     #[inline]
     fn get_sigaction(&self, signal: signal::Number) -> Result<signal::Disposition> {
@@ -397,7 +397,7 @@ where
 /// [`SignalSystem`]: crate::trap::SignalSystem
 impl<S> Sigaction for Concurrent<S>
 where
-    S: Sigaction,
+    S: Sigaction + Sigmask,
 {
     #[inline]
     fn sigaction(
@@ -425,7 +425,7 @@ where
 
 impl<S> SendSignal for Concurrent<S>
 where
-    S: SendSignal,
+    S: SendSignal + Sigmask,
 {
     #[inline]
     fn kill(
@@ -443,7 +443,7 @@ where
 
 impl<S> Isatty for Concurrent<S>
 where
-    S: Isatty,
+    S: Isatty + Sigmask,
 {
     #[inline]
     fn isatty(&self, fd: Fd) -> bool {
@@ -453,7 +453,7 @@ where
 
 impl<S> TcGetPgrp for Concurrent<S>
 where
-    S: TcGetPgrp,
+    S: Sigmask + TcGetPgrp,
 {
     #[inline]
     fn tcgetpgrp(&self, fd: Fd) -> Result<Pid> {
@@ -463,7 +463,7 @@ where
 
 impl<S> TcSetPgrp for Concurrent<S>
 where
-    S: TcSetPgrp,
+    S: Sigmask + TcSetPgrp,
 {
     #[inline]
     fn tcsetpgrp(&self, fd: Fd, pgid: Pid) -> impl Future<Output = Result<()>> + use<S> {
@@ -473,7 +473,7 @@ where
 
 impl<S> Concurrent<S>
 where
-    S: Fork,
+    S: Fork + Sigmask,
 {
     /// Creates a new child process.
     ///
@@ -494,7 +494,7 @@ where
 
 impl<S> Wait for Concurrent<S>
 where
-    S: Wait,
+    S: Sigmask + Wait,
 {
     #[inline]
     fn wait(&self, target: Pid) -> Result<Option<(Pid, ProcessState)>> {
@@ -504,7 +504,7 @@ where
 
 impl<S> Exec for Concurrent<S>
 where
-    S: Exec,
+    S: Exec + Sigmask,
 {
     #[inline]
     fn execve(
@@ -519,7 +519,7 @@ where
 
 impl<S> Exit for Concurrent<S>
 where
-    S: Exit,
+    S: Exit + Sigmask,
 {
     #[inline]
     fn exit(&self, exit_status: ExitStatus) -> impl Future<Output = Infallible> + use<S> {
@@ -529,7 +529,7 @@ where
 
 impl<S> GetUid for Concurrent<S>
 where
-    S: GetUid,
+    S: GetUid + Sigmask,
 {
     #[inline]
     fn getuid(&self) -> Uid {
@@ -551,7 +551,7 @@ where
 
 impl<S> GetPw for Concurrent<S>
 where
-    S: GetPw,
+    S: GetPw + Sigmask,
 {
     #[inline]
     fn getpwnam_dir(&self, name: &CStr) -> Result<Option<PathBuf>> {
@@ -561,7 +561,7 @@ where
 
 impl<S> Sysconf for Concurrent<S>
 where
-    S: Sysconf,
+    S: Sysconf + Sigmask,
 {
     #[inline]
     fn confstr_path(&self) -> Result<UnixString> {
@@ -571,7 +571,7 @@ where
 
 impl<S> ShellPath for Concurrent<S>
 where
-    S: ShellPath,
+    S: ShellPath + Sigmask,
 {
     #[inline]
     fn shell_path(&self) -> CString {
@@ -581,7 +581,7 @@ where
 
 impl<S> GetRlimit for Concurrent<S>
 where
-    S: GetRlimit,
+    S: GetRlimit + Sigmask,
 {
     #[inline]
     fn getrlimit(&self, resource: Resource) -> Result<LimitPair> {
@@ -591,7 +591,7 @@ where
 
 impl<S> SetRlimit for Concurrent<S>
 where
-    S: SetRlimit,
+    S: SetRlimit + Sigmask,
 {
     #[inline]
     fn setrlimit(&self, resource: Resource, limits: LimitPair) -> Result<()> {

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -354,6 +354,8 @@ impl<S> Sigmask for Concurrent<S>
 where
     S: Sigmask,
 {
+    type Sigset = S::Sigset;
+
     #[inline]
     fn sigmask(
         &self,

--- a/yash-env/src/system/concurrency/rw_all.rs
+++ b/yash-env/src/system/concurrency/rw_all.rs
@@ -18,7 +18,7 @@
 
 use super::{Concurrent, TemporaryNonBlockingGuard};
 use crate::io::Fd;
-use crate::system::{Errno, Fcntl, Read, Write};
+use crate::system::{Errno, Fcntl, Read, Sigmask, Write};
 use std::cell::LazyCell;
 use std::iter::repeat_n;
 use std::rc::Rc;
@@ -66,7 +66,7 @@ where
 
 impl<S> ReadAll for Concurrent<S>
 where
-    S: Fcntl + Read,
+    S: Fcntl + Read + Sigmask,
 {
     async fn read_all_to(&self, fd: Fd, buffer: &mut Vec<u8>) -> Result<(), Errno> {
         let this = TemporaryNonBlockingGuard::new(self, fd);
@@ -140,7 +140,7 @@ where
 
 impl<S> WriteAll for Concurrent<S>
 where
-    S: Fcntl + Write,
+    S: Fcntl + Sigmask + Write,
 {
     async fn write_all(&self, fd: Fd, mut data: &[u8]) -> Result<(), Errno> {
         if data.is_empty() {

--- a/yash-env/src/system/concurrency/signal.rs
+++ b/yash-env/src/system/concurrency/signal.rs
@@ -18,6 +18,7 @@
 
 use super::Concurrent;
 use crate::signal::Number;
+use crate::system::signal::Sigset as _;
 use crate::system::{Disposition, Errno, Sigaction, Sigmask, SigmaskOp};
 use crate::trap::SignalSystem;
 use std::rc::Rc;
@@ -89,17 +90,18 @@ where
         op: SigmaskOp,
         signal: Number,
     ) -> Result<(), Errno> {
-        let mut old_mask = Vec::new();
+        let mut mask_of_signal = S::Sigset::new();
+        mask_of_signal.add(signal)?;
+        let mut old_mask = S::Sigset::new();
         self.inner
-            .sigmask(Some((op, &[signal])), Some(&mut old_mask))
+            .sigmask(Some((op, &mask_of_signal)), Some(&mut old_mask))
             .await?;
 
         self.state
             .borrow_mut()
             .select_mask
             .get_or_insert(old_mask)
-            .retain(|&s| s != signal);
-        Ok(())
+            .remove(signal)
     }
 }
 
@@ -108,7 +110,7 @@ mod tests {
     use super::*;
     use crate::job::{ProcessResult, ProcessState};
     use crate::system::SendSignal as _;
-    use crate::system::r#virtual::{SIGQUIT, SIGTERM, SIGUSR1, VirtualSystem};
+    use crate::system::r#virtual::{SIGQUIT, SIGTERM, SIGUSR1, Sigset, VirtualSystem};
     use futures_util::FutureExt as _;
     use std::num::NonZero;
 
@@ -194,7 +196,7 @@ mod tests {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
-            .block_signals(SigmaskOp::Set, &[SIGQUIT, SIGTERM, SIGUSR1]);
+            .block_signals(SigmaskOp::Set, [SIGQUIT, SIGTERM, SIGUSR1]);
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         let result = system
@@ -216,7 +218,7 @@ mod tests {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
-            .block_signals(SigmaskOp::Set, &[SIGQUIT, SIGTERM, SIGUSR1]);
+            .block_signals(SigmaskOp::Set, [SIGQUIT, SIGTERM, SIGUSR1]);
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         system
@@ -225,8 +227,8 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(
-            system.state.borrow().select_mask.as_deref(),
-            Some([SIGQUIT, SIGUSR1].as_slice())
+            system.state.borrow().select_mask,
+            Some(Sigset::from_iter([SIGQUIT, SIGUSR1]))
         );
     }
 
@@ -240,7 +242,7 @@ mod tests {
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(Errno::EINVAL));
-        assert_eq!(system.state.borrow().select_mask.as_deref(), None);
+        assert_eq!(system.state.borrow().select_mask, None);
     }
 
     #[test]
@@ -248,7 +250,7 @@ mod tests {
         let inner = VirtualSystem::new();
         _ = inner
             .current_process_mut()
-            .block_signals(SigmaskOp::Set, &[SIGQUIT, SIGTERM, SIGUSR1]);
+            .block_signals(SigmaskOp::Set, [SIGQUIT, SIGTERM, SIGUSR1]);
         let system = Rc::new(Concurrent::new(inner.clone()));
 
         system
@@ -262,8 +264,8 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(
-            system.state.borrow().select_mask.as_deref(),
-            Some([SIGUSR1].as_slice())
+            system.state.borrow().select_mask,
+            Some(Sigset::from(SIGUSR1))
         );
     }
 }

--- a/yash-env/src/system/process.rs
+++ b/yash-env/src/system/process.rs
@@ -16,7 +16,7 @@
 
 //! Items related to process management
 
-use super::{Concurrent, ExitStatus, Result, Signals};
+use super::{Concurrent, ExitStatus, Result, Sigmask, Signals};
 use crate::Env;
 #[cfg(all(doc, unix))]
 use crate::RealSystem;
@@ -197,7 +197,7 @@ pub trait Fork {
     )]
     fn new_child_process(&self) -> Result<ChildProcessStarter<Self>>
     where
-        Self: Sized;
+        Self: Sigmask + Sized;
 }
 
 /// Trait for waiting for child processes

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -780,60 +780,32 @@ impl Signals for RealSystem {
 }
 
 impl Sigmask for RealSystem {
-    type Sigset = signal::Sigset;
+    type Sigset = Sigset;
 
     fn sigmask(
         &self,
-        op: Option<(SigmaskOp, &[signal::Number])>,
-        old_mask: Option<&mut Vec<signal::Number>>,
+        op: Option<(SigmaskOp, &Sigset)>,
+        old_mask: Option<&mut Sigset>,
     ) -> impl Future<Output = Result<()>> + use<> {
-        ready((|| unsafe {
+        ready(unsafe {
             let (how, raw_mask) = match op {
-                None => (libc::SIG_BLOCK, None),
+                None => (libc::SIG_BLOCK, std::ptr::null()),
                 Some((op, mask)) => {
                     let how = match op {
                         SigmaskOp::Add => libc::SIG_BLOCK,
                         SigmaskOp::Remove => libc::SIG_UNBLOCK,
                         SigmaskOp::Set => libc::SIG_SETMASK,
                     };
-
-                    let mut raw_mask = MaybeUninit::<libc::sigset_t>::uninit();
-                    libc::sigemptyset(raw_mask.as_mut_ptr()).errno_if_m1()?;
-                    for &signal in mask {
-                        libc::sigaddset(raw_mask.as_mut_ptr(), signal.as_raw()).errno_if_m1()?;
-                    }
-
-                    (how, Some(raw_mask))
+                    (how, mask.0.as_ptr())
                 }
             };
-            let mut old_mask_pair = match old_mask {
-                None => None,
-                Some(old_mask) => {
-                    let mut raw_old_mask = MaybeUninit::<libc::sigset_t>::uninit();
-                    // POSIX requires *all* sigset_t objects to be initialized before use.
-                    libc::sigemptyset(raw_old_mask.as_mut_ptr()).errno_if_m1()?;
-                    Some((old_mask, raw_old_mask))
-                }
-            };
+            let raw_old_mask =
+                old_mask.map_or(std::ptr::null_mut(), |old_mask| old_mask.0.as_mut_ptr());
 
-            let raw_set_ptr = raw_mask
-                .as_ref()
-                .map_or(std::ptr::null(), |raw_set| raw_set.as_ptr());
-            let raw_old_set_ptr = old_mask_pair
-                .as_mut()
-                .map_or(std::ptr::null_mut(), |(_, raw_old_mask)| {
-                    raw_old_mask.as_mut_ptr()
-                });
-            let result = libc::sigprocmask(how, raw_set_ptr, raw_old_set_ptr);
-            result.errno_if_m1().map(drop)?;
-
-            if let Some((old_mask, raw_old_mask)) = old_mask_pair {
-                old_mask.clear();
-                signal::sigset_to_vec(raw_old_mask.as_ptr(), old_mask);
-            }
-
-            Ok(())
-        })())
+            libc::sigprocmask(how, raw_mask, raw_old_mask)
+                .errno_if_m1()
+                .map(drop)
+        })
     }
 }
 
@@ -892,7 +864,7 @@ impl Select for RealSystem {
         readers: &'a mut Vec<Fd>,
         writers: &'a mut Vec<Fd>,
         timeout: Option<Duration>,
-        signal_mask: Option<&[signal::Number]>,
+        signal_mask: Option<&Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a> {
         ready((|| {
             use std::ptr::{null, null_mut};
@@ -919,25 +891,10 @@ impl Select for RealSystem {
             let writers_ptr = raw_writers.as_mut_ptr();
             let errors = null_mut();
 
-            let timeout_spec = to_timespec(timeout.unwrap_or_default());
-            let timeout_ptr = if timeout.is_some() {
-                timeout_spec.as_ptr()
-            } else {
-                null()
-            };
+            let timeout_spec = timeout.map(to_timespec);
+            let timeout_ptr = timeout_spec.as_ref().map_or(null(), |spec| spec.as_ptr());
 
-            let mut raw_mask = MaybeUninit::<libc::sigset_t>::uninit();
-            let raw_mask_ptr = match signal_mask {
-                None => null(),
-                Some(signal_mask) => {
-                    unsafe { libc::sigemptyset(raw_mask.as_mut_ptr()) }.errno_if_m1()?;
-                    for &signal in signal_mask {
-                        unsafe { libc::sigaddset(raw_mask.as_mut_ptr(), signal.as_raw()) }
-                            .errno_if_m1()?;
-                    }
-                    raw_mask.as_ptr()
-                }
-            };
+            let raw_mask_ptr = signal_mask.map_or(null(), |mask| mask.0.as_ptr());
 
             let count = unsafe {
                 libc::pselect(

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -96,6 +96,7 @@ use crate::str::UnixString;
 use enumset::EnumSet;
 pub use file_system::Stat;
 use libc::DIR;
+pub use signal::Sigset;
 use std::convert::Infallible;
 use std::convert::TryInto as _;
 use std::ffi::CStr;
@@ -779,6 +780,8 @@ impl Signals for RealSystem {
 }
 
 impl Sigmask for RealSystem {
+    type Sigset = signal::Sigset;
+
     fn sigmask(
         &self,
         op: Option<(SigmaskOp, &[signal::Number])>,

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -16,7 +16,9 @@
 
 //! Signal implementation for the real system
 
+use super::super::Result;
 use super::Disposition;
+use super::ErrnoIfM1 as _;
 pub use crate::signal::*;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
@@ -257,6 +259,73 @@ impl Name {
                 None
             }
         }
+    }
+}
+
+/// Signal set for the real system, wrapping the `sigset_t` type from libc
+///
+/// This is an implementation of the [`Sigset` trait](super::super::Sigset) for the
+/// [`RealSystem`](super::RealSystem).
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+pub struct Sigset(MaybeUninit<libc::sigset_t>);
+// TODO: The auto-derived Debug implementation does not provide useful information.
+// Consider implementing a custom Debug that shows the contents.
+
+impl Sigset {
+    /// Converts a raw `sigset_t` structure to a `Sigset` object.
+    ///
+    /// This function assumes the `sigset_t` structure to be initialized by the
+    /// `sigemptyset` or `sigfillset` calls, but it is passed as `MaybeUninit`
+    /// because of possible padding or extension fields in the structure which
+    /// may not be initialized by those calls.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the provided `sigset_t` structure is properly
+    /// initialized by a call like `sigemptyset` or `sigfillset`.
+    pub(super) const unsafe fn from_raw(sigset: MaybeUninit<libc::sigset_t>) -> Self {
+        Self(sigset)
+    }
+}
+
+impl Default for Sigset {
+    /// Creates an empty signal set.
+    fn default() -> Self {
+        let mut sigset = MaybeUninit::<libc::sigset_t>::uninit();
+        unsafe {
+            libc::sigemptyset(sigset.as_mut_ptr())
+                .errno_if_m1()
+                .expect("sigemptyset should always succeed");
+            Self::from_raw(sigset)
+        }
+    }
+}
+
+impl super::super::Sigset for Sigset {
+    fn full() -> Self {
+        let mut sigset = MaybeUninit::<libc::sigset_t>::uninit();
+        unsafe {
+            libc::sigfillset(sigset.as_mut_ptr())
+                .errno_if_m1()
+                .expect("sigfillset should always succeed");
+            Self::from_raw(sigset)
+        }
+    }
+
+    fn add(&mut self, signal: Number) -> Result<()> {
+        let result = unsafe { libc::sigaddset(self.0.as_mut_ptr(), signal.as_raw()) };
+        result.errno_if_m1().map(drop)
+    }
+
+    fn remove(&mut self, signal: Number) -> Result<()> {
+        let result = unsafe { libc::sigdelset(self.0.as_mut_ptr(), signal.as_raw()) };
+        result.errno_if_m1().map(drop)
+    }
+
+    fn contains(&self, signal: Number) -> Result<bool> {
+        let result = unsafe { libc::sigismember(self.0.as_ptr(), signal.as_raw()) };
+        result.errno_if_m1().map(|r| r > 0)
     }
 }
 

--- a/yash-env/src/system/real/signal.rs
+++ b/yash-env/src/system/real/signal.rs
@@ -22,7 +22,6 @@ use super::ErrnoIfM1 as _;
 pub use crate::signal::*;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
-use std::num::NonZero;
 use std::ops::RangeInclusive;
 
 /// Returns the range of real-time signals supported by the real system.
@@ -47,228 +46,13 @@ pub fn rt_range() -> RangeInclusive<RawNumber> {
     return 0..=-1;
 }
 
-impl Name {
-    /// Returns the raw signal number for the real system.
-    pub(super) fn to_raw_real(self) -> Option<Number> {
-        #[inline]
-        fn wrap(number: RawNumber) -> Option<Number> {
-            NonZero::new(number).map(Number::from_raw_unchecked)
-        }
-
-        match self {
-            Self::Abrt => wrap(libc::SIGABRT),
-            Self::Alrm => wrap(libc::SIGALRM),
-            Self::Bus => wrap(libc::SIGBUS),
-            Self::Chld => wrap(libc::SIGCHLD),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "solaris",
-            ))]
-            Self::Cld => wrap(libc::SIGCLD),
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "solaris",
-            )))]
-            Self::Cld => None,
-            Self::Cont => wrap(libc::SIGCONT),
-            #[cfg(not(any(
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "linux",
-                target_os = "redox",
-            )))]
-            Self::Emt => wrap(libc::SIGEMT),
-            #[cfg(any(
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "linux",
-                target_os = "redox",
-            ))]
-            Self::Emt => None,
-            Self::Fpe => wrap(libc::SIGFPE),
-            Self::Hup => wrap(libc::SIGHUP),
-            Self::Ill => wrap(libc::SIGILL),
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "linux",
-                target_os = "redox",
-            )))]
-            Self::Info => wrap(libc::SIGINFO),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "linux",
-                target_os = "redox",
-            ))]
-            Self::Info => None,
-            Self::Int => wrap(libc::SIGINT),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "solaris",
-            ))]
-            Self::Io => wrap(libc::SIGIO),
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "solaris",
-            )))]
-            Self::Io => None,
-            Self::Iot => wrap(libc::SIGIOT),
-            Self::Kill => wrap(libc::SIGKILL),
-            #[cfg(target_os = "horizon")]
-            Self::Lost => wrap(libc::SIGLOST),
-            #[cfg(not(target_os = "horizon"))]
-            Self::Lost => None,
-            Self::Pipe => wrap(libc::SIGPIPE),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "solaris",
-            ))]
-            Self::Poll => wrap(libc::SIGPOLL),
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "haiku",
-                target_os = "horizon",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "solaris",
-            )))]
-            Self::Poll => None,
-            Self::Prof => wrap(libc::SIGPROF),
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "redox",
-                target_os = "solaris",
-            ))]
-            Self::Pwr => wrap(libc::SIGPWR),
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "illumos",
-                target_os = "linux",
-                target_os = "nto",
-                target_os = "redox",
-                target_os = "solaris",
-            )))]
-            Self::Pwr => None,
-            Self::Quit => wrap(libc::SIGQUIT),
-            Self::Segv => wrap(libc::SIGSEGV),
-            #[cfg(all(
-                any(
-                    target_os = "android",
-                    target_os = "emscripten",
-                    target_os = "fuchsia",
-                    target_os = "linux"
-                ),
-                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
-            ))]
-            Self::Stkflt => wrap(libc::SIGSTKFLT),
-            #[cfg(not(all(
-                any(
-                    target_os = "android",
-                    target_os = "emscripten",
-                    target_os = "fuchsia",
-                    target_os = "linux"
-                ),
-                not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
-            )))]
-            Self::Stkflt => None,
-            Self::Stop => wrap(libc::SIGSTOP),
-            Self::Sys => wrap(libc::SIGSYS),
-            Self::Term => wrap(libc::SIGTERM),
-            #[cfg(target_os = "freebsd")]
-            Self::Thr => wrap(libc::SIGTHR),
-            #[cfg(not(target_os = "freebsd"))]
-            Self::Thr => None,
-            Self::Trap => wrap(libc::SIGTRAP),
-            Self::Tstp => wrap(libc::SIGTSTP),
-            Self::Ttin => wrap(libc::SIGTTIN),
-            Self::Ttou => wrap(libc::SIGTTOU),
-            Self::Urg => wrap(libc::SIGURG),
-            Self::Usr1 => wrap(libc::SIGUSR1),
-            Self::Usr2 => wrap(libc::SIGUSR2),
-            Self::Vtalrm => wrap(libc::SIGVTALRM),
-            Self::Winch => wrap(libc::SIGWINCH),
-            Self::Xcpu => wrap(libc::SIGXCPU),
-            Self::Xfsz => wrap(libc::SIGXFSZ),
-
-            Self::Rtmin(n) => {
-                let range = rt_range();
-                if let Some(number) = range.start().checked_add(n) {
-                    if range.contains(&number) {
-                        return wrap(number);
-                    }
-                }
-                None
-            }
-            Self::Rtmax(n) => {
-                let range = rt_range();
-                if let Some(number) = range.end().checked_add(n) {
-                    if range.contains(&number) {
-                        return wrap(number);
-                    }
-                }
-                None
-            }
-        }
-    }
-}
-
 /// Signal set for the real system, wrapping the `sigset_t` type from libc
 ///
 /// This is an implementation of the [`Sigset` trait](super::super::Sigset) for the
 /// [`RealSystem`](super::RealSystem).
 #[derive(Clone, Debug)]
 #[repr(transparent)]
-pub struct Sigset(MaybeUninit<libc::sigset_t>);
+pub struct Sigset(pub(super) MaybeUninit<libc::sigset_t>);
 // TODO: The auto-derived Debug implementation does not provide useful information.
 // Consider implementing a custom Debug that shows the contents.
 
@@ -327,28 +111,6 @@ impl super::super::Sigset for Sigset {
         let result = unsafe { libc::sigismember(self.0.as_ptr(), signal.as_raw()) };
         result.errno_if_m1().map(|r| r > 0)
     }
-}
-
-/// Returns an iterator over all signal numbers.
-fn all_signals() -> impl Iterator<Item = Number> {
-    let non_real_time = Name::iter()
-        .filter(|name| !matches!(name, Name::Rtmin(_) | Name::Rtmax(_)))
-        .filter_map(Name::to_raw_real);
-
-    let real_time = rt_range()
-        .filter_map(NonZero::new)
-        .map(Number::from_raw_unchecked);
-
-    non_real_time.chain(real_time)
-}
-
-/// Converts the signal set to a vector of signal numbers.
-///
-/// This function adds the signal numbers in the set to the vector.
-pub(super) fn sigset_to_vec(set: *const libc::sigset_t, vec: &mut Vec<Number>) {
-    vec.extend(
-        all_signals().filter(|number| unsafe { libc::sigismember(set, number.as_raw()) == 1 }),
-    );
 }
 
 impl Disposition {

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -19,9 +19,8 @@
 #[cfg(doc)]
 use super::Concurrent;
 use super::Result;
-use super::signal;
+use super::Sigmask;
 use crate::io::Fd;
-use crate::system::Signals;
 use std::ffi::c_int;
 use std::future::Future;
 use std::rc::Rc;
@@ -37,7 +36,7 @@ use std::time::Duration;
 /// represents the behavior of the `select` system call. It is used by the
 /// `Select` trait in the `concurrency` submodule to implement its
 /// functionality.
-pub trait Select: Signals {
+pub trait Select: Sigmask {
     /// Waits for a next event.
     ///
     /// In a typical configuration, this trait is not used directly. Instead,
@@ -78,7 +77,7 @@ pub trait Select: Signals {
         readers: &'a mut Vec<Fd>,
         writers: &'a mut Vec<Fd>,
         timeout: Option<Duration>,
-        signal_mask: Option<&[signal::Number]>,
+        signal_mask: Option<&Self::Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a, Self>;
 }
 
@@ -90,7 +89,7 @@ impl<S: Select> Select for Rc<S> {
         readers: &'a mut Vec<Fd>,
         writers: &'a mut Vec<Fd>,
         timeout: Option<Duration>,
-        signal_mask: Option<&[signal::Number]>,
+        signal_mask: Option<&S::Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a, S> {
         (self as &S).select(readers, writers, timeout, signal_mask)
     }

--- a/yash-env/src/system/signal.rs
+++ b/yash-env/src/system/signal.rs
@@ -21,6 +21,7 @@ use super::Concurrent;
 use super::{Pid, Result};
 pub use crate::signal::{Name, Number, RawNumber};
 use std::borrow::Cow;
+use std::fmt::Debug;
 use std::num::NonZero;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
@@ -456,8 +457,59 @@ pub enum SigmaskOp {
     Set,
 }
 
+/// Interface for signal sets
+///
+/// This trait is implemented by types that represent sets of signals,
+/// abstracting the functionality of the `sigset_t` type in POSIX.
+///
+/// Implementors of this trait must also implement the `Default` trait, where
+/// the default value must be an empty signal set.
+pub trait Sigset: Clone + Default + 'static {
+    /// Creates a new, empty signal set.
+    ///
+    /// The provided implementation simply calls [`Default::default`].
+    #[inline(always)]
+    #[must_use]
+    fn new() -> Self {
+        Default::default()
+    }
+
+    /// Creates a new signal set containing all signals.
+    #[must_use]
+    fn full() -> Self;
+
+    /// Adds a signal to the set.
+    fn add(&mut self, signal: Number) -> Result<()>;
+
+    /// Removes a signal from the set.
+    fn remove(&mut self, signal: Number) -> Result<()>;
+
+    /// Checks if a signal is in the set.
+    fn contains(&self, signal: Number) -> Result<bool>;
+
+    /// Creates a signal set from an iterator of signal numbers.
+    ///
+    /// This method is a convenient way to create a signal set from a list of
+    /// signal numbers. It iterates over the provided signal numbers and
+    /// [adds](Self::add) them to a new signal set. If any call to `add`
+    /// fails, this method returns the error immediately. Otherwise, it returns
+    /// the resulting signal set.
+    fn from_signals<I>(iter: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = Number>,
+    {
+        let mut set = Self::new();
+        for signal in iter {
+            set.add(signal)?;
+        }
+        Ok(set)
+    }
+}
+
 /// Trait for managing signal blocking mask
 pub trait Sigmask: Signals {
+    type Sigset: Sigset + Debug;
+
     /// Gets and/or sets the signal blocking mask.
     ///
     /// This trait is usually not used directly. Instead, it is used by
@@ -486,6 +538,8 @@ pub trait Sigmask: Signals {
 
 /// Delegates the `Sigmask` trait to the contained instance of `S`
 impl<S: Sigmask> Sigmask for Rc<S> {
+    type Sigset = S::Sigset;
+
     #[inline]
     fn sigmask(
         &self,

--- a/yash-env/src/system/signal.rs
+++ b/yash-env/src/system/signal.rs
@@ -531,8 +531,8 @@ pub trait Sigmask: Signals {
     /// call. See the [module-level documentation](super) for details.
     fn sigmask(
         &self,
-        op: Option<(SigmaskOp, &[Number])>,
-        old_mask: Option<&mut Vec<Number>>,
+        op: Option<(SigmaskOp, &Self::Sigset)>,
+        old_mask: Option<&mut Self::Sigset>,
     ) -> impl Future<Output = Result<()>> + use<Self>;
 }
 
@@ -543,8 +543,8 @@ impl<S: Sigmask> Sigmask for Rc<S> {
     #[inline]
     fn sigmask(
         &self,
-        op: Option<(SigmaskOp, &[Number])>,
-        old_mask: Option<&mut Vec<Number>>,
+        op: Option<(SigmaskOp, &Self::Sigset)>,
+        old_mask: Option<&mut Self::Sigset>,
     ) -> impl Future<Output = Result<()>> + use<S> {
         (self as &S).sigmask(op, old_mask)
     }

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1027,6 +1027,8 @@ impl SetPgid for VirtualSystem {
 }
 
 impl Sigmask for VirtualSystem {
+    type Sigset = signal::Sigset;
+
     fn sigmask(
         &self,
         op: Option<(SigmaskOp, &[signal::Number])>,

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1027,12 +1027,12 @@ impl SetPgid for VirtualSystem {
 }
 
 impl Sigmask for VirtualSystem {
-    type Sigset = signal::Sigset;
+    type Sigset = Sigset;
 
     fn sigmask(
         &self,
-        op: Option<(SigmaskOp, &[signal::Number])>,
-        old_mask: Option<&mut Vec<signal::Number>>,
+        op: Option<(SigmaskOp, &Sigset)>,
+        old_mask: Option<&mut Sigset>,
     ) -> impl Future<Output = Result<()>> + use<> {
         let state_changed = {
             let mut state = self.state.borrow_mut();
@@ -1042,12 +1042,12 @@ impl Sigmask for VirtualSystem {
                 .expect("the current process should be in the system state");
 
             if let Some(old_mask) = old_mask {
-                old_mask.clear();
-                old_mask.extend(process.blocked_signals());
+                old_mask.0.clear();
+                old_mask.0.extend(process.blocked_signals());
             }
 
             if let Some((op, mask)) = op {
-                let result = process.block_signals(op, mask);
+                let result = process.block_signals(op, mask.0.iter().copied());
                 if result.process_state_changed {
                     let parent_pid = process.ppid;
                     raise_sigchld(&mut state, parent_pid);
@@ -2630,7 +2630,7 @@ mod tests {
         let system = VirtualSystem::new();
         // Block SIGTSTP first
         system
-            .sigmask(Some((SigmaskOp::Add, &[SIGTSTP])), None)
+            .sigmask(Some((SigmaskOp::Add, &Sigset::from(SIGTSTP))), None)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -2638,7 +2638,7 @@ mod tests {
         let _ = system.current_process_mut().raise_signal(SIGTSTP);
         // Unblocking SIGTSTP should deliver it, stopping the process
         let result = system
-            .sigmask(Some((SigmaskOp::Remove, &[SIGTSTP])), None)
+            .sigmask(Some((SigmaskOp::Remove, &Sigset::from(SIGTSTP))), None)
             .now_or_never();
         // The future should be pending because the process is stopped
         assert_eq!(result, None);
@@ -2658,7 +2658,7 @@ mod tests {
                 // Block SIGTSTP (signal will become pending when raised)
                 child_env
                     .system
-                    .sigmask(Some((SigmaskOp::Add, &[SIGTSTP])), None)
+                    .sigmask(Some((SigmaskOp::Add, &Sigset::from(SIGTSTP))), None)
                     .await
                     .unwrap();
                 // Raise SIGTSTP; since it is blocked, it becomes pending
@@ -2667,7 +2667,7 @@ mod tests {
                 // future suspends until the process is resumed
                 child_env
                     .system
-                    .sigmask(Some((SigmaskOp::Remove, &[SIGTSTP])), None)
+                    .sigmask(Some((SigmaskOp::Remove, &Sigset::from(SIGTSTP))), None)
                     .await
                     .unwrap();
                 // After being resumed, exit cleanly

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -1042,12 +1042,11 @@ impl Sigmask for VirtualSystem {
                 .expect("the current process should be in the system state");
 
             if let Some(old_mask) = old_mask {
-                old_mask.0.clear();
-                old_mask.0.extend(process.blocked_signals());
+                old_mask.clone_from(process.blocked_signals());
             }
 
             if let Some((op, mask)) = op {
-                let result = process.block_signals(op, mask.0.iter().copied());
+                let result = process.block_signals(op, mask.iter().copied());
                 if result.process_state_changed {
                     let parent_pid = process.ppid;
                     raise_sigchld(&mut state, parent_pid);

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -20,6 +20,7 @@ use super::Disposition;
 use super::Gid;
 use super::Mode;
 use super::SigmaskOp;
+use super::Sigset;
 use super::Uid;
 use super::WakerSet;
 use super::io::FdBody;
@@ -30,12 +31,12 @@ use crate::job::ProcessResult;
 use crate::job::ProcessState;
 use crate::path::Path;
 use crate::path::PathBuf;
+use crate::system::Sigset as _;
 use crate::system::resource::INFINITY;
 use crate::system::resource::LimitPair;
 use crate::system::resource::Resource;
 use std::cell::Cell;
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::fmt::Debug;
@@ -94,10 +95,10 @@ pub struct Process {
     dispositions: HashMap<signal::Number, Disposition>,
 
     /// Set of blocked signals
-    blocked_signals: BTreeSet<signal::Number>,
+    blocked_signals: Sigset,
 
     /// Set of pending signals
-    pending_signals: BTreeSet<signal::Number>,
+    pending_signals: Sigset,
 
     /// List of signals that have been delivered and caught
     pub(crate) caught_signals: Vec<signal::Number>,
@@ -160,8 +161,8 @@ impl Process {
             state_has_changed: false,
             resumption_awaiters: WakerSet::new(),
             dispositions: HashMap::new(),
-            blocked_signals: BTreeSet::new(),
-            pending_signals: BTreeSet::new(),
+            blocked_signals: Sigset::default(),
+            pending_signals: Sigset::default(),
             caught_signals: Vec::new(),
             caught_signals_count: 0,
             signal_wakers: WakerSet::new(),
@@ -407,7 +408,7 @@ impl Process {
     }
 
     /// Returns the currently blocked signals.
-    pub fn blocked_signals(&self) -> &BTreeSet<signal::Number> {
+    pub fn blocked_signals(&self) -> &Sigset {
         &self.blocked_signals
     }
 
@@ -415,7 +416,7 @@ impl Process {
     ///
     /// A signal is pending when it has been raised but not yet delivered
     /// because it is being blocked.
-    pub fn pending_signals(&self) -> &BTreeSet<signal::Number> {
+    pub fn pending_signals(&self) -> &Sigset {
         &self.pending_signals
     }
 
@@ -437,7 +438,7 @@ impl Process {
             SigmaskOp::Add => self.blocked_signals.extend(signals),
             SigmaskOp::Remove => {
                 for signal in signals {
-                    self.blocked_signals.remove(&signal);
+                    self.blocked_signals.remove(signal).ok();
                 }
             }
         }
@@ -446,11 +447,12 @@ impl Process {
     }
 
     fn deliver_pending_signals(&mut self) -> SignalResult {
-        let signals_to_deliver = self.pending_signals.difference(&self.blocked_signals);
-        let signals_to_deliver = signals_to_deliver.copied().collect::<Vec<signal::Number>>();
+        let signals_to_deliver = self
+            .pending_signals
+            .difference_to_vec(&self.blocked_signals);
         let mut result = SignalResult::default();
         for signal in signals_to_deliver {
-            self.pending_signals.remove(&signal);
+            self.pending_signals.remove(signal).ok();
             result |= self.deliver_signal(signal);
         }
         result
@@ -552,9 +554,9 @@ impl Process {
 
         let mut result = if signal != signal::SIGKILL
             && signal != signal::SIGSTOP
-            && self.blocked_signals().contains(&signal)
+            && self.blocked_signals().contains(signal) == Ok(true)
         {
-            self.pending_signals.insert(signal);
+            self.pending_signals.add(signal).ok();
             SignalResult::default()
         } else {
             self.deliver_signal(signal)
@@ -752,16 +754,16 @@ mod tests {
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(&signal::SIGINT));
-        assert!(result_set.contains(&signal::SIGCHLD));
+        assert_eq!(result_set.contains(signal::SIGINT), Ok(true));
+        assert_eq!(result_set.contains(signal::SIGCHLD), Ok(true));
         assert_eq!(result_set.len(), 2);
 
         let result = process.block_signals(SigmaskOp::Set, [signal::SIGINT, signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(&signal::SIGINT));
-        assert!(result_set.contains(&signal::SIGQUIT));
+        assert_eq!(result_set.contains(signal::SIGINT), Ok(true));
+        assert_eq!(result_set.contains(signal::SIGQUIT), Ok(true));
         assert_eq!(result_set.len(), 2);
     }
 
@@ -772,17 +774,17 @@ mod tests {
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(&signal::SIGINT));
-        assert!(result_set.contains(&signal::SIGCHLD));
+        assert_eq!(result_set.contains(signal::SIGINT), Ok(true));
+        assert_eq!(result_set.contains(signal::SIGCHLD), Ok(true));
         assert_eq!(result_set.len(), 2);
 
         let result = process.block_signals(SigmaskOp::Add, [signal::SIGINT, signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(&signal::SIGINT));
-        assert!(result_set.contains(&signal::SIGQUIT));
-        assert!(result_set.contains(&signal::SIGCHLD));
+        assert_eq!(result_set.contains(signal::SIGINT), Ok(true));
+        assert_eq!(result_set.contains(signal::SIGQUIT), Ok(true));
+        assert_eq!(result_set.contains(signal::SIGCHLD), Ok(true));
         assert_eq!(result_set.len(), 3);
     }
 
@@ -796,7 +798,7 @@ mod tests {
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
-        assert!(result_set.contains(&signal::SIGCHLD));
+        assert_eq!(result_set.contains(signal::SIGCHLD), Ok(true));
         assert_eq!(result_set.len(), 1);
     }
 
@@ -948,7 +950,7 @@ mod tests {
         );
         assert_eq!(process.state(), ProcessState::Running);
         assert_eq!(process.caught_signals, []);
-        assert!(process.pending_signals.contains(&signal::SIGCONT));
+        assert_eq!(process.pending_signals.contains(signal::SIGCONT), Ok(true));
     }
 
     #[test]

--- a/yash-env/src/system/virtual/process.rs
+++ b/yash-env/src/system/virtual/process.rs
@@ -428,17 +428,24 @@ impl Process {
     /// that case, the caller must send a SIGCHLD to the parent process of this
     /// process.
     #[must_use = "send SIGCHLD if process state has changed"]
-    pub fn block_signals(&mut self, how: SigmaskOp, signals: &[signal::Number]) -> SignalResult {
+    pub fn block_signals<I>(&mut self, how: SigmaskOp, signals: I) -> SignalResult
+    where
+        I: IntoIterator<Item = signal::Number>,
+    {
         match how {
-            SigmaskOp::Set => self.blocked_signals = signals.iter().copied().collect(),
+            SigmaskOp::Set => self.blocked_signals = signals.into_iter().collect(),
             SigmaskOp::Add => self.blocked_signals.extend(signals),
             SigmaskOp::Remove => {
                 for signal in signals {
-                    self.blocked_signals.remove(signal);
+                    self.blocked_signals.remove(&signal);
                 }
             }
         }
 
+        self.deliver_pending_signals()
+    }
+
+    fn deliver_pending_signals(&mut self) -> SignalResult {
         let signals_to_deliver = self.pending_signals.difference(&self.blocked_signals);
         let signals_to_deliver = signals_to_deliver.copied().collect::<Vec<signal::Number>>();
         let mut result = SignalResult::default();
@@ -741,7 +748,7 @@ mod tests {
     #[test]
     fn process_sigmask_setmask() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let result = process.block_signals(SigmaskOp::Set, &[signal::SIGINT, signal::SIGCHLD]);
+        let result = process.block_signals(SigmaskOp::Set, [signal::SIGINT, signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
@@ -749,7 +756,7 @@ mod tests {
         assert!(result_set.contains(&signal::SIGCHLD));
         assert_eq!(result_set.len(), 2);
 
-        let result = process.block_signals(SigmaskOp::Set, &[signal::SIGINT, signal::SIGQUIT]);
+        let result = process.block_signals(SigmaskOp::Set, [signal::SIGINT, signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
@@ -761,7 +768,7 @@ mod tests {
     #[test]
     fn process_sigmask_block() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let result = process.block_signals(SigmaskOp::Add, &[signal::SIGINT, signal::SIGCHLD]);
+        let result = process.block_signals(SigmaskOp::Add, [signal::SIGINT, signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
@@ -769,7 +776,7 @@ mod tests {
         assert!(result_set.contains(&signal::SIGCHLD));
         assert_eq!(result_set.len(), 2);
 
-        let result = process.block_signals(SigmaskOp::Add, &[signal::SIGINT, signal::SIGQUIT]);
+        let result = process.block_signals(SigmaskOp::Add, [signal::SIGINT, signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
@@ -782,10 +789,10 @@ mod tests {
     #[test]
     fn process_sigmask_unblock() {
         let mut process = Process::with_parent_and_group(Pid(10), Pid(11));
-        let result = process.block_signals(SigmaskOp::Add, &[signal::SIGINT, signal::SIGCHLD]);
+        let result = process.block_signals(SigmaskOp::Add, [signal::SIGINT, signal::SIGCHLD]);
         assert_eq!(result, SignalResult::default());
 
-        let result = process.block_signals(SigmaskOp::Remove, &[signal::SIGINT, signal::SIGQUIT]);
+        let result = process.block_signals(SigmaskOp::Remove, [signal::SIGINT, signal::SIGQUIT]);
         assert_eq!(result, SignalResult::default());
 
         let result_set = process.blocked_signals();
@@ -929,7 +936,7 @@ mod tests {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
         let _ = process.set_state(ProcessState::stopped(signal::SIGTTOU));
         let _ = process.set_disposition(signal::SIGCONT, Disposition::Ignore);
-        let _ = process.block_signals(SigmaskOp::Add, &[signal::SIGCONT]);
+        let _ = process.block_signals(SigmaskOp::Add, [signal::SIGCONT]);
         let result = process.raise_signal(signal::SIGCONT);
         assert_eq!(
             result,
@@ -970,7 +977,7 @@ mod tests {
     fn process_raise_signal_blocked() {
         let mut process = Process::with_parent_and_group(Pid(42), Pid(11));
         process.set_disposition(signal::SIGCHLD, Disposition::Catch);
-        let result = process.block_signals(SigmaskOp::Add, &[signal::SIGCHLD]);
+        let result = process.block_signals(SigmaskOp::Add, [signal::SIGCHLD]);
         assert_eq!(
             result,
             SignalResult {
@@ -992,7 +999,7 @@ mod tests {
         assert_eq!(process.state(), ProcessState::Running);
         assert_eq!(process.caught_signals, []);
 
-        let result = process.block_signals(SigmaskOp::Set, &[]);
+        let result = process.block_signals(SigmaskOp::Set, []);
         assert_eq!(
             result,
             SignalResult {

--- a/yash-env/src/system/virtual/select.rs
+++ b/yash-env/src/system/virtual/select.rs
@@ -17,8 +17,8 @@
 //! Implementation of [`Select`] for [`VirtualSystem`]
 
 use super::{
-    Duration, Errno, Fd, Result, Select, SigmaskOp, TryInto as _, VirtualSystem, raise_sigchld,
-    signal,
+    Duration, Errno, Fd, Result, Select, SigmaskOp, Sigset, TryInto as _, VirtualSystem,
+    raise_sigchld, signal,
 };
 use crate::job::ProcessState;
 use std::cell::{Cell, LazyCell};
@@ -43,10 +43,11 @@ impl Select for VirtualSystem {
         readers: &'a mut Vec<Fd>,
         writers: &'a mut Vec<Fd>,
         timeout: Option<Duration>,
-        signal_mask: Option<&[signal::Number]>,
+        signal_mask: Option<&Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a> {
         let this = self.clone();
-        let signal_mask = signal_mask.map(|mask| mask.to_vec());
+        let signal_mask =
+            signal_mask.map(|mask| mask.0.iter().copied().collect::<Vec<signal::Number>>());
         #[allow(clippy::await_holding_refcell_ref, reason = "false positive")]
         async move {
             let (old_mask, old_caught_signals, deadline) = {
@@ -67,7 +68,7 @@ impl Select for VirtualSystem {
                             .copied()
                             .collect::<Vec<signal::Number>>();
 
-                        let result = proc.block_signals(SigmaskOp::Set, &new_mask);
+                        let result = proc.block_signals(SigmaskOp::Set, new_mask);
                         if result.process_state_changed {
                             let ppid = proc.ppid;
                             raise_sigchld(state, ppid);
@@ -185,7 +186,7 @@ impl Select for VirtualSystem {
                     .processes
                     .get_mut(&this.process_id)
                     .expect("the current process should be in the system state");
-                let result = proc.block_signals(SigmaskOp::Set, &old_mask);
+                let result = proc.block_signals(SigmaskOp::Set, old_mask);
                 if result.process_state_changed {
                     let ppid = proc.ppid;
                     raise_sigchld(&mut state, ppid);
@@ -207,7 +208,7 @@ mod tests {
     use crate::job::Pid;
     use crate::system::{
         CaughtSignals as _, Close as _, Disposition, Pipe as _, Read as _, SendSignal as _,
-        Sigaction as _, Sigmask as _, Write as _,
+        Sigaction as _, Sigmask as _, Sigset as _, Write as _,
     };
     use crate::test_helper::WakeFlag;
     use futures_util::FutureExt as _;
@@ -476,7 +477,7 @@ mod tests {
     fn system_for_catching_sigchld() -> VirtualSystem {
         let system = VirtualSystem::new();
         system
-            .sigmask(Some((SigmaskOp::Add, &[SIGCHLD])), None)
+            .sigmask(Some((SigmaskOp::Add, &Sigset::from(SIGCHLD))), None)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -491,7 +492,8 @@ mod tests {
         let mut readers = vec![];
         let mut writers = vec![];
 
-        let mut select = pin!(system.select(&mut readers, &mut writers, None, Some(&[])));
+        let mut select =
+            pin!(system.select(&mut readers, &mut writers, None, Some(&Sigset::new())));
 
         let woken = Arc::new(WakeFlag::new());
         let waker = Waker::from(Arc::clone(&woken));
@@ -501,13 +503,13 @@ mod tests {
         assert!(!woken.is_woken());
         assert_eq!(system.caught_signals(), [SIGCHLD]);
         // Check that the signal mask is the same as before the select call.
-        let mut mask = Vec::new();
+        let mut mask = Sigset::new();
         system
             .sigmask(None, Some(&mut mask))
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_eq!(mask, [SIGCHLD]);
+        assert_eq!(mask, Sigset::from(SIGCHLD));
     }
 
     #[test]
@@ -555,7 +557,8 @@ mod tests {
         let mut readers = vec![];
         let mut writers = vec![];
 
-        let mut select = pin!(system.select(&mut readers, &mut writers, None, Some(&[])));
+        let mut select =
+            pin!(system.select(&mut readers, &mut writers, None, Some(&Sigset::new())));
 
         // The future should not be ready yet, and it should not be woken up.
         let woken = Arc::new(WakeFlag::new());
@@ -565,13 +568,13 @@ mod tests {
         assert_eq!(poll, Poll::Pending);
         assert!(!woken.is_woken());
         // While waiting, the signal mask passed to select should be in effect
-        let mut mask = Vec::new();
+        let mut mask = Sigset::new();
         system
             .sigmask(None, Some(&mut mask))
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_eq!(mask, []);
+        assert_eq!(mask, Sigset::new());
 
         // Even if not woken, it must be safe to poll the future again,
         // and it should still not be ready.
@@ -595,13 +598,13 @@ mod tests {
         assert!(!woken.is_woken());
         assert_eq!(system.caught_signals(), [SIGCHLD]);
         // Check that the signal mask is the same as before the select call.
-        let mut mask = Vec::new();
+        let mut mask = Sigset::new();
         system
             .sigmask(None, Some(&mut mask))
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_eq!(mask, [SIGCHLD]);
+        assert_eq!(mask, Sigset::from(SIGCHLD));
     }
 
     #[test]
@@ -685,7 +688,7 @@ mod tests {
         let now = Instant::now();
         system.state.borrow_mut().now = Some(now);
         system
-            .sigmask(Some((SigmaskOp::Add, &[SIGTSTP])), None)
+            .sigmask(Some((SigmaskOp::Add, &Sigset::from(SIGTSTP))), None)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -700,7 +703,7 @@ mod tests {
             &mut readers,
             &mut writers,
             Some(Duration::from_secs(1)),
-            Some(&[])
+            Some(&Sigset::new())
         ));
 
         let woken = Arc::new(WakeFlag::new());
@@ -760,7 +763,7 @@ mod tests {
             &mut readers,
             &mut writers,
             Some(Duration::from_secs(1)),
-            Some(&[SIGTSTP])
+            Some(&Sigset::from(SIGTSTP))
         ));
 
         // Initially, the future should not be ready.
@@ -772,13 +775,13 @@ mod tests {
         assert!(!woken.is_woken());
 
         // While waiting, SIGTSTP is blocked by the temporary signal mask.
-        let mut mask = Vec::new();
+        let mut mask = Sigset::new();
         system
             .sigmask(None, Some(&mut mask))
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_eq!(mask, [SIGTSTP]);
+        assert_eq!(mask, Sigset::from(SIGTSTP));
 
         // Send SIGTSTP while it is blocked. It should remain pending.
         system.raise(SIGTSTP).now_or_never().unwrap().unwrap();

--- a/yash-env/src/system/virtual/select.rs
+++ b/yash-env/src/system/virtual/select.rs
@@ -46,8 +46,7 @@ impl Select for VirtualSystem {
         signal_mask: Option<&Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a> {
         let this = self.clone();
-        let signal_mask =
-            signal_mask.map(|mask| mask.0.iter().copied().collect::<Vec<signal::Number>>());
+        let signal_mask = signal_mask.map(|mask| mask.iter().copied().collect::<Vec<_>>());
         #[allow(clippy::await_holding_refcell_ref, reason = "false positive")]
         async move {
             let (old_mask, old_caught_signals, deadline) = {

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -20,7 +20,7 @@ use super::super::Result;
 use super::VirtualSystem;
 pub(super) use crate::signal::*;
 use crate::system::Signals as _;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::num::NonZero;
 
 /// Signal number for `SIGABRT` in the virtual system
@@ -352,14 +352,14 @@ impl SignalEffect {
 /// Set of signal numbers
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct Sigset(pub HashSet<Number>);
+pub struct Sigset(BTreeSet<Number>);
 
 impl super::super::Sigset for Sigset {
     /// Creates a new set containing all the signals supported by the virtual system.
     fn full() -> Self {
         let named = VirtualSystem::NAMED_SIGNALS.iter().filter_map(|(_, n)| *n);
         let realtime = RT_RANGE.map(|num| Number::from_raw_unchecked(NonZero::new(num).unwrap()));
-        Self(HashSet::from_iter(named.chain(realtime)))
+        Self(BTreeSet::from_iter(named.chain(realtime)))
     }
 
     /// Adds the specified signal to the set.
@@ -400,11 +400,16 @@ impl super::super::Sigset for Sigset {
     where
         I: IntoIterator<Item = Number>,
     {
-        Ok(Self(HashSet::from_iter(iter)))
+        Ok(Self(BTreeSet::from_iter(iter)))
     }
 }
 
 impl From<Number> for Sigset {
+    /// Creates a new set containing the specified signal.
+    ///
+    /// The current implementation does not check whether the given signal is
+    /// valid or not. The future implementation may return an empty set if the
+    /// signal is invalid.
     fn from(signal: Number) -> Self {
         let mut set = Sigset::default();
         set.0.insert(signal);
@@ -413,7 +418,97 @@ impl From<Number> for Sigset {
 }
 
 impl FromIterator<Number> for Sigset {
+    /// Creates a new set containing the signals in the given iterator.
+    ///
+    /// The current implementation does not check whether the given signals are
+    /// valid or not. The future implementation may silently ignore any invalid
+    /// signal.
     fn from_iter<T: IntoIterator<Item = Number>>(iter: T) -> Self {
-        Self(HashSet::from_iter(iter))
+        Self(BTreeSet::from_iter(iter))
+    }
+}
+
+/// Iterator over the signals in a [`Sigset`]
+///
+/// Use `Sigset::iter` to create an iterator over a `Sigset`.
+#[derive(Debug)]
+pub struct IntoIter(std::collections::btree_set::IntoIter<Number>);
+
+impl Iterator for IntoIter {
+    type Item = Number;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl IntoIterator for Sigset {
+    type Item = Number;
+    type IntoIter = IntoIter;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.0.into_iter())
+    }
+}
+
+/// Iterator over the signals in a [`Sigset`] reference
+pub struct Iter<'a>(std::collections::btree_set::Iter<'a, Number>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a Number;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> IntoIterator for &'a Sigset {
+    type Item = &'a Number;
+    type IntoIter = Iter<'a>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.0.iter())
+    }
+}
+
+impl Extend<Number> for Sigset {
+    #[inline(always)]
+    fn extend<I: IntoIterator<Item = Number>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl<'a> Extend<&'a Number> for Sigset {
+    #[inline(always)]
+    fn extend<I: IntoIterator<Item = &'a Number>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl Sigset {
+    /// Returns the number of signals in the set.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether the set is empty or not.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the signals in the set.
+    #[inline(always)]
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+
+    pub(super) fn difference_to_vec(&self, other: &Sigset) -> Vec<Number> {
+        self.0.difference(&other.0).copied().collect()
     }
 }

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -358,7 +358,7 @@ impl super::super::Sigset for Sigset {
     /// Creates a new set containing all the signals supported by the virtual system.
     fn full() -> Self {
         let named = VirtualSystem::NAMED_SIGNALS.iter().filter_map(|(_, n)| *n);
-        let realtime = VirtualSystem::new().iter_sigrt();
+        let realtime = RT_RANGE.map(|num| Number::from_raw_unchecked(NonZero::new(num).unwrap()));
         Self(HashSet::from_iter(named.chain(realtime)))
     }
 

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -403,3 +403,17 @@ impl super::super::Sigset for Sigset {
         Ok(Self(HashSet::from_iter(iter)))
     }
 }
+
+impl From<Number> for Sigset {
+    fn from(signal: Number) -> Self {
+        let mut set = Sigset::default();
+        set.0.insert(signal);
+        set
+    }
+}
+
+impl FromIterator<Number> for Sigset {
+    fn from_iter<T: IntoIterator<Item = Number>>(iter: T) -> Self {
+        Self(HashSet::from_iter(iter))
+    }
+}

--- a/yash-env/src/system/virtual/signal.rs
+++ b/yash-env/src/system/virtual/signal.rs
@@ -16,7 +16,11 @@
 
 //! Functions about signals
 
+use super::super::Result;
+use super::VirtualSystem;
 pub(super) use crate::signal::*;
+use crate::system::Signals as _;
+use std::collections::HashSet;
 use std::num::NonZero;
 
 /// Signal number for `SIGABRT` in the virtual system
@@ -342,5 +346,60 @@ impl SignalEffect {
             Name::Xfsz => Self::Terminate { core_dump: true },
             Name::Rtmin(_) | Name::Rtmax(_) => Self::Terminate { core_dump: false },
         }
+    }
+}
+
+/// Set of signal numbers
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Sigset(pub HashSet<Number>);
+
+impl super::super::Sigset for Sigset {
+    /// Creates a new set containing all the signals supported by the virtual system.
+    fn full() -> Self {
+        let named = VirtualSystem::NAMED_SIGNALS.iter().filter_map(|(_, n)| *n);
+        let realtime = VirtualSystem::new().iter_sigrt();
+        Self(HashSet::from_iter(named.chain(realtime)))
+    }
+
+    /// Adds the specified signal to the set.
+    ///
+    /// The current implementation does not check whether the given signal is
+    /// valid or not. The future implementation may return an error if the
+    /// signal is invalid.
+    fn add(&mut self, signal: Number) -> Result<()> {
+        self.0.insert(signal);
+        Ok(())
+    }
+
+    /// Removes the specified signal from the set.
+    ///
+    /// The current implementation does not check whether the given signal is
+    /// valid or not. The future implementation may return an error if the
+    /// signal is invalid.
+    fn remove(&mut self, signal: Number) -> Result<()> {
+        self.0.remove(&signal);
+        Ok(())
+    }
+
+    /// Checks whether the specified signal is in the set or not.
+    ///
+    /// The current implementation does not check whether the given signal is
+    /// valid or not. The future implementation may return an error if the
+    /// signal is invalid.
+    fn contains(&self, signal: Number) -> Result<bool> {
+        Ok(self.0.contains(&signal))
+    }
+
+    /// Creates a new set containing the signals in the given iterator.
+    ///
+    /// The current implementation does not check whether the given signals are
+    /// valid or not. The future implementation may return an error if any of
+    /// the signals is invalid.
+    fn from_signals<I>(iter: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = Number>,
+    {
+        Ok(Self(HashSet::from_iter(iter)))
     }
 }


### PR DESCRIPTION
## Description

Replace slice/vector signal mask parameters with implementation-specific signal set types across Sigmask and Select.
    
This removes per-call conversions inside RealSystem, so sigprocmask and pselect can consume native sigset_t-backed data directly. The change also keeps mask handling consistent in Concurrent and VirtualSystem.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for v0.14.0 documenting revamped signal-handling APIs.

* **Refactor**
  * Introduced a typed signal-set abstraction and migrated signal-mask APIs to use it.
  * Unified and tightened signal-handling across real and virtual systems for safer, more consistent behavior.
  * Adjusted tests to reflect the new signal-set API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->