### PR TITLE
Unimplementing Sigmask, GetSigaction, and Sigaction from Concurrent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "annotate-snippets",
  "assert_matches",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -868,7 +868,7 @@ version = "1.1.1"
 
 [[package]]
 name = "yash-semantics"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.17.0" }
-yash-env = { path = "yash-env", version = "0.14.0" }
+yash-builtin = { path = "yash-builtin", version = "0.18.0" }
+yash-env = { path = "yash-env", version = "0.15.0" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
-yash-prompt = { path = "yash-prompt", version = "0.12.0" }
+yash-prompt = { path = "yash-prompt", version = "0.13.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.16.0" }
-yash-syntax = { path = "yash-syntax", version = "0.21.0" }
+yash-semantics = { path = "yash-semantics", version = "0.17.0" }
+yash-syntax = { path = "yash-syntax", version = "0.22.0" }
 
 [workspace.lints.clippy]
 allow_attributes_without_reason = "warn"

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,14 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.18.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.14.0 → 0.15.0
+    - yash-semantics (optional) 0.16.0 → 0.17.0
+
 ## [0.17.0] - 2026-05-23
 
 ### Changed
@@ -780,6 +788,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.17.0
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.16.0
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.15.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,8 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.0] - Unreleased
+
 ## [0.14.0] - 2026-05-23
 
 ### Added
@@ -1294,6 +1296,7 @@ This version has been yanked due to an issue that prevents the crate from buildi
 
 - Initial implementation of the `yash-env` crate
 
