### PR TITLE
Allow interrupting interactive shells

### DIFF
--- a/docs/src/environment/traps.md
+++ b/docs/src/environment/traps.md
@@ -77,3 +77,7 @@ In an [interactive shell](../interactive/index.html), certain signals are automa
 - If [job control](../interactive/job_control.md) is enabled, `SIGTSTP`, `SIGTTIN`, and `SIGTTOU` are also ignored.
 
 This ensures the shell remains responsive and in control, even if these signals are sent. You can still set traps for these signals if needed. In [subshells](index.html#subshells), which are non-interactive, this automatic ignoring does not apply.
+
+## Interruption in interactive shells
+
+(Since 3.1.0) In an [interactive shell](../interactive/index.html) with the default `SIGINT` trap, pressing `Ctrl+C` (or otherwise sending `SIGINT`) interrupts command execution: the shell discards any pending commands and returns to the prompt.

--- a/docs/src/interactive/README.md
+++ b/docs/src/interactive/README.md
@@ -49,6 +49,7 @@ When the shell is interactive:
 - The `ignoreeof` [shell option](../environment/options.md) is honored.
 - [Starting an asynchronous command prints its job number and process ID](../language/commands/lists.md#asynchronous-commands).
 - The shell does not exit immediately on most [shell errors](../termination.md#shell-errors).
+- [Commands can be interrupted](../environment/traps.md#interruption-in-interactive-shells).
 - [Some signals are automatically ignored](../environment/traps.md#auto-ignored-signals).
 - [Signals ignored on entry can be trapped](../environment/traps.md#restrictions).
 - [Command prompts](prompt.md) are displayed when reading input.

--- a/docs/src/topic_index.md
+++ b/docs/src/topic_index.md
@@ -76,6 +76,7 @@
 - [`ignoreeof` shell option](environment/options.md#ignoreeof)
 - [interactive shell](interactive/index.html)
 - [`interactive` shell option](environment/options.md#interactive--i)
+- [interruption](environment/traps.md#interruption-in-interactive-shells)
 - [job](interactive/job_control.md#job-control-concepts)
 - [job control](interactive/job_control.md)
 - [job ID](interactive/job_control.md#job-ids)

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -59,6 +59,7 @@
 			"hasher",
 			"idempotence",
 			"ignoreeof",
+			"interruptible",
 			"isatty",
 			"itertools",
 			"libc",

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -11,6 +11,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.18.0] - Unreleased
 
+### Added
+
+- The `wait` built-in now interrupts the interactive shell when `SIGINT` is
+  caught with the default action while waiting for jobs.
+
 ### Changed
 
 - Public dependency versions:

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -18,6 +18,15 @@ A _private dependency_ is used internally and not visible to downstream users.
     - yash-env 0.14.0 → 0.15.0
     - yash-semantics (optional) 0.16.0 → 0.17.0
 
+### Fixed
+
+- Previously, the `fg` built-in always returned an interrupt when invoked in an
+  interactive shell (unless there was an error). This was undesirable because
+  any commands that followed `fg` would unconditionally be ignored. Now, `fg`
+  only returns an interrupt in the following cases:
+    - The job was suspended, or
+    - The job was terminated by `SIGINT` and the `SIGINT` trap is not set.
+
 ## [0.17.0] - 2026-05-23
 
 ### Changed

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -18,6 +18,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `eval`, `.`/`source`, `fg`, and `wait` built-ins returned from `iter()`
+  now have `handles_signals_internally` set to `true`, indicating that these
+  built-ins handle signals themselves and the caller must not perform additional
+  signal checks while they are executing.
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0
     - yash-env 0.14.0 → 0.15.0

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -26,6 +26,15 @@
 //! running. The signal is not sent to jobs that have already terminated, to
 //! prevent unrelated processes that happen to have the same process IDs as the
 //! jobs from receiving the signal.
+//!
+//! The [`main`] function returns `Break(Interrupt(Some(...)))` if the shell is
+//! interactive and one of the following conditions is met:
+//!
+//! - The job is suspended, or
+//! - The job is terminated by `SIGINT` and the `SIGINT` trap is set to the default action.
+//!
+//! This return value should be propagated to the top-level loop, which should
+//! interrupt the shell and return to the prompt.
 
 use crate::bg::OperandErrorKind;
 use crate::bg::ResumeError;
@@ -47,8 +56,10 @@ use yash_env::option::State::Off;
 use yash_env::semantics::Divert::Interrupt;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::system::Signals;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::{Close, Dup, Isatty, Open, SendSignal, TcSetPgrp, Wait};
+use yash_env::trap::Action;
 use yash_env::trap::SignalSystem;
 
 /// Resumes the job at the specified index.
@@ -150,6 +161,33 @@ where
     Ok(resume_job_by_index(env, index).await?)
 }
 
+// XXX This function is identical to yash_env::job::sigint_is_defaulted
+fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
+    let state = env.traps.get_state(S::SIGINT).0;
+    state.is_none_or(|state| state.action == Action::Default)
+}
+
+/// Returns whether the `fg` built-in should return an interrupt.
+///
+/// Interactive shells get interrupted and return to the prompt when a
+/// foreground job is suspended or terminated by SIGINT. This function
+/// determines whether the built-in should return an interrupt based on the
+/// shell's options and the result of the job.
+fn should_interrupt<S: Signals>(env: &Env<S>, result: &ProcessResult) -> bool {
+    if !env.is_interactive() {
+        return false;
+    }
+    if result.is_stopped() {
+        return true;
+    }
+    if let ProcessResult::Signaled { signal, .. } = result
+        && *signal == S::SIGINT
+    {
+        return sigint_is_defaulted(env);
+    }
+    false
+}
+
 /// Entry point of the `fg` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> crate::Result
 where
@@ -189,7 +227,7 @@ where
     };
 
     match result {
-        Ok(result) if env.is_interactive() => {
+        Ok(result) if should_interrupt(env, &result) => {
             let divert = Break(Interrupt(Some(ExitStatus::from(result))));
             crate::Result::with_exit_status_and_divert(env.exit_status, divert)
         }
@@ -210,16 +248,20 @@ mod tests {
     use yash_env::job::ProcessResult;
     use yash_env::option::Option::Interactive;
     use yash_env::option::State::On;
+    use yash_env::source::Location;
     use yash_env::subshell::Config;
     use yash_env::system::Concurrent;
     use yash_env::system::GetPid as _;
     use yash_env::system::TcGetPgrp as _;
     use yash_env::system::r#virtual::Process;
+    use yash_env::system::r#virtual::SIGHUP;
+    use yash_env::system::r#virtual::SIGINT;
     use yash_env::system::r#virtual::SIGSTOP;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
     use yash_env::test_helper::in_virtual_system;
     use yash_env::test_helper::stub_tty;
+    use yash_env::trap::Action;
 
     async fn suspend(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
         let target = env.system.getpid();
@@ -432,6 +474,87 @@ mod tests {
 
         let result = resume_job_by_index(&mut env, index).now_or_never().unwrap();
         assert_eq!(result, Err(ResumeError::Unmonitored));
+    }
+
+    #[test]
+    fn should_interrupt_if_interactive_and_suspended() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        let result = ProcessResult::Stopped(SIGSTOP);
+        assert!(should_interrupt(&env, &result));
+    }
+
+    #[test]
+    fn should_interrupt_if_interactive_and_terminated_by_sigint_and_sigint_trap_is_default() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        let result = ProcessResult::Signaled {
+            signal: SIGINT,
+            core_dump: false,
+        };
+        assert!(should_interrupt(&env, &result));
+    }
+
+    #[test]
+    fn should_not_interrupt_if_interactive_and_terminated_by_sigint_but_sigint_is_ignored() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGINT,
+                Action::Ignore,
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let result = ProcessResult::Signaled {
+            signal: SIGINT,
+            core_dump: false,
+        };
+        assert!(!should_interrupt(&env, &result));
+    }
+
+    #[test]
+    fn should_not_interrupt_if_interactive_and_terminated_by_sigint_but_sigint_trap_is_custom() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGINT,
+                Action::Command("echo foo".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let result = ProcessResult::Signaled {
+            signal: SIGINT,
+            core_dump: false,
+        };
+        assert!(!should_interrupt(&env, &result));
+    }
+
+    #[test]
+    fn should_not_interrupt_if_interactive_and_terminated_by_other_than_sigint() {
+        let mut env = Env::new_virtual();
+        env.options.set(Interactive, On);
+        let result = ProcessResult::Signaled {
+            signal: SIGHUP,
+            core_dump: false,
+        };
+        assert!(!should_interrupt(&env, &result));
+    }
+
+    #[test]
+    fn should_not_interrupt_if_non_interactive() {
+        let env = Env::new_virtual();
+        let result = ProcessResult::Stopped(SIGSTOP);
+        assert!(!should_interrupt(&env, &result));
     }
 
     #[test]

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -59,7 +59,6 @@ use yash_env::semantics::Field;
 use yash_env::system::Signals;
 use yash_env::system::concurrency::{WaitForSignals, WriteAll};
 use yash_env::system::{Close, Dup, Isatty, Open, SendSignal, TcSetPgrp, Wait};
-use yash_env::trap::Action;
 use yash_env::trap::SignalSystem;
 
 /// Resumes the job at the specified index.
@@ -161,12 +160,6 @@ where
     Ok(resume_job_by_index(env, index).await?)
 }
 
-// XXX This function is identical to yash_env::job::sigint_is_defaulted
-fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
-    let state = env.traps.get_state(S::SIGINT).0;
-    state.is_none_or(|state| state.action == Action::Default)
-}
-
 /// Returns whether the `fg` built-in should return an interrupt.
 ///
 /// Interactive shells get interrupted and return to the prompt when a
@@ -183,7 +176,7 @@ fn should_interrupt<S: Signals>(env: &Env<S>, result: &ProcessResult) -> bool {
     if let ProcessResult::Signaled { signal, .. } = result
         && *signal == S::SIGINT
     {
-        return sigint_is_defaulted(env);
+        return env.sigint_has_default_action();
     }
     false
 }

--- a/yash-builtin/src/lib.rs
+++ b/yash-builtin/src/lib.rs
@@ -159,10 +159,11 @@ where
         + 'static,
 {
     [
-        (
-            ".",
-            Builtin::new(Special, |env, args| Box::pin(source::main(env, args))),
-        ),
+        (".", {
+            let mut builtin = Builtin::new(Special, |env, args| Box::pin(source::main(env, args)));
+            builtin.handles_signals_internally = true;
+            builtin
+        }),
         (
             ":",
             Builtin::new(Special, |env, args| Box::pin(ready(colon::main(env, args)))),
@@ -193,10 +194,11 @@ where
             "continue",
             Builtin::new(Special, |env, args| Box::pin(r#continue::main(env, args))),
         ),
-        (
-            "eval",
-            Builtin::new(Special, |env, args| Box::pin(eval::main(env, args))),
-        ),
+        ("eval", {
+            let mut builtin = Builtin::new(Special, |env, args| Box::pin(eval::main(env, args)));
+            builtin.handles_signals_internally = true;
+            builtin
+        }),
         (
             "exec",
             Builtin::new(Special, |env, args| Box::pin(exec::main(env, args))),
@@ -214,10 +216,11 @@ where
             "false",
             Builtin::new(Substitutive, |env, args| Box::pin(r#false::main(env, args))),
         ),
-        (
-            "fg",
-            Builtin::new(Mandatory, |env, args| Box::pin(fg::main(env, args))),
-        ),
+        ("fg", {
+            let mut builtin = Builtin::new(Mandatory, |env, args| Box::pin(fg::main(env, args)));
+            builtin.handles_signals_internally = true;
+            builtin
+        }),
         (
             "getopts",
             Builtin::new(Mandatory, |env, args| Box::pin(getopts::main(env, args))),
@@ -256,10 +259,11 @@ where
             "shift",
             Builtin::new(Special, |env, args| Box::pin(shift::main(env, args))),
         ),
-        (
-            "source",
-            Builtin::new(Special, |env, args| Box::pin(source::main(env, args))),
-        ),
+        ("source", {
+            let mut builtin = Builtin::new(Special, |env, args| Box::pin(source::main(env, args)));
+            builtin.handles_signals_internally = true;
+            builtin
+        }),
         (
             "times",
             Builtin::new(Special, |env, args| Box::pin(times::main(env, args))),
@@ -298,10 +302,11 @@ where
             "unset",
             Builtin::new(Special, |env, args| Box::pin(unset::main(env, args))),
         ),
-        (
-            "wait",
-            Builtin::new(Mandatory, |env, args| Box::pin(wait::main(env, args))),
-        ),
+        ("wait", {
+            let mut builtin = Builtin::new(Mandatory, |env, args| Box::pin(wait::main(env, args)));
+            builtin.handles_signals_internally = true;
+            builtin
+        }),
     ]
     .into_iter()
 }

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -87,15 +87,22 @@ where
                 // The current process has child processes, but none of them has
                 // changed its state. Wait for a signal.
                 let signals = env.wait_for_signals().await;
+
+                // If SIGINT is caught and defaulted, interrupt the built-in
+                // with SIGINT. We don't have to check if the shell is
+                // interactive here, because a defaulted SIGINT would have
+                // killed the shell immediately.
+                if signals.contains(&S::SIGINT) && env.sigint_has_default_action() {
+                    return Err(Error::Trapped(
+                        S::SIGINT,
+                        Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT)))),
+                    ));
+                }
+
+                // For other caught signals, run the corresponding trap actions if any.
                 for signal in signals.iter().cloned() {
                     if let Some(result) = run_trap_if_caught(env, signal).await {
                         return Err(Error::Trapped(signal, result));
-                    }
-                    if signal == S::SIGINT && env.sigint_has_default_action() {
-                        return Err(Error::Trapped(
-                            S::SIGINT,
-                            Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT)))),
-                        ));
                     }
                 }
             }
@@ -129,6 +136,8 @@ mod tests {
     use yash_env::VirtualSystem;
     use yash_env::job::Job;
     use yash_env::job::ProcessState;
+    use yash_env::option::Option::Interactive;
+    use yash_env::option::State::On;
     use yash_env::semantics::{Divert, ExitStatus};
     use yash_env::source::Location;
     use yash_env::subshell::Config;
@@ -260,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn sigint_with_default_action() {
+    fn sigint_with_default_action_in_interactive_mode() {
         in_virtual_system(|mut env, state| async move {
             type TestSystem = Rc<Concurrent<VirtualSystem>>;
             env.any.insert(Box::new(RunSignalTrapIfCaught::<TestSystem>(
@@ -270,6 +279,7 @@ mod tests {
                     )
                 },
             )));
+            env.options.set(Interactive, On);
 
             let system = VirtualSystem {
                 state,
@@ -288,24 +298,22 @@ mod tests {
                 .await
                 .unwrap();
 
-            {
-                // The job is not finished, so the function keeps waiting.
-                let mut future = pin!(wait_for_any_job_or_trap(&mut env));
-                assert_eq!(poll!(&mut future), Poll::Pending);
+            // The job is not finished, so the function keeps waiting.
+            let mut future = pin!(wait_for_any_job_or_trap(&mut env));
+            assert_eq!(poll!(&mut future), Poll::Pending);
 
-                // Send SIGINT to the current process.
-                _ = system.current_process_mut().raise_signal(SIGINT);
+            // Send SIGINT to the current process.
+            _ = system.current_process_mut().raise_signal(SIGINT);
 
-                // The function should return with an interrupt.
-                let result = future.await;
-                assert_eq!(
-                    result,
-                    Err(Error::Trapped(
-                        SIGINT,
-                        Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT)))),
-                    )),
-                );
-            }
+            // The function should return with an interrupt.
+            let result = future.await;
+            assert_eq!(
+                result,
+                Err(Error::Trapped(
+                    SIGINT,
+                    Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT)))),
+                )),
+            );
         });
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -20,13 +20,15 @@
 //! trap action. The [`Error`](enum@Error) type represents errors that may occur
 //! in the function.
 
