### PR TITLE
Use native fd_set in select parameters

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
+- The `system::FdSet` trait has been added to represent a set of file
+  descriptors, abstracting the `fd_set` type from POSIX.
+- The `system::real::FdSet` struct has been added as the concrete `FdSet`
+  implementation for the real system.
+- The `system::virtual::fd_set` module has been added, containing the `FdSet`
+  struct as the concrete `FdSet` implementation for the virtual system.
 - The `system::Sigset` trait has been added to represent a set of signals,
   abstracting the `sigset_t` type from POSIX.
 - The `system::real::Sigset` struct has been added as the concrete `Sigset`

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -113,6 +113,9 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `system::Select::select`
 - The `system::Select` trait now requires the `system::Sigmask` trait as a
   supertrait.
+- The `system::Select` trait now has the associated type `FdSet`, which must be
+  specified when implementing the trait. This type is now used in the signature
+  of the `select` method to represent the set of file descriptors to monitor.
 - The `system::virtual::Process::blocked_signals` and
   `system::virtual::Process::pending_signals` methods now return a reference to
   `system::virtual::Sigset` instead of a reference to

--- a/yash-env/src/io.rs
+++ b/yash-env/src/io.rs
@@ -24,10 +24,10 @@ use crate::system::{Close, Dup, FdFlag, Isatty};
 use annotate_snippets::Renderer;
 use std::borrow::Cow;
 #[cfg(unix)]
-use std::os::unix::io::RawFd;
+pub(crate) use std::os::unix::io::RawFd;
 
 #[cfg(not(unix))]