+[0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.14.0
 [0.13.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.2
 [0.13.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.1

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -11,12 +11,27 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.15.0] - Unreleased
 
+### Added
+
+- The following trait implementations have been added:
+    - `impl<S> job::RunBlocking for Concurrent<S>`
+    - `impl<S> job::RunBlocking for Rc<Concurrent<S>>`
+    - `impl<S> job::RunUnblocking for Concurrent<S>`
+    - `impl<S> job::RunUnblocking for Rc<Concurrent<S>>`
+    - `impl<S> subshell::BlockSignals for Concurrent<S>`
+    - `impl<S> subshell::BlockSignals for Rc<Concurrent<S>>`
+
 ### Removed
 
 - The following deprecated items have been removed:
     - `system::Fork::new_child_process`
     - `system::ChildProcessStarter`
     - `system::ChildProcessTask`
+- The `system::Sigmask`, `system::GetSigaction`, and `system::Sigaction` trait
+  are no longer implemented for `system::concurrency::Concurrent<S>`. The
+  functionality provided by these traits should now be accessed through the
+  higher-level traits `subshell::BlockSignals`, `job::RunBlocking`, and
+  `job::RunUnblocking`.
 
 ## [0.14.0] - 2026-05-23
 

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -11,6 +11,13 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.15.0] - Unreleased
 
+### Removed
+
+- The following deprecated items have been removed:
+    - `system::Fork::new_child_process`
+    - `system::ChildProcessStarter`
+    - `system::ChildProcessTask`
+
 ## [0.14.0] - 2026-05-23
 
 ### Added

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-env/src/job/tcsetpgrp.rs
+++ b/yash-env/src/job/tcsetpgrp.rs
@@ -29,15 +29,15 @@ use crate::system::{
 ///
 /// This trait represents the capability required by [`tcsetpgrp_with_block`] to
 /// run a function with a signal blocked. It is automatically implemented for
-/// any type that implements [`Sigmask`].
+/// any type that implements [`Sigmask`]. Additionally, [`Concurrent`]
+/// implements this trait by delegating to the inner type while not implementing
+/// [`Sigmask`] itself, which allows `Concurrent` to maintain internal
+/// consistency about signal masks while still providing this capability.
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask. Typical implementations of this trait will internally depend on
 /// [`Sigmask`] to perform the actual signal mask modification, but the trait
-/// itself does not require this as a supertrait. Using this trait as the public
-/// capability leaves room for types such as [`Concurrent`] to stop exposing
-/// `Sigmask` directly in a future release while still providing the behavior
-/// required by callers.
+/// itself does not require this as a supertrait.
 pub trait RunBlocking: Signals {
     /// Runs the given function with the specified signal blocked.
     ///
@@ -111,15 +111,17 @@ where
 /// This trait represents the capability required by [`tcsetpgrp_without_block`]
 /// to run a function with a signal unblocked and the default disposition. It is
 /// automatically implemented for any type that implements [`Sigmask`] and
-/// [`Sigaction`].
+/// [`Sigaction`]. Additionally, [`Concurrent`] implements this trait by
+/// delegating to the inner type while not implementing [`Sigmask`] or
+/// [`Sigaction`] itself, which allows `Concurrent` to maintain internal
+/// consistency about signal masks and dispositions while still providing this
+/// capability.
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask and disposition. Typical implementations of this trait will internally
 /// depend on [`Sigmask`] and [`Sigaction`] to perform the actual signal mask
 /// and disposition modification, but the trait itself does not require them as
-/// supertraits. Using this trait as the public capability leaves room for types
-/// such as [`Concurrent`] to stop exposing `Sigmask` directly in a future
-/// release while still providing the behavior required by callers.
+/// supertraits.
 pub trait RunUnblocking: Signals {
     /// Runs the given function with the specified signal unblocked and the
     /// default disposition.

--- a/yash-env/src/subshell.rs
+++ b/yash-env/src/subshell.rs
@@ -245,15 +245,14 @@ where
 /// temporarily block SIGINT and SIGQUIT while starting a subshell. Any type
 /// that implements [`Sigmask`] automatically implements this trait.
 /// Additionally, [`Concurrent`] implements this trait by delegating to the
-/// inner system.
+/// inner system while not implementing `Sigmask` itself, which allows
+/// `Concurrent` to maintain internal consistency about signal masks while still
+/// providing this capability to its users.
 ///
 /// This trait defines a higher-level interface to temporarily modify the signal
 /// mask. Typically, implementors of this trait will internally depend on
 /// `Sigmask` to perform the actual signal mask modification, but the details
-/// are abstracted away. In particular, using this trait as the public
-/// capability leaves room for types such as [`Concurrent`] to stop exposing
-/// `Sigmask` directly in a future release while still providing the behavior
-/// required by callers.
+/// are abstracted away.
 ///
 /// [`Concurrent`]: crate::system::concurrency::Concurrent
 pub trait BlockSignals: Signals {

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -130,9 +130,7 @@ pub use self::file_system::{
 #[allow(deprecated, reason = "for backward compatible API")]
 pub use self::future::FlexFuture;
 pub use self::io::{Close, Dup, Fcntl, FdFlag, Pipe, Read, Write};
-pub use self::process::{
-    ChildProcessStarter, ChildProcessTask, Exec, Exit, Fork, GetPid, SetPgid, Wait,
-};
+pub use self::process::{Exec, Exit, Fork, GetPid, SetPgid, Wait};
 #[cfg(all(doc, unix))]
 use self::real::RealSystem;
 use self::resource::{GetRlimit, SetRlimit};

--- a/yash-env/src/system/concurrency.rs
+++ b/yash-env/src/system/concurrency.rs
@@ -20,10 +20,7 @@
 //! systems that enables concurrent execution of multiple possibly blocking I/O
 //! tasks on a single thread.
 
-use super::{
-    CaughtSignals, ChildProcessStarter, Clock, Errno, Fcntl, FdSet, Fork, Read, Result, Sigmask,
-    Write,
-};
+use super::{CaughtSignals, Clock, Errno, Fcntl, FdSet, Fork, Read, Result, Sigmask, Write};
 use crate::io::Fd;
 use crate::job::Pid;
 use crate::waker::{ScheduledWakerQueue, WakerSet};
@@ -669,20 +666,6 @@ where
                 let child_task = child_task(child_concurrent, shared_data);
                 RunLoop::run_loop(&runner, child_task).await;
             })
-    }
-
-    /// This method is not implemented for `Rc<Concurrent<_>>`.
-    ///
-    /// If called, this method will panic with an "unimplemented" message. We
-    /// cannot implement this method because the return type of this method does
-    /// not match with that of the inner system `S`.
-    ///
-    /// The [`run_in_child_process`](Self::run_in_child_process) method should
-    /// be used instead to create child processes in the context of `Concurrent`
-    /// systems. The inherent method [`Concurrent::new_child_process`] can also
-    /// be used but it will be deprecated/removed soon.
-    fn new_child_process(&self) -> Result<ChildProcessStarter<Self>> {
-        unimplemented!("use `run_in_child_process` instead")
     }
 }
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -18,11 +18,10 @@
 
 use super::super::resource::{LimitPair, Resource};
 use super::super::{
-    Chdir, ChildProcessStarter, Clock, Close, CpuTimes, Dir, Dup, Exec, Exit, Fcntl, FdFlag, Fork,
-    Fstat, GetCwd, GetPid, GetPw, GetRlimit, GetSigaction, GetUid, Gid, IsExecutableFile, Isatty,
-    Mode, OfdAccess, Open, OpenFlag, Pipe, Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath,
-    Sigaction, Sigmask, SigmaskOp, Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Uid, Umask, Wait,
-    signal,
+    Chdir, Clock, Close, CpuTimes, Dir, Dup, Exec, Exit, Fcntl, FdFlag, Fstat, GetCwd, GetPid,
+    GetPw, GetRlimit, GetSigaction, GetUid, Gid, IsExecutableFile, Isatty, Mode, OfdAccess, Open,
+    OpenFlag, Pipe, Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath, Sigaction, Sigmask,
+    SigmaskOp, Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Uid, Umask, Wait, signal,
 };
 use super::Concurrent;
 use crate::io::Fd;
@@ -468,27 +467,6 @@ where
     #[inline]
     fn tcsetpgrp(&self, fd: Fd, pgid: Pid) -> impl Future<Output = Result<()>> + use<S> {
         self.inner.tcsetpgrp(fd, pgid)
-    }
-}
-
-impl<S> Concurrent<S>
-where
-    S: Fork + Sigmask,
-{
-    /// Creates a new child process.
-    ///
-    /// Returns the `ChildProcessStarter<S>` returned by the inner system's
-    /// [`Fork::new_child_process`] method. This method is an inherent method of
-    /// `Concurrent<S>` instead of an implementation of the `Fork` trait because
-    /// the return type does not match with that of the inner system `S`.
-    #[deprecated(
-        since = "0.14.0",
-        note = "use the `Fork::run_in_child_process` method instead"
-    )]
-    #[inline]
-    pub fn new_child_process(&self) -> Result<ChildProcessStarter<S>> {
-        #[allow(deprecated, reason = "the caller and callee are both deprecated")]
-        self.inner.new_child_process()
     }
 }
 

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -19,9 +19,9 @@
 use super::super::resource::{LimitPair, Resource};
 use super::super::{
     Chdir, Clock, Close, CpuTimes, Dir, Dup, Exec, Exit, Fcntl, FdFlag, Fstat, GetCwd, GetPid,
-    GetPw, GetRlimit, GetSigaction, GetUid, Gid, IsExecutableFile, Isatty, Mode, OfdAccess, Open,
-    OpenFlag, Pipe, Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath, Sigaction, Sigmask,
-    SigmaskOp, Signals, Sysconf, TcGetPgrp, TcSetPgrp, Times, Uid, Umask, Wait, signal,
+    GetPw, GetRlimit, GetUid, Gid, IsExecutableFile, Isatty, Mode, OfdAccess, Open, OpenFlag, Pipe,
+    Result, Seek, SendSignal, SetPgid, SetRlimit, ShellPath, Sigmask, Signals, Sysconf, TcGetPgrp,
+    TcSetPgrp, Times, Uid, Umask, Wait, signal,
 };
 use super::Concurrent;
 use crate::io::Fd;