+use std::ops::ControlFlow::Break;
 use thiserror::Error;
 use yash_env::Env;
 use yash_env::job::Pid;
+use yash_env::semantics::{Divert, ExitStatus};
 use yash_env::signal;
 use yash_env::system::concurrency::WaitForSignals;
-use yash_env::system::{Errno, Wait};
-use yash_env::trap::{RunSignalTrapIfCaught, SignalSystem};
+use yash_env::system::{Errno, Signals, Wait};
+use yash_env::trap::{Action, RunSignalTrapIfCaught, SignalSystem};
 
 /// Errors that may occur while waiting for a job
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
@@ -41,6 +43,13 @@ pub enum Error {
     /// An unexpected error occurred in the underlying system.
     #[error("system error: {0}")]
     SystemError(#[from] Errno),
+}
+
+// XXX This function is identical to yash_env::job::sigint_is_defaulted and
+// yash_builtin::fg::sigint_is_defaulted. We should unify them.
+fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
+    let state = env.traps.get_state(S::SIGINT).0;
+    state.is_none_or(|state| state.action == Action::Default)
 }
 
 /// Waits for a job status change or trap.
@@ -89,6 +98,12 @@ where
                     if let Some(result) = run_trap_if_caught(env, signal).await {
                         return Err(Error::Trapped(signal, result));
                     }
+                    if signal == S::SIGINT && sigint_is_defaulted(env) {
+                        return Err(Error::Trapped(
+                            S::SIGINT,
+                            Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT)))),
+                        ));
+                    }
                 }
             }
 
@@ -114,19 +129,19 @@ mod tests {
     use futures_util::FutureExt as _;
     use futures_util::poll;
     use std::future::{pending, ready};
-    use std::ops::ControlFlow::Continue;
+    use std::ops::ControlFlow::{Break, Continue};
     use std::pin::pin;
     use std::rc::Rc;
     use std::task::Poll;
     use yash_env::VirtualSystem;
     use yash_env::job::Job;
     use yash_env::job::ProcessState;
-    use yash_env::semantics::ExitStatus;
+    use yash_env::semantics::{Divert, ExitStatus};
     use yash_env::source::Location;
     use yash_env::subshell::Config;
     use yash_env::system::Concurrent;
     use yash_env::system::SendSignal as _;
-    use yash_env::system::r#virtual::{SIGSTOP, SIGTERM};
+    use yash_env::system::r#virtual::{SIGINT, SIGSTOP, SIGTERM};
     use yash_env::test_helper::in_virtual_system;
     use yash_env::trap::Action;
     use yash_env::variable::Value;
@@ -248,6 +263,56 @@ mod tests {
                 env.variables.get("foo").unwrap().value,
                 Some(Value::scalar("bar")),
             );
+        });
+    }
+
+    #[test]
+    fn sigint_with_default_action() {
+        in_virtual_system(|mut env, state| async move {
+            type TestSystem = Rc<Concurrent<VirtualSystem>>;
+            env.any.insert(Box::new(RunSignalTrapIfCaught::<TestSystem>(
+                |env, signal| {
+                    Box::pin(
+                        async move { yash_semantics::trap::run_trap_if_caught(env, signal).await },
+                    )
+                },
+            )));
+
+            let system = VirtualSystem {
+                state,
+                process_id: env.main_pid,
+            };
+
+            // Enable internal dispositions so SIGINT is caught with default action.
+            env.traps
+                .enable_internal_dispositions_for_terminators(&env.system)
+                .await
+                .unwrap();
+
+            // Start a child process that never exits.
+            Config::new()
+                .start(&mut env, async |_, _| pending().await)
+                .await
+                .unwrap();
+
+            {
+                // The job is not finished, so the function keeps waiting.
+                let mut future = pin!(wait_for_any_job_or_trap(&mut env));
+                assert_eq!(poll!(&mut future), Poll::Pending);
+
+                // Send SIGINT to the current process.
+                _ = system.current_process_mut().raise_signal(SIGINT);
+
+                // The function should return with an interrupt.
+                let result = future.await;
+                assert_eq!(
+                    result,
+                    Err(Error::Trapped(
+                        SIGINT,
+                        Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT)))),
+                    )),
+                );
+            }
         });
     }
 

--- a/yash-builtin/src/wait/core.rs
+++ b/yash-builtin/src/wait/core.rs
@@ -27,8 +27,8 @@ use yash_env::job::Pid;
 use yash_env::semantics::{Divert, ExitStatus};
 use yash_env::signal;
 use yash_env::system::concurrency::WaitForSignals;
-use yash_env::system::{Errno, Signals, Wait};
-use yash_env::trap::{Action, RunSignalTrapIfCaught, SignalSystem};
+use yash_env::system::{Errno, Wait};
+use yash_env::trap::{RunSignalTrapIfCaught, SignalSystem};
 
 /// Errors that may occur while waiting for a job
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
@@ -43,13 +43,6 @@ pub enum Error {
     /// An unexpected error occurred in the underlying system.
     #[error("system error: {0}")]
     SystemError(#[from] Errno),
-}
-
-// XXX This function is identical to yash_env::job::sigint_is_defaulted and
-// yash_builtin::fg::sigint_is_defaulted. We should unify them.
-fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
-    let state = env.traps.get_state(S::SIGINT).0;
-    state.is_none_or(|state| state.action == Action::Default)
 }
 
 /// Waits for a job status change or trap.
@@ -98,7 +91,7 @@ where
                     if let Some(result) = run_trap_if_caught(env, signal).await {
                         return Err(Error::Trapped(signal, result));
                     }
-                    if signal == S::SIGINT && sigint_is_defaulted(env) {
+                    if signal == S::SIGINT && env.sigint_has_default_action() {
                         return Err(Error::Trapped(
                             S::SIGINT,
                             Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT)))),

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The interactive shell now allows interrupting command execution with the
   `SIGINT` signal.
 
+### Fixed
+
+- Previously, the `fg` built-in always returned an interrupt when invoked in an
+  interactive shell (unless there was an error). This was undesirable because
+  any commands that followed `fg` would unconditionally be ignored. Now, `fg`
+  only returns an interrupt in the following cases:
+    - The job was suspended, or
+    - The job was terminated by `SIGINT` and the `SIGINT` trap is not set.
+
 ## [3.0.8] - 2026-05-23
 
 ### Fixed

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,13 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - Unreleased
+
+### Added
+
+- The interactive shell now allows interrupting command execution with the
+  `SIGINT` signal.
+
 ## [3.0.8] - 2026-05-23
 
 ### Fixed
@@ -326,6 +333,7 @@ later.
 
 - Initial release of the shell
 
+[3.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.1.0
 [3.0.8]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.8
 [3.0.7]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.7
 [3.0.5]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.5

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -292,6 +292,11 @@ fn input() {
 }
 
 #[test]
+fn intr() {
+    run_with_pty("intr-y.sh")
+}
+
+#[test]
 fn job_control() {
     run_with_pty("job-p.sh")
 }

--- a/yash-cli/tests/scripted_test/intr-y.sh
+++ b/yash-cli/tests/scripted_test/intr-y.sh
@@ -1,0 +1,8 @@
+# intr-y.sh: yash-specific test suite for interrupt handling
+
+test_o -e 0 'interrupting a command in interactive mode' -i --norcfile
+kill -INT $$; echo 'This should not be printed.'
+kill -l $?
+__IN__
+INT
+__OUT__

--- a/yash-cli/tests/scripted_test/intr-y.sh
+++ b/yash-cli/tests/scripted_test/intr-y.sh
@@ -1,8 +1,38 @@
 # intr-y.sh: yash-specific test suite for interrupt handling
 
-test_o -e 0 'interrupting a command in interactive mode' -i --norcfile
+test_o -e 0 'interrupting the shell in interactive mode' -im --norcfile
 kill -INT $$; echo 'This should not be printed.'
 kill -l $?
 __IN__
 INT
+__OUT__
+
+test_o -e 0 'interrupting an external utility in interactive mode' -im --norcfile
+sh -c 'kill -INT $$'; echo 'This should not be printed.'
+kill -l $?
+__IN__
+INT
+__OUT__
+
+test_o -e 0 'interrupting a subshell in interactive mode' -im --norcfile
+(kill -INT 0); echo 'This should not be printed.'
+kill -l $?
+__IN__
+INT
+__OUT__
+
+test_o -e 0 'interrupting a multi-command pipeline in interactive mode' -im --norcfile
+sleep 1 | kill -INT 0; echo 'This should not be printed.'
+kill -l $?
+__IN__
+INT
+__OUT__
+
+test_o -e 0 'interrupting a redirection in interactive mode' -im --norcfile
+> foo$(kill -INT 0); echo 'This should not be printed.'
+kill -l $?
+test -e foo || echo 'The file was not created.'
+__IN__
+INT
+The file was not created.
 __OUT__

--- a/yash-cli/tests/scripted_test/intr-y.sh
+++ b/yash-cli/tests/scripted_test/intr-y.sh
@@ -36,3 +36,10 @@ __IN__
 INT
 The file was not created.
 __OUT__
+
+test_o -e 0 'interrupting a command substitution in interactive mode' -im --norcfile
+echo $(sh -c 'kill -INT $$'); echo 'This should not be printed.'
+kill -l $?
+__IN__
+INT
+__OUT__

--- a/yash-cli/tests/scripted_test/intr-y.sh
+++ b/yash-cli/tests/scripted_test/intr-y.sh
@@ -44,6 +44,13 @@ __IN__
 INT
 __OUT__
 
+test_o -e 0 'interrupting a built-in in interactive mode' -im --norcfile
+kill -INT $$
+kill -l $?
+__IN__
+INT
+__OUT__
+
 # There is no test for interrupting the wait built-in because there is no
 # reliable way to send SIGINT to the shell after the wait built-in has started
 # waiting but before it finishes. The unit test in yash-builtin covers this.

--- a/yash-cli/tests/scripted_test/intr-y.sh
+++ b/yash-cli/tests/scripted_test/intr-y.sh
@@ -43,3 +43,7 @@ kill -l $?
 __IN__
 INT
 __OUT__
+
+# There is no test for interrupting the wait built-in because there is no
+# reliable way to send SIGINT to the shell after the wait built-in has started
+# waiting but before it finishes. The unit test in yash-builtin covers this.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
+- The `job::handle_job_status` function has been added as a replacement for the
+  deprecated `job::add_job_if_suspended`. In addition to the behavior of
+  `add_job_if_suspended`, `handle_job_status` returns
+  `Break(Divert::Interrupt(...))` when the process was terminated by `SIGINT`
+  and the interactive shell's trap action for `SIGINT` is the default.
 - The following trait implementations have been added:
     - `impl<S> job::RunBlocking for Concurrent<S>`
     - `impl<S> job::RunBlocking for Rc<Concurrent<S>>`
@@ -37,6 +42,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- `semantics::command::run_external_utility_in_subshell` now returns
+  `Break(Divert::Interrupt(...))` when the external utility is killed by
+  `SIGINT` in an interactive shell with the default `SIGINT` disposition.
 - The `system::Exec::execve` method now accepts the `args` and `envs` arguments
   as generic types implementing the new `system::c_string::IntoCStrArray` trait
   instead of `&[CString]`. This allows callers to pass string arrays without
@@ -48,6 +56,8 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Deprecated
 
+- The `job::add_job_if_suspended` function has been deprecated in favor of
+  `job::handle_job_status`.
 - The `JobList::add` method has been deprecated in favor of `JobList::insert`.
 
 ### Removed

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,13 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
+- The `Builtin<S>` struct has a new `handles_signals_internally` field. When
+  `true`, the built-in is responsible for all signal handling during its
+  execution and the caller must not perform additional signal checks. When
+  `false` (the default), the simple command execution code checks for a caught
+  SIGINT signal and interrupts the shell if needed. Built-ins that handle
+  signals themselves (such as `wait`, `fg`, and `eval`) should set this field to
+  `true`.
 - The `job::handle_job_status` function has been added as a replacement for the
   deprecated `job::add_job_if_suspended`. In addition to the behavior of
   `add_job_if_suspended`, `handle_job_status` returns

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
+- The `Env::sigint_has_default_action` method has been added, which tests
+  whether the SIGINT trap action is the default (i.e., no custom trap has been
+  set for SIGINT).
 - The `Builtin<S>` struct has a new `handles_signals_internally` field. When
   `true`, the built-in is responsible for all signal handling during its
   execution and the caller must not perform additional signal checks. When

--- a/yash-env/src/builtin.rs
+++ b/yash-env/src/builtin.rs
@@ -269,6 +269,23 @@ pub struct Builtin<S> {
     ///
     /// [method description]: crate::decl_util::Glossary::is_declaration_utility
     pub is_declaration_utility: Option<bool>,
+
+    /// Whether the built-in handles signals internally
+    ///
+    /// If `true`, the built-in is responsible for all signal handling during
+    /// its execution, including checking for caught signals and returning
+    /// `Break(Divert::Interrupt(...))` if appropriate. The caller must not
+    /// perform any additional signal checks while the built-in is executing.
+    ///
+    /// If `false` (the default), the built-in does not check for signals at
+    /// all. The caller then checks for a caught SIGINT concurrently with the
+    /// built-in's execution and interrupts the shell if needed. This allows the
+    /// shell to respond to SIGINT even for built-ins that never look at signals
+    /// themselves.
+    ///
+    /// Set this field to `true` for built-ins that handle signals themselves
+    /// (like `fg`, `wait`, `eval`, and `source`), to prevent double-processing.
+    pub handles_signals_internally: bool,
 }
 
 // Not derived automatically because S may not implement Clone or Copy.
@@ -286,6 +303,10 @@ impl<S> Debug for Builtin<S> {
             .field("type", &self.r#type)
             .field("execute", &self.execute)
             .field("is_declaration_utility", &self.is_declaration_utility)
+            .field(
+                "handles_signals_internally",
+                &self.handles_signals_internally,
+            )
             .finish()
     }
 }
@@ -296,6 +317,7 @@ impl<S> PartialEq for Builtin<S> {
         self.r#type == other.r#type
             && std::ptr::fn_addr_eq(self.execute, other.execute)
             && self.is_declaration_utility == other.is_declaration_utility
+            && self.handles_signals_internally == other.handles_signals_internally
     }
 }
 
