### PR TITLE
Higher-level traits for hiding Concurrent internals

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -14,8 +14,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 ### Changed
 
 - The `iter` function now requires
-  `S: std::clone::Clone + yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
-  in addition to the existing bounds on `S`.
+  `S: std::clone::Clone + yash_env::job::RunBlocking + yash_env::job::RunUnblocking + yash_env::subshell::BlockSignals + yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  in addition to the existing bounds on `S`, and no longer requires
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask`.
 - The following functions now require the bound
   `S: yash_env::system::Isatty + yash_env::system::concurrency::WriteAll` instead of
   `S: yash_env::system::Isatty + yash_env::system::Fcntl + yash_env::system::Write`:
@@ -83,22 +84,37 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `command::Invoke::execute`
     - `command::main`
     - `fg::main`
-- The `trap::Command::execute` function now requires the bound
-  `S: yash_env::trap::SignalSystem` instead of
+- In the following functions, the bound
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask` has been removed and the bound
+  `S: yash_env::subshell::BlockSignals + yash_env::job::RunBlocking + yash_env::job::RunUnblocking`
+  has been added while other bounds remain unchanged:
+    - `command::Command::execute`
+    - `command::Invoke::execute`
+    - `command::main`
+- In the `fg::main` function, the bound
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask` has been removed and the bound
+  `S: yash_env::job::RunBlocking` has been added while other bounds remain unchanged.
+- In the `set::main` function, the bound
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask` has been removed and the bound
+  `S: yash_env::job::RunBlocking + yash_env::job::RunUnblocking` has been added while other bounds remain unchanged.
+- The `exec::main` function no longer requires
   `S: yash_env::system::Sigaction + yash_env::system::Sigmask`.