@@ -337,90 +337,13 @@ where
     }
 }
 
-/// Exposes the inner system's `sigmask` method.
-///
-/// This implementation of `Sigmask` simply delegates to the inner system's
-/// `sigmask` method, which bypasses the internal state of `Concurrent` and may
-/// prevent the [`peek`](super::Select::peek) and
-/// [`select`](super::Select::select) methods from responding to received
-/// signals without race conditions. To ensure that the signal mask is
-/// configured in a way that allows `Concurrent` to respond to signals
-/// correctly, direct calls to `sigmask` should be avoided, and, if necessary,
-/// only used to temporarily change the signal mask for specific operations
-/// while ensuring that the original mask is restored afterward before a next
-/// call to `peek`, `select`, or `set_disposition`.
-impl<S> Sigmask for Concurrent<S>
-where
-    S: Sigmask,
-{
-    type Sigset = S::Sigset;
-
-    #[inline]
-    fn sigmask(
-        &self,
-        op_and_signals: Option<(SigmaskOp, &Self::Sigset)>,
-        old_mask: Option<&mut Self::Sigset>,
-    ) -> impl Future<Output = Result<()>> + use<S> {
-        self.inner.sigmask(op_and_signals, old_mask)
-    }
-}
-
-impl<S> GetSigaction for Concurrent<S>
-where
-    S: GetSigaction + Sigmask,
-{
-    #[inline]
-    fn get_sigaction(&self, signal: signal::Number) -> Result<signal::Disposition> {
-        self.inner.get_sigaction(signal)
-    }
-}
-
-/// Exposes the inner system's `sigaction` method.
-///
-/// This implementation of `Sigaction` simply delegates to the inner system's
-/// `sigaction` method, which bypasses the internal state of `Concurrent` and
-/// may prevent the [`peek`](super::Select::peek) and
-/// [`select`](super::Select::select) methods from responding to received
-/// signals without race conditions. To ensure that signal dispositions are
-/// configured in a way that allows `Concurrent` to respond to signals
-/// correctly, direct calls to `sigaction` should be avoided, and, if necessary,
-/// only used to temporarily change the signal disposition for specific
-/// operations while ensuring that the original disposition is restored
-/// afterward before a next call to `peek`, `select`, or `set_disposition`.
-///
-/// The standard way to set a signal disposition to `Concurrent` is to use the
-/// `set_disposition` method provided by the [`SignalSystem`] trait, which
-/// ensures that the signal disposition and the signal mask are updated
-/// consistently.
-///
-/// [`SignalSystem`]: crate::trap::SignalSystem
-impl<S> Sigaction for Concurrent<S>
-where
-    S: Sigaction + Sigmask,
-{
-    #[inline]
-    fn sigaction(
-        &self,
-        signal: signal::Number,
-        disposition: signal::Disposition,
-    ) -> Result<signal::Disposition> {
-        self.inner.sigaction(signal, disposition)
-    }
-}
-
-// CaughtSignals is not implemented for Concurrent<S> because Concurrent needs to
-// control the signal dispositions and the signal mask itself to ensure that the
-// select method can respond to received signals without race conditions. Instead,
-// Concurrent<S> implements the SignalSystem trait, which provides the necessary
-// methods for configuring signal dispositions and masks in a controlled manner.
-//
-// Note: Sigmask, GetSigaction, and Sigaction are implemented above as delegating
-// implementations. However, direct calls to sigmask() and sigaction() bypass
-// Concurrent's internal state and may prevent peek() and select() from responding
-// to received signals without race conditions. To ensure correct behavior, use the
-// set_disposition method from the SignalSystem trait instead. If direct sigmask or
-// sigaction calls are necessary, temporarily change the mask/disposition and restore
-// it afterward before calling peek(), select(), or set_disposition().
+// Sigmask, GetSigaction, Sigaction, and CaughtSignals are not implemented for
+// Concurrent<S> because Concurrent needs to control the signal dispositions and
+// the signal mask itself to ensure that its internal invariants hold
+// consistently and that the select method can respond to received signals as
+// expected. Concurrent<S> instead implements the SignalSystem, BlockSignals,
+// RunBlocking, and RunUnblocking traits, which provide the necessary methods
+// for configuring signal dispositions and masks in a controlled manner.
 
 impl<S> SendSignal for Concurrent<S>
 where