@@ -306,6 +328,7 @@ impl<S> std::hash::Hash for Builtin<S> {
         self.r#type.hash(state);
         self.execute.hash(state);
         self.is_declaration_utility.hash(state);
+        self.handles_signals_internally.hash(state);
     }
 }
 
@@ -314,12 +337,15 @@ impl<S> Builtin<S> {
     ///
     /// The `type` and `execute` fields are set to the given arguments.
     /// The `is_declaration_utility` field is set to `Some(false)`, indicating
-    /// that the built-in is not a declaration utility.
+    /// that the built-in is not a declaration utility. The
+    /// `handles_signals_internally` field is set to `false`, meaning that
+    /// the built-in does not handle signals internally by default.
     pub const fn new(r#type: Type, execute: Main<S>) -> Self {
         Self {
             r#type,
             execute,
             is_declaration_utility: Some(false),
+            handles_signals_internally: false,
         }
     }
 }

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -1039,8 +1039,9 @@ where
     Continue(exit_status)
 }
 
-// XXX This function is identical to yash_semantics::trap::signal::sigint_is_defaulted.
-// We should unify them, but this function does not seem useful enough to be exposed in this module.
+// XXX This function is identical to yash_semantics::trap::signal::sigint_is_defaulted and
+// yash_builtin::fg::sigint_is_defaulted. We should unify them, but this function does not
+// seem useful enough to be exposed as a public API.
 fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
     let state = env.traps.get_state(S::SIGINT).0;
     state.is_none_or(|state| state.action == Action::Default)

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -44,6 +44,8 @@
 use crate::Env;
 use crate::semantics::{Divert, ExitStatus};
 use crate::signal;
+use crate::system::Signals;
+use crate::trap::Action;
 use slab::Slab;
 use std::collections::HashMap;
 use std::iter::FusedIterator;
@@ -936,7 +938,7 @@ impl JobList {
 /// Adds a job if the process is suspended.
 ///
 /// This is a convenience function for handling the result of
-/// [`Subshell::start_and_wait`](crate::subshell::Subshell::start_and_wait).
+/// [`Subshell::start_and_wait`](crate::subshell::Config::start_and_wait).
 ///
 /// If the process result indicates that the process is stopped, this function
 /// adds a job to the job list in the environment. The job is marked as
@@ -950,6 +952,7 @@ impl JobList {
 ///
 /// Returns the exit status of the process that should be assigned to
 /// `env.exit_status`.
+#[deprecated(since = "0.15.0", note = "use `handle_job_status` instead")]
 pub fn add_job_if_suspended<S, F>(
     env: &mut Env<S>,
     pid: Pid,
@@ -976,6 +979,73 @@ where
     Continue(exit_status)
 }
 
+/// Handles an interrupted or suspended job.
+///
+/// This function is a convenience function for handling the result of
+/// [`Subshell::start_and_wait`](crate::subshell::Config::start_and_wait), which
+/// starts a process and returns its result.
+///
+/// If the current environment is [interactive](Env::is_interactive), the trap
+/// action for SIGINT is [`Action::Default`], and the process result indicates
+/// that the process was terminated by SIGINT, then this function returns
+/// `Break(Divert::Interrupt(Some(result.into())))`.
+///
+/// If the process result indicates that the process is stopped, this function
+/// [inserts a job to the job list](JobList::insert) in the environment.
+/// The job is marked as job-controlled and its state is derived from the process
+/// result. The job name is set to the result of the `job_name` closure, which
+/// is called only if the job is inserted. If the current environment is
+/// interactive, this function returns
+/// `Break(Divert::Interrupt(Some(result.into())))`.
+///
+/// This function returns the exit status of the process derived from the
+/// process result (`result.into()`) that should be assigned to
+/// `env.exit_status`, except for the cases of interactive interruption and
+/// suspension described above.
+pub fn handle_job_status<S, F>(
+    env: &mut Env<S>,
+    pid: Pid,
+    result: ProcessResult,
+    job_name: F,
+) -> crate::semantics::Result<ExitStatus>
+where
+    S: Signals,
+    F: FnOnce() -> String,
+{
+    let exit_status = result.into();
+
+    if result.is_stopped() {
+        let mut job = Job::new(pid);
+        job.job_controlled = true;
+        job.state = result.into();
+        job.name = job_name();
+        env.jobs.insert(job);
+
+        if env.is_interactive() {
+            return Break(Divert::Interrupt(Some(exit_status)));
+        }
+    }
+
+    if let ProcessResult::Signaled { signal, .. } = result
+        && signal == S::SIGINT
+        // Unlike yash_semantics::trap::run_traps_for_caught_signals,
+        // we cannot omit the check for interactivity here.
+        && env.is_interactive()
+        && sigint_is_defaulted(env)
+    {
+        return Break(Divert::Interrupt(Some(exit_status)));
+    }
+
+    Continue(exit_status)
+}
+
+// XXX This function is identical to yash_semantics::trap::signal::sigint_is_defaulted.
+// We should unify them, but this function does not seem useful enough to be exposed in this module.
+fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
+    let state = env.traps.get_state(S::SIGINT).0;
+    state.is_none_or(|state| state.action == Action::Default)
+}
+
 pub mod fmt;
 pub mod id;
 mod tcsetpgrp;
@@ -988,7 +1058,7 @@ mod tests {
     use crate::option::Option::Interactive;
     use crate::option::State::On;
     use crate::signal;
-    use crate::system::r#virtual::{SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU};
+    use crate::system::r#virtual::{SIGINT, SIGSTOP, SIGTERM, SIGTSTP, SIGTTIN, SIGTTOU};
     use std::num::NonZero;
 
     #[test]
@@ -1591,62 +1661,235 @@ mod tests {
         assert_eq!(list.previous_job(), Some(i10));
     }
 
-    #[test]
-    fn do_not_add_job_if_exited() {
-        let mut env = Env::new_virtual();
-        let result = add_job_if_suspended(
-            &mut env,
-            Pid(123),
-            ProcessResult::Exited(ExitStatus(42)),
-            || "foo".to_string(),
-        );
-        assert_eq!(result, Continue(ExitStatus(42)));
-        assert_eq!(env.jobs.len(), 0);
+    #[allow(deprecated, reason = "to test the deprecated function")]
+    mod add_job_if_suspended {
+        use super::*;
+
+        #[test]
+        fn do_not_add_job_if_exited() {
+            let mut env = Env::new_virtual();
+            let result = add_job_if_suspended(
+                &mut env,
+                Pid(123),
+                ProcessResult::Exited(ExitStatus(42)),
+                || "foo".to_string(),
+            );
+            assert_eq!(result, Continue(ExitStatus(42)));
+            assert_eq!(env.jobs.len(), 0);
+        }
+
+        #[test]
+        fn do_not_add_job_if_signaled() {
+            let mut env = Env::new_virtual();
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let result = add_job_if_suspended(
+                &mut env,
+                Pid(123),
+                ProcessResult::Signaled {
+                    signal,
+                    core_dump: false,
+                },
+                || "foo".to_string(),
+            );
+            assert_eq!(result, Continue(ExitStatus::from(signal)));
+            assert_eq!(env.jobs.len(), 0);
+        }
+
+        #[test]
+        fn add_job_if_stopped() {
+            let mut env = Env::new_virtual();
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let process_result = ProcessResult::Stopped(signal);
+            let result =
+                add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
+            assert_eq!(result, Continue(ExitStatus::from(signal)));
+            assert_eq!(env.jobs.len(), 1);
+            let job = env.jobs.get(0).unwrap();
+            assert_eq!(job.pid, Pid(123));
+            assert!(job.job_controlled);
+            assert_eq!(job.state, ProcessState::Halted(process_result));
+            assert_eq!(job.name, "foo");
+        }
+
+        #[test]
+        fn break_if_stopped_and_interactive() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let process_result = ProcessResult::Stopped(signal);
+            let result =
+                add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
+            assert_eq!(
+                result,
+                Break(Divert::Interrupt(Some(ExitStatus::from(signal))))
+            );
+            assert_eq!(env.jobs.len(), 1);
+        }
     }
 
-    #[test]
-    fn do_not_add_job_if_signaled() {
-        let mut env = Env::new_virtual();
-        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
-        let result = add_job_if_suspended(
-            &mut env,
-            Pid(123),
-            ProcessResult::Signaled {
-                signal,
+    mod handle_job_status {
+        use super::*;
+        use crate::source::Location;
+        use futures_util::FutureExt as _;
+
+        #[test]
+        fn do_not_insert_job_if_exited() {
+            let mut env = Env::new_virtual();
+            let result = handle_job_status(
+                &mut env,
+                Pid(123),
+                ProcessResult::Exited(ExitStatus(42)),
+                || unreachable!(),
+            );
+            assert_eq!(result, Continue(ExitStatus(42)));
+            assert_eq!(env.jobs.len(), 0);
+        }
+
+        #[test]
+        fn do_not_insert_job_if_signaled() {
+            let mut env = Env::new_virtual();
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let result = handle_job_status(
+                &mut env,
+                Pid(123),
+                ProcessResult::Signaled {
+                    signal,
+                    core_dump: false,
+                },
+                || unreachable!(),
+            );
+            assert_eq!(result, Continue(ExitStatus::from(signal)));
+            assert_eq!(env.jobs.len(), 0);
+        }
+
+        #[test]
+        fn insert_job_if_stopped() {
+            let mut env = Env::new_virtual();
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let process_result = ProcessResult::Stopped(signal);
+            let result =
+                handle_job_status(&mut env, Pid(123), process_result, || "foo".to_string());
+            assert_eq!(result, Continue(ExitStatus::from(signal)));
+            assert_eq!(env.jobs.len(), 1);
+            let job = &env.jobs[0];
+            assert_eq!(job.pid, Pid(123));
+            assert!(job.job_controlled);
+            assert_eq!(job.state, ProcessState::Halted(process_result));
+            assert_eq!(job.name, "foo");
+        }
+
+        #[test]
+        fn interrupt_if_stopped_and_interactive() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
+            let process_result = ProcessResult::Stopped(signal);
+            let result =
+                handle_job_status(&mut env, Pid(123), process_result, || "foo".to_string());
+            assert_eq!(
+                result,
+                Break(Divert::Interrupt(Some(ExitStatus::from(signal))))
+            );
+            assert_eq!(env.jobs.len(), 1);
+        }
+
+        #[test]
+        fn do_not_interrupt_if_stopped_but_non_interactive() {
+            let mut env = Env::new_virtual();
+            // non-interactive by default (Interactive option not set)
+            let process_result = ProcessResult::Stopped(SIGTSTP);
+            let result =
+                handle_job_status(&mut env, Pid(123), process_result, || "job".to_string());
+            assert_eq!(result, Continue(ExitStatus::from(SIGTSTP)));
+        }
+
+        #[test]
+        fn interrupt_interactive_shell_for_default_sigint_action() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            // SIGINT trap action is Action::Default by default
+            let process_result = ProcessResult::Signaled {
+                signal: SIGINT,
                 core_dump: false,
-            },
-            || "foo".to_string(),
-        );
-        assert_eq!(result, Continue(ExitStatus::from(signal)));
-        assert_eq!(env.jobs.len(), 0);
-    }
+            };
+            let result = handle_job_status(&mut env, Pid(123), process_result, || unreachable!());
+            assert_eq!(
+                result,
+                Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT))))
+            );
+            assert_eq!(env.jobs.len(), 0);
+        }
 
-    #[test]
-    fn add_job_if_stopped() {
-        let mut env = Env::new_virtual();
-        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
-        let process_result = ProcessResult::Stopped(signal);
-        let result = add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
-        assert_eq!(result, Continue(ExitStatus::from(signal)));
-        assert_eq!(env.jobs.len(), 1);
-        let job = env.jobs.get(0).unwrap();
-        assert_eq!(job.pid, Pid(123));
-        assert!(job.job_controlled);
-        assert_eq!(job.state, ProcessState::Halted(process_result));
-        assert_eq!(job.name, "foo");
-    }
+        #[test]
+        fn do_not_interrupt_if_signaled_by_other_than_sigint() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            let process_result = ProcessResult::Signaled {
+                signal: SIGTERM,
+                core_dump: false,
+            };
+            let result = handle_job_status(&mut env, Pid(123), process_result, || unreachable!());
+            assert_eq!(result, Continue(ExitStatus::from(SIGTERM)));
+            assert_eq!(env.jobs.len(), 0);
+        }
 
