### PR TITLE
Enhance execve with c_string module and optimization improvements

### DIFF
--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -35,6 +35,15 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `OwnedCStrs`: An owning wrapper that keeps both the strings and the
       pointer array alive together.
 
+### Changed
+
+- The `system::Exec::execve` method now accepts the `args` and `envs` arguments
+  as generic types implementing the new `system::c_string::IntoCStrArray` trait
+  instead of `&[CString]`. This allows callers to pass string arrays without
+  unnecessary allocations. Existing callers passing `&[CString]` slices continue
+  to work; callers passing fixed-size array references should now pass slices
+  instead.
+
 ### Deprecated
 
 - The `JobList::add` method has been deprecated in favor of `JobList::insert`.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -22,6 +22,18 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `impl<S> subshell::BlockSignals for Rc<Concurrent<S>>`
 - The `JobList::insert` method has been added as a new name for the existing
   `add` method.
+- The `system::c_string` module has been added, providing abstractions for
+  building and passing null-terminated arrays of pointers to C-style strings to
+  the `system::Exec::execve` method. It contains the following items:
+    - `AsCStrArray`: A sealed trait for types that can expose a pointer to a
+      null-terminated array of pointers to C-style strings.
+    - `IntoCStrArray`: A sealed trait for types that can be converted into an
+      `AsCStrArray`. This is the bound required by `system::Exec::execve`.
+    - `CStrPtr`: A transparent wrapper for a raw pointer to an existing
+      null-terminated C-string-pointer array.
+    - `BorrowedCStrs`: An owning pointer-array wrapper over borrowed string data.
+    - `OwnedCStrs`: An owning wrapper that keeps both the strings and the
+      pointer array alive together.
 
 ### Deprecated
 

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -152,7 +152,10 @@ pub async fn replace_current_process<S: Exec + ShellPath + SignalSystem>(
 
     let args = to_c_strings(args);
     let envs = env.variables.env_c_strings();
-    let Err(errno) = env.system.execve(path.as_c_str(), &args, &envs).await;
+    let Err(errno) = env
+        .system
+        .execve(path.as_c_str(), args.as_slice(), envs.as_slice())
+        .await;
     env.exit_status = match errno {
         Errno::ENOEXEC => {
             fall_back_on_sh(&env.system, path.clone(), args, envs).await;
@@ -196,7 +199,7 @@ async fn fall_back_on_sh<S: ShellPath + Exec>(
     c"sh".clone_into(&mut args[0]);
 
     let sh_path = system.shell_path();
-    system.execve(&sh_path, &args, &envs).await.ok();
+    system.execve(&sh_path, args, envs).await.ok();
 }
 
 /// Error returned when starting a subshell fails in [`run_external_utility_in_subshell`]

--- a/yash-env/src/system.rs
+++ b/yash-env/src/system.rs
@@ -96,6 +96,7 @@
 //! concurrently. `RealSystem` implementations return ready futures after the
 //! underlying system calls complete (which may block the current thread).
 
+pub mod c_string;
 pub mod concurrency;
 mod errno;
 mod file_system;

--- a/yash-env/src/system/c_string.rs
+++ b/yash-env/src/system/c_string.rs
@@ -1,0 +1,619 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Utilities for working with C-style strings ([`CStr`] and [`CString`]) in Rust
+//!
+//! This module provides abstractions for building and passing null-terminated
+//! arrays of pointers to C-style strings, primarily for [`Exec::execve`].
+//!
+//! This module defines two main traits:
+//!
+//! - [`AsCStrArray`]: unsafe low-level contract for types that can expose
+//!   a pointer to a null-terminated array of pointers to C-style strings.
+//! - [`IntoCStrArray`]: ergonomic conversion trait used by [`Exec::execve`];
+//!   accepts both native `AsCStrArray` implementors and convertible container
+//!   types.
+//!
+//! And provides several struct implementations for different use cases:
+//!
+//! - [`CStrPtr`]: transparent wrapper for a raw pointer to an existing
+//!   null-terminated C-string-pointer array.
+//! - [`BorrowedCStrs`]: owning pointer-array wrapper over borrowed string data,
+//!   suitable when you already have `&CStr`/`&CString` values.
+//! - [`OwnedCStrs`]: owning wrapper that keeps both the strings and the pointer
+//!   array alive together.
+//!
+//! In short, use [`BorrowedCStrs`] for borrowed inputs, [`OwnedCStrs`] for
+//! owned inputs, and [`CStrPtr`] only when interoperating with raw FFI data.
+//!
+//! [`Exec::execve`]: super::Exec::execve
+
+use std::ffi::{CStr, CString, c_char};
+use std::marker::PhantomData;
+
+/// Converts an iterator of `AsRef<CStr>` items into an iterator of pointers to
+/// C-style strings, with a null pointer appended at the end.
+fn null_terminated_pointers<I>(iter: I) -> impl Iterator<Item = *const c_char>
+where
+    I: IntoIterator,
+    I::Item: AsRef<CStr>,
+{
+    iter.into_iter()
+        .map(|s| s.as_ref().as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+}
+
+/// Dummy trait to prevent external implementations of `AsCStrArray` and
+/// `IntoCStrArray`
+trait Sealed {}
+
+/// Abstraction over an array of C-style strings, for arguments to [`Exec::execve`]
+///
+/// The native `execve` system call expects two arrays of C-style strings, which
+/// must be passed as pointers to null-terminated arrays of pointers to
+/// null-terminated byte strings. This trait abstracts over how ownership and
+/// lifetime of these arrays and strings are managed in Rust, allowing
+/// different types to be used as long as they can provide the required pointer
+/// to the array of C-style strings. The main requirement is that the array must
+/// be null-terminated and that the pointers in the array must point to valid
+/// C-style strings. Implementations of `Exec::execve` can then use this trait
+/// to accept different types of string arrays and to obtain the required
+/// pointers for the system call without needing to know the details of how the
+/// strings are stored or managed in Rust.
+///
+/// This trait is sealed to prevent external implementations, as the safety
+/// guarantees of the methods depend on the implementor upholding certain
+/// invariants about the pointers and the lifetime of the strings.
+///
+/// See also [`IntoCStrArray`] for types that can be converted into a
+/// `AsCStrArray`.
+///
+/// [`Exec::execve`]: super::Exec::execve
+#[allow(
+    clippy::missing_safety_doc,
+    reason = "users cannot implement sealed traits"
+)]
+#[expect(private_bounds, reason = "this trait is sealed")]
+// SAFETY: This trait is unsafe because improper implementations can lead to
+// undefined behavior when the pointers returned by `as_ptr` or `as_mut_ptr` are
+// used. The implementation of the `execve` function assumes that the array and
+// strings pointed to by these pointers are valid and remain unmodified while
+// they are in use. Interior mutability may break these assumptions, so the
+// implementor must ensure that no such mutations can occur.
+pub unsafe trait AsCStrArray: Sealed {
+    /// Returns a pointer to the array of C-style strings.
+    ///
+    /// The array must be null-terminated, i.e., the last pointer in the array
+    /// must be a null pointer. Each pointer in the array must point to a valid
+    /// C-style string (i.e., a null-terminated sequence of bytes). The array
+    /// and strings must remain valid and unmodified until `self` is mutated or
+    /// dropped. The caller must not mutate the array or strings through this
+    /// pointer.
+    fn as_ptr(&self) -> *const *const c_char;
+
+    /// Returns a pointer to the array of C-style strings.
+    ///
+    /// This method just returns the same pointer as [`as_ptr`](Self::as_ptr),
+    /// but with a different type signature. The mutability of the pointer is
+    /// only for matching the expected type signature of [`execve`] and does not
+    /// imply that the strings can actually be mutated through this pointer.
+    /// The caller must not mutate the array or strings through this pointer.
+    /// The array and strings must remain valid and unmodified until `self` is
+    /// mutated or dropped.
+    ///
+    /// [`execve`]: super::Exec::execve
+    #[inline(always)]
+    fn as_mut_ptr(&mut self) -> *const *mut c_char {
+        self.as_ptr().cast()
+    }
+
+    /// Constructs a `Vec<CString>` from the array of C-style strings.
+    ///
+    /// This method is a convenience for converting the array of C-style strings
+    /// into a more Rust-friendly format. It iterates over the pointers in the
+    /// array, converts each C-style string into a `CString`, and collects them
+    /// into a `Vec<CString>`. The returned `Vec<CString>` owns the new
+    /// allocations for the array and strings, so it is safe to use and modify
+    /// independently of `self`.
+    #[must_use]
+    fn to_vec(&self) -> Vec<CString> {
+        let mut vec = Vec::new();
+        let mut ptr = self.as_ptr();
+        loop {
+            // SAFETY: The `as_ptr` method guarantees that the returned pointer
+            // points to a null-terminated array of pointers to valid C-style
+            // strings, so it's safe to read from the pointer.
+            let c_str_ptr = unsafe { *ptr };
+            if c_str_ptr.is_null() {
+                break;
+            }
+            // SAFETY: Likewise, `c_str_ptr` points to a valid C-style string,
+            // so it's safe to create a `CStr` from it.
+            let c_str = unsafe { CStr::from_ptr(c_str_ptr) };
+            vec.push(c_str.to_owned());
+            // SAFETY: The `as_ptr` method guarantees that the array is
+            // null-terminated, so it's safe to advance the pointer until we
+            // reach the null pointer.
+            ptr = unsafe { ptr.add(1) };
+        }
+        vec
+    }
+}
+
+impl<T> Sealed for &T where T: Sealed + ?Sized {}
+unsafe impl<T> AsCStrArray for &T
+where
+    T: AsCStrArray + ?Sized,
+{
+    #[inline(always)]
+    fn as_ptr(&self) -> *const *const c_char {
+        (self as &T).as_ptr()
+    }
+}
+
+impl<T> Sealed for &mut T where T: Sealed + ?Sized {}
+unsafe impl<T> AsCStrArray for &mut T
+where
+    T: AsCStrArray + ?Sized,
+{
+    #[inline(always)]
+    fn as_ptr(&self) -> *const *const c_char {
+        (self as &T).as_ptr()
+    }
+}
+
+/// Simple wrapper to treat a raw pointer to an array of C-style strings as a [`AsCStrArray`]
+///
+/// This is useful for passing raw pointers obtained from other sources (e.g.,
+/// FFI) to functions that expect an `AsCStrArray`. However, it is the caller's
+/// responsibility to ensure that the pointer validly points to a
+/// null-terminated array of pointers to valid C-style strings, and that the
+/// array and strings remain valid for the required lifetime. This wrapper does
+/// not take ownership of the array or strings.
+///
+/// You should prefer [`BorrowedCStrs`] or [`OwnedCStrs`] over this type when
+/// possible, as they provide ownership and lifetime guarantees for the strings.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct CStrPtr(*const *const c_char);
+
+impl CStrPtr {
+    /// Create a new `CStrPtr` from a raw pointer to an array of C-style strings.
+    ///
+    /// The given pointer is directly returned by the [`as_ptr`](Self::as_ptr)
+    /// method.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `ptr` points to a valid null-terminated
+    /// array of pointers to valid C-style strings. The array and strings must
+    /// remain valid and unmodified until the `CStrPtr` is dropped.
+    #[must_use]
+    pub unsafe fn new(ptr: *const *const c_char) -> Self {
+        Self(ptr)
+    }
+}
+
+impl Sealed for CStrPtr {}
+unsafe impl AsCStrArray for CStrPtr {
+    #[inline(always)]
+    fn as_ptr(&self) -> *const *const c_char {
+        self.0
+    }
+}
+
+/// An [`AsCStrArray`] backed by a [`Vec`] of borrowed [`CStr`]s
+///
+/// A `BorrowedCStrs<'a>` works as if it owns a `Vec<&'a CStr>`: it owns the
+/// allocation for the array of pointers, but the `&CStr`s themselves are
+/// borrowed from elsewhere. It is useful if you already have a collection of
+/// `&CStr`s (or [`CString`]s) you can borrow and want to pass them to a
+/// function that expects an `AsCStrArray`.
+///
+/// This struct implements [`FromIterator`], which can be used to create a
+/// `BorrowedCStrs` from existing C-style strings. The implementation can also
+/// be used via the [`IntoCStrArray`] trait.
+#[derive(Clone, Debug)]
+pub struct BorrowedCStrs<'a> {
+    pointers: Vec<*const c_char>,
+    phantom: PhantomData<Vec<&'a CStr>>,
+}
+
+impl<'a> Sealed for BorrowedCStrs<'a> {}
+unsafe impl<'a> AsCStrArray for BorrowedCStrs<'a> {
+    #[inline(always)]
+    fn as_ptr(&self) -> *const *const c_char {
+        self.pointers.as_ptr()
+    }
+}
+
+impl<'a, T> FromIterator<&'a T> for BorrowedCStrs<'a>
+where
+    T: AsRef<CStr> + ?Sized,
+{
+    #[inline(always)]
+    fn from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Self {
+        let pointers = null_terminated_pointers(iter).collect();
+
+        // SAFETY: The `null_terminated_pointers` function creates a
+        // null-terminated array of pointers, and the pointers in the array
+        // point to C-style strings borrowed from the input iterator. The
+        // strings remain valid and unmodified for the lifetime of the
+        // `BorrowedCStrs` because they are borrowed immutably through the
+        // `PhantomData`.
+        unsafe { Self::from_vec(pointers) }
+    }
+}
+
+impl BorrowedCStrs<'_> {
+    /// Creates a new `BorrowedCStrs` from a `Vec<*const c_char>`.
+    ///
+    /// This function directly uses the given pointers as the content of the
+    /// `BorrowedCStrs`. The given pointers are returned by the
+    /// [`as_ptr`](Self::as_ptr) method.
+    ///
+    /// This function takes ownership of the given `Vec`, but not the strings
+    /// pointed to by the pointers.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointers in the given `Vec` point to
+    /// valid C-style strings, and that the `Vec` is null-terminated (i.e., the
+    /// last pointer is a null pointer). The array and strings must remain valid
+    /// and unmodified for the required lifetime of the `BorrowedCStrs`.
+    #[inline(always)]
+    #[must_use]
+    pub unsafe fn from_vec(pointers: Vec<*const c_char>) -> Self {
+        Self {
+            pointers,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Consumes the `BorrowedCStrs` and returns the owned array of pointers as
+    /// a `Vec<*const c_char>`.
+    ///
+    /// This function just returns the null-terminated array of pointers without
+    /// any ownership or lifetime guarantees for the strings. The caller must
+    /// ensure pointer validity if they intend to use the returned pointers.
+    #[inline(always)]
+    #[must_use]
+    pub fn into_vec(self) -> Vec<*const c_char> {
+        self.pointers
+    }
+}
+
+/// Consumes a `BorrowedCStrs` and extracts the owned array of pointers as a
+/// `Vec<*const c_char>`. (See [`BorrowedCStrs::into_vec`].)
+impl From<BorrowedCStrs<'_>> for Vec<*const c_char> {
+    #[inline(always)]
+    fn from(c_str_vec: BorrowedCStrs) -> Self {
+        c_str_vec.into_vec()
+    }
+}
+
+/// A [`AsCStrArray`] backed by a collection of owned strings
+///
+/// This struct is a counterpart to [`BorrowedCStrs`] that owns the strings
+/// themselves instead of borrowing them. `OwnedCStrs` owns both the allocation
+/// for the array of pointers and the `Vec` of owned strings, ensuring that the
+/// pointers remain valid for the lifetime of the `OwnedCStrs`.
+///
+/// The implementation of [`FromIterator`] allows you to create an `OwnedCStrs`
+/// from an iterator of `CString`s, which can be useful when you want to create
+/// an `AsCStrArray` from scratch and need to own the strings themselves.
+#[derive(Debug)]
+pub struct OwnedCStrs {
+    pointers: Vec<*const c_char>,
+    values: Vec<CString>,
+}
+
+impl Sealed for OwnedCStrs {}
+unsafe impl AsCStrArray for OwnedCStrs {
+    #[inline(always)]
+    fn as_ptr(&self) -> *const *const c_char {
+        self.pointers.as_ptr()
+    }
+}
+
+impl OwnedCStrs {
+    /// Creates a new `OwnedCStrs` from a `Vec<CString>`.
+    ///
+    /// The given `values` is stored in the `OwnedCStrs` for the lifetime of it
+    /// to keep the strings valid and unmodified. A null-terminated array of
+    /// pointers to the C-style strings is created from the `values` and stored
+    /// in the `OwnedCStrs` as well. The pointer to the array is returned by the
+    /// [`as_ptr`](Self::as_ptr) method.
+    #[must_use]
+    pub fn new(values: Vec<CString>) -> Self {
+        let pointers = null_terminated_pointers(&values).collect();
+
+        // SAFETY: `null_terminated_pointers` creates a null-terminated array,
+        // and the pointers in the array point to C-style strings borrowed from
+        // the `values`. The strings remain valid and unmodified for the
+        // lifetime of the `OwnedCStrs` because they are owned by it and not
+        // mutated through the pointers.
+        unsafe { Self::from_pointers_and_values(pointers, values) }
+    }
+
+    /// Creates a new `OwnedCStrs` from its inner components.
+    ///
+    /// This function directly uses the given `pointers` as the content of the
+    /// `OwnedCStrs`. The `pointers` is a null-terminated array of pointers to
+    /// C-style strings that is returned by the [`as_ptr`](Self::as_ptr) method.
+    /// The `values` is a `Vec<CString>` stored in the `OwnedCStrs` for the
+    /// lifetime of it.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointers in the first `Vec` point to
+    /// valid C-style strings, and that the `Vec` is null-terminated (i.e., the
+    /// last pointer is a null pointer). The strings must remain valid and
+    /// unmodified for the lifetime of the `OwnedCStrs`.
+    ///
+    /// This function does not require that the `pointers` point to strings
+    /// contained in `values`. However, if the strings pointed to by `pointers`
+    /// are modified or dropped through other means while the `OwnedCStrs` is
+    /// alive, it may lead to undefined behavior when the pointers are used. If
+    /// the strings pointed to by `pointers` are not contained in `values`, you
+    /// should consider using [`BorrowedCStrs`] instead, as it supports
+    /// lifetime-based safety guarantees for the strings.
+    #[inline(always)]
+    #[must_use]
+    pub unsafe fn from_pointers_and_values(
+        pointers: Vec<*const c_char>,
+        values: Vec<CString>,
+    ) -> Self {
+        Self { pointers, values }
+    }
+
+    /// Consumes the `OwnedCStrs` and returns the owned array of pointers and values.
+    ///
+    /// This function just returns its inner components. The caller is
+    /// responsible for ensuring the validity of the returned pointers if they
+    /// intend to use them. If `self` was created by [`OwnedCStrs::new`], the
+    /// C-style strings pointed to by the returned pointers will be valid until
+    /// the returned `values` are mutated or dropped.
+    #[inline(always)]
+    #[must_use]
+    pub fn into_pointers_and_values(self) -> (Vec<*const c_char>, Vec<CString>) {
+        (self.pointers, self.values)
+    }
+}
+
+/// Clones an `OwnedCStrs` by cloning its owned strings and reconstructing the
+/// pointer array to point to the new strings.
+impl Clone for OwnedCStrs {
+    fn clone(&self) -> Self {
+        let strings = self.values.clone();
+        // The new pointers must point to the new strings, so we create a new
+        // `OwnedCStrs` from the cloned strings instead of just cloning the
+        // pointers.
+        Self::new(strings)
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.values.clone_from(&source.values);
+        // The new pointers must point to the new strings, so we need to
+        // reinitialize the content of the pointers array.
+        self.pointers.clear();
+        self.pointers.extend(null_terminated_pointers(&self.values));
+    }
+}
+
+/// Converts a `Vec<CString>` into an `OwnedCStrs`. (See [`OwnedCStrs::new`].)
+impl From<Vec<CString>> for OwnedCStrs {
+    #[inline(always)]
+    fn from(values: Vec<CString>) -> Self {
+        Self::new(values)
+    }
+}
+
+/// Creates an `OwnedCStrs` from an iterator of values that can be converted into `CString`s.
+impl<A> FromIterator<A> for OwnedCStrs
+where
+    A: Into<CString>,
+{
+    fn from_iter<I: IntoIterator<Item = A>>(iter: I) -> Self {
+        let values = iter.into_iter().map(Into::into).collect();
+        Self::new(values)
+    }
+}
+
+/// Types that can be converted into an [`AsCStrArray`]
+///
+/// This trait is the bound that is actually required for the [`Exec::execve`]
+/// function. By using this trait instead of [`AsCStrArray`] directly, `execve`
+/// can accept types that either implement `AsCStrArray` directly or can be
+/// converted into one, such as `Vec<CString>`. This reduces the need for users
+/// to manually convert their string collections into `BorrowedCStrs`s or other
+/// `AsCStrArray` implementors before passing them to `execve`.
+///
+/// Note that implementations of this trait may perform conversions that involve
+/// heap allocations, so users should be aware of the potential performance
+/// implications when using this trait with types that do not directly implement
+/// `AsCStrArray`.
+///
+/// This trait is currently sealed to avoid breakage in a possible future
+/// extension. Please open an
+/// [issue](https://github.com/magicant/yash-rs/issues) if you have a use case
+/// for implementing this trait for a type defined outside this crate and would
+/// like it to be unsealed.
+///
+/// [`Exec::execve`]: super::Exec::execve
+#[expect(private_bounds, reason = "this trait is sealed")]
+pub trait IntoCStrArray: Sealed {
+    /// The type that `self` can be converted into, which must implement `AsCStrArray`.
+    type CStrArray: AsCStrArray;
+
+    /// Converts `self` into a type that implements `AsCStrArray`.
+    #[must_use]
+    fn into_c_str_array(self) -> Self::CStrArray;
+}
+
+/// Any type that implements `AsCStrArray` can be converted into a
+/// `AsCStrArray` by identity conversion.
+impl<T: AsCStrArray> IntoCStrArray for T {
+    type CStrArray = Self;
+
+    #[inline(always)]
+    fn into_c_str_array(self) -> Self::CStrArray {
+        self
+    }
+}
+
+impl<T> Sealed for &[T] where T: AsRef<CStr> {}
+/// Converts a slice of `&CStr`s into a `BorrowedCStrs`. (See
+/// [`BorrowedCStrs::from_iter`].)
+impl<'a, T> IntoCStrArray for &'a [T]
+where
+    T: AsRef<CStr>,
+{
+    type CStrArray = BorrowedCStrs<'a>;
+
+    #[inline(always)]
+    fn into_c_str_array(self) -> BorrowedCStrs<'a> {
+        BorrowedCStrs::from_iter(self)
+    }
+}
+
+impl<T> Sealed for Vec<T> where T: Into<CString> {}
+/// Converts a `Vec<T>` into an `OwnedCStrs`. (See [`OwnedCStrs::from_iter`].)
+impl<T> IntoCStrArray for Vec<T>
+where
+    T: Into<CString>,
+{
+    type CStrArray = OwnedCStrs;
+
+    #[inline(always)]
+    fn into_c_str_array(self) -> OwnedCStrs {
+        OwnedCStrs::from_iter(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_c_strings(words: &[&str]) -> Vec<CString> {
+        words.iter().map(|s| CString::new(*s).unwrap()).collect()
+    }
+
+    #[test]
+    fn as_c_str_array_to_vec() {
+        let strings = make_c_strings(&["foo", "bar", "baz"]);
+        let owned = OwnedCStrs::new(strings.clone());
+        assert_eq!(owned.to_vec(), strings);
+
+        // Empty array should round-trip to an empty Vec
+        let empty = OwnedCStrs::new(vec![]);
+        assert_eq!(empty.to_vec(), Vec::<CString>::new());
+    }
+
+    #[test]
+    fn borrowed_c_strs_from_iterator() {
+        let strings = make_c_strings(&["alpha", "beta"]);
+
+        // Collect borrows into BorrowedCStrs
+        let borrowed: BorrowedCStrs = strings.iter().collect();
+
+        // Content round-trips correctly
+        assert_eq!(borrowed.to_vec(), strings);
+
+        // The pointers in the array must actually borrow from `strings`
+        let ptr = borrowed.as_ptr();
+        unsafe {
+            assert_eq!(*ptr, strings[0].as_ptr());
+            assert_eq!(*ptr.add(1), strings[1].as_ptr());
+            // Array is null-terminated
+            assert!((*ptr.add(2)).is_null());
+        }
+    }
+
+    #[test]
+    fn owned_c_strs_new() {
+        let strings = make_c_strings(&["hello", "world"]);
+
+        let owned = OwnedCStrs::new(strings.clone());
+
+        // Content is preserved
+        assert_eq!(owned.to_vec(), strings);
+
+        // Pointers must be self-consistent (point into the owned values)
+        let (pointers, values) = owned.into_pointers_and_values();
+        for (i, value) in values.iter().enumerate() {
+            assert_eq!(pointers[i], value.as_ptr());
+        }
+        assert!(pointers[values.len()].is_null());
+    }
+
+    #[test]
+    fn owned_c_strs_clone() {
+        let strings = make_c_strings(&["foo", "bar"]);
+        let owned = OwnedCStrs::new(strings.clone());
+
+        let cloned = owned.clone();
+
+        // Cloned content matches the original
+        assert_eq!(cloned.to_vec(), strings);
+
+        // The clone must own its own copy of the strings, so the pointers
+        // must point to different memory than the original's pointers.
+        let orig_ptr = owned.as_ptr();
+        let clone_ptr = cloned.as_ptr();
+        unsafe {
+            assert_ne!(orig_ptr, clone_ptr);
+            assert_ne!(*orig_ptr, *clone_ptr);
+            assert_ne!(*orig_ptr.add(1), *clone_ptr.add(1));
+        }
+    }
+
+    #[test]
+    fn owned_c_strs_clone_from() {
+        let strings1 = make_c_strings(&["one"]);
+        let strings2 = make_c_strings(&["two", "three"]);
+        let source = OwnedCStrs::new(strings2.clone());
+        let mut dest = OwnedCStrs::new(strings1);
+
+        dest.clone_from(&source);
+
+        assert_eq!(dest.to_vec(), strings2);
+
+        // dest's pointers must be self-consistent (point into dest's own values)
+        let (pointers, values) = dest.into_pointers_and_values();
+        for (i, value) in values.iter().enumerate() {
+            assert_eq!(pointers[i], value.as_ptr());
+        }
+        assert!(pointers[values.len()].is_null());
+    }
+
+    #[test]
+    fn owned_c_strs_from_iterator() {
+        let strings = make_c_strings(&["x", "y", "z"]);
+
+        // Collect owned CStrings via the FromIterator impl
+        let owned: OwnedCStrs = strings.iter().cloned().collect();
+
+        assert_eq!(owned.to_vec(), strings);
+
+        // The pointers in the array must be self-consistent (point into the owned values)
+        let (pointers, values) = owned.into_pointers_and_values();
+        for (i, value) in values.iter().enumerate() {
+            assert_eq!(pointers[i], value.as_ptr());
+        }
+        assert!(pointers[values.len()].is_null());
+    }
+}

--- a/yash-env/src/system/concurrency/delegates.rs
+++ b/yash-env/src/system/concurrency/delegates.rs
@@ -16,6 +16,7 @@
 
 //! Trait implementations for `Concurrent<S>` that delegate to the inner system `S`
 
+use super::super::c_string::IntoCStrArray;
 use super::super::resource::{LimitPair, Resource};
 use super::super::{
     Chdir, Clock, Close, CpuTimes, Dir, Dup, Exec, Exit, Fcntl, FdFlag, Fstat, GetCwd, GetPid,
@@ -408,12 +409,16 @@ where
     S: Exec + Sigmask,
 {
     #[inline]
-    fn execve(
+    fn execve<A, E>(
         &self,
         path: &CStr,
-        args: &[CString],
-        envs: &[CString],
-    ) -> impl Future<Output = Result<Infallible>> + use<S> {
+        args: A,
+        envs: E,
+    ) -> impl Future<Output = Result<Infallible>> + use<S, A, E>
+    where
+        A: IntoCStrArray,
+        E: IntoCStrArray,
+    {
         self.inner.execve(path, args, envs)
     }
 }

--- a/yash-env/src/system/process.rs
+++ b/yash-env/src/system/process.rs
@@ -16,6 +16,7 @@
 
 //! Items related to process management
 
+use super::c_string::IntoCStrArray;
 use super::{ExitStatus, Result, Signals};
 #[cfg(all(doc, unix))]
 use crate::RealSystem;
@@ -24,7 +25,7 @@ use crate::VirtualSystem;
 use crate::job::Pid;
 use crate::job::ProcessState;
 use std::convert::Infallible;
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::rc::Rc;
 
 /// Trait for getting the current process ID and other process-related information
@@ -170,27 +171,40 @@ impl<S: Wait> Wait for Rc<S> {
 
 /// Trait for executing a new program in the current process
 pub trait Exec {
-    // TODO Consider passing raw pointers for optimization
     /// Replaces the current process with an external utility.
     ///
     /// This is a thin wrapper around the `execve` system call.
-    fn execve(
+    ///
+    /// The `args` and `envs` arguments are the argument and environment string
+    /// arrays passed to the new program. They accept any type that implements
+    /// [`IntoCStrArray`], including `&[CString]`, `Vec<CString>`, and the
+    /// dedicated array types in the [`c_string`](super::c_string) module. This
+    /// allows callers to avoid unnecessary allocations when they already hold a
+    /// suitable representation of the string arrays.
+    fn execve<A, E>(
         &self,
         path: &CStr,
-        args: &[CString],
-        envs: &[CString],
-    ) -> impl Future<Output = Result<Infallible>> + use<Self>;
+        args: A,
+        envs: E,
+    ) -> impl Future<Output = Result<Infallible>> + use<Self, A, E>
+    where
+        A: IntoCStrArray,
+        E: IntoCStrArray;
 }
 
 /// Delegates the `Exec` trait to the contained instance of `S`
 impl<S: Exec> Exec for Rc<S> {
     #[inline]
-    fn execve(
+    fn execve<A, E>(
         &self,
         path: &CStr,
-        args: &[CString],
-        envs: &[CString],
-    ) -> impl Future<Output = Result<Infallible>> + use<S> {
+        args: A,
+        envs: E,
+    ) -> impl Future<Output = Result<Infallible>> + use<S, A, E>
+    where
+        A: IntoCStrArray,
+        E: IntoCStrArray,
+    {
         (self as &S).execve(path, args, envs)
     }
 }

--- a/yash-env/src/system/real.rs
+++ b/yash-env/src/system/real.rs
@@ -80,6 +80,7 @@ use super::Uid;
 use super::Umask;
 use super::Wait;
 use super::Write;
+use super::c_string::{AsCStrArray as _, IntoCStrArray};
 use super::resource::LimitPair;
 use super::resource::Resource;
 #[cfg(doc)]
@@ -979,32 +980,29 @@ impl Wait for RealSystem {
 }
 
 impl Exec for RealSystem {
-    fn execve(
+    fn execve<A, E>(
         &self,
         path: &CStr,
-        args: &[CString],
-        envs: &[CString],
-    ) -> impl Future<Output = Result<Infallible>> + use<> {
-        fn to_pointer_array<S: AsRef<CStr>>(strs: &[S]) -> Vec<*const libc::c_char> {
-            strs.iter()
-                .map(|s| s.as_ref().as_ptr())
-                .chain(std::iter::once(std::ptr::null()))
-                .collect()
-        }
-        // TODO Uncomment when upgrading to libc 1.0
-        // // This function makes mutable char pointers from immutable string
-        // // slices since `execve` requires mutable pointers.
-        // fn to_pointer_array<S: AsRef<CStr>>(strs: &[S]) -> Vec<*mut libc::c_char> {
-        //     strs.iter()
-        //         .map(|s| s.as_ref().as_ptr().cast_mut())
-        //         .chain(std::iter::once(std::ptr::null_mut()))
-        //         .collect()
-        // }
-
-        let args = to_pointer_array(args);
-        let envs = to_pointer_array(envs);
+        args: A,
+        envs: E,
+    ) -> impl Future<Output = Result<Infallible>> + use<A, E>
+    where
+        A: IntoCStrArray,
+        E: IntoCStrArray,
+    {
+        let args = args.into_c_str_array();
+        let envs = envs.into_c_str_array();
         loop {
+            // SAFETY: `AsCStrArray::as_ptr` returns a pointer to a
+            // null-terminated array of pointers to valid C-style strings, which
+            // is exactly what `execve` expects. The strings remain valid because
+            // `args` and `envs` are kept alive for the duration of the call.
             let _ = unsafe { libc::execve(path.as_ptr(), args.as_ptr(), envs.as_ptr()) };
+            // TODO Uncomment when upgrading to libc 1.0
+            // // `execve` requires mutable pointers in libc 1.0.
+            // let _ = unsafe {
+            //     libc::execve(path.as_ptr(), args.as_mut_ptr(), envs.as_mut_ptr())
+            // };
             let errno = Errno::last();
             if errno != Errno::EINTR {
                 return ready(Err(errno));

--- a/yash-env/src/system/virtual.rs
+++ b/yash-env/src/system/virtual.rs
@@ -121,6 +121,7 @@ use super::Uid;
 use super::Umask;
 use super::Wait;
 use super::Write;
+use super::c_string::{AsCStrArray, IntoCStrArray};
 use super::resource::INFINITY;
 use super::resource::LimitPair;
 use super::resource::Resource;
@@ -1302,42 +1303,59 @@ impl Exec for VirtualSystem {
     /// The `execve` system call cannot be simulated in the userland. This
     /// function returns `ENOSYS` if the file at `path` is a native executable,
     /// `ENOEXEC` if a non-executable file, and `ENOENT` otherwise.
-    fn execve(
+    fn execve<A, E>(
         &self,
         path: &CStr,
-        args: &[CString],
-        envs: &[CString],
-    ) -> impl Future<Output = Result<Infallible>> + use<> {
-        let os_path = UnixStr::from_bytes(path.to_bytes());
-        let mut state = self.state.borrow_mut();
-        let fs = &state.file_system;
-        let file = match fs.get(os_path) {
-            Ok(file) => file,
-            Err(e) => return ready(Err(e)),
-        };
-        // TODO Check file permissions
-        let is_executable = matches!(
-            &file.borrow().body,
-            FileBody::Regular {
-                is_native_executable: true,
-                ..
-            }
-        );
-        if is_executable {
-            // Save arguments in the Process
-            let process = state.processes.get_mut(&self.process_id).unwrap();
-            let path = path.to_owned();
-            let args = args.to_owned();
-            let envs = envs.to_owned();
-            process.last_exec = Some((path, args, envs));
+        args: A,
+        envs: E,
+    ) -> impl Future<Output = Result<Infallible>> + use<A, E>
+    where
+        A: IntoCStrArray,
+        E: IntoCStrArray,
+    {
+        fn inner<A, E>(
+            this: &VirtualSystem,
+            path: &CStr,
+            args: A,
+            envs: E,
+        ) -> impl Future<Output = Result<Infallible>> + use<A, E>
+        where
+            A: AsCStrArray,
+            E: AsCStrArray,
+        {
+            let os_path = UnixStr::from_bytes(path.to_bytes());
+            let mut state = this.state.borrow_mut();
+            let fs = &state.file_system;
+            let file = match fs.get(os_path) {
+                Ok(file) => file,
+                Err(e) => return ready(Err(e)),
+            };
+            // TODO Check file permissions
+            let is_executable = matches!(
+                &file.borrow().body,
+                FileBody::Regular {
+                    is_native_executable: true,
+                    ..
+                }
+            );
+            if is_executable {
+                // Save arguments in the Process
+                let process = state.processes.get_mut(&this.process_id).unwrap();
+                let path = path.to_owned();
+                let args = args.into_c_str_array().to_vec();
+                let envs = envs.into_c_str_array().to_vec();
+                process.last_exec = Some((path, args, envs));
 
-            // TODO: We should abort the currently running task and start the new one.
-            // Just returning `pending()` would break existing tests that rely on
-            // the current behavior.
-            ready(Err(Errno::ENOSYS))
-        } else {
-            ready(Err(Errno::ENOEXEC))
+                // TODO: We should abort the currently running task and start the new one.
+                // Just returning `pending()` would break existing tests that rely on
+                // the current behavior.
+                ready(Err(Errno::ENOSYS))
+            } else {
+                ready(Err(Errno::ENOEXEC))
+            }
         }
+
+        inner(self, path, args.into_c_str_array(), envs.into_c_str_array())
     }
 }
 
@@ -2960,7 +2978,11 @@ mod tests {
         let pid = env
             .run_in_child_process((), move |child_env: Env<VirtualSystem>, ()| async move {
                 let path = CString::new(path).unwrap();
-                child_env.system.execve(&path, &[], &[]).await.ok();
+                child_env
+                    .system
+                    .execve(&path, &[] as &[CString], &[] as &[CString])
+                    .await
+                    .ok();
                 child_env.system.exit(child_env.exit_status).await;
             })
             .0
@@ -3249,7 +3271,10 @@ mod tests {
         state.file_system.save(path, content).unwrap();
         drop(state);
         let path = CString::new(path).unwrap();
-        let result = system.execve(&path, &[], &[]).now_or_never().unwrap();
+        let result = system
+            .execve(&path, &[] as &[CString], &[] as &[CString])
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Err(Errno::ENOSYS));
     }
 
@@ -3268,9 +3293,11 @@ mod tests {
         state.file_system.save(path, content).unwrap();
         drop(state);
         let path = CString::new(path).unwrap();
-        let args = [c"file".to_owned(), c"bar".to_owned()];
-        let envs = [c"foo=FOO".to_owned(), c"baz".to_owned()];
-        system.execve(&path, &args, &envs).now_or_never();
+        let args = [c"file", c"bar"];
+        let envs = [c"foo=FOO", c"baz"];
+        system
+            .execve(&path, args.as_slice(), envs.as_slice())
+            .now_or_never();
 
         let process = system.current_process();
         let arguments = process.last_exec.as_ref().unwrap();
@@ -3290,7 +3317,10 @@ mod tests {
         state.file_system.save(path, content).unwrap();
         drop(state);
         let path = CString::new(path).unwrap();
-        let result = system.execve(&path, &[], &[]).now_or_never().unwrap();
+        let result = system
+            .execve(&path, &[] as &[CString], &[] as &[CString])
+            .now_or_never()
+            .unwrap();
         assert_eq!(result, Err(Errno::ENOEXEC));
     }
 
@@ -3298,7 +3328,7 @@ mod tests {
     fn execve_returns_enoent_on_file_not_found() {
         let system = VirtualSystem::new();
         let result = system
-            .execve(c"/no/such/file", &[], &[])
+            .execve(c"/no/such/file", &[] as &[CString], &[] as &[CString])
             .now_or_never()
             .unwrap();
         assert_eq!(result, Err(Errno::ENOENT));


### PR DESCRIPTION
## Description

Resolves #796.

This pull request adds the `yash_env::system::c_string` module with several traits and structs. The `IntoCStrArray` trait is now used in the signature of the `yash_env::system::Exec::execve` method, making room for possible further optimization.

## Checklist

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible C-string abstractions for building/passing null-terminated C-string pointer arrays to execution APIs.

* **Changes**
  * Execution APIs now accept generic argument/environment types convertible to C-string arrays, broadening accepted input forms while maintaining compatibility with prior slice-style callers.

* **Documentation**
  * Changelog updated with usage notes and compatibility guidance for the new C-string handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->