--- a/yash-env/src/system/concurrency/signal.rs
+++ b/yash-env/src/system/concurrency/signal.rs
@@ -128,12 +128,22 @@ where
 {
     type SavedMask = S::SavedMask;
 
+    /// Blocks SIGINT and SIGQUIT, returning the previous signal mask.
+    ///
+    /// Between `block_sigint_sigquit` and
+    /// [`restore_sigmask`](Self::restore_sigmask), the disposition of any
+    /// signal must not be changed with the
+    /// [`set_disposition`](SignalSystem::set_disposition) method, or the
+    /// `restore_sigmask` method will leave the signal mask in an inconsistent
+    /// state. You must not call the [`select`](crate::system::Select::select)
+    /// method either, since it does not take the effect of
+    /// `block_sigint_sigquit` into account.
     async fn block_sigint_sigquit(&self) -> Result<Self::SavedMask, Errno> {
-        self.inner.block_sigint_sigquit().await
+        (self as &Concurrent<S>).block_sigint_sigquit().await
     }
 
     async fn restore_sigmask(&self, mask: Self::SavedMask) -> Result<(), Errno> {
-        self.inner.restore_sigmask(mask).await
+        (self as &Concurrent<S>).restore_sigmask(mask).await
     }
 }
 
@@ -153,11 +163,18 @@ impl<S> RunBlocking for Rc<Concurrent<S>>
 where
     S: Sigmask + RunBlocking,
 {
+    /// Runs the given function with the specified signal blocked.
+    ///
+    /// The disposition of any signal must not be changed with inside the
+    /// function, or the signal mask will be left in an inconsistent state after
+    /// the function returns. The function must not call the
+    /// [`select`](crate::system::Select::select) method either, since it does
+    /// not take the effect of `run_blocking` into account.
     async fn run_blocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
     where
         F: AsyncFnOnce() -> Result<T, Errno>,
     {
-        self.inner.run_blocking(signal, f).await
+        (self as &Concurrent<S>).run_blocking(signal, f).await
     }
 }
 