-    #[test]
-    fn break_if_stopped_and_interactive() {
-        let mut env = Env::new_virtual();
-        env.options.set(Interactive, On);
-        let signal = signal::Number::from_raw_unchecked(NonZero::new(42).unwrap());
-        let process_result = ProcessResult::Stopped(signal);
-        let result = add_job_if_suspended(&mut env, Pid(123), process_result, || "foo".to_string());
-        assert_eq!(
-            result,
-            Break(Divert::Interrupt(Some(ExitStatus::from(signal))))
-        );
-        assert_eq!(env.jobs.len(), 1);
+        #[test]
+        fn do_not_interrupt_non_interactive_shell_for_default_sigint_action() {
+            let mut env = Env::new_virtual();
+            // non-interactive by default, SIGINT trap is Action::Default by default
+            let process_result = ProcessResult::Signaled {
+                signal: SIGINT,
+                core_dump: false,
+            };
+            let result = handle_job_status(&mut env, Pid(123), process_result, || unreachable!());
+            assert_eq!(result, Continue(ExitStatus::from(SIGINT)));
+            assert_eq!(env.jobs.len(), 0);
+        }
+
+        #[test]
+        fn do_not_interrupt_interactive_shell_for_ignore_sigint_action() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            env.traps
+                .set_action(
+                    &env.system,
+                    SIGINT,
+                    Action::Ignore,
+                    Location::dummy(""),
+                    false,
+                )
+                .now_or_never()
+                .unwrap()
+                .unwrap();
+            let process_result = ProcessResult::Signaled {
+                signal: SIGINT,
+                core_dump: false,
+            };
+            let result = handle_job_status(&mut env, Pid(123), process_result, || unreachable!());
+            assert_eq!(result, Continue(ExitStatus::from(SIGINT)));
+        }
+
+        #[test]
+        fn do_not_interrupt_interactive_shell_for_custom_sigint_action() {
+            let mut env = Env::new_virtual();
+            env.options.set(Interactive, On);
+            env.traps
+                .set_action(
+                    &env.system,
+                    SIGINT,
+                    Action::Command("echo interrupt".into()),
+                    Location::dummy(""),
+                    false,
+                )
+                .now_or_never()
+                .unwrap()
+                .unwrap();
+            let process_result = ProcessResult::Signaled {
+                signal: SIGINT,
+                core_dump: false,
+            };
+            let result = handle_job_status(&mut env, Pid(123), process_result, || unreachable!());
+            assert_eq!(result, Continue(ExitStatus::from(SIGINT)));
+        }
     }
 }

--- a/yash-env/src/job.rs
+++ b/yash-env/src/job.rs
@@ -45,6 +45,7 @@ use crate::Env;
 use crate::semantics::{Divert, ExitStatus};
 use crate::signal;
 use crate::system::Signals;
+#[cfg(any(doc, test))]
 use crate::trap::Action;
 use slab::Slab;
 use std::collections::HashMap;
@@ -1031,20 +1032,12 @@ where
         // Unlike yash_semantics::trap::run_traps_for_caught_signals,
         // we cannot omit the check for interactivity here.
         && env.is_interactive()
-        && sigint_is_defaulted(env)
+        && env.sigint_has_default_action()
     {
         return Break(Divert::Interrupt(Some(exit_status)));
     }
 
     Continue(exit_status)
-}
-
-// XXX This function is identical to yash_semantics::trap::signal::sigint_is_defaulted and
-// yash_builtin::fg::sigint_is_defaulted. We should unify them, but this function does not
-// seem useful enough to be exposed as a public API.
-fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
-    let state = env.traps.get_state(S::SIGINT).0;
-    state.is_none_or(|state| state.action == Action::Default)
 }
 
 pub mod fmt;

--- a/yash-env/src/lib.rs
+++ b/yash-env/src/lib.rs
@@ -75,6 +75,7 @@ use self::system::OfdAccess;
 use self::system::Open;
 use self::system::OpenFlag;
 use self::system::SignalList;
+use self::system::Signals;
 use self::system::TcSetPgrp;
 use self::system::Wait;
 use self::system::concurrency::Select;
@@ -82,6 +83,7 @@ use self::system::concurrency::WaitForSignals;
 #[cfg(unix)]
 pub use self::system::real::RealSystem;
 pub use self::system::r#virtual::VirtualSystem;
+use self::trap::Action;
 use self::trap::SignalSystem;
 use self::trap::TrapSet;
 use self::variable::PPID;
@@ -605,6 +607,27 @@ impl<S> Env<S> {
     #[must_use]
     pub fn controls_jobs(&self) -> bool {
         self.options.get(Monitor) == On && !self.stack.contains(&Frame::Subshell)
+    }
+
+    /// Tests whether the SIGINT trap action is the default.
+    ///
+    /// Returns `true` if and only if SIGINT has not been set to a non-default
+    /// trap action.
+    ///
+    /// This method is useful when deciding whether a caught SIGINT should
+    /// immediately interrupt the current operation by returning
+    /// [`Divert::Interrupt`] in an [interactive](Self::is_interactive) shell.
+    /// If this method returns `true`, there is no user-defined trap for SIGINT,
+    /// so the shell can treat the signal as an immediate interrupt. If it
+    /// returns `false`, the shell should instead defer to the user-defined trap
+    /// action.
+    #[must_use]
+    pub fn sigint_has_default_action(&self) -> bool
+    where
+        S: Signals,
+    {
+        let state = self.traps.get_state(S::SIGINT).0;
+        state.is_none_or(|state| state.action == Action::Default)
     }
 
     /// Get an existing variable or create a new one.

--- a/yash-env/src/semantics/command.rs
+++ b/yash-env/src/semantics/command.rs
@@ -22,7 +22,7 @@ pub mod search;
 
 use crate::Env;
 use crate::function::Function;
-use crate::job::{RunBlocking, RunUnblocking, add_job_if_suspended};
+use crate::job::{RunBlocking, RunUnblocking, handle_job_status};
 use crate::semantics::{ExitStatus, Field, Result};
 use crate::source::Location;
 use crate::source::pretty::{Report, ReportType, Snippet};
@@ -294,7 +294,7 @@ where
         });
 
     match subshell_result.await {
-        Ok((pid, result)) => add_job_if_suspended(env, pid, result, || job_name),
+        Ok((pid, result)) => handle_job_status(env, pid, result, || job_name),
         Err(errno) => {
             handle_start_subshell_error(env, StartSubshellError { utility, errno }).await;
             Continue(ExitStatus::NOEXEC)

--- a/yash-env/src/subshell/config.rs
+++ b/yash-env/src/subshell/config.rs
@@ -244,6 +244,8 @@ impl Config {
     ///
     /// When a job-controlled subshell suspends, this function does not add it
     /// to `env.jobs`. You have to do it for yourself if necessary.
+    /// [`handle_job_status`](crate::job::handle_job_status) is a convenient
+    /// helper for doing so.
     pub async fn start_and_wait<S, F>(
         // Why take `self` by value? See the comment in `start`.
         self,

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -14,10 +14,15 @@ A _private dependency_ is used internally and not visible to downstream users.
 ### Added
 
 - `expansion::ErrorCause::Interrupted` is a new variant that represents a
-  command substitution being interrupted by `SIGINT`. When this error is
-  handled (via the `Handle` trait), it returns
+  command substitution or pathname expansion being interrupted by `SIGINT`.
+  When this error is handled (via the `Handle` trait), it returns
   `Break(Divert::Interrupt(Some(exit_status)))` without printing an error
   message.
+- `expansion::glob::Interrupted` is a new type indicating that pathname
+  expansion was interrupted by `SIGINT`. It is yielded as `Err(Interrupted)`
+  by the `expansion::glob::Glob` iterator when a SIGINT signal is received
+  while scanning directories in an interactive shell with the default `SIGINT`
+  disposition.
 - Private dependency:
     - futures-util 0.3.31
 
@@ -45,6 +50,13 @@ A _private dependency_ is used internally and not visible to downstream users.
   This affects `impl command::Command for yash_syntax::syntax::SimpleCommand`.
 - The `Runtime` trait now requires `Clone` as a supertrait.
 - The `expansion::ErrorCause` enum is now `non_exhaustive`.
+- `expansion::glob::glob` now additionally requires
+  `S: yash_env::system::concurrency::WaitForSignals + yash_env::system::concurrency::Select + yash_env::system::Signals`,
+  and `expansion::glob::Glob<'_, S>` now implements
+  `Iterator<Item = Result<expansion::glob::Field, expansion::glob::Interrupted>>`
+  instead of `Iterator<Item = expansion::glob::Field>`.
+  The iterator yields `Err(Interrupted)` when a SIGINT is caught during
+  directory scanning in an interactive shell with the default SIGINT disposition.
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0
     - yash-env 0.14.0 → 0.15.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -17,10 +17,24 @@ A _private dependency_ is used internally and not visible to downstream users.
   SIGINT signal and interrupts the current command with SIGINT if the signal is
   caught and the disposition of SIGINT is default. This behavior is not
   specified in POSIX, but it is a common behavior of interactive shells.
+- Executing an external utility, subshell, pipeline, or redirection in an
+  interactive shell with the default `SIGINT` disposition now interrupts the
+  shell (returns `Break(Divert::Interrupt(...))`) when the child process is
+  killed by `SIGINT`. This complements the behavior of
+  `trap::run_traps_for_caught_signals`. This affects the following items:
+    - `impl command::Command for yash_syntax::syntax::SimpleCommand`
+    - `impl command::Command for yash_syntax::syntax::Pipeline`
+    - `impl command::Command for yash_syntax::syntax::CompoundCommand`
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0
     - yash-env 0.14.0 → 0.15.0
     - yash-syntax 0.21.0 → 0.22.0
+
+### Deprecated
+
+- The `job::add_job_if_suspended` re-export has been deprecated following the
+  deprecation of `yash_env::job::add_job_if_suspended`. Use
+  `yash_env::job::handle_job_status` instead.
 
 ## [0.16.0] - 2026-05-23
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -11,20 +11,31 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.17.0] - Unreleased
 
+### Added
+
+- `expansion::ErrorCause::Interrupted` is a new variant that represents a
+  command substitution being interrupted by `SIGINT`. When this error is
+  handled (via the `Handle` trait), it returns
+  `Break(Divert::Interrupt(Some(exit_status)))` without printing an error
+  message.
+
 ### Changed
 
 - The `trap::run_traps_for_caught_signals` function now checks for a caught
   SIGINT signal and interrupts the current command with SIGINT if the signal is
   caught and the disposition of SIGINT is default. This behavior is not
   specified in POSIX, but it is a common behavior of interactive shells.
-- Executing an external utility, subshell, pipeline, or redirection in an
-  interactive shell with the default `SIGINT` disposition now interrupts the
-  shell (returns `Break(Divert::Interrupt(...))`) when the child process is
-  killed by `SIGINT`. This complements the behavior of
+- Executing an external utility, subshell, pipeline, redirection, or command
+  substitution in an interactive shell with the default `SIGINT` disposition
+  now interrupts the shell (returns `Break(Divert::Interrupt(...))`) when the
+  child process is killed by `SIGINT`. This complements the behavior of
   `trap::run_traps_for_caught_signals`. This affects the following items:
     - `impl command::Command for yash_syntax::syntax::SimpleCommand`
     - `impl command::Command for yash_syntax::syntax::Pipeline`
     - `impl command::Command for yash_syntax::syntax::CompoundCommand`
+    - `impl expansion::initial::Expand for yash_syntax::syntax::TextUnit` (as
+      well as for other syntax types that contain `TextUnit` such as `WordUnit`)
+- The `expansion::ErrorCause` enum is now `non_exhaustive`.
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0
     - yash-env 0.14.0 → 0.15.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -18,6 +18,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   handled (via the `Handle` trait), it returns
   `Break(Divert::Interrupt(Some(exit_status)))` without printing an error
   message.
+- Private dependency:
+    - futures-util 0.3.31
 
 ### Changed
 
@@ -35,6 +37,13 @@ A _private dependency_ is used internally and not visible to downstream users.
     - `impl command::Command for yash_syntax::syntax::CompoundCommand`
     - `impl expansion::initial::Expand for yash_syntax::syntax::TextUnit` (as
       well as for other syntax types that contain `TextUnit` such as `WordUnit`)
+- Executing a built-in utility in an interactive shell now interrupts the shell
+  (returns `Break(Divert::Interrupt(...))`) when SIGINT is caught while the
+  built-in is running and the built-in's `handles_signals_internally` field is
+  `false`. SIGINT is detected concurrently with the built-in's execution: the
+  built-in's future is dropped if SIGINT arrives before the built-in finishes.
+  This affects `impl command::Command for yash_syntax::syntax::SimpleCommand`.
+- The `Runtime` trait now requires `Clone` as a supertrait.
 - The `expansion::ErrorCause` enum is now `non_exhaustive`.
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,6 +13,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `trap::run_traps_for_caught_signals` function now checks for a caught
+  SIGINT signal and interrupts the current command with SIGINT if the signal is
+  caught and the disposition of SIGINT is default. This behavior is not
+  specified in POSIX, but it is a common behavior of interactive shells.
 - Public dependency versions:
     - Rust 1.87.0 → 1.96.0
     - yash-env 0.14.0 → 0.15.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 [dependencies]
 either = { workspace = true }
 enumset = { workspace = true }
+futures-util = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }
 yash-arith = { workspace = true }

--- a/yash-semantics/src/command/compound_command/subshell.rs
+++ b/yash-semantics/src/command/compound_command/subshell.rs
@@ -23,7 +23,7 @@ use std::ops::ControlFlow::Break;
 use std::rc::Rc;
 use yash_env::Env;
 use yash_env::io::print_error;
-use yash_env::job::add_job_if_suspended;
+use yash_env::job::handle_job_status;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
@@ -43,7 +43,7 @@ pub async fn execute<S: Runtime + 'static>(
     });
     match subshell.await {
         Ok((pid, result)) => {
-            env.exit_status = add_job_if_suspended(env, pid, result, || body.to_string())?;
+            env.exit_status = handle_job_status(env, pid, result, || body.to_string())?;
             env.apply_errexit()
         }
         Err(errno) => {

--- a/yash-semantics/src/command/pipeline.rs
+++ b/yash-semantics/src/command/pipeline.rs
@@ -25,8 +25,7 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::Env;
 use yash_env::io::Fd;
-use yash_env::job::Pid;
-use yash_env::job::add_job_if_suspended;
+use yash_env::job::{Pid, handle_job_status};
 use yash_env::option::Option::{Exec, Interactive, PipeFail};
 use yash_env::option::State::{Off, On};
 use yash_env::semantics::Divert;
@@ -132,7 +131,7 @@ async fn execute_job_controlled_pipeline<S: Runtime + 'static>(
     });
     match subshell.await {
         Ok((pid, result)) => {
-            env.exit_status = add_job_if_suspended(env, pid, result, || to_job_name(commands))?;
+            env.exit_status = handle_job_status(env, pid, result, || to_job_name(commands))?;
             Continue(())
         }
         Err(errno) => {

--- a/yash-semantics/src/command/simple_command/absent.rs
+++ b/yash-semantics/src/command/simple_command/absent.rs
@@ -27,7 +27,7 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::Env;
 use yash_env::io::print_error;
-use yash_env::job::add_job_if_suspended;
+use yash_env::job::handle_job_status;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
@@ -64,7 +64,7 @@ pub async fn execute_absent_target<S: Runtime + 'static>(
             env.exit_status = redir_exit_status.unwrap_or(exit_status);
         });
         match subshell.await {
-            Ok((pid, result)) => add_job_if_suspended(env, pid, result, || {
+            Ok((pid, result)) => handle_job_status(env, pid, result, || {
                 redirs
                     .iter()
                     .format_with(" ", |redir, f| f(&format_args!("{redir}")))

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -21,7 +21,6 @@ use crate::Handle as _;
 use crate::Runtime;
 use crate::command::search::search_path;
 use crate::redir::RedirGuard;
-use crate::trap::sigint_is_defaulted;
 use crate::xtrace::XTrace;
 use crate::xtrace::print;
 use crate::xtrace::trace_fields;
@@ -93,8 +92,9 @@ pub async fn execute_builtin<S: Runtime + 'static>(
 
         let env = &mut env.push_frame(FrameBuiltin { name, is_special }.into());
 
-        let interruptible =
-            !builtin.handles_signals_internally && env.is_interactive() && sigint_is_defaulted(env);
+        let interruptible = !builtin.handles_signals_internally
+            && env.is_interactive()
+            && env.sigint_has_default_action();
         if !interruptible {
             break 'result (builtin.execute)(env, fields).await;
         }

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -21,11 +21,14 @@ use crate::Handle as _;
 use crate::Runtime;
 use crate::command::search::search_path;
 use crate::redir::RedirGuard;
+use crate::trap::sigint_is_defaulted;
 use crate::xtrace::XTrace;
 use crate::xtrace::print;
 use crate::xtrace::trace_fields;
 use either::Either;
+use futures_util::future::{Either as SelectResult, select};
 use std::ops::ControlFlow::{Break, Continue};
+use std::pin::pin;
 use yash_env::Env;
 use yash_env::builtin::Builtin;
 use yash_env::io::print_error;
@@ -90,7 +93,51 @@ pub async fn execute_builtin<S: Runtime + 'static>(
 
         let env = &mut env.push_frame(FrameBuiltin { name, is_special }.into());
 
-        (builtin.execute)(env, fields).await
+        let interruptible =
+            !builtin.handles_signals_internally && env.is_interactive() && sigint_is_defaulted(env);
+        if !interruptible {
+            break 'result (builtin.execute)(env, fields).await;
+        }
+
+        // If the built-in is interruptible, we need to wait for either the built-in to finish or
+        // SIGINT to be received. To do so, we run two futures concurrently, one for the built-in
+        // and one for waiting for SIGINT, and wait for either of them to complete.
+        // Waiting for SIGINT is effectively equivalent to `env.wait_for_signal(S::SIGINT).await`,
+        // but it's not possible because `env` is borrowed by the future for the built-in. Instead,
+        // we mock the behavior by calling `system.wait_for_signals().await` and
+        // `env.traps.catch_signal()` manually. Note that we need to call `env.traps.catch_signal()`
+        // for all signals received while waiting, not just SIGINT, because otherwise they would be
+        // lost and never handled.
+        let mut caught = Vec::new();
+        let system = env.system.clone();
+        let result = {
+            let builtin_fut = (builtin.execute)(env, fields);
+            let sigint_fut = pin!(async {
+                loop {
+                    let signals = system.wait_for_signals().await;
+                    caught.extend(signals.iter().copied());
+                    if signals.contains(&S::SIGINT) {
+                        return;
+                    }
+                }
+            });
+
+            // These futures live only in this inner scope so that the borrow
+            // of `caught` and `env` ends before they are used again below.
+            match select(builtin_fut, sigint_fut).await {
+                SelectResult::Left((result, _sigint_fut)) => Some(result),
+                SelectResult::Right(((), _builtin_fut)) => None,
+            }
+        };
+
+        for signal in caught {
+            env.traps.catch_signal(signal);
+        }
+
+        match result {
+            Some(result) => result,
+            None => return Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT)))),
+        }
     };
 
     if result.should_retain_redirs() {
@@ -109,22 +156,28 @@ mod tests {
     use crate::tests::return_builtin;
     use assert_matches::assert_matches;
     use futures_util::FutureExt as _;
+    use futures_util::poll;
     use std::cell::RefCell;
     use std::pin::Pin;
     use std::rc::Rc;
     use std::str::from_utf8;
     use yash_env::VirtualSystem;
     use yash_env::builtin::Type::{Elective, Extension, Mandatory, Special, Substitutive};
+    use yash_env::option::Interactive;
     use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
     use yash_env::stack::Frame;
     use yash_env::system::Concurrent;
     use yash_env::system::Errno;
     use yash_env::system::Mode;
+    use yash_env::system::SendSignal as _;
+    use yash_env::system::Signals as _;
     use yash_env::system::r#virtual::FileBody;
     use yash_env::system::r#virtual::Inode;
+    use yash_env::system::r#virtual::SIGINT;
     use yash_env::test_helper::assert_stderr;
     use yash_env::test_helper::assert_stdout;
+    use yash_env::test_helper::in_virtual_system;
     use yash_env::variable::Scope::Global;
     use yash_env::variable::Value;
     use yash_syntax::syntax;
@@ -365,6 +418,64 @@ mod tests {
         let command: syntax::SimpleCommand = "special".parse().unwrap();
         _ = command.execute(&mut env).now_or_never().unwrap();
         assert_eq!(env.stack[..], []);
+    }
+
+    #[test]
+    fn sigint_interrupts_builtin_by_default_if_interactive() {
+        in_virtual_system(|mut env, state| async move {
+            let system = VirtualSystem {
+                process_id: env.main_pid,
+                state,
+            };
+
+            env.options.set(Interactive, On);
+            env.traps
+                .enable_internal_dispositions_for_terminators(&env.system)
+                .await
+                .unwrap();
+            env.builtins.insert(
+                "foo",
+                Builtin::new(Mandatory, |_env, _args| Box::pin(std::future::pending())),
+            );
+
+            let command: syntax::SimpleCommand = "foo".parse().unwrap();
+            let mut execute_fut = pin!(command.execute(&mut env));
+            assert_eq!(poll!(execute_fut.as_mut()), std::task::Poll::Pending);
+
+            system.raise(VirtualSystem::SIGINT).await.unwrap();
+            let result = execute_fut.await;
+            assert_eq!(
+                result,
+                Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT))))
+            );
+        })
+    }
+
+    #[test]
+    fn sigint_not_checked_when_handles_signals_internally_is_true() {
+        in_virtual_system(|mut env, state| async move {
+            let system = VirtualSystem {
+                process_id: env.main_pid,
+                state,
+            };
+
+            env.options.set(Interactive, On);
+            env.traps
+                .enable_internal_dispositions_for_terminators(&env.system)
+                .await
+                .unwrap();
+            let mut builtin =
+                Builtin::new(Mandatory, |_env, _args| Box::pin(std::future::pending()));
+            builtin.handles_signals_internally = true;
+            env.builtins.insert("foo", builtin);
+
+            let command: syntax::SimpleCommand = "foo".parse().unwrap();
+            let mut execute_fut = pin!(command.execute(&mut env));
+            assert_eq!(poll!(execute_fut.as_mut()), std::task::Poll::Pending);
+
+            system.raise(VirtualSystem::SIGINT).await.unwrap();
+            assert_eq!(poll!(execute_fut.as_mut()), std::task::Poll::Pending);
+        });
     }
 
     #[test]

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -183,7 +183,7 @@ impl ErrorCause {
             UnsetParameter { .. } => "cannot expand unset parameter",
             VacantExpansion(error) => error.message_or_default(),
             NonassignableParameter(_) => "cannot assign to parameter",
-            Interrupted(_) => "command substitution interrupted",
+            Interrupted(_) => "word expansion interrupted",
         }
     }
 

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -135,6 +135,7 @@ pub struct AssignReadOnlyError {
 
 /// Types of errors that may occur in the word expansion.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorCause {
     /// System error while performing a command substitution.
     #[error("error in command substitution: {0}")]
@@ -159,6 +160,14 @@ pub enum ErrorCause {
     /// Assignment to a nonassignable parameter
     #[error(transparent)]
     NonassignableParameter(#[from] NonassignableError),
+
+    /// Command substitution process was killed by SIGINT.
+    ///
+    /// This variant is used to propagate a SIGINT interruption that occurred
+    /// in a command substitution process. The exit status is the exit status
+    /// derived from the SIGINT signal.
+    #[error("command substitution interrupted by SIGINT")]
+    Interrupted(ExitStatus),
 }
 
 impl ErrorCause {
@@ -174,6 +183,7 @@ impl ErrorCause {
             UnsetParameter { .. } => "cannot expand unset parameter",
             VacantExpansion(error) => error.message_or_default(),
             NonassignableParameter(_) => "cannot assign to parameter",
+            Interrupted(_) => "command substitution interrupted",
         }
     }
 
@@ -196,6 +206,7 @@ impl ErrorCause {
                 }
             },
             NonassignableParameter(e) => e.to_string(),
+            Interrupted(_) => "killed by SIGINT".to_owned(),
         }
         .into()
     }