-- The `trap::main` function now requires the bound
-  `S: yash_env::system::Isatty + yash_env::trap::SignalSystem + yash_env::system::concurrency::WriteAll`
-  instead of
-  `S: yash_env::system::Fcntl + yash_env::system::Isatty + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Write`.
-- The `wait::core::wait_for_any_job_or_trap` and `wait::status::wait_while_running`
-  functions now require the bound
-  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::Wait + yash_env::trap::SignalSystem + 'static`
-  instead of
-  `S: yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Wait + 'static`.
-- The `wait::main` and `wait::Command::execute` functions now require the bound
-  `S: yash_env::system::Isatty + yash_env::system::concurrency::WaitForSignals + yash_env::system::Wait + yash_env::trap::SignalSystem + 'static`
-  instead of
-  `S: yash_env::system::Fcntl + yash_env::system::Isatty + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Wait + yash_env::system::Write + 'static`.
+- In the `trap::Command::execute` function, the bound
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask` has been removed and the bound
+  `S: yash_env::trap::SignalSystem` has been added while other bounds remain unchanged.
+- In the `trap::main` function, the bound
+  `S: yash_env::system::Fcntl + yash_env::system::Isatty + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Write` has been removed and the bound
+  `S: yash_env::system::Isatty + yash_env::trap::SignalSystem + yash_env::system::concurrency::WriteAll` has been added while other bounds remain unchanged.
+- In the following functions, the bound
+  `S: yash_env::system::Sigaction + yash_env::system::Sigmask` has been removed and the bound
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::trap::SignalSystem` has been added while other bounds remain unchanged:
+    - `wait::core::wait_for_any_job_or_trap`
+    - `wait::status::wait_while_running`
+- In the following functions, the bound
+  `S: yash_env::system::Fcntl + yash_env::system::Sigaction + yash_env::system::Sigmask + yash_env::system::Write` has been removed and the bound
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::trap::SignalSystem` has been added while other bounds remain unchanged:
+    - `wait::main`
+    - `wait::Command::execute`
 - Public dependency versions:
     - yash-env 0.13.0 → 0.14.0
     - yash-semantics (optional) 0.15.0 → 0.16.0

--- a/yash-builtin/src/command.rs
+++ b/yash-builtin/src/command.rs
@@ -47,14 +47,17 @@ use crate::common::report::report_error;
 use enumset::EnumSet;
 use enumset::EnumSetType;
 use yash_env::Env;
+use yash_env::job::RunBlocking;
+use yash_env::job::RunUnblocking;
 use yash_env::semantics::Field;
+use yash_env::subshell::BlockSignals;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 #[cfg(all(doc, unix))]
 use yash_env::system::real::RealSystem;
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
     Close, Dup, Exec, Exit, Fork, Fstat, GetCwd, GetPid, IsExecutableFile, Isatty, Open,
-    SendSignal, SetPgid, ShellPath, Sigaction, Sigmask, Sysconf, TcSetPgrp, Wait,
+    SendSignal, SetPgid, ShellPath, Sysconf, TcSetPgrp, Wait,
 };
 use yash_env::trap::SignalSystem;
 
@@ -174,7 +177,8 @@ impl Command {
     /// Executes the `command` built-in with the specified environment.
     pub async fn execute<S>(self, env: &mut Env<S>) -> crate::Result
     where
-        S: Close
+        S: BlockSignals
+            + Close
             + Dup
             + Exec
             + Exit
@@ -185,12 +189,12 @@ impl Command {
             + IsExecutableFile
             + Isatty
             + Open
+            + RunBlocking
+            + RunUnblocking
             + SendSignal
             + SetPgid
             + SetRlimit
             + ShellPath
-            + Sigaction
-            + Sigmask
             + SignalSystem
             + Sysconf
             + TcSetPgrp
@@ -216,7 +220,8 @@ pub mod syntax;
 /// This function parses the arguments into [`Command`] and executes it.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
-    S: Close
+    S: BlockSignals
+        + Close
         + Dup
         + Exec
         + Exit
@@ -227,12 +232,12 @@ where
         + IsExecutableFile
         + Isatty
         + Open
+        + RunBlocking
+        + RunUnblocking
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + Sysconf
         + TcSetPgrp

--- a/yash-builtin/src/command/invoke.rs
+++ b/yash-builtin/src/command/invoke.rs
@@ -23,16 +23,19 @@ use crate::common::report::report_failure;
 use crate::exec::ExecFailure;
 use std::ops::ControlFlow::{Break, Continue};
 use yash_env::Env;
+use yash_env::job::RunBlocking;
+use yash_env::job::RunUnblocking;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::semantics::command::RunFunction;
 use yash_env::semantics::command::run_external_utility_in_subshell;
 use yash_env::semantics::command::search::{Target, search};
+use yash_env::subshell::BlockSignals;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
     Close, Dup, Exec, Exit, Fork, GetPid, IsExecutableFile, Isatty, Open, SendSignal, SetPgid,
-    ShellPath, Sigaction, Sigmask, Sysconf, TcSetPgrp, Wait,
+    ShellPath, Sysconf, TcSetPgrp, Wait,
 };
 use yash_env::trap::SignalSystem;
 
@@ -40,7 +43,8 @@ impl Invoke {
     /// Execute the command
     pub async fn execute<S>(self, env: &mut Env<S>) -> crate::Result
     where
-        S: Close
+        S: BlockSignals
+            + Close
             + Dup
             + Exec
             + Exit
@@ -49,12 +53,12 @@ impl Invoke {
             + IsExecutableFile
             + Isatty
             + Open
+            + RunBlocking
+            + RunUnblocking
             + SendSignal
             + SetPgid
             + SetRlimit
             + ShellPath
-            + Sigaction
-            + Sigmask
             + SignalSystem
             + Sysconf
             + TcSetPgrp
@@ -94,7 +98,8 @@ async fn invoke_target<S>(
     mut fields: Vec<Field>,
 ) -> crate::Result
 where
-    S: Close
+    S: BlockSignals
+        + Close
         + Dup
         + Exec
         + Exit
@@ -102,12 +107,12 @@ where
         + GetPid
         + Isatty
         + Open
+        + RunBlocking
+        + RunUnblocking
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + TcSetPgrp
         + Wait

--- a/yash-builtin/src/exec.rs
+++ b/yash-builtin/src/exec.rs
@@ -45,7 +45,7 @@ use yash_env::semantics::{Divert::Abort, ExitStatus, Field};
 use yash_env::source::Location;
 use yash_env::source::pretty::{Report, ReportType, Snippet};
 use yash_env::system::concurrency::WriteAll;
-use yash_env::system::{Exec, IsExecutableFile, Isatty, ShellPath, Sigaction, Sigmask};
+use yash_env::system::{Exec, IsExecutableFile, Isatty, ShellPath};
 use yash_env::trap::SignalSystem;
 
 // TODO Split into syntax and semantics submodules
@@ -53,7 +53,7 @@ use yash_env::trap::SignalSystem;
 /// Entry point for executing the `exec` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
-    S: Exec + IsExecutableFile + Isatty + ShellPath + Sigmask + Sigaction + SignalSystem + WriteAll,
+    S: Exec + IsExecutableFile + Isatty + ShellPath + SignalSystem + WriteAll,
 {
     // TODO Support non-POSIX options
     let args = match parse_arguments(&[], Mode::with_env(env), args) {

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -39,6 +39,7 @@ use yash_env::io::Fd;
 use yash_env::job::JobList;
 use yash_env::job::ProcessResult;
 use yash_env::job::ProcessState;
+use yash_env::job::RunBlocking;
 use yash_env::job::id::parse;
 use yash_env::job::tcsetpgrp_with_block;
 use yash_env::option::Option::Monitor;
@@ -47,7 +48,7 @@ use yash_env::semantics::Divert::Interrupt;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
-use yash_env::system::{Close, Dup, Isatty, Open, SendSignal, Sigaction, Sigmask, TcSetPgrp, Wait};
+use yash_env::system::{Close, Dup, Isatty, Open, SendSignal, TcSetPgrp, Wait};
 use yash_env::trap::SignalSystem;
 
 /// Resumes the job at the specified index.
@@ -65,10 +66,9 @@ where
         + Dup
         + Isatty
         + Open
+        + RunBlocking
         + SendSignal
         + SignalSystem
-        + Sigmask
-        + Sigaction
         + TcSetPgrp
         + Wait
         + WaitForSignals
@@ -137,10 +137,9 @@ where
         + Dup
         + Isatty
         + Open
+        + RunBlocking
         + SendSignal
         + SignalSystem
-        + Sigmask
-        + Sigaction
         + TcSetPgrp
         + Wait
         + WaitForSignals
@@ -158,10 +157,9 @@ where
         + Dup
         + Isatty
         + Open
+        + RunBlocking
         + SendSignal
         + SignalSystem
-        + Sigmask
-        + Sigaction
         + TcSetPgrp
         + Wait
         + WaitForSignals

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -96,14 +96,16 @@ use yash_env::Env;
 use yash_env::builtin::Type::{Elective, Mandatory, Special, Substitutive};
 #[doc(no_inline)]
 pub use yash_env::builtin::*;
+use yash_env::job::{RunBlocking, RunUnblocking};
 #[cfg(doc)]
 use yash_env::stack::{Frame, Stack};
+use yash_env::subshell::BlockSignals;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::resource::{GetRlimit, SetRlimit};
 use yash_env::system::{
     Chdir, Clock, Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetCwd, GetPid, GetPw, GetUid,
-    IsExecutableFile, Isatty, Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, Sigaction,
-    Sigmask, Sysconf, TcGetPgrp, TcSetPgrp, Times, Umask, Wait, Write,
+    IsExecutableFile, Isatty, Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, Sysconf,
+    TcGetPgrp, TcSetPgrp, Times, Umask, Wait, Write,
 };
 use yash_env::trap::SignalSystem;
 
@@ -116,7 +118,8 @@ pub fn iter<S>() -> impl Iterator<Item = (&'static str, Builtin<S>)>
 where
     // Some of these traits are not used in any built-in, but we include them
     // here for future extensibility.
-    S: Chdir
+    S: BlockSignals
+        + Chdir
         + Clock
         + Clone
         + Close
@@ -136,13 +139,13 @@ where
         + Open
         + Pipe
         + Read
+        + RunBlocking
+        + RunUnblocking
         + Seek
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + Sysconf
         + TcGetPgrp

--- a/yash-builtin/src/set.rs
+++ b/yash-builtin/src/set.rs
@@ -31,6 +31,8 @@ use crate::common::output;
 use crate::common::report::report_error;
 use yash_env::Env;
 use yash_env::builtin::Result;
+use yash_env::job::RunBlocking;
+use yash_env::job::RunUnblocking;
 use yash_env::option::State;
 #[cfg(doc)]
 use yash_env::option::canonicalize;
@@ -44,7 +46,7 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::stack::Frame::Subshell;
 use yash_env::system::concurrency::WriteAll;
-use yash_env::system::{Close, Dup, GetPid, Isatty, Open, Sigaction, Sigmask, TcSetPgrp};
+use yash_env::system::{Close, Dup, GetPid, Isatty, Open, TcSetPgrp};
 use yash_env::trap::SignalSystem;
 use yash_env::variable::Scope::Global;
 
@@ -95,7 +97,7 @@ where
 /// option is enabled.
 async fn ensure_foreground<S>(env: &mut Env<S>)
 where
-    S: Open + Dup + Close + GetPid + Sigmask + Sigaction + TcSetPgrp,
+    S: Open + Dup + Close + GetPid + RunBlocking + RunUnblocking + TcSetPgrp,
 {
     if env.options.get(Monitor) == State::On {
         env.ensure_foreground().await.ok();
@@ -108,7 +110,7 @@ async fn modify<S>(
     options: Vec<(yash_env::option::Option, State)>,
     positional_params: Option<Vec<Field>>,
 ) where
-    S: Open + Dup + Close + GetPid + Sigaction + Sigmask + SignalSystem + TcSetPgrp,
+    S: Open + Dup + Close + GetPid + RunBlocking + RunUnblocking + SignalSystem + TcSetPgrp,
 {
     // Modify options
     let mut monitor_changed = false;
@@ -145,9 +147,9 @@ where
         + Close
         + GetPid
         + Isatty
+        + RunBlocking
+        + RunUnblocking
         + SignalSystem
-        + Sigmask
-        + Sigaction
         + TcSetPgrp
         + WriteAll
         + 'static,

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -158,6 +158,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `job::tcsetpgrp_without_block` function now requires the trait bound
   `S: job::RunUnblocking + system::TcSetPgrp` instead of
   `S: system::Sigmask + system::Sigaction + system::TcSetPgrp`.
+- The `semantics::exit_or_raise` function now requires the trait bound
+  `S: job::RunUnblocking + system::SendSignal + system::resource::SetRlimit + system::Exit`
+  instead of
+  `S: system::Sigmask + system::Sigaction + system::SendSignal + system::resource::SetRlimit + system::Exit`.
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -63,8 +63,12 @@ A _private dependency_ is used internally and not visible to downstream users.
   more flexible and ergonomic way to configure subshells.
 - The `Default` trait is now implemented for `Env<S>` where
   `S: Default + system::GetPid`.
-- The `job::RunBlocking` trait has been added to provide a higher-level interface
-  for running a function with a signal blocked.
+- The `job::RunBlocking` and `job::RunUnblocking` traits have been added to
+  provide higher-level interfaces for running functions with signals blocked or
+  unblocked, respectively. These traits are now used in the
+  `job::tcsetpgrp_with_block` and `job::tcsetpgrp_without_block` functions
+  instead of the previous `system::Sigmask` and `system::Sigaction` trait
+  bounds.
 
 ### Changed
 
@@ -151,6 +155,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `job::tcsetpgrp_with_block` function now requires the trait bound
   `S: job::RunBlocking + system::TcSetPgrp` instead of
   `S: system::Sigmask + system::TcSetPgrp`.
+- The `job::tcsetpgrp_without_block` function now requires the trait bound
+  `S: job::RunUnblocking + system::TcSetPgrp` instead of
+  `S: system::Sigmask + system::Sigaction + system::TcSetPgrp`.
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -99,8 +99,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       `S: system::Exec + system::ShellPath + trap::SignalSystem` instead of
       `S: system::Exec + system::ShellPath + system::Sigmask + system::Sigaction`.
     - The `semantics::command::run_external_utility_in_subshell` function now
-      additionally requires the trait bound
-      `S: system::concurrency::WaitForSignals + trap::SignalSystem`.
+      additionally requires the trait bounds
+      `S: subshell::BlockSignals + job::RunBlocking + job::RunUnblocking + system::concurrency::WaitForSignals + trap::SignalSystem`
+      and no longer requires `S: system::Sigaction + system::Sigmask`.
     - The implementation of `input::Input` for `input::Echo` now requires the
       trait bound `S: system::concurrency::WriteAll` instead of
       `S: system::Fcntl + system::Write`.
@@ -162,6 +163,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `job::tcsetpgrp_without_block` function now requires the trait bound
   `S: job::RunUnblocking + system::TcSetPgrp` instead of
   `S: system::Sigmask + system::Sigaction + system::TcSetPgrp`.
+- The `Env::ensure_foreground` method now additionally requires the trait bounds
+  `S: job::RunBlocking + job::RunUnblocking` and no longer requires
+  `S: system::Sigmask + system::Sigaction`.
 - The `semantics::exit_or_raise` function now requires the trait bound
   `S: job::RunUnblocking + system::SendSignal + system::resource::SetRlimit + system::Exit`
   instead of

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -63,6 +63,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   more flexible and ergonomic way to configure subshells.
 - The `Default` trait is now implemented for `Env<S>` where
   `S: Default + system::GetPid`.
+- The `job::RunBlocking` trait has been added to provide a higher-level interface
+  for running a function with a signal blocked.
 
 ### Changed
 
@@ -146,6 +148,9 @@ A _private dependency_ is used internally and not visible to downstream users.
   descriptors, rather than being limited to `Concurrent` systems. The
   implementation of `input::Input` for `FdReader2` now only requires the system
   to implement the `Read` trait.
+- The `job::tcsetpgrp_with_block` function now requires the trait bound
+  `S: job::RunBlocking + system::TcSetPgrp` instead of
+  `S: system::Sigmask + system::TcSetPgrp`.
 
 ### Deprecated
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -69,6 +69,10 @@ A _private dependency_ is used internally and not visible to downstream users.
   `job::tcsetpgrp_with_block` and `job::tcsetpgrp_without_block` functions
   instead of the previous `system::Sigmask` and `system::Sigaction` trait
   bounds.
+- The `subshell::BlockSignals` trait has been added to provide a higher-level
+  interface for blocking signals in the subshell configuration. This trait is
+  now used in the `subshell::Config::start` method instead of the previous
+  `system::Sigmask` and `system::Sigaction` trait bounds.
 
 ### Changed
 
@@ -162,6 +166,16 @@ A _private dependency_ is used internally and not visible to downstream users.
   `S: job::RunUnblocking + system::SendSignal + system::resource::SetRlimit + system::Exit`
   instead of
   `S: system::Sigmask + system::Sigaction + system::SendSignal + system::resource::SetRlimit + system::Exit`.
+- The `S: job::RunBlocking + job::RunUnblocking + subshell::BlockSignals` bound
+  has been added to and the `S: system::Sigmask + system::Sigaction` bound has
+  been removed from the following functions:
+    - `subshell::Config::start`
+    - `subshell::Config::start_and_wait`
+    - `subshell::Subshell::new`
+    - `subshell::Subshell::job_control`
+    - `subshell::Subshell::ignore_sigint_sigquit`
+    - `subshell::Subshell::start`
+    - `subshell::Subshell::start_and_wait`
 
 ### Deprecated
 

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -1581,9 +1581,6 @@ mod tests {
         assert_eq!(list.previous_job(), Some(i10));
     }
 
-    // TODO tcsetpgrp_with_block tests
-    // TODO tcsetpgrp_without_block tests
-
     #[test]
     fn do_not_add_job_if_exited() {
         let mut env = Env::new_virtual();

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -42,10 +42,8 @@
 //! special parameter.
 
 use crate::Env;
-use crate::io::Fd;
 use crate::semantics::{Divert, ExitStatus};
 use crate::signal;
-use crate::system::{Disposition, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _, TcSetPgrp};
 use slab::Slab;
 use std::collections::HashMap;
 use std::iter::FusedIterator;
@@ -925,91 +923,6 @@ impl JobList {
     }
 }
 
-/// Switches the foreground process group with SIGTTOU blocked.
-///
-/// This is a convenience function to change the foreground process group
-/// safely. If you call [`TcSetPgrp::tcsetpgrp`] from a background process, the
-/// process is stopped by SIGTTOU by default. To prevent this effect, SIGTTOU
-/// must be blocked or ignored when `tcsetpgrp` is called. This function uses
-/// [`Sigmask::sigmask`] to block SIGTTOU before calling `tcsetpgrp` and also to
-/// restore the original signal mask after `tcsetpgrp`.
-///
-/// Use [`tcsetpgrp_without_block`] if you need to make sure the shell is in the
-/// foreground before changing the foreground job.
-pub async fn tcsetpgrp_with_block<S>(system: &S, fd: Fd, pgid: Pid) -> crate::system::Result<()>
-where
-    S: Signals + Sigmask + TcSetPgrp + ?Sized,
-{
-    let mut old_mask = S::Sigset::new();
-
-    system
-        .sigmask(
-            Some((SigmaskOp::Add, &S::Sigset::from_signals([S::SIGTTOU])?)),
-            Some(&mut old_mask),
-        )
-        .await?;
-
-    let result = system.tcsetpgrp(fd, pgid).await;
-
-    let result_2 = system
-        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
-        .await;
-
-    result.and(result_2)
-}
-
-/// Switches the foreground process group with the default SIGTTOU settings.
-///
-/// This is a convenience function to ensure the shell has been in the
-/// foreground and optionally change the foreground process group. This
-/// function calls [`Sigaction::sigaction`] to restore the action for
-/// SIGTTOU to the default disposition (which is to suspend the shell
-/// process), [`Sigmask::sigmask`] to unblock SIGTTOU, and
-/// [`TcSetPgrp::tcsetpgrp`] to modify the foreground job. If the calling
-/// process is not in the foreground, `tcsetpgrp` will suspend the process
-/// with SIGTTOU until another job-controlling process resumes it in the
-/// foreground. After `tcsetpgrp` completes, this function calls `sigmask`
-/// and `sigaction` to restore the original state.
-///
-/// Note that if `pgid` is the process group ID of the current process, this
-/// function does not change the foreground job, but the process is still
-/// subject to suspension if it has not been in the foreground.
-///
-/// Use [`tcsetpgrp_with_block`] to change the job even if the current shell is
-/// not in the foreground.
-pub async fn tcsetpgrp_without_block<S>(system: &S, fd: Fd, pgid: Pid) -> crate::system::Result<()>
-where
-    S: Signals + Sigaction + Sigmask + TcSetPgrp + ?Sized,
-{
-    let sigttou = S::Sigset::from_signals([S::SIGTTOU])?;
-
-    match system.sigaction(S::SIGTTOU, Disposition::Default) {
-        Err(e) => Err(e),
-        Ok(old_handling) => {
-            let mut old_mask = S::Sigset::new();
-            let result = match system
-                .sigmask(Some((SigmaskOp::Remove, &sigttou)), Some(&mut old_mask))
-                .await
-            {
-                Err(e) => Err(e),
-                Ok(()) => {
-                    let result = system.tcsetpgrp(fd, pgid).await;
-
-                    let result_2 = system
-                        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
-                        .await;
-
-                    result.and(result_2)
-                }
-            };
-
-            let result_2 = system.sigaction(S::SIGTTOU, old_handling).map(drop);
-
-            result.and(result_2)
-        }
-    }
-}
-
 /// Adds a job if the process is suspended.
 ///
 /// This is a convenience function for handling the result of
@@ -1055,6 +968,9 @@ where
 
 pub mod fmt;
 pub mod id;
+mod tcsetpgrp;
+
+pub use self::tcsetpgrp::*;
 
 #[cfg(test)]
 mod tests {

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -29,15 +29,15 @@ use crate::system::{
 ///
 /// This trait represents the capability required by [`tcsetpgrp_with_block`] to
 /// run a function with a signal blocked. It is automatically implemented for
-/// any type that implements [`Sigmask`]. Additionally, [`Concurrent`]
-/// implements this trait by delegating to the inner type while not implementing
-/// [`Sigmask`] itself, which allows `Concurrent` to maintain internal
-/// consistency about signal masks while still providing this capability.
+/// any type that implements [`Sigmask`].
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask. Typical implementations of this trait will internally depend on
 /// [`Sigmask`] to perform the actual signal mask modification, but the trait
-/// itself does not require this as a supertrait.
+/// itself does not require this as a supertrait. Using this trait as the public
+/// capability leaves room for types such as [`Concurrent`] to stop exposing
+/// `Sigmask` directly in a future release while still providing the behavior
+/// required by callers.
 pub trait RunBlocking: Signals {
     /// Runs the given function with the specified signal blocked.
     ///
@@ -111,17 +111,15 @@ where
 /// This trait represents the capability required by [`tcsetpgrp_without_block`]
 /// to run a function with a signal unblocked and the default disposition. It is
 /// automatically implemented for any type that implements [`Sigmask`] and
-/// [`Sigaction`]. Additionally, [`Concurrent`] implements this trait by
-/// delegating to the inner type while not implementing [`Sigmask`] or
-/// [`Sigaction`] itself, which allows `Concurrent` to maintain internal
-/// consistency about signal masks and dispositions while still providing this
-/// capability.
+/// [`Sigaction`].
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask and disposition. Typical implementations of this trait will internally
 /// depend on [`Sigmask`] and [`Sigaction`] to perform the actual signal mask
 /// and disposition modification, but the trait itself does not require them as
-/// supertraits.
+/// supertraits. Using this trait as the public capability leaves room for types
+/// such as [`Concurrent`] to stop exposing `Sigmask` directly in a future
+/// release while still providing the behavior required by callers.
 pub trait RunUnblocking: Signals {
     /// Runs the given function with the specified signal unblocked and the
     /// default disposition.

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -221,3 +221,411 @@ where
         .run_unblocking(S::SIGTTOU, || system.tcsetpgrp(fd, pgid))
         .await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal;
+    use crate::system::r#virtual::{
+        SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGIOT,
+        SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP, SIGTSTP,
+        SIGTTIN, SIGTTOU, SIGURG, SIGUSR1, SIGUSR2, SIGVTALRM, SIGWINCH, SIGXCPU, SIGXFSZ,
+    };
+    use crate::system::{Errno, GetSigaction};
+    use futures_util::FutureExt as _;
+    use std::cell::{Cell, RefCell};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::ops::RangeInclusive;
+
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    struct TestSigset(BTreeSet<signal::Number>);
+
+    impl crate::system::Sigset for TestSigset {
+        fn full() -> Self {
+            unimplemented!("not needed for tests")
+        }
+
+        fn insert(&mut self, signal: signal::Number) -> Result<()> {
+            self.0.insert(signal);
+            Ok(())
+        }
+
+        fn remove(&mut self, signal: signal::Number) -> Result<()> {
+            self.0.remove(&signal);
+            Ok(())
+        }
+
+        fn contains(&self, signal: signal::Number) -> Result<bool> {
+            Ok(self.0.contains(&signal))
+        }
+    }
+
+    #[derive(Default)]
+    struct MockSystem {
+        mask: RefCell<TestSigset>,
+        dispositions: RefCell<BTreeMap<signal::Number, Disposition>>,
+        sigmask_errors: RefCell<BTreeMap<usize, Errno>>,
+        sigaction_errors: RefCell<BTreeMap<usize, Errno>>,
+        sigmask_call_count: Cell<usize>,
+        sigaction_call_count: Cell<usize>,
+    }
+
+    impl MockSystem {
+        fn set_mask(&self, mask: TestSigset) {
+            self.mask.replace(mask);
+        }
+
+        fn set_disposition(&self, signal: signal::Number, disposition: Disposition) {
+            self.dispositions.borrow_mut().insert(signal, disposition);
+        }
+
+        fn disposition_of(&self, signal: signal::Number) -> Disposition {
+            self.dispositions
+                .borrow()
+                .get(&signal)
+                .copied()
+                .unwrap_or_default()
+        }
+
+        fn is_blocked(&self, signal: signal::Number) -> bool {
+            self.mask
+                .borrow()
+                .contains(signal)
+                .expect("signals in tests are always valid")
+        }
+
+        fn set_sigmask_error_on_call(&self, call: usize, error: Errno) {
+            self.sigmask_errors.borrow_mut().insert(call, error);
+        }
+
+        fn set_sigaction_error_on_call(&self, call: usize, error: Errno) {
+            self.sigaction_errors.borrow_mut().insert(call, error);
+        }
+    }
+
+    impl Signals for MockSystem {
+        const SIGABRT: signal::Number = SIGABRT;
+        const SIGALRM: signal::Number = SIGALRM;
+        const SIGBUS: signal::Number = SIGBUS;
+        const SIGCHLD: signal::Number = SIGCHLD;
+        const SIGCLD: Option<signal::Number> = None;
+        const SIGCONT: signal::Number = SIGCONT;
+        const SIGEMT: Option<signal::Number> = None;
+        const SIGFPE: signal::Number = SIGFPE;
+        const SIGHUP: signal::Number = SIGHUP;
+        const SIGILL: signal::Number = SIGILL;
+        const SIGINFO: Option<signal::Number> = None;
+        const SIGINT: signal::Number = SIGINT;
+        const SIGIO: Option<signal::Number> = None;
+        const SIGIOT: signal::Number = SIGIOT;
+        const SIGKILL: signal::Number = SIGKILL;
+        const SIGLOST: Option<signal::Number> = None;
+        const SIGPIPE: signal::Number = SIGPIPE;
+        const SIGPOLL: Option<signal::Number> = None;
+        const SIGPROF: signal::Number = SIGPROF;
+        const SIGPWR: Option<signal::Number> = None;
+        const SIGQUIT: signal::Number = SIGQUIT;
+        const SIGSEGV: signal::Number = SIGSEGV;
+        const SIGSTKFLT: Option<signal::Number> = None;
+        const SIGSTOP: signal::Number = SIGSTOP;
+        const SIGSYS: signal::Number = SIGSYS;
+        const SIGTERM: signal::Number = SIGTERM;
+        const SIGTHR: Option<signal::Number> = None;
+        const SIGTRAP: signal::Number = SIGTRAP;
+        const SIGTSTP: signal::Number = SIGTSTP;
+        const SIGTTIN: signal::Number = SIGTTIN;
+        const SIGTTOU: signal::Number = SIGTTOU;
+        const SIGURG: signal::Number = SIGURG;
+        const SIGUSR1: signal::Number = SIGUSR1;
+        const SIGUSR2: signal::Number = SIGUSR2;
+        const SIGVTALRM: signal::Number = SIGVTALRM;
+        const SIGWINCH: signal::Number = SIGWINCH;
+        const SIGXCPU: signal::Number = SIGXCPU;
+        const SIGXFSZ: signal::Number = SIGXFSZ;
+
+        fn sigrt_range(&self) -> Option<RangeInclusive<signal::Number>> {
+            None
+        }
+    }
+
+    impl Sigmask for MockSystem {
+        type Sigset = TestSigset;
+
+        fn sigmask(
+            &self,
+            op: Option<(SigmaskOp, &Self::Sigset)>,
+            old_mask: Option<&mut Self::Sigset>,
+        ) -> impl Future<Output = Result<()>> + use<> {
+            let call_count = self.sigmask_call_count.get() + 1;
+            self.sigmask_call_count.set(call_count);
+
+            if let Some(error) = self.sigmask_errors.borrow_mut().remove(&call_count) {
+                return std::future::ready(Err(error));
+            }
+
+            let result = {
+                let mut mask = self.mask.borrow_mut();
+                if let Some(old_mask) = old_mask {
+                    old_mask.clone_from(&mask);
+                }
+
+                if let Some((op, signals)) = op {
+                    match op {
+                        SigmaskOp::Add => {
+                            for &signal in &signals.0 {
+                                mask.insert(signal).unwrap();
+                            }
+                        }
+                        SigmaskOp::Remove => {
+                            for &signal in &signals.0 {
+                                mask.remove(signal).unwrap();
+                            }
+                        }
+                        SigmaskOp::Set => {
+                            *mask = signals.clone();
+                        }
+                    }
+                }
+
+                Ok(())
+            };
+
+            std::future::ready(result)
+        }
+    }
+
+    impl GetSigaction for MockSystem {
+        fn get_sigaction(&self, signal: signal::Number) -> Result<Disposition> {
+            Ok(self.disposition_of(signal))
+        }
+    }
+
+    impl Sigaction for MockSystem {
+        fn sigaction(&self, signal: signal::Number, action: Disposition) -> Result<Disposition> {
+            let call_count = self.sigaction_call_count.get() + 1;
+            self.sigaction_call_count.set(call_count);
+
+            if let Some(error) = self.sigaction_errors.borrow_mut().remove(&call_count) {
+                return Err(error);
+            }
+
+            Ok(self
+                .dispositions
+                .borrow_mut()
+                .insert(signal, action)
+                .unwrap_or_default())
+        }
+    }
+
+    #[test]
+    fn run_blocking_blocks_signal_and_restores_mask_on_success() {
+        let system = MockSystem::default();
+        let called = Cell::new(false);
+
+        let result = system
+            .run_blocking(MockSystem::SIGTTOU, async || {
+                called.set(true);
+                assert!(system.is_blocked(MockSystem::SIGTTOU));
+                Ok(())
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Ok(()));
+        assert!(called.get());
+        assert!(!system.is_blocked(MockSystem::SIGTTOU));
+    }
+
+    #[test]
+    fn run_blocking_does_not_run_function_when_initial_sigmask_fails() {
+        let system = MockSystem::default();
+        system.set_sigmask_error_on_call(1, Errno::EINVAL);
+
+        let result = system
+            .run_blocking(MockSystem::SIGTTOU, async || -> Result<()> {
+                unreachable!("closure should not be called")
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINVAL));
+    }
+
+    #[test]
+    fn run_blocking_discards_restore_error_when_function_returns_error() {
+        let system = MockSystem::default();
+        system.set_sigmask_error_on_call(2, Errno::EPERM);
+
+        let result = system
+            .run_blocking(MockSystem::SIGTTOU, async || Err::<(), _>(Errno::EINTR))
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINTR));
+    }
+
+    #[test]
+    fn run_blocking_propagates_restore_error_when_function_succeeds() {
+        let system = MockSystem::default();
+        system.set_sigmask_error_on_call(2, Errno::EPERM);
+
+        let result = system
+            .run_blocking(MockSystem::SIGTTOU, async || Ok(()))
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EPERM));
+    }
+
+    #[test]
+    fn run_unblocking_for_sigkill_runs_function_without_sigaction_or_sigmask() {
+        let system = MockSystem::default();
+        let called = Cell::new(false);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGKILL, async || {
+                called.set(true);
+                Err::<(), _>(Errno::EINTR)
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINTR));
+        assert!(called.get());
+        assert_eq!(system.sigmask_call_count.get(), 0);
+        assert_eq!(system.sigaction_call_count.get(), 0);
+    }
+
+    #[test]
+    fn run_unblocking_for_sigstop_runs_function_without_sigaction_or_sigmask() {
+        let system = MockSystem::default();
+        let called = Cell::new(false);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGSTOP, async || {
+                called.set(true);
+                Err::<(), _>(Errno::EINTR)
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINTR));
+        assert!(called.get());
+        assert_eq!(system.sigmask_call_count.get(), 0);
+        assert_eq!(system.sigaction_call_count.get(), 0);
+    }
+
+    #[test]
+    fn run_unblocking_sets_default_unblocks_and_restores_on_success() {
+        let system = MockSystem::default();
+        let called = Cell::new(false);
+        let mut initial_mask = TestSigset::new();
+        initial_mask.insert(MockSystem::SIGTTOU).unwrap();
+        system.set_mask(initial_mask.clone());
+        system.set_disposition(MockSystem::SIGTTOU, Disposition::Ignore);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || {
+                called.set(true);
+                assert_eq!(
+                    system.disposition_of(MockSystem::SIGTTOU),
+                    Disposition::Default
+                );
+                assert!(!system.is_blocked(MockSystem::SIGTTOU));
+                Ok(())
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Ok(()));
+        assert!(called.get());
+        assert!(system.is_blocked(MockSystem::SIGTTOU));
+        assert_eq!(
+            system.disposition_of(MockSystem::SIGTTOU),
+            Disposition::Ignore
+        );
+    }
+
+    #[test]
+    fn run_unblocking_returns_error_when_unblock_sigmask_fails_and_restores_disposition() {
+        let system = MockSystem::default();
+        system.set_disposition(MockSystem::SIGTTOU, Disposition::Ignore);
+        system.set_sigmask_error_on_call(1, Errno::EPERM);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || -> Result<()> {
+                unreachable!("closure should not be called")
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EPERM));
+        assert_eq!(
+            system.disposition_of(MockSystem::SIGTTOU),
+            Disposition::Ignore
+        );
+    }
+
+    #[test]
+    fn run_unblocking_discards_restore_errors_when_function_returns_error() {
+        let system = MockSystem::default();
+        let called = Cell::new(false);
+        system.set_sigmask_error_on_call(2, Errno::EPERM);
+        system.set_sigaction_error_on_call(2, Errno::EINVAL);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || {
+                called.set(true);
+                Err::<(), _>(Errno::EINTR)
+            })
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINTR));
+        assert!(called.get());
+    }
+
+    #[test]
+    fn run_unblocking_propagates_restore_mask_error_when_function_succeeds() {
+        let system = MockSystem::default();
+        system.set_sigmask_error_on_call(2, Errno::EPERM);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || Ok(()))
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EPERM));
+    }
+
+    #[test]
+    fn run_unblocking_restores_sigaction_on_sigmask_restoration_error() {
+        let system = MockSystem::default();
+        system.set_disposition(MockSystem::SIGTTOU, Disposition::Ignore);
+        system.set_sigmask_error_on_call(2, Errno::EPERM);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || Ok(()))
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EPERM));
+        assert_eq!(
+            system.disposition_of(MockSystem::SIGTTOU),
+            Disposition::Ignore
+        );
+    }
+
+    #[test]
+    fn run_unblocking_propagates_restore_action_error_when_function_succeeds() {
+        let system = MockSystem::default();
+        system.set_sigaction_error_on_call(2, Errno::EINVAL);
+
+        let result = system
+            .run_unblocking(MockSystem::SIGTTOU, async || Ok(()))
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(result, Err(Errno::EINVAL));
+    }
+}

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -18,9 +18,72 @@
 
 use super::Pid;
 use crate::io::Fd;
+use crate::signal;
+#[cfg(doc)]
+use crate::system::Concurrent;
 use crate::system::{
     Disposition, Result, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _, TcSetPgrp,
 };
+
+/// A trait to run a function with a signal blocked
+///
+/// This trait represents the capability required by [`tcsetpgrp_with_block`] to
+/// run a function with a signal blocked. It is automatically implemented for
+/// any type that implements [`Sigmask`]. Additionally, [`Concurrent`]
+/// implements this trait by delegating to the inner type while not implementing
+/// [`Sigmask`] itself, which allows `Concurrent` to maintain internal
+/// consistency about signal masks while still providing this capability.
+///
+/// This trait defines a higher-level interface to temporarily modify the signal
+/// mask. Typical implementations of this trait will internally depend on
+/// [`Sigmask`] to perform the actual signal mask modification, but the trait
+/// itself does not require this as a supertrait.
+pub trait RunBlocking: Signals {
+    /// Runs the given function with the specified signal blocked.
+    ///
+    /// This function blocks the given signal, runs the given function, and then
+    /// restores the original signal mask. If all operations succeed, the result
+    /// of the function is returned. If any operation fails, an error is
+    /// returned.
+    ///
+    /// This function restores the original signal mask even if the given
+    /// function returns an error, in which case any error restoring the signal
+    /// mask is discarded. If the signal cannot be blocked, this function
+    /// returns an error without running the function.
+    fn run_blocking<F, T>(
+        &self,
+        signal: signal::Number,
+        f: F,
+    ) -> impl Future<Output = Result<T>> + use<'_, Self, F, T>
+    where
+        F: AsyncFnOnce() -> Result<T>;
+}
+
+impl<S> RunBlocking for S
+where
+    S: Sigmask + ?Sized,
+{
+    async fn run_blocking<F, T>(&self, signal: signal::Number, f: F) -> Result<T>
+    where
+        F: AsyncFnOnce() -> Result<T>,
+    {
+        let mut old_mask = S::Sigset::new();
+        self.sigmask(
+            Some((SigmaskOp::Add, &S::Sigset::from_signals([signal])?)),
+            Some(&mut old_mask),
+        )
+        .await?;
+
+        let main_result = f().await;
+
+        let restore_result = self.sigmask(Some((SigmaskOp::Set, &old_mask)), None).await;
+        if main_result.is_ok() {
+            restore_result?;
+        }
+
+        main_result
+    }
+}
 
 /// Switches the foreground process group with SIGTTOU blocked.
 ///
@@ -28,30 +91,19 @@ use crate::system::{
 /// safely. If you call [`TcSetPgrp::tcsetpgrp`] from a background process, the
 /// process is stopped by SIGTTOU by default. To prevent this effect, SIGTTOU
 /// must be blocked or ignored when `tcsetpgrp` is called. This function uses
-/// [`Sigmask::sigmask`] to block SIGTTOU before calling `tcsetpgrp` and also to
-/// restore the original signal mask after `tcsetpgrp`.
+/// [`RunBlocking::run_blocking`] to block SIGTTOU while calling `tcsetpgrp`,
+/// which ensures that the shell is not suspended even if it is not in the
+/// foreground.
 ///
 /// Use [`tcsetpgrp_without_block`] if you need to make sure the shell is in the
 /// foreground before changing the foreground job.
 pub async fn tcsetpgrp_with_block<S>(system: &S, fd: Fd, pgid: Pid) -> Result<()>
 where
-    S: Signals + Sigmask + TcSetPgrp + ?Sized,
+    S: RunBlocking + TcSetPgrp + ?Sized,
 {
-    let mut old_mask = S::Sigset::new();
     system
-        .sigmask(
-            Some((SigmaskOp::Add, &S::Sigset::from_signals([S::SIGTTOU])?)),
-            Some(&mut old_mask),
-        )
-        .await?;
-
-    let result = system.tcsetpgrp(fd, pgid).await;
-
-    let result_2 = system
-        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
-        .await;
-
-    result.and(result_2)
+        .run_blocking(S::SIGTTOU, || system.tcsetpgrp(fd, pgid))
+        .await
 }
 
 /// Switches the foreground process group with the default SIGTTOU settings.

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -106,54 +106,120 @@ where
         .await
 }
 
+/// A trait to run a function with a signal unblocked and the default disposition
+///
+/// This trait represents the capability required by [`tcsetpgrp_without_block`]
+/// to run a function with a signal unblocked and the default disposition. It is
+/// automatically implemented for any type that implements [`Sigmask`] and
+/// [`Sigaction`]. Additionally, [`Concurrent`] implements this trait by
+/// delegating to the inner type while not implementing [`Sigmask`] or
+/// [`Sigaction`] itself, which allows `Concurrent` to maintain internal
+/// consistency about signal masks and dispositions while still providing this
+/// capability.
+///
+/// This trait defines a higher-level interface to temporarily modify the signal
+/// mask and disposition. Typical implementations of this trait will internally
+/// depend on [`Sigmask`] and [`Sigaction`] to perform the actual signal mask
+/// and disposition modification, but the trait itself does not require them as
+/// supertraits.
+pub trait RunUnblocking: Signals {
+    /// Runs the given function with the specified signal unblocked and the
+    /// default disposition.
+    ///
+    /// For most signals, this function restores the default disposition for the
+    /// given signal, unblocks it, runs the given function, and then restores
+    /// the original signal mask and disposition. If all operations succeed, the
+    /// result of the function is returned. If any operation fails, an error is
+    /// returned.
+    ///
+    /// This function restores the original signal mask and disposition even if
+    /// the given function returns an error, in which case any error restoring
+    /// the signal mask or disposition is discarded. If the signal cannot be
+    /// unblocked or the disposition cannot be changed, this function returns an
+    /// error without running the function.
+    ///
+    /// For signals whose mask or disposition cannot be changed (i.e., [SIGKILL]
+    /// and [SIGSTOP]), this function does not try to unblock the signal or
+    /// restore its default disposition and instead simply runs the given
+    /// function.
+    ///
+    /// [SIGKILL]: crate::system::Signals::SIGKILL
+    /// [SIGSTOP]: crate::system::Signals::SIGSTOP
+    fn run_unblocking<F, T>(
+        &self,
+        signal: signal::Number,
+        f: F,
+    ) -> impl Future<Output = Result<T>> + use<'_, Self, F, T>
+    where
+        F: AsyncFnOnce() -> Result<T>;
+}
+
+impl<S> RunUnblocking for S
+where
+    S: Sigmask + Sigaction + ?Sized,
+{
+    async fn run_unblocking<F, T>(&self, signal: signal::Number, f: F) -> Result<T>
+    where
+        F: AsyncFnOnce() -> Result<T>,
+    {
+        if signal == S::SIGKILL || signal == S::SIGSTOP {
+            // These signals cannot be ignored or blocked, so we just run the function.
+            return f().await;
+        }
+
+        let sigset = S::Sigset::from_signals([signal])?;
+
+        let old_handling = self.sigaction(signal, Disposition::Default)?;
+
+        let mut old_mask = S::Sigset::new();
+        let unblock_result = self
+            .sigmask(Some((SigmaskOp::Remove, &sigset)), Some(&mut old_mask))
+            .await;
+        if let Err(e) = unblock_result {
+            _ = self.sigaction(signal, old_handling);
+            return Err(e);
+        }
+
+        let main_result = f().await;
+
+        let restore_mask_result = self.sigmask(Some((SigmaskOp::Set, &old_mask)), None).await;
+        let restore_action_result = self.sigaction(signal, old_handling);
+
+        if main_result.is_ok() {
+            restore_mask_result?;
+            restore_action_result?;
+        }
+        main_result
+    }
+}
+
 /// Switches the foreground process group with the default SIGTTOU settings.
 ///
 /// This is a convenience function to ensure the shell has been in the
-/// foreground and optionally change the foreground process group. This
-/// function calls [`Sigaction::sigaction`] to restore the action for
-/// SIGTTOU to the default disposition (which is to suspend the shell
-/// process), [`Sigmask::sigmask`] to unblock SIGTTOU, and
-/// [`TcSetPgrp::tcsetpgrp`] to modify the foreground job. If the calling
-/// process is not in the foreground, `tcsetpgrp` will suspend the process
-/// with SIGTTOU until another job-controlling process resumes it in the
-/// foreground. After `tcsetpgrp` completes, this function calls `sigmask`
-/// and `sigaction` to restore the original state.
+/// foreground and optionally change the foreground process group. If you call
+/// [`TcSetPgrp::tcsetpgrp`] from a background process that has not ignored or
+/// blocked SIGTTOU, the process is stopped by SIGTTOU. This behavior can be
+/// used to ensure the shell is in the foreground before starting job control
+/// operations.
 ///
-/// Note that if `pgid` is the process group ID of the current process, this
-/// function does not change the foreground job, but the process is still
-/// subject to suspension if it has not been in the foreground.
+/// This function temporarily restores the default disposition for SIGTTOU and
+/// unblocks it while calling `tcsetpgrp`, which ensures that the shell is
+/// suspended if it is not in the foreground. The suspended shell must be
+/// resumed by another job-controlling process, after which this function
+/// continues. If the shell is already in the foreground, this function behaves
+/// the same as usual `tcsetpgrp`.
+///
+/// To simply make sure the shell is in the foreground without changing the
+/// foreground job, you can call this function with `pgid` set to the process
+/// group ID of the current process.
 ///
 /// Use [`tcsetpgrp_with_block`] to change the job even if the current shell is
 /// not in the foreground.
 pub async fn tcsetpgrp_without_block<S>(system: &S, fd: Fd, pgid: Pid) -> Result<()>
 where
-    S: Signals + Sigaction + Sigmask + TcSetPgrp + ?Sized,
+    S: RunUnblocking + TcSetPgrp + ?Sized,
 {
-    let sigttou = S::Sigset::from_signals([S::SIGTTOU])?;
-
-    match system.sigaction(S::SIGTTOU, Disposition::Default) {
-        Err(e) => Err(e),
-        Ok(old_handling) => {
-            let mut old_mask = S::Sigset::new();
-            let result = match system
-                .sigmask(Some((SigmaskOp::Remove, &sigttou)), Some(&mut old_mask))
-                .await
-            {
-                Err(e) => Err(e),
-                Ok(()) => {
-                    let result = system.tcsetpgrp(fd, pgid).await;
-
-                    let result_2 = system
-                        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
-                        .await;
-
-                    result.and(result_2)
-                }
-            };
-
-            let result_2 = system.sigaction(S::SIGTTOU, old_handling).map(drop);
-
-            result.and(result_2)
-        }
-    }
+    system
+        .run_unblocking(S::SIGTTOU, || system.tcsetpgrp(fd, pgid))
+        .await
 }

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -1,0 +1,107 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2021 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Items related to the `tcsetpgrp` operation
+
+use super::Pid;
+use crate::io::Fd;
+use crate::system::{
+    Disposition, Result, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _, TcSetPgrp,
+};
+
+/// Switches the foreground process group with SIGTTOU blocked.
+///
+/// This is a convenience function to change the foreground process group
+/// safely. If you call [`TcSetPgrp::tcsetpgrp`] from a background process, the
+/// process is stopped by SIGTTOU by default. To prevent this effect, SIGTTOU
+/// must be blocked or ignored when `tcsetpgrp` is called. This function uses
+/// [`Sigmask::sigmask`] to block SIGTTOU before calling `tcsetpgrp` and also to
+/// restore the original signal mask after `tcsetpgrp`.
+///
+/// Use [`tcsetpgrp_without_block`] if you need to make sure the shell is in the
+/// foreground before changing the foreground job.
+pub async fn tcsetpgrp_with_block<S>(system: &S, fd: Fd, pgid: Pid) -> Result<()>
+where
+    S: Signals + Sigmask + TcSetPgrp + ?Sized,
+{
+    let mut old_mask = S::Sigset::new();
+    system
+        .sigmask(
+            Some((SigmaskOp::Add, &S::Sigset::from_signals([S::SIGTTOU])?)),
+            Some(&mut old_mask),
+        )
+        .await?;
+
+    let result = system.tcsetpgrp(fd, pgid).await;
+
+    let result_2 = system
+        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
+        .await;
+
+    result.and(result_2)
+}
+
+/// Switches the foreground process group with the default SIGTTOU settings.
+///
+/// This is a convenience function to ensure the shell has been in the
+/// foreground and optionally change the foreground process group. This
+/// function calls [`Sigaction::sigaction`] to restore the action for
+/// SIGTTOU to the default disposition (which is to suspend the shell
+/// process), [`Sigmask::sigmask`] to unblock SIGTTOU, and
+/// [`TcSetPgrp::tcsetpgrp`] to modify the foreground job. If the calling
+/// process is not in the foreground, `tcsetpgrp` will suspend the process
+/// with SIGTTOU until another job-controlling process resumes it in the
+/// foreground. After `tcsetpgrp` completes, this function calls `sigmask`
+/// and `sigaction` to restore the original state.
+///
+/// Note that if `pgid` is the process group ID of the current process, this
+/// function does not change the foreground job, but the process is still
+/// subject to suspension if it has not been in the foreground.
+///
+/// Use [`tcsetpgrp_with_block`] to change the job even if the current shell is
+/// not in the foreground.
+pub async fn tcsetpgrp_without_block<S>(system: &S, fd: Fd, pgid: Pid) -> Result<()>
+where
+    S: Signals + Sigaction + Sigmask + TcSetPgrp + ?Sized,
+{
+    let sigttou = S::Sigset::from_signals([S::SIGTTOU])?;
+
+    match system.sigaction(S::SIGTTOU, Disposition::Default) {
+        Err(e) => Err(e),
+        Ok(old_handling) => {
+            let mut old_mask = S::Sigset::new();
+            let result = match system
+                .sigmask(Some((SigmaskOp::Remove, &sigttou)), Some(&mut old_mask))
+                .await
+            {
+                Err(e) => Err(e),
+                Ok(()) => {
+                    let result = system.tcsetpgrp(fd, pgid).await;
+
+                    let result_2 = system
+                        .sigmask(Some((SigmaskOp::Set, &old_mask)), None)
+                        .await;
+
+                    result.and(result_2)
+                }
+            };
+
+            let result_2 = system.sigaction(S::SIGTTOU, old_handling).map(drop);
+
+            result.and(result_2)
+        }
+    }
+}

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -52,6 +52,8 @@ use self::job::JobList;
 use self::job::Pid;
 use self::job::ProcessResult;
 use self::job::ProcessState;
+use self::job::RunBlocking;
+use self::job::RunUnblocking;
 use self::option::On;
 use self::option::OptionSet;
 use self::option::{AllExport, ErrExit, Interactive, Monitor};
@@ -72,10 +74,7 @@ use self::system::Mode;
 use self::system::OfdAccess;
 use self::system::Open;
 use self::system::OpenFlag;
-use self::system::Sigaction;
-use self::system::Sigmask;
 use self::system::SignalList;
-use self::system::Signals;
 #[allow(deprecated, reason = "for backward compatible API")]
 pub use self::system::System;
 use self::system::TcSetPgrp;
@@ -441,7 +440,7 @@ impl<S> Env<S> {
     /// job-controlling process that can bring the shell into the foreground.
     pub async fn ensure_foreground(&mut self) -> Result<(), Errno>
     where
-        S: Open + Dup + Close + GetPid + Signals + Sigmask + Sigaction + TcSetPgrp,
+        S: Open + Dup + Close + GetPid + RunBlocking + RunUnblocking + TcSetPgrp,
     {
         let fd = self.get_tty().await?;
 

--- a/yash-env/src/semantics.rs
+++ b/yash-env/src/semantics.rs
@@ -17,13 +17,12 @@
 //! Type definitions for command execution.
 
 use crate::Env;
+use crate::job::RunUnblocking;
 use crate::signal;
 use crate::source::Location;
 use crate::system::resource::{LimitPair, Resource, SetRlimit};
 use crate::system::r#virtual::SignalEffect;
-use crate::system::{
-    Disposition, Exit, SendSignal, Sigaction, Sigmask, SigmaskOp, Signals, Sigset as _,
-};
+use crate::system::{Exit, SendSignal, Signals};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::ffi::c_int;
@@ -349,11 +348,11 @@ pub mod expansion;
 /// terminates the process with the given exit status.
 pub async fn exit_or_raise<S>(system: &S, exit_status: ExitStatus) -> !
 where
-    S: Signals + Sigmask + Sigaction + SendSignal + SetRlimit + Exit + ?Sized,
+    S: RunUnblocking + SendSignal + SetRlimit + Exit + ?Sized,
 {
     async fn maybe_raise<S>(system: &S, exit_status: ExitStatus) -> crate::system::Result<()>
     where
-        S: Signals + Sigmask + Sigaction + SendSignal + SetRlimit + ?Sized,
+        S: RunUnblocking + SendSignal + SetRlimit + ?Sized,
     {
         let Some(signal) = exit_status.to_signal(system, /* exact */ true) else {
             return Ok(());
@@ -369,21 +368,10 @@ where
         // Disable core dump
         system.setrlimit(Resource::CORE, LimitPair { soft: 0, hard: 0 })?;
 
-        if signal.1 != S::SIGKILL {
-            // Reset signal disposition
-            system.sigaction(signal.1, Disposition::Default)?;
-        }
-
-        // Unblock the signal
-        system
-            .sigmask(
-                Some((SigmaskOp::Remove, &S::Sigset::from_signals([signal.1])?)),
-                None,
-            )
-            .await?;
-
         // Send the signal to the current process
-        system.raise(signal.1).await?;
+        system
+            .run_unblocking(signal.1, || system.raise(signal.1))
+            .await?;
 
         Ok(())
     }

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -22,16 +22,16 @@ pub mod search;
 
 use crate::Env;
 use crate::function::Function;
-use crate::job::add_job_if_suspended;
+use crate::job::{RunBlocking, RunUnblocking, add_job_if_suspended};
 use crate::semantics::{ExitStatus, Field, Result};
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
-use crate::subshell::Config;
+use crate::subshell::{BlockSignals, Config};
 use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
 use crate::system::{
-    Close, Dup, Errno, Exec, Exit, Fork, GetPid, Open, SendSignal, SetPgid, ShellPath, Sigaction,
-    Sigmask, TcSetPgrp, Wait,
+    Close, Dup, Errno, Exec, Exit, Fork, GetPid, Open, SendSignal, SetPgid, ShellPath, TcSetPgrp,
+    Wait,
 };
 use crate::trap::SignalSystem;
 use itertools::Itertools as _;
@@ -256,19 +256,20 @@ pub async fn run_external_utility_in_subshell<S>(
     ) -> PinFuture<'_>,
 ) -> Result<ExitStatus>
 where
-    S: Close
+    S: BlockSignals
+        + Close
         + Dup
         + Exec
         + Exit
         + Fork
         + GetPid
         + Open
+        + RunBlocking
+        + RunUnblocking
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + TcSetPgrp
         + Wait

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -31,6 +31,8 @@
 use crate::Env;
 use crate::job::Pid;
 use crate::job::ProcessResult;
+use crate::job::RunBlocking;
+use crate::job::RunUnblocking;
 use crate::system::Close;
 use crate::system::Dup;
 use crate::system::Errno;
@@ -40,9 +42,9 @@ use crate::system::GetPid;
 use crate::system::Open;
 use crate::system::SendSignal;
 use crate::system::SetPgid;
-use crate::system::Sigaction;
 use crate::system::Sigmask;
 use crate::system::SigmaskOp;
+use crate::system::Signals;
 use crate::system::Sigset as _;
 use crate::system::TcSetPgrp;
 use crate::system::Wait;
@@ -90,17 +92,18 @@ impl<S, F> std::fmt::Debug for Subshell<S, F> {
 #[allow(deprecated, reason = "for backward compatible API")]
 impl<S, F> Subshell<S, F>
 where
-    S: Close
+    S: BlockSignals
+        + Close
         + Dup
         + Exit
         + Fork
         + GetPid
         + Open
+        + RunBlocking
+        + RunUnblocking
         + SendSignal
         + SetPgid
         + SetRlimit
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + TcSetPgrp
         + WaitForSignals
@@ -236,10 +239,59 @@ where
     }
 }
 
-async fn block_sigint_sigquit<S: Sigmask>(system: &S) -> Result<S::Sigset, Errno> {
-    let mut old_mask = S::Sigset::new();
-    system
-        .sigmask(
+/// Trait to temporarily block the SIGINT and SIGQUIT signals
+///
+/// This trait represents the capability required by [`Config::start`] to
+/// temporarily block SIGINT and SIGQUIT while starting a subshell. Any type
+/// that implements [`Sigmask`] automatically implements this trait.
+/// Additionally, [`Concurrent`] implements this trait by delegating to the
+/// inner system while not implementing `Sigmask` itself, which allows
+/// `Concurrent` to maintain internal invariants about signal masks while still
+/// providing this capability to its users.
+///
+/// This trait defines a higher-level interface to temporarily modify the signal
+/// mask. Typically, implementors of this trait will internally depend on
+/// `Sigmask` to perform the actual signal mask modification, but the details
+/// are abstracted away.
+///
+/// [`Concurrent`]: crate::system::concurrency::Concurrent
+pub trait BlockSignals: Signals {
+    type SavedMask;
+
+    /// Blocks SIGINT and SIGQUIT, returning the previous signal mask.
+    ///
+    /// After this function returns successfully, one of the following must be
+    /// performed:
+    ///
+    /// - Call [`restore_sigmask`](Self::restore_sigmask) with the returned mask
+    ///   to restore the original signal mask,
+    /// - Call [`SignalSystem::set_disposition`] to re-set the disposition of
+    ///   SIGINT and SIGQUIT, which installs a new signal mask,
+    /// - [Exit](Exit::exit) the process without restoring the signal mask.
+    fn block_sigint_sigquit(
+        &self,
+    ) -> impl Future<Output = Result<Self::SavedMask, Errno>> + use<'_, Self>;
+
+    /// Restores the signal mask.
+    ///
+    /// This function restores the signal mask to the state represented by
+    /// `mask`, which should be a value returned by a previous call to
+    /// [`block_sigint_sigquit`](Self::block_sigint_sigquit).
+    fn restore_sigmask(
+        &self,
+        mask: Self::SavedMask,
+    ) -> impl Future<Output = Result<(), Errno>> + use<'_, Self>;
+}
+
+impl<S> BlockSignals for S
+where
+    S: Sigmask + ?Sized,
+{
+    type SavedMask = S::Sigset;
+
+    async fn block_sigint_sigquit(&self) -> Result<Self::SavedMask, Errno> {
+        let mut old_mask = S::Sigset::new();
+        self.sigmask(
             Some((
                 SigmaskOp::Add,
                 &S::Sigset::from_signals([S::SIGINT, S::SIGQUIT])?,
@@ -247,11 +299,12 @@ async fn block_sigint_sigquit<S: Sigmask>(system: &S) -> Result<S::Sigset, Errno
             Some(&mut old_mask),
         )
         .await?;
-    Ok(old_mask)
-}
+        Ok(old_mask)
+    }
 
-async fn restore_sigmask<S: Sigmask>(system: &S, mask: &S::Sigset) -> Result<(), Errno> {
-    system.sigmask(Some((SigmaskOp::Set, mask)), None).await
+    async fn restore_sigmask(&self, mask: Self::SavedMask) -> Result<(), Errno> {
+        self.sigmask(Some((SigmaskOp::Set, &mask)), None).await
+    }
 }
 
 mod config;

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -245,14 +245,15 @@ where
 /// temporarily block SIGINT and SIGQUIT while starting a subshell. Any type
 /// that implements [`Sigmask`] automatically implements this trait.
 /// Additionally, [`Concurrent`] implements this trait by delegating to the
-/// inner system while not implementing `Sigmask` itself, which allows
-/// `Concurrent` to maintain internal invariants about signal masks while still
-/// providing this capability to its users.
+/// inner system.
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask. Typically, implementors of this trait will internally depend on
 /// `Sigmask` to perform the actual signal mask modification, but the details
-/// are abstracted away.
+/// are abstracted away. In particular, using this trait as the public
+/// capability leaves room for types such as [`Concurrent`] to stop exposing
+/// `Sigmask` directly in a future release while still providing the behavior
+/// required by callers.
 ///
 /// [`Concurrent`]: crate::system::concurrency::Concurrent
 pub trait BlockSignals: Signals {

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -16,19 +16,16 @@
 
 //! Subshell creation via [`Config`]
 
+use super::BlockSignals;
 use super::JobControl;
-use super::block_sigint_sigquit;
-use super::restore_sigmask;
 use crate::Env;
-use crate::job::tcsetpgrp_with_block;
-use crate::job::{Pid, ProcessResult};
+use crate::job::{Pid, ProcessResult, RunBlocking, RunUnblocking, tcsetpgrp_with_block};
 use crate::semantics::exit_or_raise;
 use crate::stack::Frame;
 use crate::system::concurrency::WaitForSignals;
 use crate::system::resource::SetRlimit;
 use crate::system::{
-    Close, Dup, Errno, Exit, Fork, GetPid, Open, SendSignal, SetPgid, Sigaction, Sigmask,
-    TcSetPgrp, Wait,
+    Close, Dup, Errno, Exit, Fork, GetPid, Open, SendSignal, SetPgid, TcSetPgrp, Wait,
 };
 use crate::trap::SignalSystem;
 
@@ -134,17 +131,18 @@ impl Config {
         task: F,
     ) -> Result<(Pid, Option<JobControl>), Errno>
     where
-        S: Close
+        S: BlockSignals
+            + Close
             + Dup
             + Exit
             + Fork
             + GetPid
             + Open
+            + RunBlocking
+            + RunUnblocking
             + SendSignal
             + SetPgid
             + SetRlimit
-            + Sigaction
-            + Sigmask
             + SignalSystem
             + TcSetPgrp
             + 'static,
@@ -163,7 +161,7 @@ impl Config {
             // Block SIGINT and SIGQUIT before forking the child process to
             // prevent the child from being killed by those signals until the
             // child starts ignoring them.
-            Some(block_sigint_sigquit(&env.system).await?)
+            Some(env.system.block_sigint_sigquit().await?)
         } else {
             None
         };
@@ -208,7 +206,7 @@ impl Config {
         // this before returning the error if the child process creation failed,
         // to avoid leaving the parent process with an unexpected signal mask.
         if let Some(mask) = original_mask {
-            restore_sigmask(&env.system, &mask).await.ok();
+            env.system.restore_sigmask(mask).await.ok();
         }
 
         let child_pid = result?;
@@ -253,17 +251,18 @@ impl Config {
         task: F,
     ) -> Result<(Pid, ProcessResult), Errno>
     where
-        S: Close
+        S: BlockSignals
+            + Close
             + Dup
             + Exit
             + Fork
             + GetPid
             + Open
+            + RunBlocking
+            + RunUnblocking
             + SendSignal
             + SetPgid
             + SetRlimit
-            + Sigaction
-            + Sigmask
             + SignalSystem
             + TcSetPgrp
             + Wait

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -15,15 +15,19 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - The `Runtime` trait now requires the `yash_env::system::concurrency::ReadAll`,
   `yash_env::system::concurrency::Select`,
+  `yash_env::job::RunBlocking`,
+  `yash_env::job::RunUnblocking`,
+  `yash_env::subshell::BlockSignals`,
   `yash_env::system::concurrency::WaitForSignals`,
   `yash_env::system::concurrency::WriteAll`, and
   `yash_env::trap::SignalSystem`
   traits as supertraits, and no longer requires the
   `yash_env::system::CaughtSignals`, `yash_env::system::Select`, and
-  `yash_env::system::Write` traits. The blanket implementation of `Runtime` has
-  been adjusted accordingly.
+  `yash_env::system::Write`, `yash_env::system::Sigaction`, and
+  `yash_env::system::Sigmask` traits. The blanket implementation of `Runtime`
+  has been adjusted accordingly.
 - The type parameter bound
-  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
+  `S: yash_env::subshell::BlockSignals + yash_env::job::RunBlocking + yash_env::job::RunUnblocking + yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::WriteAll + yash_env::trap::SignalSystem`
   has been added to `command::simple_command::start_external_utility_in_subshell_and_wait`.
 - The implementation of the `Handle` trait for `yash_syntax::parser::Error`,
   `expansion::Error`, and `redir::Error` now requires the trait bounds

--- a/yash-semantics/src/command/simple_command/external.rs
+++ b/yash-semantics/src/command/simple_command/external.rs
@@ -29,17 +29,20 @@ use std::ops::ControlFlow::Continue;
 use yash_env::Env;
 use yash_env::io::print_error;
 use yash_env::io::print_report;
+use yash_env::job::RunBlocking;
+use yash_env::job::RunUnblocking;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::semantics::Result;
 use yash_env::semantics::command::ReplaceCurrentProcessError;
 use yash_env::semantics::command::run_external_utility_in_subshell;
+use yash_env::subshell::BlockSignals;
 use yash_env::system::concurrency::WaitForSignals;
 use yash_env::system::concurrency::WriteAll;
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
-    Close, Dup, Exec, Exit, Fork, GetPid, Isatty, Open, SendSignal, SetPgid, ShellPath, Sigaction,
-    Sigmask, TcSetPgrp, Wait,
+    Close, Dup, Exec, Exit, Fork, GetPid, Isatty, Open, SendSignal, SetPgid, ShellPath, TcSetPgrp,
+    Wait,
 };
 use yash_env::trap::SignalSystem;
 use yash_env::variable::Context;
@@ -107,7 +110,8 @@ pub async fn start_external_utility_in_subshell_and_wait<S>(
     fields: Vec<Field>,
 ) -> Result<ExitStatus>
 where
-    S: Close
+    S: BlockSignals
+        + Close
         + Dup
         + Exec
         + Exit
@@ -115,12 +119,12 @@ where
         + GetPid
         + Isatty
         + Open
+        + RunBlocking
+        + RunUnblocking
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + TcSetPgrp
         + Wait

--- a/yash-semantics/src/runtime.rs
+++ b/yash-semantics/src/runtime.rs
@@ -17,11 +17,13 @@
 //! Definition of `Runtime`
 
 use std::fmt::Debug;
+use yash_env::job::{RunBlocking, RunUnblocking};
+use yash_env::subshell::BlockSignals;
 use yash_env::system::concurrency::{ReadAll, Select, WaitForSignals, WriteAll};
 use yash_env::system::resource::SetRlimit;
 use yash_env::system::{
     Clock, Close, Dup, Exec, Exit, Fcntl, Fork, Fstat, GetPid, GetPw, IsExecutableFile, Isatty,
-    Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, Sigaction, Sigmask, TcSetPgrp, Wait,
+    Open, Pipe, Read, Seek, SendSignal, SetPgid, ShellPath, TcSetPgrp, Wait,
 };
 use yash_env::trap::SignalSystem;
 
@@ -34,7 +36,8 @@ use yash_env::trap::SignalSystem;
 /// implementation. Therefore, this trait serves as a convenient shorthand to
 /// express the required capabilities.
 pub trait Runtime:
-    Clock
+    BlockSignals
+    + Clock
     + Close
     + Debug
     + Dup
@@ -51,14 +54,14 @@ pub trait Runtime:
     + Pipe
     + Read
     + ReadAll
+    + RunBlocking
+    + RunUnblocking
     + Seek
     + Select
     + SendSignal
     + SetPgid
     + SetRlimit
     + ShellPath
-    + Sigaction
-    + Sigmask
     + SignalSystem
     + TcSetPgrp
     + Wait
@@ -70,7 +73,8 @@ pub trait Runtime:
 /// Any type automatically implements `Runtime` if it implements all the
 /// supertraits of `Runtime`.
 impl<S> Runtime for S where
-    S: Clock
+    S: BlockSignals
+        + Clock
         + Close
         + Debug
         + Dup
@@ -87,14 +91,14 @@ impl<S> Runtime for S where
         + Pipe
         + Read
         + ReadAll
+        + RunBlocking
+        + RunUnblocking
         + Seek
         + Select
         + SendSignal
         + SetPgid
         + SetRlimit
         + ShellPath
-        + Sigaction
-        + Sigmask
         + SignalSystem
         + TcSetPgrp
         + Wait


### PR DESCRIPTION
## Description

Resolves #791

The `Concurrent` struct (which was add in yash-env-0.13.0) implemented the `Sigmask`, `GetSigaction`, and `Sigaction` traits by delegating to the inner system instance. This was needed because some dependents use those traits' methods to modify the signal mask and dispositions in a way the `SignalSystem` trait does not support. However, this delegation was not ideal because it exposed the inner system's signal handling capabilities directly, which could lead to confusion and misuse. To address this, the `Concurrent` struct has been refactored to implement new `BlockSignals`, `RunBlocking`, and `RunUnblocking` traits instead, which provide a higher-level interface for blocking signals and running code with signals blocked or unblocked. The `Sigmask`, `GetSigaction`, and `Sigaction` trait bounds have been removed from the relevant functions and replaced with the new traits. This change improves the clarity and safety of the API by providing a more focused interface for signal handling in the context of subshell configuration and job control.

This pull request does not yet remove the `Sigmask`, `GetSigaction`, and `Sigaction` trait implementations for the `Concurrent` struct, as they are still kept for backward compatibility. At the least, the `Fork` trait implementation for `Rc<Concurrent<S>>` requires `Concurrent<S>` to implement `Sigmask` to meet its trait bounds. This will be addressed in a future pull request.

## Todo

- [x] Update `yash_env::job::tcsetpgrp_with_block`
- [x] Update `yash_env::job::tcsetpgrp_without_block`
- [x] Update `yash_env::semantics::exit_or_raise`
- [x] Update `yash_env::subshell::Config::start`
- [x] Redefine trait bounds for operations that depend on the previous traits
- [ ] ~~Remove the implementations of `Sigmask`, `GetSigaction`, and `Sigaction` for `Concurrency`~~ (postponed to yash-env-0.15.0)

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified signal and job-control behavior across built-ins, subshells, and runtime; introduced capability-based APIs for blocking/unblocking signals and safer async process-group operations to improve job control and subshell interaction.

* **Documentation**
  * Updated changelogs and docs to describe the new capability-based API surface and revised runtime/subshell/builtin requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicant/yash-rs/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->