@@ -177,11 +194,18 @@ impl<S> RunUnblocking for Rc<Concurrent<S>>
 where
     S: Sigmask + RunUnblocking,
 {
+    /// Runs the given function with the specified signal unblocked.
+    ///
+    /// The disposition of any signal must not be changed with inside the
+    /// function, or the signal mask will be left in an inconsistent state after
+    /// the function returns. The function must not call the
+    /// [`select`](crate::system::Select::select) method either, since it does
+    /// not take the effect of `run_unblocking` into account.
     async fn run_unblocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
     where
         F: AsyncFnOnce() -> Result<T, Errno>,
     {
-        self.inner.run_unblocking(signal, f).await
+        (self as &Concurrent<S>).run_unblocking(signal, f).await
     }
 }
 

--- a/yash-env/src/system/concurrency/signal.rs
+++ b/yash-env/src/system/concurrency/signal.rs
@@ -17,7 +17,9 @@
 //! Implementation of `Concurrent` related to signals
 
 use super::Concurrent;
+use crate::job::{RunBlocking, RunUnblocking};
 use crate::signal::Number;
+use crate::subshell::BlockSignals;
 use crate::system::signal::Sigset as _;
 use crate::system::{Disposition, Errno, Sigaction, Sigmask, SigmaskOp};
 use crate::trap::SignalSystem;
@@ -102,6 +104,84 @@ where
             .select_mask
             .get_or_insert(old_mask)
             .remove(signal)