@@ -216,6 +227,7 @@ impl ErrorCause {
             UnsetParameter { .. } => None,
             VacantExpansion(_) => None,
             NonassignableParameter(_) => None,
+            Interrupted(_) => None,
         }
     }
 
@@ -228,7 +240,8 @@ impl ErrorCause {
             | ArithError(_)
             | AssignReadOnly(_)
             | VacantExpansion(_)
-            | NonassignableParameter(_) => None,
+            | NonassignableParameter(_)
+            | Interrupted(_) => None,
 
             UnsetParameter { .. } => Some("unset parameters are disallowed by the nounset option"),
         }
@@ -276,6 +289,7 @@ impl Error {
             ErrorCause::UnsetParameter { .. } => None,
             ErrorCause::VacantExpansion(_) => None,
             ErrorCause::NonassignableParameter(e) => Some(e.vacancy),
+            ErrorCause::Interrupted(_) => None,
         };
         if let Some(vacancy) = vacancy {
             let message = match vacancy {

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -161,12 +161,12 @@ pub enum ErrorCause {
     #[error(transparent)]
     NonassignableParameter(#[from] NonassignableError),
 
-    /// Command substitution process was killed by SIGINT.
+    /// Expansion interrupted by SIGINT in an interactive shell
     ///
     /// This variant is used to propagate a SIGINT interruption that occurred
-    /// in a command substitution process. The exit status is the exit status
-    /// derived from the SIGINT signal.
-    #[error("command substitution interrupted by SIGINT")]
+    /// during word expansion (e.g., in a command substitution or pathname
+    /// expansion). The exit status is derived from the SIGINT signal.
+    #[error("expansion interrupted by SIGINT")]
     Interrupted(ExitStatus),
 }
 
@@ -430,7 +430,19 @@ where
 
     // pathname expansion (including quote removal and attribute stripping) //
     for field in split_fields {
-        results.extend(glob(env.inner, field));
+        let glob = glob(env.inner, field);
+        match glob.try_into_vec_iter() {
+            Ok(fields) => results.extend(fields),
+            Err(once) => match { once }.next().unwrap() {
+                Ok(field) => results.extend(std::iter::once(field)),
+                Err(interrupted) => {
+                    return Err(Error {
+                        cause: ErrorCause::Interrupted(interrupted.into()),
+                        location: word.location.clone(),
+                    });
+                }
+            },
+        }
     }
 
     Ok(env.last_command_subst_exit_status)

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -77,7 +77,7 @@ impl From<Field> for Inner {
     }
 }
 
-/// Iterator that provides results of parameter expansion
+/// Iterator that provides results of pathname expansion
 ///
 /// This iterator is created with the [`glob`] function.
 #[derive(Debug)]
@@ -248,7 +248,7 @@ impl<S: Fstat + Open> SearchEnv<'_, S> {
     }
 }
 
-/// Performs parameter expansion.
+/// Performs pathname expansion.
 ///
 /// This function returns an iterator that yields fields resulting from the
 /// expansion.

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -53,7 +53,6 @@
 use super::attr::AttrChar;
 use super::attr::AttrField;
 use super::attr::Origin;
-use crate::trap::sigint_is_defaulted;
 use std::ffi::CString;
 use std::iter::Once;
 use std::marker::PhantomData;
@@ -329,7 +328,7 @@ pub fn glob<S: Fstat + Open + Select + Signals + WaitForSignals>(
 
     // TODO Quick check for *, ?, [ containment
 
-    let interruptible = env.is_interactive() && sigint_is_defaulted(env);
+    let interruptible = env.is_interactive() && env.sigint_has_default_action();
     let mut search_env = SearchEnv {
         env,
         interruptible,

--- a/yash-semantics/src/expansion/glob.rs
+++ b/yash-semantics/src/expansion/glob.rs
@@ -53,27 +53,57 @@
 use super::attr::AttrChar;
 use super::attr::AttrField;
 use super::attr::Origin;
+use crate::trap::sigint_is_defaulted;
 use std::ffi::CString;
 use std::iter::Once;
 use std::marker::PhantomData;
+use std::ops::ControlFlow::{self, Break, Continue};
 use yash_env::Env;
 use yash_env::option::State::Off;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
-use yash_env::system::{AT_FDCWD, Dir as _, Fstat, Open};
+use yash_env::system::concurrency::{Select, WaitForSignals};
+use yash_env::system::{AT_FDCWD, Dir as _, Fstat, Open, Signals};
 use yash_fnmatch::Config;
 use yash_fnmatch::Pattern;
 use yash_fnmatch::PatternChar;
 use yash_syntax::source::Location;
 
+/// Error value indicating that pathname expansion was interrupted
+///
+/// This error is returned when a SIGINT signal is received while scanning
+/// directories in an interactive shell with SIGINT defaulted. The contained
+/// [`ExitStatus`] is derived from the SIGINT signal.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Interrupted(pub ExitStatus);
+
+impl From<Interrupted> for ExitStatus {
+    fn from(intr: Interrupted) -> ExitStatus {
+        intr.0
+    }
+}
+
 #[derive(Debug)]
 enum Inner {
-    One(Once<Field>),
+    One(Once<Result<Field, Interrupted>>),
     Many(std::vec::IntoIter<Field>),
 }
 
 impl From<Field> for Inner {
     fn from(field: Field) -> Self {
-        Inner::One(std::iter::once(field))
+        Inner::One(std::iter::once(Ok(field)))
+    }
+}
+
+impl From<Interrupted> for Inner {
+    fn from(intr: Interrupted) -> Self {
+        Inner::One(std::iter::once(Err(intr)))
+    }
+}
+
+impl From<Result<Field, Interrupted>> for Inner {
+    fn from(result: Result<Field, Interrupted>) -> Self {
+        Inner::One(std::iter::once(result))
     }
 }
 
@@ -103,12 +133,27 @@ impl<S> From<Inner> for Glob<'_, S> {
     }
 }
 