-type RawFd = i32;
+pub(crate) type RawFd = i32;
 
 /// File descriptor
 ///

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -136,7 +136,7 @@ pub use self::process::{
 #[cfg(all(doc, unix))]
 use self::real::RealSystem;
 use self::resource::{GetRlimit, SetRlimit};
-pub use self::select::Select;
+pub use self::select::{FdSet, Select};
 pub use self::signal::{
     CaughtSignals, Disposition, GetSigaction, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals,
     Sigset,

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -21,7 +21,8 @@
 //! tasks on a single thread.
 
 use super::{
-    CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, Fork, Read, Result, Sigmask, Write,
+    CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, FdSet, Fork, Read, Result, Sigmask,
+    Write,
 };
 use crate::io::Fd;
 use crate::job::Pid;
@@ -507,8 +508,8 @@ where
         let mut state = self.state.borrow_mut();
 
         // Prepare parameters for the `select` call based on the current state
-        let mut readers = state.reads.keys().cloned().collect();
-        let mut writers = state.writes.keys().cloned().collect();
+        let mut readers = S::FdSet::from_fds(state.reads.keys().cloned());
+        let mut writers = S::FdSet::from_fds(state.writes.keys().cloned());
         let timeout = if peek {
             Some(Duration::ZERO)
         } else {
@@ -554,8 +555,8 @@ where
     }
 }
 
-fn wake_tasks_for_ready_fds(task_map: &mut HashMap<Fd, WakerSet>, ready_fds: &[Fd]) {
-    task_map.retain(|fd, wakers| {
+fn wake_tasks_for_ready_fds<S: FdSet>(task_map: &mut HashMap<Fd, WakerSet>, ready_fds: &S) {
+    task_map.retain(|&fd, wakers| {
         if ready_fds.contains(fd) {
             wakers.wake_all();
             false

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -861,36 +861,21 @@ impl SendSignal for RealSystem {
 }
 
 impl Select for RealSystem {
+    type FdSet = FdSet;
+
     fn select<'a>(
         &self,
-        readers: &'a mut Vec<Fd>,
-        writers: &'a mut Vec<Fd>,
+        readers: &'a mut FdSet,
+        writers: &'a mut FdSet,
         timeout: Option<Duration>,
         signal_mask: Option<&Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a> {
-        ready((|| {
+        ready({
             use std::ptr::{null, null_mut};
 
-            let max_fd = readers.iter().chain(writers.iter()).max();
-            let nfds = max_fd
-                .map(|fd| fd.0.checked_add(1).ok_or(Errno::EBADF))
-                .transpose()?
-                .unwrap_or(0);
-
-            fn to_raw_fd_set(fds: &[Fd]) -> MaybeUninit<libc::fd_set> {
-                let mut raw_fds = MaybeUninit::<libc::fd_set>::uninit();
-                unsafe {
-                    libc::FD_ZERO(raw_fds.as_mut_ptr());
-                    for fd in fds {
-                        libc::FD_SET(fd.0, raw_fds.as_mut_ptr());
-                    }
-                }
-                raw_fds
-            }
-            let mut raw_readers = to_raw_fd_set(readers);
-            let mut raw_writers = to_raw_fd_set(writers);
-            let readers_ptr = raw_readers.as_mut_ptr();
-            let writers_ptr = raw_writers.as_mut_ptr();
+            let upper_bound = readers.upper_bound().max(writers.upper_bound());
+            let readers_ptr = readers.as_mut_ptr();
+            let writers_ptr = writers.as_mut_ptr();
             let errors = null_mut();
 
             let timeout_spec = timeout.map(to_timespec);
@@ -898,9 +883,9 @@ impl Select for RealSystem {
 
             let raw_mask_ptr = signal_mask.map_or(null(), |mask| mask.0.as_ptr());
 
-            let count = unsafe {
+            unsafe {
                 libc::pselect(
-                    nfds,
+                    upper_bound.0,
                     readers_ptr,
                     writers_ptr,
                     errors,
@@ -908,13 +893,8 @@ impl Select for RealSystem {
                     raw_mask_ptr,
                 )
             }
-            .errno_if_m1()?;
-
-            readers.retain(|fd| unsafe { libc::FD_ISSET(fd.0, readers_ptr) });
-            writers.retain(|fd| unsafe { libc::FD_ISSET(fd.0, writers_ptr) });
-
-            Ok(count)
-        })())
+            .errno_if_m1()
+        })
     }
 }
 

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -22,6 +22,7 @@
 //! shell environment.
 
 mod errno;
+mod fd_set;
 mod file_system;
 mod open_flag;
 mod resource;
@@ -94,6 +95,7 @@ use crate::semantics::ExitStatus;
 use crate::str::UnixStr;
 use crate::str::UnixString;
 use enumset::EnumSet;
+pub use fd_set::FdSet;
 pub use file_system::Stat;
 use libc::DIR;
 pub use signal::Sigset;

--- a/yash-env/src/system/real/fd_set.rs
+++ b/yash-env/src/system/real/fd_set.rs
@@ -1,0 +1,104 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Implementation of file descriptor sets for use with `select` system call
+
+use crate::io::Fd;
+use crate::system::FdSet as FdSetTrait;
+use std::mem::MaybeUninit;
+use std::os::fd::RawFd;
+
+/// File descriptor set for the real system, wrapping the `fd_set` type from libc
+///
+/// This is an implementation of the [`FdSet` trait](crate::system::FdSet) for the
+/// [`RealSystem`](super::RealSystem).
+#[derive(Clone)]
+pub struct FdSet {
+    /// The underlying `fd_set` structure from libc
+    ///
+    /// We use `MaybeUninit` because `fd_set` may contain uninitialized fields
+    /// or padding bytes that are not initialized by `FD_ZERO`.
+    fds: MaybeUninit<libc::fd_set>,
+
+    /// An FD that is greater than any FD currently in the set
+    ///
+    /// This is used to optimize the `select` system call by providing an upper bound
+    /// on the FDs in the set. The `select` system call only needs to check FDs
+    /// up to this upper bound, which can improve performance when the set
+    /// contains a small number of FDs that are much smaller than `FD_SETSIZE`.
+    upper_bound: Fd,
+}
+
+impl Default for FdSet {
+    fn default() -> Self {
+        let mut fds = MaybeUninit::<libc::fd_set>::uninit();
+        unsafe { libc::FD_ZERO(fds.as_mut_ptr()) };
+        Self {
+            fds,
+            upper_bound: Fd(0),
+        }
+    }
+}
+
+impl FdSetTrait for FdSet {
+    const MAX_FD: Fd = Fd(libc::FD_SETSIZE as RawFd - 1);
+
+    fn insert(&mut self, fd: Fd) {
+        if 0 <= fd.0 && fd <= Self::MAX_FD {
+            // SAFETY: We just verified that `fd` is within the valid range for
+            // an `fd_set`.
+            // SAFETY: POSIX also requires that `fd` be valid (i.e. open), but
+            // we cannot verify that here. We assume that the underlying
+            // `fd_set` implementation accepts invalid FDs and the `select`
+            // system call will handle them appropriately.
+            unsafe { libc::FD_SET(fd.0, self.fds.as_mut_ptr()) };
+
+            self.upper_bound = self.upper_bound.max(Fd(fd.0 + 1));
+        }
+    }
+
+    fn remove(&mut self, fd: Fd) {
+        if 0 <= fd.0 && fd <= Self::MAX_FD {
+            // SAFETY: The same as in `insert`.
+            unsafe { libc::FD_CLR(fd.0, self.fds.as_mut_ptr()) };
+        }
+    }
+
+    fn contains(&self, fd: Fd) -> bool {
+        0 <= fd.0 && fd <= Self::MAX_FD && unsafe { libc::FD_ISSET(fd.0, self.fds.as_ptr()) }
+    }
+}
+
+impl std::fmt::Debug for FdSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fds = (0..=Self::MAX_FD.0).filter(|&fd| self.contains(Fd(fd)));
+        f.debug_set().entries(fds).finish()
+    }
+}
+
+impl FdSet {
+    #[inline(always)]
+    #[must_use]
+    pub(super) fn as_mut_ptr(&mut self) -> *mut libc::fd_set {
+        self.fds.as_mut_ptr()
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(super) fn upper_bound(&self) -> Fd {
+        self.upper_bound
+    }
+}

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -26,6 +26,49 @@ use std::future::Future;
 use std::rc::Rc;
 use std::time::Duration;
 
+/// Trait for representing a set of file descriptors (FDs)
+///
+/// This is an abstraction over the `fd_set` type used in the `select` system
+/// call. It represents a set of [`Fd`]s that can be monitored for events such
+/// as readability or writability.
+///
+/// As per POSIX, an `fd_set` can only contain FDs in the range of `0` to
+/// `FD_SETSIZE - 1`. The [`MAX_FD`](Self::MAX_FD) associated constant in this
+/// trait represents the maximum FD that can be stored in the set.
+pub trait FdSet: Clone + Default + 'static {
+    /// The maximum FD that can be stored in the set. This corresponds to
+    /// `FD_SETSIZE - 1` in C libraries. The exact value may depend on the
+    /// implementation.
+    const MAX_FD: Fd;
+
+    /// Creates a new, empty FD set.
+    ///
+    /// The provided implementation simply calls [`Default::default`].
+    #[inline(always)]
+    #[must_use]
+    fn new() -> Self {
+        Default::default()
+    }
+
+    /// Adds an FD to the set.
+    ///
+    /// If the provided FD is greater than [`MAX_FD`](Self::MAX_FD) or negative,
+    /// it will be silently ignored.
+    fn insert(&mut self, fd: Fd);
+
+    /// Removes an FD from the set.
+    ///
+    /// If the provided FD is greater than [`MAX_FD`](Self::MAX_FD) or negative,
+    /// it will be silently ignored.
+    fn remove(&mut self, fd: Fd);
+
+    /// Checks if an FD is in the set.
+    ///
+    /// If the provided FD is greater than [`MAX_FD`](Self::MAX_FD) or negative,
+    /// this function will return `false`.
+    fn contains(&self, fd: Fd) -> bool;
+}
+
 /// Trait for performing the `select` operation
 ///
 /// This trait provides the `select` method, which represents the `select`

--- a/yash-env/src/system/select.rs
+++ b/yash-env/src/system/select.rs
@@ -22,6 +22,7 @@ use super::Result;
 use super::Sigmask;
 use crate::io::Fd;
 use std::ffi::c_int;
+use std::fmt::Debug;
 use std::future::Future;
 use std::rc::Rc;
 use std::time::Duration;
@@ -67,6 +68,24 @@ pub trait FdSet: Clone + Default + 'static {
     /// If the provided FD is greater than [`MAX_FD`](Self::MAX_FD) or negative,
     /// this function will return `false`.
     fn contains(&self, fd: Fd) -> bool;
+
+    /// Creates a new FD set from an iterator of FDs.
+    ///
+    /// This is a convenience method that creates a new FD set and inserts all
+    /// the FDs from the provided iterator into it. If any FD in the iterator is
+    /// greater than [`MAX_FD`](Self::MAX_FD) or negative, it will be silently
+    /// ignored.
+    #[must_use]
+    fn from_fds<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Fd>,
+    {
+        let mut set = Self::new();
+        for fd in iter {
+            set.insert(fd);
+        }
+        set
+    }
 }
 
 /// Trait for performing the `select` operation
@@ -80,6 +99,13 @@ pub trait FdSet: Clone + Default + 'static {
 /// `Select` trait in the `concurrency` submodule to implement its
 /// functionality.
 pub trait Select: Sigmask {
+    /// The type of the file descriptor set used in the `select` method
+    ///
+    /// This type is used in the [`select`](Self::select) method to specify
+    /// file descriptor sets. The exact type will depend on the implementation
+    /// of the trait.
+    type FdSet: FdSet + Debug;
+
     /// Waits for a next event.
     ///
     /// In a typical configuration, this trait is not used directly. Instead,
@@ -117,8 +143,8 @@ pub trait Select: Sigmask {
     /// details.
     fn select<'a>(
         &self,
-        readers: &'a mut Vec<Fd>,
-        writers: &'a mut Vec<Fd>,
+        readers: &'a mut Self::FdSet,
+        writers: &'a mut Self::FdSet,
         timeout: Option<Duration>,
         signal_mask: Option<&Self::Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a, Self>;
@@ -126,11 +152,13 @@ pub trait Select: Sigmask {
 
 /// Delegates the `Select` trait to the contained instance of `S`
 impl<S: Select> Select for Rc<S> {
+    type FdSet = S::FdSet;
+
     #[inline]
     fn select<'a>(
         &self,
-        readers: &'a mut Vec<Fd>,
-        writers: &'a mut Vec<Fd>,
+        readers: &'a mut S::FdSet,
+        writers: &'a mut S::FdSet,
         timeout: Option<Duration>,
         signal_mask: Option<&S::Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a, S> {

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -57,6 +57,7 @@
 //!
 //! TBD: Explain how to use `VirtualSystem` with an executor.
 
+pub mod fd_set;
 mod file_body;
 mod file_system;
 mod io;

--- a/yash-env/src/system/virtual/fd_set.rs
+++ b/yash-env/src/system/virtual/fd_set.rs
@@ -1,0 +1,156 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! File descriptor set for the virtual system
+//!
+//! This module defines the [`FdSet` struct](FdSet), which is an implementation
+//! of the [`FdSet` trait](FdSetTrait) for the
+//! [`VirtualSystem`](super::VirtualSystem). The module also provides iterators
+//! for iterating over the file descriptors in an `FdSet`.
+
+use crate::io::{Fd, RawFd};
+use crate::system::FdSet as FdSetTrait;
+use std::collections::BTreeSet;
+
+/// File descriptor set for the virtual system
+///
+/// This is an implementation of the [`FdSet` trait](FdSetTrait) for the
+/// [`VirtualSystem`](super::VirtualSystem). It represents a set of file
+/// descriptors that can be monitored for events such as readability or
+/// writability in the virtual system. Currently, the `FdSet` struct internally
+/// uses a `BTreeSet` to store the file descriptors, which allows for efficient
+/// insertion, removal, and lookup of file descriptors.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FdSet(BTreeSet<Fd>);
+
+impl FdSetTrait for FdSet {
+    const MAX_FD: Fd = Fd(RawFd::MAX);
+
+    #[inline(always)]
+    fn insert(&mut self, fd: Fd) {
+        if fd.0 >= 0 {
+            self.0.insert(fd);
+        }
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, fd: Fd) {
+        self.0.remove(&fd);
+    }
+
+    #[inline(always)]
+    fn contains(&self, fd: Fd) -> bool {
+        self.0.contains(&fd)
+    }
+}
+
+impl From<Fd> for FdSet {
+    #[inline(always)]
+    fn from(fd: Fd) -> Self {
+        let mut set = Self::new();
+        set.insert(fd);
+        set
+    }
+}
+
+impl FromIterator<Fd> for FdSet {
+    #[inline(always)]
+    fn from_iter<I: IntoIterator<Item = Fd>>(iter: I) -> Self {
+        Self(FromIterator::from_iter(iter))
+    }
+}
+
+/// Iterator over the file descriptors in an `FdSet`
+///
+/// Use `FdSet::into_iter` to create an iterator from an `FdSet`.
+#[derive(Debug)]
+pub struct IntoIter(std::collections::btree_set::IntoIter<Fd>);
+
+impl Iterator for IntoIter {
+    type Item = Fd;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl IntoIterator for FdSet {
+    type Item = Fd;
+    type IntoIter = IntoIter;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.0.into_iter())
+    }
+}
+
+/// Iterator over the file descriptors in an `FdSet` by reference
+///
+/// Use `FdSet::iter` to create an iterator from a reference to an `FdSet`.
+#[derive(Debug)]
+pub struct Iter<'a>(std::collections::btree_set::Iter<'a, Fd>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a Fd;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> IntoIterator for &'a FdSet {
+    type Item = &'a Fd;
+    type IntoIter = Iter<'a>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.0.iter())
+    }
+}
+
+impl Extend<Fd> for FdSet {
+    fn extend<I: IntoIterator<Item = Fd>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl<'a> Extend<&'a Fd> for FdSet {
+    fn extend<I: IntoIterator<Item = &'a Fd>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl FdSet {
+    /// Returns the number of file descriptors in the set.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether the set is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the file descriptors in the set.
+    #[inline(always)]
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+}

--- a/yash-env/src/system/virtual/select.rs
+++ b/yash-env/src/system/virtual/select.rs
@@ -16,11 +16,13 @@
 
 //! Implementation of [`Select`] for [`VirtualSystem`]
 
+use super::fd_set::FdSet;
 use super::{
-    Duration, Errno, Fd, Result, Select, SigmaskOp, Sigset, TryInto as _, VirtualSystem,
-    raise_sigchld, signal,
+    Duration, Errno, Result, Select, SigmaskOp, Sigset, TryInto as _, VirtualSystem, raise_sigchld,
+    signal,
 };
 use crate::job::ProcessState;
+use crate::system::FdSet as _;
 use std::cell::{Cell, LazyCell};
 use std::ffi::c_int;
 use std::future::poll_fn;
@@ -28,6 +30,8 @@ use std::rc::Rc;
 use std::task::{Poll, Waker};
 
 impl Select for VirtualSystem {
+    type FdSet = FdSet;
+
     /// Waits for a next event.
     ///
     /// The `VirtualSystem` implementation for this method simulates the
@@ -40,8 +44,8 @@ impl Select for VirtualSystem {
     /// while still providing the expected behavior of `select`.
     fn select<'a>(
         &self,
-        readers: &'a mut Vec<Fd>,
-        writers: &'a mut Vec<Fd>,
+        readers: &'a mut FdSet,
+        writers: &'a mut FdSet,
         timeout: Option<Duration>,
         signal_mask: Option<&Sigset>,
     ) -> impl Future<Output = Result<c_int>> + use<'a> {
@@ -114,15 +118,15 @@ impl Select for VirtualSystem {
                 }
 
                 // Find ready FDs
-                let mut ready_readers = Vec::new();
-                let mut ready_writers = Vec::new();
+                let mut ready_readers = FdSet::new();
+                let mut ready_writers = FdSet::new();
                 for fd in readers.iter().cloned() {
                     let Some(fd_body) = proc.fds().get(&fd) else {
                         return Poll::Ready(Err(Errno::EBADF));
                     };
                     let ofd = fd_body.open_file_description.borrow();
                     if ofd.is_ready_for_reading() {
-                        ready_readers.push(fd);
+                        ready_readers.insert(fd);
                     }
                 }
                 for fd in writers.iter().cloned() {
@@ -131,7 +135,7 @@ impl Select for VirtualSystem {
                     };
                     let ofd = fd_body.open_file_description.borrow();
                     if ofd.is_ready_for_writing() {
-                        ready_writers.push(fd);
+                        ready_writers.insert(fd);
                     }
                 }
                 let count = (ready_readers.len() + ready_writers.len())
@@ -153,8 +157,8 @@ impl Select for VirtualSystem {
                     }
                 };
                 if expired {
-                    readers.clear();
-                    writers.clear();
+                    *readers = FdSet::new();
+                    *writers = FdSet::new();
                     return Poll::Ready(Ok(0));
                 }
 
@@ -204,6 +208,7 @@ mod tests {
     use super::super::Process;
     use super::super::{PIPE_BUF, PIPE_SIZE, SIGCHLD, SIGCONT, SIGTSTP};
     use super::*;
+    use crate::io::Fd;
     use crate::job::Pid;
     use crate::system::{
         CaughtSignals as _, Close as _, Disposition, Pipe as _, Read as _, SendSignal as _,
@@ -219,8 +224,8 @@ mod tests {
     #[test]
     fn select_with_no_condition_blocks_forever() {
         let system = VirtualSystem::new();
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
         let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
         // Polling the future should return pending, and it should not be woken up.
@@ -235,8 +240,8 @@ mod tests {
     #[test]
     fn select_with_zero_timeout_returns_immediately() {
         let system = VirtualSystem::new();
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
         let mut select =
             pin!(system.select(&mut readers, &mut writers, Some(Duration::ZERO), None));
 
@@ -252,8 +257,8 @@ mod tests {
     #[test]
     fn select_regular_file_is_always_ready() {
         let system = VirtualSystem::new();
-        let mut readers = vec![Fd::STDIN];
-        let mut writers = vec![Fd::STDOUT, Fd::STDERR];
+        let mut readers = FdSet::from_fds([Fd::STDIN]);
+        let mut writers = FdSet::from_fds([Fd::STDOUT, Fd::STDERR]);
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -264,8 +269,8 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(3)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, [Fd::STDIN]);
-        assert_eq!(writers, [Fd::STDOUT, Fd::STDERR]);
+        assert_eq!(readers, FdSet::from_fds([Fd::STDIN]));
+        assert_eq!(writers, FdSet::from_fds([Fd::STDOUT, Fd::STDERR]));
     }
 
     #[test]
@@ -273,8 +278,8 @@ mod tests {
         let system = VirtualSystem::new();
         let (reader, writer) = system.pipe().unwrap();
         system.close(writer).unwrap();
-        let mut readers = vec![reader];
-        let mut writers = vec![];
+        let mut readers = FdSet::from_fds([reader]);
+        let mut writers = FdSet::new();
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -285,8 +290,8 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(1)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, [reader]);
-        assert_eq!(writers, []);
+        assert_eq!(readers, FdSet::from_fds([reader]));
+        assert_eq!(writers, FdSet::new());
     }
 
     #[test]
@@ -294,8 +299,8 @@ mod tests {
         let system = VirtualSystem::new();
         let (reader, writer) = system.pipe().unwrap();
         system.write(writer, &[0]).now_or_never().unwrap().unwrap();
-        let mut readers = vec![reader];
-        let mut writers = vec![];
+        let mut readers = FdSet::from_fds([reader]);
+        let mut writers = FdSet::new();
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -306,16 +311,16 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(1)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, [reader]);
-        assert_eq!(writers, []);
+        assert_eq!(readers, FdSet::from_fds([reader]));
+        assert_eq!(writers, FdSet::new());
     }
 
     #[test]
     fn select_pipe_reader_gets_ready_when_some_data_is_written() {
         let system = VirtualSystem::new();
         let (reader, writer) = system.pipe().unwrap();
-        let mut readers = vec![reader];
-        let mut writers = vec![];
+        let mut readers = FdSet::from_fds([reader]);
+        let mut writers = FdSet::new();
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -340,16 +345,16 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(1)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, [reader]);
-        assert_eq!(writers, []);
+        assert_eq!(readers, FdSet::from_fds([reader]));
+        assert_eq!(writers, FdSet::new());
     }
 
     #[test]
     fn select_pipe_writer_is_ready_if_pipe_is_not_full() {
         let system = VirtualSystem::new();
         let (_reader, writer) = system.pipe().unwrap();
-        let mut readers = vec![];
-        let mut writers = vec![writer];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::from_fds([writer]);
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -360,16 +365,16 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(1)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, []);
-        assert_eq!(writers, [writer]);
+        assert_eq!(readers, FdSet::new());
+        assert_eq!(writers, FdSet::from_fds([writer]));
     }
 
     #[test]
     fn select_pipe_writer_gets_ready_when_some_data_is_read() {
         let system = VirtualSystem::new();
         let (reader, writer) = system.pipe().unwrap();
-        let mut readers = vec![];
-        let mut writers = vec![writer];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::from_fds([writer]);
 
         // Fill the pipe buffer.
         system
@@ -405,41 +410,41 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(1)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, []);
-        assert_eq!(writers, [writer]);
+        assert_eq!(readers, FdSet::new());
+        assert_eq!(writers, FdSet::from_fds([writer]));
     }
 
     #[test]
     fn select_on_unreadable_fd() {
         let system = VirtualSystem::new();
         let (_reader, writer) = system.pipe().unwrap();
-        let mut fds = vec![writer];
+        let mut fds = FdSet::from_fds([writer]);
         let result = system
-            .select(&mut fds, &mut vec![], None, None)
+            .select(&mut fds, &mut FdSet::new(), None, None)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(1));
-        assert_eq!(fds, [writer]);
+        assert_eq!(fds, FdSet::from_fds([writer]));
     }
 
     #[test]
     fn select_on_unwritable_fd() {
         let system = VirtualSystem::new();
         let (reader, _writer) = system.pipe().unwrap();
-        let mut fds = vec![reader];
+        let mut fds = FdSet::from_fds([reader]);
         let result = system
-            .select(&mut vec![], &mut fds, None, None)
+            .select(&mut FdSet::new(), &mut fds, None, None)
             .now_or_never()
             .unwrap();
         assert_eq!(result, Ok(1));
-        assert_eq!(fds, [reader]);
+        assert_eq!(fds, FdSet::from_fds([reader]));
     }
 
     #[test]
     fn select_on_invalid_fd_for_readers() {
         let system = VirtualSystem::new();
-        let mut readers = vec![Fd(17)];
-        let mut writers = vec![];
+        let mut readers = FdSet::from_fds([Fd(17)]);
+        let mut writers = FdSet::new();
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -450,15 +455,15 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Err(Errno::EBADF)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, [Fd(17)]);
-        assert_eq!(writers, []);
+        assert_eq!(readers, FdSet::from_fds([Fd(17)]));
+        assert_eq!(writers, FdSet::new());
     }
 
     #[test]
     fn select_on_invalid_fd_for_writers() {
         let system = VirtualSystem::new();
-        let mut readers = vec![];
-        let mut writers = vec![Fd(17)];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::from_fds([Fd(17)]);
         {
             let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -469,8 +474,8 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Err(Errno::EBADF)));
             assert!(!woken.is_woken());
         }
-        assert_eq!(readers, []);
-        assert_eq!(writers, [Fd(17)]);
+        assert_eq!(readers, FdSet::new());
+        assert_eq!(writers, FdSet::from_fds([Fd(17)]));
     }
 
     fn system_for_catching_sigchld() -> VirtualSystem {
@@ -488,8 +493,8 @@ mod tests {
     fn select_on_pending_signal() {
         let system = system_for_catching_sigchld();
         let _ = system.current_process_mut().raise_signal(SIGCHLD);
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
 
         let mut select =
             pin!(system.select(&mut readers, &mut writers, None, Some(&Sigset::new())));
@@ -515,8 +520,8 @@ mod tests {
     fn select_interrupted_by_signal() {
         let system = VirtualSystem::new();
         system.sigaction(SIGCHLD, Disposition::Catch).unwrap();
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
 
         let mut select = pin!(system.select(&mut readers, &mut writers, None, None));
 
@@ -553,8 +558,8 @@ mod tests {
     #[test]
     fn select_on_signal_delivered_while_waiting() {
         let system = system_for_catching_sigchld();
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
 
         let mut select =
             pin!(system.select(&mut readers, &mut writers, None, Some(&Sigset::new())));
@@ -621,8 +626,8 @@ mod tests {
             .now_or_never()
             .unwrap()
             .unwrap();
-        let mut readers = vec![reader_1];
-        let mut writers = vec![writer_2];
+        let mut readers = FdSet::from_fds([reader_1]);
+        let mut writers = FdSet::from_fds([writer_2]);
         let timeout = Duration::new(42, 195);
 
         {
@@ -664,8 +669,8 @@ mod tests {
             assert_eq!(poll, Poll::Ready(Ok(0)));
         }
         // After a timeout, no readers or writers should be ready
-        assert_eq!(readers, []);
-        assert_eq!(writers, []);
+        assert_eq!(readers, FdSet::new());
+        assert_eq!(writers, FdSet::new());
     }
 
     fn virtual_system_with_parent_process() -> VirtualSystem {
@@ -695,8 +700,8 @@ mod tests {
         // Send SIGTSTP while it is blocked
         system.raise(SIGTSTP).now_or_never().unwrap().unwrap();
 
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
 
         let mut select = pin!(system.select(
             &mut readers,
@@ -755,8 +760,8 @@ mod tests {
         let now = Instant::now();
         system.state.borrow_mut().now = Some(now);
 
-        let mut readers = vec![];
-        let mut writers = vec![];
+        let mut readers = FdSet::new();
+        let mut writers = FdSet::new();
 
         let mut select = pin!(system.select(
             &mut readers,


### PR DESCRIPTION
## Description

Replaces the `Vec<Fd>` parameters of the `Select::select` method with a generic associated type `FdSet` that represents a set of file descriptors. This allows the `RealSystem` implementation to use a more efficient representation of the file descriptor sets that is compatible with the underlying `select` system call.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [ ] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a new FdSet abstraction for file-descriptor sets and updated select-related APIs to use it instead of plain vectors
  * Applied the FdSet approach across real and virtual system implementations for consistent FD handling

* **Documentation**
  * Changelog updated to describe the new FdSet and related Select API changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicant/yash-rs/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->