+    }
+}
+
+impl<S> BlockSignals for Concurrent<S>
+where
+    S: Sigmask + BlockSignals,
+{
+    type SavedMask = S::SavedMask;
+
+    async fn block_sigint_sigquit(&self) -> Result<Self::SavedMask, Errno> {
+        self.inner.block_sigint_sigquit().await
+    }
+
+    async fn restore_sigmask(&self, mask: Self::SavedMask) -> Result<(), Errno> {
+        self.inner.restore_sigmask(mask).await
+    }
+}
+
+impl<S> BlockSignals for Rc<Concurrent<S>>
+where
+    S: Sigmask + BlockSignals,
+{
+    type SavedMask = S::SavedMask;
+
+    async fn block_sigint_sigquit(&self) -> Result<Self::SavedMask, Errno> {
+        self.inner.block_sigint_sigquit().await
+    }
+
+    async fn restore_sigmask(&self, mask: Self::SavedMask) -> Result<(), Errno> {
+        self.inner.restore_sigmask(mask).await
+    }
+}
+
+impl<S> RunBlocking for Concurrent<S>
+where
+    S: Sigmask + RunBlocking,
+{
+    async fn run_blocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
+    where
+        F: AsyncFnOnce() -> Result<T, Errno>,
+    {
+        self.inner.run_blocking(signal, f).await
+    }
+}
+
+impl<S> RunBlocking for Rc<Concurrent<S>>
+where
+    S: Sigmask + RunBlocking,
+{
+    async fn run_blocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
+    where
+        F: AsyncFnOnce() -> Result<T, Errno>,
+    {
+        self.inner.run_blocking(signal, f).await
+    }
+}
+
+impl<S> RunUnblocking for Concurrent<S>
+where
+    S: Sigmask + RunUnblocking,
+{
+    async fn run_unblocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
+    where
+        F: AsyncFnOnce() -> Result<T, Errno>,
+    {
+        self.inner.run_unblocking(signal, f).await
+    }
+}
+
+impl<S> RunUnblocking for Rc<Concurrent<S>>
+where
+    S: Sigmask + RunUnblocking,
+{
+    async fn run_unblocking<F, T>(&self, signal: Number, f: F) -> Result<T, Errno>
+    where
+        F: AsyncFnOnce() -> Result<T, Errno>,
+    {
+        self.inner.run_unblocking(signal, f).await
     }
 }
 

--- a/yash-env/src/system/process.rs
+++ b/yash-env/src/system/process.rs
@@ -16,8 +16,7 @@
 
 //! Items related to process management
 
-use super::{Concurrent, ExitStatus, Result, Sigmask, Signals};
-use crate::Env;
+use super::{ExitStatus, Result, Signals};
 #[cfg(all(doc, unix))]
 use crate::RealSystem;
 #[cfg(doc)]
@@ -26,7 +25,6 @@ use crate::job::Pid;
 use crate::job::ProcessState;
 use std::convert::Infallible;
 use std::ffi::{CStr, CString};
-use std::pin::Pin;
 use std::rc::Rc;
 
 /// Trait for getting the current process ID and other process-related information
@@ -101,46 +99,6 @@ impl<S: SetPgid> SetPgid for Rc<S> {
     }
 }
 
-type PinFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
-
-/// Task executed in a child process
-///
-/// This is an argument passed to a [`ChildProcessStarter`]. The task is
-/// executed in a child process initiated by the starter. The environment passed
-/// to the task is a clone of the parent environment, but it has a different
-/// process ID than the parent.
-///
-/// Note that the output type of the task is `Infallible`. This is to ensure
-/// that the task [exits](super::Exit::exit) cleanly or
-/// [kills](super::SendSignal::kill) itself with a signal.
-pub type ChildProcessTask<S> =
-    Box<dyn for<'a> FnOnce(&'a mut Env<Rc<Concurrent<S>>>) -> PinFuture<'a, Infallible>>;
-
-/// Abstract function that starts a child process
-///
-/// [`Fork::new_child_process`] returns a child process starter. You need to
-/// pass the parent environment and a task to the starter to complete the child
-/// process creation. The starter provides a unified interface that hides the
-/// differences between [`RealSystem`] and [`VirtualSystem`].
-///
-/// [`RealSystem::new_child_process`] performs a `fork` system call and returns
-/// a starter in the parent and child processes. When the starter is called in
-/// the parent, it just returns the child process ID. The starter in the child
-/// process runs the task and exits the process with the exit status of the
-/// task.
-///
-/// [`VirtualSystem::new_child_process`] does not create a real child process.
-/// Instead, the starter runs the task concurrently in the current process using
-/// the executor contained in the system. A new
-/// [`Process`](super::virtual::Process) is added to the system to represent the
-/// child process. The starter returns its process ID.
-///
-/// This function only starts the child, which continues to run asynchronously
-/// after the function returns its PID. To wait for the child to finish and
-/// obtain its exit status, use [`wait`](Wait::wait).
-pub type ChildProcessStarter<S> =
-    Box<dyn FnOnce(&mut Env<Rc<Concurrent<S>>>, ChildProcessTask<S>) -> Pid>;
-
 /// Trait for spawning new processes
 pub trait Fork {
     /// Runs a task in a new child process.
@@ -177,27 +135,6 @@ pub trait Fork {
         Self: Sized,
         D: Clone + 'static,
         F: AsyncFnOnce(Self, D) + 'static;
-
-    /// Creates a new child process.
-    ///
-    /// This is a wrapper around the [`fork` system
-    /// call](https://pubs.opengroup.org/onlinepubs/9799919799/functions/fork.html).
-    /// Users of [`Env`] should not call it directly. Instead, use
-    /// [`Subshell`](crate::subshell::Subshell) so that the environment can
-    /// condition the state of the child process before it starts running.
-    ///
-    /// Because we need the parent environment to create the child environment,
-    /// this method cannot initiate the child task directly. Instead, it returns
-    /// a [`ChildProcessStarter`] function that takes the parent environment and
-    /// the child task. The caller must call the starter to make sure the parent
-    /// and child processes perform correctly after forking.
-    #[deprecated(
-        since = "0.14.0",
-        note = "use the `run_in_child_process` method instead"
-    )]
-    fn new_child_process(&self) -> Result<ChildProcessStarter<Self>>
-    where
-        Self: Sigmask + Sized;
 }
 
 /// Trait for waiting for child processes

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -31,7 +31,6 @@ mod signal;
 use super::AT_FDCWD;
 use super::CaughtSignals;
 use super::Chdir;