-impl<S: Fstat + Open> Iterator for Glob<'_, S> {
-    type Item = Field;
-    fn next(&mut self) -> Option<Field> {
+impl<S: Fstat + Open + Select + Signals + WaitForSignals> Iterator for Glob<'_, S> {
+    type Item = Result<Field, Interrupted>;
+    fn next(&mut self) -> Option<Result<Field, Interrupted>> {
         match &mut self.inner {
             Inner::One(once) => once.next(),
-            Inner::Many(many) => many.next(),
+            Inner::Many(many) => many.next().map(Ok),
+        }
+    }
+}
+
+impl<S> Glob<'_, S> {
+    /// An escape hatch to decompose the `Glob` iterator.
+    ///
+    /// This method will be removed when `Glob` is re-implemented with a
+    /// generator.
+    pub(super) fn try_into_vec_iter(
+        self,
+    ) -> Result<std::vec::IntoIter<Field>, Once<Result<Field, Interrupted>>> {
+        match self.inner {
+            Inner::One(once) => Err(once),
+            Inner::Many(many) => Ok(many),
         }
     }
 }
@@ -158,14 +203,15 @@ fn remove_quotes_and_strip(chars: &[AttrChar]) -> impl Iterator<Item = char> + '
 #[derive(Debug)]
 struct SearchEnv<'e, S> {
     env: &'e mut Env<S>,
+    interruptible: bool,
     prefix: String,
     origin: Location,
     results: Vec<Field>,
 }
 
-impl<S: Fstat + Open> SearchEnv<'_, S> {
+impl<S: Fstat + Open + Select + Signals + WaitForSignals> SearchEnv<'_, S> {
     /// Recursively searches directories for matching pathnames.
-    fn search_dir(&mut self, suffix: &[AttrChar]) {
+    fn search_dir(&mut self, suffix: &[AttrChar]) -> ControlFlow<Interrupted> {
         let (this, new_suffix) = match suffix.iter().position(|c| c.value == '/') {
             None => (suffix, None),
             Some(index) => (&suffix[..index], Some(&suffix[index + 1..])),
@@ -175,10 +221,10 @@ impl<S: Fstat + Open> SearchEnv<'_, S> {
             None => {
                 self.push_component(new_suffix, false, |prefix| {
                     prefix.extend(remove_quotes_and_strip(this))
-                });
+                })?;
             }
             Some(Ok(literal)) => {
-                self.push_component(new_suffix, false, |prefix| prefix.push_str(&literal));
+                self.push_component(new_suffix, false, |prefix| prefix.push_str(&literal))?;
             }
             Some(Err(pattern)) => {
                 let dir_path = if self.prefix.is_empty() {
@@ -186,22 +232,31 @@ impl<S: Fstat + Open> SearchEnv<'_, S> {
                 } else if let Ok(dir_path) = CString::new(self.prefix.as_str()) {
                     dir_path
                 } else {
-                    return;
+                    return Continue(());
                 };
 
                 if let Ok(mut dir) = self.env.system.opendir(&dir_path) {
                     while let Ok(Some(entry)) = dir.next() {
+                        if self.interruptible
+                            && self
+                                .env
+                                .poll_signals()
+                                .is_some_and(|sigs| sigs.contains(&S::SIGINT))
+                        {
+                            return Break(Interrupted(ExitStatus::from(S::SIGINT)));
+                        }
                         if let Some(name) = entry.name.to_str()
                             && name != "."
                             && name != ".."
                             && pattern.is_match(name)
                         {
-                            self.push_component(new_suffix, true, |prefix| prefix.push_str(name));
+                            self.push_component(new_suffix, true, |prefix| prefix.push_str(name))?;
                         }
                     }
                 }
             }
         }
+        Continue(())
     }
 
     fn file_exists(&mut self) -> bool {
@@ -222,14 +277,19 @@ impl<S: Fstat + Open> SearchEnv<'_, S> {
     /// assumed to exist.
     ///
     /// `push` is a closure that appends the suffix to the prefix.
-    fn push_component<F>(&mut self, suffix: Option<&[AttrChar]>, file_exists: bool, push: F)
+    fn push_component<F>(
+        &mut self,
+        suffix: Option<&[AttrChar]>,
+        file_exists: bool,
+        push: F,
+    ) -> ControlFlow<Interrupted>
     where
         F: FnOnce(&mut String),
     {
         let old_prefix_len = self.prefix.len();
         push(&mut self.prefix);
 
-        match suffix {
+        let result = match suffix {
             None => {
                 if file_exists || self.file_exists() {
                     self.results.push(Field {
@@ -237,40 +297,52 @@ impl<S: Fstat + Open> SearchEnv<'_, S> {
                         origin: self.origin.clone(),
                     });
                 }
+                Continue(())
             }
             Some(suffix) => {
                 self.prefix.push('/');
-                self.search_dir(suffix);
+                self.search_dir(suffix)
             }
-        }
+        };
 
         self.prefix.truncate(old_prefix_len);
+        result
     }
 }
 
 /// Performs pathname expansion.
 ///
-/// This function returns an iterator that yields fields resulting from the
-/// expansion.
+/// This function returns a [`Glob`] iterator yielding the expanded fields.
+/// If a SIGINT signal is received while scanning directories in an interactive
+/// shell with SIGINT defaulted, the iterator yields `Err(interrupted)` where
+/// `interrupted` carries the exit status representing the signal. After
+/// interruption, the iterator may or may not yield more results.
 ///
 /// If the `Glob` option is `Off` in `env.options`, the expansion is skipped.
-pub fn glob<S: Fstat + Open>(env: &mut Env<S>, field: AttrField) -> Glob<'_, S> {
+pub fn glob<S: Fstat + Open + Select + Signals + WaitForSignals>(
+    env: &mut Env<S>,
+    field: AttrField,
+) -> Glob<'_, S> {
     if env.options.get(yash_env::option::Option::Glob) == Off {
         return Glob::from(Inner::from(field.remove_quotes_and_strip()));
     }
 
     // TODO Quick check for *, ?, [ containment
 
+    let interruptible = env.is_interactive() && sigint_is_defaulted(env);
     let mut search_env = SearchEnv {
         env,
+        interruptible,
         prefix: String::with_capacity(1024 /*nix::libc::PATH_MAX*/),
         origin: field.origin,
         results: Vec::new(),
     };
-    search_env.search_dir(&field.chars);
+    if let Break(interrupted) = search_env.search_dir(&field.chars) {
+        return Glob::from(Inner::from(interrupted));
+    }
 
     let mut results = search_env.results;
-    Glob::from(if results.is_empty() {
+    let inner = if results.is_empty() {
         let field = AttrField {
             chars: field.chars,
             origin: search_env.origin,
@@ -279,7 +351,8 @@ pub fn glob<S: Fstat + Open>(env: &mut Env<S>, field: AttrField) -> Glob<'_, S> 
     } else {
         results.sort_unstable_by(|a, b| a.value.cmp(&b.value));
         Inner::Many(results.into_iter())
-    })
+    };
+    Glob::from(inner)
 }
 
 #[cfg(test)]
@@ -291,7 +364,10 @@ mod tests {
     use yash_env::VirtualSystem;
     use yash_env::path::Path;
     use yash_env::str::UnixStr;
+    use yash_env::system::Concurrent;
     use yash_env::system::Mode;
+    use yash_env::system::r#virtual::SIGINT;
+    use yash_env::trap::Action;
     use yash_syntax::source::Location;
 
     fn dummy_attr_field(s: &str) -> AttrField {
@@ -308,7 +384,7 @@ mod tests {
         AttrField { chars, origin }
     }
 
-    fn env_with_dummy_files<I, P>(paths: I) -> Env<VirtualSystem>
+    fn env_with_dummy_files<I, P>(paths: I) -> Env<Rc<Concurrent<VirtualSystem>>>
     where
         I: IntoIterator<Item = P>,
         P: AsRef<Path>,
@@ -319,7 +395,7 @@ mod tests {
             state.file_system.save(path, Rc::default()).unwrap();
         }
         drop(state);
-        Env::with_system(system)
+        Env::with_system(Rc::new(Concurrent::new(system)))
     }
 
     #[test]
@@ -327,7 +403,7 @@ mod tests {
         let mut env = Env::new_virtual();
         let f = dummy_attr_field("abc");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "abc");
+        assert_eq!(i.next().unwrap().unwrap().value, "abc");
         assert_eq!(i.next(), None);
     }
 
@@ -337,7 +413,7 @@ mod tests {
         // The backslash escapes the '?', so this is not a pattern.
         let f = dummy_attr_field(r"\?");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, r"\?");
+        assert_eq!(i.next().unwrap().unwrap().value, r"\?");
         assert_eq!(i.next(), None);
     }
 
@@ -348,7 +424,7 @@ mod tests {
         f.chars[1].is_quoting = true;
         f.chars[4].is_quoting = true;
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "abcde");
+        assert_eq!(i.next().unwrap().unwrap().value, "abcde");
         assert_eq!(i.next(), None);
     }
 
@@ -358,7 +434,7 @@ mod tests {
         let mut f = dummy_attr_field("foo.*");
         f.chars[4].is_quoted = true;
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo.*");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.*");
         assert_eq!(i.next(), None);
     }
 
@@ -368,7 +444,7 @@ mod tests {
         let mut f = dummy_attr_field("foo.*");
         f.chars[4].origin = Origin::HardExpansion;
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo.*");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.*");
         assert_eq!(i.next(), None);
     }
 
@@ -377,7 +453,7 @@ mod tests {
         let mut env = env_with_dummy_files(["foo.exe"]);
         let f = dummy_attr_field("*.txt");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "*.txt");
+        assert_eq!(i.next().unwrap().unwrap().value, "*.txt");
         assert_eq!(i.next(), None);
     }
 
@@ -386,7 +462,7 @@ mod tests {
         let mut env = env_with_dummy_files(["foo.exe", "foo.txt"]);
         let f = dummy_attr_field("*.txt");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo.txt");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.txt");
         assert_eq!(i.next(), None);
     }
 
@@ -395,8 +471,8 @@ mod tests {
         let mut env = env_with_dummy_files(["foo.exe", "foo.txt"]);
         let f = dummy_attr_field("foo.*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo.exe");
-        assert_eq!(i.next().unwrap().value, "foo.txt");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.exe");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.txt");
         assert_eq!(i.next(), None);
     }
 
@@ -405,7 +481,7 @@ mod tests {
         let mut env = env_with_dummy_files([".foo"]);
         let f = dummy_attr_field(".*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, ".foo");
+        assert_eq!(i.next().unwrap().unwrap().value, ".foo");
         assert_eq!(i.next(), None);
     }
 
@@ -414,8 +490,8 @@ mod tests {
         let mut env = env_with_dummy_files(["/foo.exe", "/foo.txt"]);
         let f = dummy_attr_field("/foo.*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "/foo.exe");
-        assert_eq!(i.next().unwrap().value, "/foo.txt");
+        assert_eq!(i.next().unwrap().unwrap().value, "/foo.exe");
+        assert_eq!(i.next().unwrap().unwrap().value, "/foo.txt");
         assert_eq!(i.next(), None);
     }
 
@@ -427,10 +503,10 @@ mod tests {
         ]);
         let f = dummy_attr_field("a/?/a/?");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "a/a/a/a");
-        assert_eq!(i.next().unwrap().value, "a/a/a/b");
-        assert_eq!(i.next().unwrap().value, "a/b/a/a");
-        assert_eq!(i.next().unwrap().value, "a/b/a/b");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/a/a/a");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/a/a/b");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/b/a/a");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/b/a/b");
         assert_eq!(i.next(), None);
     }
 
@@ -451,9 +527,9 @@ mod tests {
         ]);
         let f = dummy_attr_field("/?/a/?/a");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "/a/a/a/a");
-        assert_eq!(i.next().unwrap().value, "/a/a/b/a");
-        assert_eq!(i.next().unwrap().value, "/b/a/a/a");
+        assert_eq!(i.next().unwrap().unwrap().value, "/a/a/a/a");
+        assert_eq!(i.next().unwrap().unwrap().value, "/a/a/b/a");
+        assert_eq!(i.next().unwrap().unwrap().value, "/b/a/a/a");
         assert_eq!(i.next(), None);
     }
 
@@ -462,8 +538,8 @@ mod tests {
         let mut env = env_with_dummy_files(["a/a/_", "a/b/_", "a/c"]);
         let f = dummy_attr_field("a/*/");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "a/a/");
-        assert_eq!(i.next().unwrap().value, "a/b/");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/a/");
+        assert_eq!(i.next().unwrap().unwrap().value, "a/b/");
         assert_eq!(i.next(), None);
     }
 
@@ -472,8 +548,8 @@ mod tests {
         let mut env = env_with_dummy_files(["a/b", "b/a"]);
         let f = dummy_attr_field("?//?");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "a//b");
-        assert_eq!(i.next().unwrap().value, "b//a");
+        assert_eq!(i.next().unwrap().unwrap().value, "a//b");
+        assert_eq!(i.next().unwrap().unwrap().value, "b//a");
         assert_eq!(i.next(), None);
     }
 
@@ -489,10 +565,10 @@ mod tests {
             let dir = state.file_system.get("foo").unwrap();
             dir.borrow_mut().permissions = Mode::ALL_READ | Mode::ALL_WRITE;
         }