-use super::ChildProcessStarter;
 use super::Clock;
 use super::Close;
 use super::CpuTimes;
@@ -114,7 +113,6 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::io::IntoRawFd as _;
 use std::pin::pin;
 use std::ptr::NonNull;
-use std::rc::Rc;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::compiler_fence;
@@ -941,27 +939,6 @@ impl Fork for RealSystem {
         let mut context = Context::from_waker(Waker::noop());
         _ = child_task.poll(&mut context);
         panic!("child task running in RealSystem should not return");
-    }
-
-    /// Creates a new child process.
-    ///
-    /// This implementation calls the `fork` system call and returns both in the
-    /// parent and child process. In the parent, the returned
-    /// `ChildProcessStarter` ignores any arguments and returns the child
-    /// process ID. In the child, the starter runs the task and exits the
-    /// process.
-    fn new_child_process(&self) -> Result<ChildProcessStarter<Self>> {
-        let raw_pid = unsafe { libc::fork() }.errno_if_m1()?;
-        if raw_pid != 0 {
-            // Parent process
-            return Ok(Box::new(move |_env, _task| Pid(raw_pid)));
-        }
-
-        // Child process
-        Ok(Box::new(|env, task| {
-            let system = Rc::clone(&env.system);
-            match system.run_real(task(env)) {}
-        }))
     }
 }
 

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -134,8 +134,6 @@ use crate::path::PathBuf;
 use crate::semantics::ExitStatus;
 use crate::str::UnixStr;
 use crate::str::UnixString;
-use crate::system::ChildProcessStarter;
-use crate::system::Concurrent;
 use crate::waker::ScheduledWakerQueue;
 use crate::waker::WakerSet;
 use enumset::EnumSet;
@@ -1277,49 +1275,6 @@ impl Fork for VirtualSystem {
 
         (Ok(child_process_id), shared_data)
     }
-
-    /// Creates a new child process.
-    ///
-    /// This implementation does not create any real child process. Instead,
-    /// it returns a child process starter that runs its task concurrently in
-    /// the same process.
-    ///
-    /// To run the concurrent task, this function needs an executor that has
-    /// been set in the [`SystemState`]. If the system state does not have an
-    /// executor, this function fails with `Errno::ENOSYS`.
-    ///
-    /// The process ID of the child will be the maximum of existing process IDs
-    /// plus 1. If there are no other processes, it will be 2.
-    fn new_child_process(&self) -> Result<ChildProcessStarter<Self>> {
-        let mut state = self.state.borrow_mut();
-        let executor = state.executor.clone().ok_or(Errno::ENOSYS)?;
-        let process_id = state
-            .processes
-            .keys()
-            .max()
-            .map_or(Pid(2), |pid| Pid(pid.0 + 1));
-        let parent_process = &state.processes[&self.process_id];
-        let child_process = Process::fork_from(self.process_id, parent_process);
-        state.processes.insert(process_id, child_process);
-        drop(state);
-
-        let state = Rc::clone(&self.state);
-        Ok(Box::new(move |parent_env, task| {
-            let system = VirtualSystem { state, process_id };
-            let mut child_env = parent_env.clone_with_system(Rc::new(Concurrent::new(system)));
-            let concurrent = Rc::clone(&child_env.system);
-
-            let task_runner = async move {
-                let task = async move { match task(&mut child_env).await {} };
-                concurrent.run_virtual(task).await
-            };
-            executor
-                .spawn(Box::pin(task_runner))
-                .expect("the executor failed to start the child process task");
-
-            process_id
-        }))
-    }
 }
 
 impl Wait for VirtualSystem {
@@ -1549,7 +1504,8 @@ pub struct SystemState {
     /// Task manager that can execute asynchronous tasks
     ///
     /// The virtual system uses this executor to run (virtual) child processes.
-    /// If `executor` is `None`, [`VirtualSystem::new_child_process`] will fail.
+    /// If `executor` is `None`, [`VirtualSystem::run_in_child_process`] will
+    /// fail.
     pub executor: Option<Rc<dyn Executor>>,
 
     /// Processes running in the system
@@ -3151,37 +3107,6 @@ mod tests {
             })
             .0;
         assert_eq!(result, Err(Errno::ENOSYS));
-    }
-
-    #[test]
-    fn new_child_process_without_executor() {
-        let system = VirtualSystem::new();
-        #[allow(deprecated, reason = "it's what we want to test")]
-        let result = system.new_child_process();
-        match result {
-            Ok(_) => panic!("unexpected Ok value"),
-            Err(e) => assert_eq!(e, Errno::ENOSYS),
-        }
-    }
-
-    #[test]
-    fn new_child_process_with_executor() {
-        let (system, _executor) = virtual_system_with_executor();
-
-        #[allow(deprecated, reason = "it's what we want to test")]
-        let result = system.new_child_process();
-
-        let state = system.state.borrow();
-        assert_eq!(state.processes.len(), 2);
-        drop(state);
-
-        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
-        let child_process = result.unwrap();
-        let pid = child_process(
-            &mut env,
-            Box::new(|env| Box::pin(async move { env.system.exit(env.exit_status).await })),
-        );
-        assert_eq!(pid, Pid(3));
     }
 
     #[test]

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -9,6 +9,14 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.13.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.14.0 → 0.15.0
+    - yash-syntax 0.21.0 → 0.22.0
+
 ## [0.12.0] - 2026-05-23
 
 ### Changed
@@ -170,6 +178,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.13.0
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.11.0
 [0.10.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.10.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -9,6 +9,14 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.17.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.14.0 → 0.15.0
+    - yash-syntax 0.21.0 → 0.22.0
+
 ## [0.16.0] - 2026-05-23
 
 ### Changed
@@ -482,6 +490,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.17.0
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.16.0
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.14.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -9,6 +9,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.22.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.14.0 → 0.15.0
+
 ## [0.21.0] - 2026-05-23
 
 ### Changed
@@ -658,6 +665,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.22.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.22.0
 [0.21.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.21.0
 [0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.20.0
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.19.0

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.87.0"


### PR DESCRIPTION
## Description

This pull request completes #791 by actually removing the implementations of the `Sigmask`, `GetSigaction`, and `Sigaction` traits for `Concurrent` and adding the implementations of the `BlockSignals`, `RunBlocking`, and `RunUnblocking` traits, which were not done in #792.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved concurrent signal handling and safer job execution semantics.

* **Refactor**
  * Simplified process management and signal-masking behavior; removed a deprecated child-process creation path to unify child-process execution.

* **Chores**
  * Bumped workspace crate versions: yash-builtin→0.18.0, yash-env→0.15.0, yash-prompt→0.13.0, yash-semantics→0.17.0, yash-syntax→0.22.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicant/yash-rs/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->