-        let mut env = Env::with_system(system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let f = dummy_attr_field("foo/*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo/bar");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo/bar");
         assert_eq!(i.next(), None);
     }
 
@@ -501,7 +577,7 @@ mod tests {
         let mut env = env_with_dummy_files(["foo.txt"]);
         let f = dummy_attr_field("*[[:wrong:]]*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "*[[:wrong:]]*");
+        assert_eq!(i.next().unwrap().unwrap().value, "*[[:wrong:]]*");
         assert_eq!(i.next(), None);
     }
 
@@ -510,7 +586,7 @@ mod tests {
         let mut env = env_with_dummy_files(["abd", "a/d"]);
         let f = dummy_attr_field("a[b/c]d");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "a[b/c]d");
+        assert_eq!(i.next().unwrap().unwrap().value, "a[b/c]d");
         assert_eq!(i.next(), None);
     }
 
@@ -519,7 +595,7 @@ mod tests {
         let mut env = env_with_dummy_files(["x", "y/y"]);
         let f = dummy_attr_field("\0/*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "\0/*");
+        assert_eq!(i.next().unwrap().unwrap().value, "\0/*");
         assert_eq!(i.next(), None);
     }
 
@@ -528,7 +604,7 @@ mod tests {
         let mut env = env_with_dummy_files([UnixStr::from_bytes(b"foo/\xFF")]);
         let f = dummy_attr_field("foo/*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo/*");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo/*");
         assert_eq!(i.next(), None);
     }
 
@@ -538,7 +614,94 @@ mod tests {
         env.options.set(yash_env::option::Option::Glob, Off);
         let f = dummy_attr_field("foo.*");
         let mut i = glob(&mut env, f);
-        assert_eq!(i.next().unwrap().value, "foo.*");
+        assert_eq!(i.next().unwrap().unwrap().value, "foo.*");
+        assert_eq!(i.next(), None);
+    }
+
+    fn raise_sigint(system: &VirtualSystem) {
+        let _ = system.current_process_mut().raise_signal(SIGINT);
+    }
+
+    #[test]
+    fn sigint_interrupts_glob_in_interactive_shell() {
+        use futures_util::FutureExt as _;
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        env.options.set(
+            yash_env::option::Option::Interactive,
+            yash_env::option::State::On,
+        );
+        env.traps
+            .enable_internal_dispositions_for_terminators(&env.system)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        {
+            let mut state = system.state.borrow_mut();
+            state.file_system.save("foo", Rc::default()).unwrap();
+        }
+        raise_sigint(&system);
+
+        let f = dummy_attr_field("*");
+        let mut i = glob(&mut env, f);
+        let Err(interrupted) = i.next().unwrap() else {
+            panic!("expected Err(Interrupted)");
+        };
+        assert_eq!(interrupted.0, ExitStatus::from(SIGINT));
+        assert_eq!(i.next(), None);
+    }
+
+    #[test]
+    fn sigint_does_not_interrupt_glob_in_non_interactive_shell() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        {
+            let mut state = system.state.borrow_mut();
+            state
+                .file_system
+                .save("testdir/foo", Rc::default())
+                .unwrap();
+        }
+        raise_sigint(&system);
+
+        let f = dummy_attr_field("testdir/*");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().unwrap().value, "testdir/foo");
+        assert_eq!(i.next(), None);
+    }
+
+    #[test]
+    fn sigint_does_not_interrupt_glob_when_sigint_is_trapped() {
+        use futures_util::FutureExt as _;
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        env.options.set(
+            yash_env::option::Option::Interactive,
+            yash_env::option::State::On,
+        );
+        env.traps
+            .set_action(
+                &env.system,
+                SIGINT,
+                Action::Command("echo trapped".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        {
+            let mut state = system.state.borrow_mut();
+            state
+                .file_system
+                .save("testdir/foo", Rc::default())
+                .unwrap();
+        }
+        raise_sigint(&system);
+
+        let f = dummy_attr_field("testdir/*");
+        let mut i = glob(&mut env, f);
+        assert_eq!(i.next().unwrap().unwrap().value, "testdir/foo");
         assert_eq!(i.next(), None);
     }
 }

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -26,9 +26,12 @@ use crate::Runtime;
 use crate::expansion::ErrorCause;
 use crate::read_eval_loop;
 use crate::trap::run_exit_trap;
+use crate::trap::sigint_is_defaulted;
 use std::cell::RefCell;
 use yash_env::io::Fd;
 use yash_env::job::Pid;
+use yash_env::job::ProcessResult;
+use yash_env::semantics::ExitStatus;
 use yash_env::subshell::Config;
 use yash_env::subshell::JobControl;
 use yash_env::system::concurrency::ReadAll;
@@ -139,15 +142,34 @@ where
     env.inner.system.read_all_to(reader, &mut result).await.ok();
     env.inner.system.close(reader).ok();
 
-    // Wait for the subshell
-    match env.inner.wait_for_subshell_to_finish(pid).await {
-        Ok((_pid, exit_status)) => env.last_command_subst_exit_status = Some(exit_status),
-        Err(errno) => {
-            return Err(Error {
-                cause: ErrorCause::CommandSubstError(errno),
-                location,
-            });
+    // Wait for the subshell to terminate (ignoring intermediate stopped states)
+    let process_result = loop {
+        match env.inner.wait_for_subshell_to_halt(pid).await {
+            Ok((_pid, result)) if result.is_stopped() => continue,
+            Ok((_pid, result)) => break result,
+            Err(errno) => {
+                return Err(Error {
+                    cause: ErrorCause::CommandSubstError(errno),
+                    location,
+                });
+            }
         }
+    };
+
+    let exit_status = ExitStatus::from(process_result);
+    env.last_command_subst_exit_status = Some(exit_status);
+
+    // If the subshell was killed by SIGINT in an interactive shell with the
+    // default SIGINT disposition, propagate the interrupt.
+    if let ProcessResult::Signaled { signal, .. } = process_result
+        && signal == S::SIGINT
+        && env.inner.is_interactive()
+        && sigint_is_defaulted(env.inner)
+    {
+        return Err(Error {
+            cause: ErrorCause::Interrupted(exit_status),
+            location,
+        });
     }
 
     // TODO Reject invalid UTF-8 sequence if strict POSIX mode is on
@@ -176,8 +198,16 @@ mod tests {
     use crate::tests::echo_builtin;
     use crate::tests::return_builtin;
     use futures_util::FutureExt as _;
+    use std::pin::Pin;
+    use yash_env::builtin::Builtin;
+    use yash_env::option::Option::Interactive;
+    use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
+    use yash_env::semantics::Field;
+    use yash_env::system::r#virtual::SIGINT;
+    use yash_env::system::{GetPid, SendSignal};
     use yash_env::test_helper::in_virtual_system;
+    use yash_env::trap::Action;
 
     #[test]
     fn empty_substitution() {
@@ -255,5 +285,104 @@ mod tests {
             .unwrap();
         let cause = ErrorCause::CommandSubstError(Errno::ENOSYS);
         assert_eq!(result, Err(Error { cause, location }));
+    }
+
+    fn kill_self_with_sigint_main<S: GetPid + SendSignal>(
+        env: &mut yash_env::Env<S>,
+        _args: Vec<Field>,
+    ) -> Pin<Box<dyn Future<Output = yash_env::builtin::Result> + '_>> {
+        Box::pin(async move {
+            let pid = env.system.getpid();
+            env.system.kill(pid, Some(SIGINT)).await.ok();
+            yash_env::builtin::Result::default()
+        })
+    }
+
+    #[test]
+    fn interrupt_interactive_shell_when_command_subst_killed_by_sigint() {
+        in_virtual_system(|mut env, _state| async move {
+            env.builtins.insert(
+                "kill_self",
+                Builtin::new(
+                    yash_env::builtin::Type::Mandatory,
+                    kill_self_with_sigint_main,
+                ),
+            );
+            env.options.set(Interactive, On);
+            // SIGINT trap action is Action::Default by default
+
+            let command = "kill_self".to_string();
+            let location = Location::dummy("loc");
+            let mut expansion_env = Env::new(&mut env);
+            let result = expand(command, location.clone(), &mut expansion_env).await;
+
+            assert_eq!(
+                result,
+                Err(Error {
+                    cause: ErrorCause::Interrupted(ExitStatus::from(SIGINT)),
+                    location,
+                })
+            );
+        })
+    }
+
+    #[test]
+    fn no_interrupt_for_non_interactive_shell_when_command_subst_killed_by_sigint() {
+        in_virtual_system(|mut env, _state| async move {
+            env.builtins.insert(
+                "kill_self",
+                Builtin::new(
+                    yash_env::builtin::Type::Mandatory,
+                    kill_self_with_sigint_main,
+                ),
+            );
+            // Not setting Interactive option
+
+            let command = "kill_self".to_string();
+            let location = Location::dummy("loc");
+            let mut expansion_env = Env::new(&mut env);
+            let result = expand(command, location, &mut expansion_env).await;
+
+            assert_eq!(result, Ok(Phrase::one_empty_field()));
+            assert_eq!(
+                expansion_env.last_command_subst_exit_status,
+                Some(ExitStatus::from(SIGINT))
+            );
+        })
+    }
+
+    #[test]
+    fn no_interrupt_when_sigint_trapped_and_command_subst_killed_by_sigint() {
+        in_virtual_system(|mut env, _state| async move {
+            env.builtins.insert(
+                "kill_self",
+                Builtin::new(
+                    yash_env::builtin::Type::Mandatory,
+                    kill_self_with_sigint_main,
+                ),
+            );
+            env.options.set(Interactive, On);
+            env.traps
+                .set_action(
+                    &env.system,
+                    SIGINT,
+                    Action::Command("echo trapped".into()),
+                    Location::dummy(""),
+                    false,
+                )
+                .await
+                .unwrap();
+
+            let command = "kill_self".to_string();
+            let location = Location::dummy("loc");
+            let mut expansion_env = Env::new(&mut env);
+            let result = expand(command, location, &mut expansion_env).await;
+
+            assert_eq!(result, Ok(Phrase::one_empty_field()));
+            assert_eq!(
+                expansion_env.last_command_subst_exit_status,
+                Some(ExitStatus::from(SIGINT))
+            );
+        })
     }
 }

--- a/yash-semantics/src/expansion/initial/command_subst.rs
+++ b/yash-semantics/src/expansion/initial/command_subst.rs
@@ -26,7 +26,6 @@ use crate::Runtime;
 use crate::expansion::ErrorCause;
 use crate::read_eval_loop;
 use crate::trap::run_exit_trap;
-use crate::trap::sigint_is_defaulted;
 use std::cell::RefCell;
 use yash_env::io::Fd;
 use yash_env::job::Pid;
@@ -164,7 +163,7 @@ where
     if let ProcessResult::Signaled { signal, .. } = process_result
         && signal == S::SIGINT
         && env.inner.is_interactive()
-        && sigint_is_defaulted(env.inner)
+        && env.inner.sigint_has_default_action()
     {
         return Err(Error {
             cause: ErrorCause::Interrupted(exit_status),

--- a/yash-semantics/src/handle.rs
+++ b/yash-semantics/src/handle.rs
@@ -17,6 +17,7 @@
 //! Error handlers.
 
 use crate::ExitStatus;
+use crate::expansion::ErrorCause;
 use std::ops::ControlFlow::{Break, Continue};
 use yash_env::Env;
 use yash_env::io::print_report;
@@ -64,9 +65,14 @@ where
 /// Prints an error message and returns a divert result indicating a non-zero
 /// exit status.
 ///
-/// This implementation handles the error by printing an error message to the
-/// standard error and returning `Divert::Interrupt(Some(ExitStatus::ERROR))`.
-/// If the [`ErrExit`] option is set, `Divert::Exit(Some(ExitStatus::ERROR))` is
+/// If the error cause is [`ErrorCause::Interrupted`], this implementation
+/// returns `Break(Divert::Interrupt(Some(exit_status)))` without printing an
+/// error message, where `exit_status` is the exit status contained in the
+/// error cause.
+///
+/// Otherwise, this implementation prints an error message to the standard
+/// error and returns `Divert::Interrupt(Some(ExitStatus::ERROR))`. If the
+/// [`ErrExit`] option is set, `Divert::Exit(Some(ExitStatus::ERROR))` is
 /// returned instead.
 ///
 /// Note that other POSIX-compliant implementations may use different non-zero
@@ -78,6 +84,10 @@ where
     S: Isatty + WriteAll,
 {
     async fn handle(&self, env: &mut Env<S>) -> super::Result {
+        if let ErrorCause::Interrupted(exit_status) = &self.cause {
+            return Break(Divert::Interrupt(Some(*exit_status)));
+        }
+
         print_report(env, &self.to_report()).await;
 
         if env.errexit_is_applicable() {

--- a/yash-semantics/src/job.rs
+++ b/yash-semantics/src/job.rs
@@ -16,5 +16,6 @@
 
 //! Utilities for job control
 
+#[allow(deprecated, reason = "for backward compatible re-exports")]
 #[doc(no_inline)]
 pub use yash_env::job::add_job_if_suspended;

--- a/yash-semantics/src/runtime.rs
+++ b/yash-semantics/src/runtime.rs
@@ -38,6 +38,7 @@ use yash_env::trap::SignalSystem;
 pub trait Runtime:
     BlockSignals
     + Clock
+    + Clone
     + Close
     + Debug
     + Dup
@@ -75,6 +76,7 @@ pub trait Runtime:
 impl<S> Runtime for S where
     S: BlockSignals
         + Clock
+        + Clone
         + Close
         + Debug
         + Dup

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -106,6 +106,7 @@ async fn run_trap<S: Runtime + 'static>(
 mod signal;
 pub use signal::run_trap_if_caught;
 pub use signal::run_traps_for_caught_signals;
+pub(crate) use signal::sigint_is_defaulted;
 
 mod exit;
 pub use exit::run_exit_trap;

--- a/yash-semantics/src/trap.rs
+++ b/yash-semantics/src/trap.rs
@@ -106,7 +106,6 @@ async fn run_trap<S: Runtime + 'static>(
 mod signal;
 pub use signal::run_trap_if_caught;
 pub use signal::run_traps_for_caught_signals;
-pub(crate) use signal::sigint_is_defaulted;
 
 mod exit;
 pub use exit::run_exit_trap;

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -26,7 +26,6 @@ use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::signal;
 use yash_env::stack::Frame;
-use yash_env::system::Signals;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
 use yash_env::trap::Origin;
@@ -96,7 +95,9 @@ fn in_trap<S>(env: &Env<S>) -> bool {
 pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>) -> Result {
     let signals = env.poll_signals();
 
-    if signals.is_some_and(|signals| signals.contains(&S::SIGINT)) && sigint_is_defaulted(env) {
+    if signals.is_some_and(|signals| signals.contains(&S::SIGINT))
+        && env.sigint_has_default_action()
+    {
         // If SIGINT is caught and defaulted, interrupt the current command with SIGINT.
         // We don't have to check if the shell is interactive here, because a
         // defaulted SIGINT would have killed the shell immediately.
@@ -122,12 +123,6 @@ pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>
     }
 
     Continue(())
-}
-
-// XXX This function is identical to yash_env::job::sigint_is_defaulted
-pub(crate) fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
-    let state = env.traps.get_state(S::SIGINT).0;
-    state.is_none_or(|state| state.action == Action::Default)
 }
 
 #[cfg(test)]

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -124,6 +124,7 @@ pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>
     Continue(())
 }
 
+// XXX This function is identical to yash_env::job::sigint_is_defaulted
 fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
     let state = env.traps.get_state(S::SIGINT).0;
     state.is_none_or(|state| state.action == Action::Default)

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -125,7 +125,7 @@ pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>
 }
 
 // XXX This function is identical to yash_env::job::sigint_is_defaulted
-fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
+pub(crate) fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
     let state = env.traps.get_state(S::SIGINT).0;
     state.is_none_or(|state| state.action == Action::Default)
 }

--- a/yash-semantics/src/trap/signal.rs
+++ b/yash-semantics/src/trap/signal.rs
@@ -18,12 +18,15 @@
 
 use super::run_trap;
 use crate::Runtime;
-use std::ops::ControlFlow::Continue;
+use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::Env;
+use yash_env::semantics::Divert;
+use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Result;
 use yash_env::signal;
 use yash_env::stack::Frame;
+use yash_env::system::Signals;
 use yash_env::trap::Action;
 use yash_env::trap::Condition;
 use yash_env::trap::Origin;
@@ -81,8 +84,25 @@ fn in_trap<S>(env: &Env<S>) -> bool {
 /// not care for the reentrance of trap actions, so we should not assume they
 /// are reentrant. As an exception, this function does run traps in a subshell
 /// executed in a trap.
+///
+/// If a SIGINT signal has been caught and the trap action for SIGINT is
+/// [`Action::Default`], then this function returns
+/// `Result::Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT))))`
+/// immediately without running any trap actions. This behavior is not specified
+/// in POSIX, but it is a common behavior of interactive shells to allow users
+/// to interrupt a long-running command. Note that the
+/// [internal dispositions for SIGINT](TrapSet::enable_internal_dispositions_for_terminators)
+/// must be enabled for this behavior to work.
 pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>) -> Result {
-    env.poll_signals();
+    let signals = env.poll_signals();
+
+    if signals.is_some_and(|signals| signals.contains(&S::SIGINT)) && sigint_is_defaulted(env) {
+        // If SIGINT is caught and defaulted, interrupt the current command with SIGINT.
+        // We don't have to check if the shell is interactive here, because a
+        // defaulted SIGINT would have killed the shell immediately.
+        // We do this before the below `in_trap` check to allow interrupting trap actions.
+        return Break(Divert::Interrupt(Some(ExitStatus::from(S::SIGINT))));
+    }
 
     if in_trap(env) {
         // Do not run a trap action while running another
@@ -104,6 +124,11 @@ pub async fn run_traps_for_caught_signals<S: Runtime + 'static>(env: &mut Env<S>
     Continue(())
 }
 
+fn sigint_is_defaulted<S: Signals>(env: &Env<S>) -> bool {
+    let state = env.traps.get_state(S::SIGINT).0;
+    state.is_none_or(|state| state.action == Action::Default)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,6 +139,8 @@ mod tests {
     use std::ops::ControlFlow::Break;
     use std::pin::Pin;
     use yash_env::builtin::Builtin;
+    use yash_env::option::Option::Interactive;
+    use yash_env::option::State::On;
     use yash_env::semantics::Divert;
     use yash_env::semantics::ExitStatus;
     use yash_env::semantics::Field;
@@ -125,10 +152,15 @@ mod tests {
     use yash_env::trap::Action;
     use yash_syntax::source::Location;
 
-    fn signal_env() -> (Env<Rc<Concurrent<VirtualSystem>>>, VirtualSystem) {
+    fn env_with_echo() -> (Env<Rc<Concurrent<VirtualSystem>>>, VirtualSystem) {
         let system = VirtualSystem::default();
         let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
         env.builtins.insert("echo", echo_builtin());
+        (env, system)
+    }
+
+    fn env_with_sigint_trap() -> (Env<Rc<Concurrent<VirtualSystem>>>, VirtualSystem) {
+        let (mut env, system) = env_with_echo();
         env.traps
             .set_action(
                 &env.system,
@@ -143,6 +175,15 @@ mod tests {
         (env, system)
     }
 
+    fn make_interactive(env: &mut Env<Rc<Concurrent<VirtualSystem>>>) {
+        env.options.set(Interactive, On);
+        env.traps
+            .enable_internal_dispositions_for_terminators(&env.system)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+    }
+
     fn raise_signal(system: &VirtualSystem, signal: signal::Number) {
         let _ = system
             .state
@@ -155,7 +196,7 @@ mod tests {
 
     #[test]
     fn nothing_to_do_without_signals_caught() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         let result = run_traps_for_caught_signals(&mut env)
             .now_or_never()
             .unwrap();
@@ -165,7 +206,7 @@ mod tests {
 
     #[test]
     fn running_trap() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         raise_signal(&system, SIGINT);
         let result = run_traps_for_caught_signals(&mut env)
             .now_or_never()
@@ -176,7 +217,7 @@ mod tests {
 
     #[test]
     fn no_reentrance() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         raise_signal(&system, SIGINT);
         let mut env = env.push_frame(Frame::Trap(Condition::Signal(SIGTERM)));
         let result = run_traps_for_caught_signals(&mut env)
@@ -188,7 +229,7 @@ mod tests {
 
     #[test]
     fn allow_reentrance_in_exit_trap() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         raise_signal(&system, SIGINT);
         let mut env = env.push_frame(Frame::Trap(Condition::Exit));
         let result = run_traps_for_caught_signals(&mut env)
@@ -200,7 +241,7 @@ mod tests {
 
     #[test]
     fn allow_reentrance_in_subshell() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         raise_signal(&system, SIGINT);
         let mut env = env.push_frame(Frame::Trap(Condition::Signal(SIGTERM)));
         let mut env = env.push_frame(Frame::Subshell);
@@ -247,7 +288,7 @@ mod tests {
 
     #[test]
     fn exit_status_is_restored_after_running_trap() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         env.exit_status = ExitStatus(42);
         raise_signal(&system, SIGINT);
         let _ = run_traps_for_caught_signals(&mut env)
@@ -258,7 +299,7 @@ mod tests {
 
     #[test]
     fn exit_status_inside_trap() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         for signal in [SIGUSR1, SIGUSR2] {
             env.traps
                 .set_action(
@@ -285,7 +326,7 @@ mod tests {
 
     #[test]
     fn exit_from_trap_with_specified_exit_status() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
@@ -309,7 +350,7 @@ mod tests {
 
     #[test]
     fn exit_from_trap_without_specified_exit_status() {
-        let (mut env, system) = signal_env();
+        let (mut env, system) = env_with_sigint_trap();
         env.builtins.insert("exit", exit_builtin());
         env.traps
             .set_action(
@@ -329,5 +370,127 @@ mod tests {
             .unwrap();
         assert_eq!(result, Break(Divert::Exit(None)));
         assert_eq!(env.exit_status, ExitStatus(42));
+    }
+
+    #[test]
+    fn no_trap_actions_performed_if_interrupted_by_sigint() {
+        let (mut env, system) = env_with_echo();
+        env.builtins.insert("exit", exit_builtin());
+        make_interactive(&mut env);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGUSR1,
+                Action::Command("exit 56".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        raise_signal(&system, SIGUSR1);
+        raise_signal(&system, SIGINT);
+
+        let result = run_traps_for_caught_signals(&mut env)
+            .now_or_never()
+            .unwrap();
+        assert_eq!(
+            result,
+            Break(Divert::Interrupt(Some(ExitStatus::from(SIGINT))))
+        );
+        assert_stdout(&system.state, |stdout| assert_eq!(stdout, ""));
+    }
+
+    #[test]
+    fn no_interruption_if_sigint_is_ignored() {
+        let (mut env, system) = env_with_echo();
+        env.builtins.insert("exit", exit_builtin());
+        make_interactive(&mut env);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGINT,
+                Action::Ignore,
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        env.traps
+            .set_action(
+                &env.system,
+                SIGUSR1,
+                Action::Command("echo USR1".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        raise_signal(&system, SIGUSR1);
+        raise_signal(&system, SIGINT);
+
+        let result = run_traps_for_caught_signals(&mut env)
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result, Continue(()));
+        assert_stdout(&system.state, |stdout| assert_eq!(stdout, "USR1\n"));
+    }
+
+    #[test]
+    fn no_interruption_if_sigint_is_trapped() {
+        let (mut env, system) = env_with_sigint_trap();
+        env.builtins.insert("exit", exit_builtin());
+        make_interactive(&mut env);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGUSR1,
+                Action::Command("echo USR1".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        raise_signal(&system, SIGUSR1);
+        raise_signal(&system, SIGINT);
+
+        let result = run_traps_for_caught_signals(&mut env)
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result, Continue(()));
+        assert_stdout(&system.state, |stdout| {
+            assert!(
+                stdout == "USR1\ntrapped\n" || stdout == "trapped\nUSR1\n",
+                "unexpected stdout: {stdout}"
+            );
+        });
+    }
+
+    #[test]
+    fn no_interruption_with_signal_other_than_sigint() {
+        let (mut env, system) = env_with_echo();
+        env.builtins.insert("exit", exit_builtin());
+        make_interactive(&mut env);
+        env.traps
+            .set_action(
+                &env.system,
+                SIGUSR1,
+                Action::Command("echo USR1; exit 56".into()),
+                Location::dummy(""),
+                false,
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        raise_signal(&system, SIGUSR1);
+        raise_signal(&system, SIGTERM);
+
+        let result = run_traps_for_caught_signals(&mut env)
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result, Break(Divert::Exit(Some(ExitStatus(56)))));
     }
 }


### PR DESCRIPTION
## Description

Resolves #417.

What are addressed in this PR:

- [x] Interrupt if the synchronous subshell is terminated by SIGINT in a simple command (absent or not)
- [x] Interrupt if the synchronous subshell is terminated by SIGINT in a multi-component pipeline
- [x] Interrupt if the synchronous subshell is terminated by SIGINT in a subshell command
- [x] Interrupt if the synchronous subshell is terminated by SIGINT in the `fg` built-in
- [x] Interrupt if a command substitution process is terminated by SIGINT
- [x] Interrupt if the shell catches SIGINT while waiting for a job in the `wait` built-in
- [x] Interrupt if the shell catches SIGINT while executing a built-in
- [x] Interrupt if the shell catches SIGINT while globbing
- [x] Interrupt if the shell has caught SIGINT when handling traps (`run_traps_for_caught_signals`)

### Miscellaneous todos

- [x] Unify `sigint_is_defaulted`

## Checklist

<!-- If you are unsure about any of these items, please ask for clarification -->

- Implementation
    - [x] Code should follow the existing style and conventions
- Tests
    - [x] Unit tests should be added in the same file as the code being tested
    - [x] If the change affects observable behavior of the shell executable, scripted tests should be added or updated (`yash-cli/tests/scripted_test.rs`)
- Versioning
    - [x] The version number in `Cargo.toml` for the affected crates should be updated according to the type of change (patch, minor, major) so that `Cargo.toml` forecasts the next release version
        - For library crates other than `yash-cli`, changes in public API affect the version number
            - If a crate re-exports items from a dependency, bumping the dependency's major/minor version should also bump the crate's major/minor version
        - For the `yash-cli` binary crate, changes in observable behavior affect the version number
        - Avoid double version bumps if already done in a previous PR
        - If a PR affects multiple crates, all affected crates should have their version numbers updated accordingly
    - [x] The root `Cargo.toml` should be updated to reflect the new version numbers of the affected crates
- Changelog
    - [x] The `[x.y.z] - Unreleased` heading should be added to `CHANGELOG.md` of affected crates if it does not already exist, where `x.y.z` is the next version to be released
        - If the changes in the PR affect observable behavior of the `yash-cli` binary, the `[x.y.z] - Unreleased` heading should also be added to `CHANGELOG.md` of `yash-cli` regardless of whether `yash-cli` itself is being updated
    - [x] The Unreleased section should contain the changes made in this PR, grouped by type (Added, Changed, Deprecated, Removed, Fixed, Security)
        - For library crates other than `yash-cli`, `CHANGELOG.md` should contain changes in public API
        - For the `yash-cli` binary crate, `CHANGELOG.md` should contain changes in observable behavior
    - [x] If a dependency has been added, removed, or updated in `Cargo.toml`, it should be mentioned in the changelog
        - Private and public dependencies should be mentioned separately. Private dependencies are crates whose items are not re-exported by the dependent crate. Bumping a private dependency version does not require a version bump of the dependent crate.
        - For example, if you add a public function in `yash-syntax`, bumping its minor version, then `CHANGELOG.md` of `yash-syntax` should mention the new function, and `CHANGELOG.md` of all crates depending on `yash-syntax` should mention that `yash-syntax` has been updated to the new version.
- Documentation
    - [x] The documentation (`docs/src`) should be updated to reflect the new behavior
    - [x] The documentation should mention the version number of `yash-cli` that introduces the new behavior (unless it is a bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive shells can be interrupted with SIGINT (Ctrl+C), affecting pipelines, subshells, redirections, command substitutions, pathname globbing, and some built-ins.
  * Some built-ins may now be interruptible in interactive sessions when they don't handle signals internally.

* **Bug Fixes**
  * `fg` and `wait` behavior refined: interrupts are returned only in appropriate interactive/SIGINT-default cases.

* **Documentation**
  * Added docs describing SIGINT interruption semantics.

* **Tests**
  * New unit and scripted tests covering interactive SIGINT behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->