### PR TITLE
Prevent exit when there are suspended jobs (#562)

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -101,6 +101,11 @@ For each step, in order:
    straightforward. Avoid `git add -A`/`git add .` only if unrelated changes
    somehow remain in the tree.
 
+   **Always include `Cargo.lock`** in any commit that bumps a crate version
+   in `Cargo.toml`. Cargo updates `Cargo.lock` automatically when you run
+   `cargo test` or `cargo build`, and forgetting to stage it leaves the lock
+   file inconsistent with the manifests.
+
 5. **Write the commit message.**
    Follow the project convention — see
    [commit-message skill](../commit-message/SKILL.md):

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -58,6 +58,13 @@ When the shell gains a new feature or option, begin the relevant paragraph with 
 - [docs/src/environment/traps.md](../../../docs/src/environment/traps.md) — `(Since 3.1.0) In an interactive shell …`
 - [docs/src/environment/options.md](../../../docs/src/environment/options.md) — `(Since 3.0.0) If set, the shell returns …`
 
+Common mistakes to avoid:
+
+- **Wrong position**: do NOT embed the tag in the middle or end of a sentence. It must be
+  the very first thing on the first line of the paragraph.
+- **Wrong format**: do NOT write `(since yash-rs x.y.z)`. The correct form is `(Since x.y.z)`:
+  capital S, no "yash-rs" prefix.
+
 ### Naming and indexing keywords
 
 - When a feature has a distinctive name, introduce it in **bold** the first time it appears

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,15 @@ Use repository-specific review criteria in
 
 ## Safe change workflow (recommended)
 
+Before writing any code for a task that will produce git commits, invoke the
+`commit` skill via the `Skill` tool. The skill drives the work as an
+incremental loop — one logical step at a time, each passing `./check.sh`
+before being committed. Do not write all the code first and commit at the end.
+
+Per-step loop:
+
 1. Read relevant crate README and docs section.
-2. Implement minimal changes in affected crate(s).
-3. Run targeted tests, then `./check.sh`.
-4. If versions or public behavior changed, update changelog/docs and run semver/release checks.
+2. Implement minimal changes for this step.
+3. Run `cargo fmt`, then `./check.sh` (must exit 0 with no warnings).
+4. Stage and commit the step.
+5. If versions or public behavior changed, update changelog/docs and run semver/release checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.18.0" }
-yash-env = { path = "yash-env", version = "0.15.0" }
+yash-builtin = { path = "yash-builtin", version = "0.18.1" }
+yash-env = { path = "yash-env", version = "0.15.1" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.13.0" }

--- a/docs/src/builtins/exit.md
+++ b/docs/src/builtins/exit.md
@@ -5,7 +5,7 @@ The **`exit`** built-in causes the currently executing shell to exit.
 ## Synopsis
 
 ```sh
-exit [exit_status]
+exit [-f] [exit_status]
 ```
 
 ## Description
@@ -15,9 +15,17 @@ environment with the specified exit status.
 
 The shell executes the [EXIT trap](../termination.md#exit-trap), if any, before exiting, except when the built-in is invoked in the trap itself.
 
+(Since 3.2.0) In an [interactive shell](../interactive/index.html), if there are
+[suspended jobs](../interactive/job_control.md), the built-in prints a warning
+and refuses to exit. Use the `-f` option to override this protection and exit
+immediately.
+
 ## Options
 
-None. (TBD: non-portable extensions)
+`-f`, `--force`
+: (Since 3.2.0) Force exit even when there are suspended jobs. Without this option, the
+  built-in prints a warning and returns a non-zero exit status if there are
+  any suspended jobs in an interactive shell.
 
 ## Operands
 
@@ -31,6 +39,10 @@ it is a syntax error.
 
 This implementation treats an *exit_status* value greater than 2147483647 as
 a syntax error.
+
+If there are suspended jobs in an interactive shell and `-f` is not given,
+the built-in prints a warning to standard error and returns exit status 1
+without exiting.
 
 ## Exit status
 
@@ -54,6 +66,17 @@ $ exit 42
 ```
 <!-- markdownlint-enable MD014 -->
 
+To force exit when there are suspended jobs:
+
+```shell,no_run
+$ sleep 100
+^Z
+[1] + Stopped                 sleep 100
+$ exit
+# There are stopped jobs. Type `exit -f` to exit anyway.
+$ exit -f
+```
+
 ## Compatibility
 
 The `exit` built-in is specified by POSIX.1-2024.
@@ -63,3 +86,6 @@ In some shells, the `exit` built-in lacks support for the [`--` separator](index
 The behavior is undefined in POSIX if *exit_status* is greater than 255.
 The current implementation passes such a value as is in the result, but this
 behavior may change in the future.
+
+The `-f`/`--force` option and the suspended-jobs protection are
+non-portable extensions.

--- a/docs/src/termination.md
+++ b/docs/src/termination.md
@@ -10,6 +10,8 @@ A shell session terminates in the following cases:
 
 ## Preventing accidental exits
 
+### Ignoring EOF
+
 When the input to the shell is a terminal, you can signal an end-of-file with the `eof` sequence (usually `Ctrl+D`). However, you might not want the shell to exit immediately when this happens, especially if you often hit the sequence by mistake. Enable the `ignoreeof` [shell option] to prevent the shell from exiting on end-of-file and let it wait for more input.
 
 ```shell,no_run
@@ -19,7 +21,26 @@ $
 $ exit
 ```
 
-This option is only effective in [interactive shells](interactive/index.html) and only when the input is a terminal. As an escape, entering 50 eof sequences in a row will still cause the shell to exit, regardless of the `ignoreeof` option.
+This option is only effective in [interactive shells](interactive/index.html) and only when the input is a terminal. As a safeguard against an input that repeatedly delivers EOF, entering 50 `eof` sequences in a row will still cause the shell to exit.
+
+### Suspended jobs
+
+(Since 3.2.0) The shell refuses to exit if there are [suspended jobs](interactive/job_control.md) to prevent them from being killed by the `SIGHUP` signal sent by the operating system.
+
+```shell,no_run
+$ sleep 100
+^Z
+[1] + Stopped                 sleep 100
+$ 
+# There are stopped jobs. Type `exit -f` to exit anyway.
+$ exit
+# There are stopped jobs. Type `exit -f` to exit anyway.
+$ exit -f
+```
+
+This applies not only when end-of-file is reached but also when you use the [`exit` built-in](builtins/exit.md). Use `exit -f` (or `exit --force`) to bypass the check and exit immediately.
+
+This protection is only effective in [interactive shells](interactive/index.html). When it is triggered by end-of-file, the input must additionally be a terminal, and—as a safeguard against an input that repeatedly delivers EOF—entering 50 `eof` sequences in a row will still cause the shell to exit. The `exit` built-in, by contrast, refuses to exit whenever the shell is interactive, regardless of the input type.
 
 ## Exiting subshells
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -9,6 +9,25 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.18.1] - Unreleased
+
+### Added
+
+- The `exit` built-in now refuses to exit when there are suspended jobs in an
+  interactive shell (non-POSIX extension). It prints a warning to standard
+  error and returns a non-zero exit status instead of exiting. The warning
+  message is read from [`SuspendedJobsGuardConfig`] in `env.any`; if absent,
+  the check is skipped.
+- The `exit` built-in has a new `-f`/`--force` option that forces the shell to
+  exit even when there are suspended jobs.
+
+### Changed
+
+- Private dependency versions:
+    - yash-env 0.15.0 → 0.15.1
+
+[`SuspendedJobsGuardConfig`]: https://docs.rs/yash-env/0.15.1/yash_env/input/struct.SuspendedJobsGuardConfig.html
+
 ## [0.18.0] - 2026-06-11
 
 ### Added
@@ -807,6 +826,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.1
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.17.0
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.16.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -42,19 +42,36 @@
 //!
 //! In case of an error, the result will have a [`Divert::Interrupt`] value
 //! instead, in which case the shell will not exit if it is interactive.
+//!
+//! ## Suspended-jobs protection
+//!
+//! When [`yash_env::input::SuspendedJobsGuardConfig`] is present in `env.any`,
+//! the built-in refuses to exit if there are suspended jobs and the `-f` option
+//! is not given. It prints the configured message and returns
+//! [`Divert::Interrupt`] with exit status 1.
+//!
+//! If `SuspendedJobsGuardConfig` is absent from `env.any`, the check is
+//! skipped and the built-in exits normally.
+//!
+//! Note: [`yash_env::input::IgnoreEofConfig`] is used by
+//! [`yash_env::input::EofGuard`] for the `ignore-eof` option behavior and is
+//! not consulted by this built-in.
 
 use crate::common::report::{report_error, syntax_error};
-use crate::common::syntax::{Mode, parse_arguments};
+use crate::common::syntax::{Mode, OptionSpec, parse_arguments};
 use std::num::ParseIntError;
 use std::ops::ControlFlow::Break;
 use yash_env::Env;
 use yash_env::builtin::Result;
+use yash_env::input::SuspendedJobsGuardConfig;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
 use yash_env::system::Isatty;
 use yash_env::system::concurrency::WriteAll;
+
+const OPTIONS: &[OptionSpec] = &[OptionSpec::new().short('f').long("force")];
 
 // TODO Split into syntax and semantics submodules
 
@@ -73,11 +90,11 @@ pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
     S: Isatty + WriteAll,
 {
-    // TODO Support non-POSIX options
-    let args = match parse_arguments(&[], Mode::with_env(env), args) {
-        Ok((_options, operands)) => operands,
+    let (options, args) = match parse_arguments(OPTIONS, Mode::with_env(env), args) {
+        Ok(result) => result,
         Err(error) => return report_error(env, &error).await,
     };
+    let force = options.iter().any(|o| o.spec.get_short() == Some('f'));
 
     if let Some(arg) = args.get(1) {
         return syntax_error(env, "too many operands", &arg.origin).await;
@@ -91,6 +108,19 @@ where
             Err(e) => return operand_parse_error(env, &arg.origin, e).await,
         },
     };
+    // TODO: skip this check in PosixlyCorrect mode
+    if !force
+        && env.is_interactive()
+        && let Some(config) = env.any.get::<SuspendedJobsGuardConfig>()
+        && env.jobs.iter().any(|(_, job)| job.state.is_stopped())
+    {
+        env.system.print_error(&config.message).await;
+        return Result::with_exit_status_and_divert(
+            ExitStatus::FAILURE,
+            Break(Divert::Interrupt(None)),
+        );
+    }
+
     Result::with_exit_status_and_divert(env.exit_status, Break(Divert::Exit(exit_status)))
 }
 
@@ -100,9 +130,13 @@ mod tests {
     use futures_util::FutureExt as _;
     use std::rc::Rc;
     use yash_env::VirtualSystem;
+    use yash_env::job::{Job, Pid, ProcessState};
+    use yash_env::option::On;
+    use yash_env::option::Option::Interactive;
     use yash_env::stack::Builtin;
     use yash_env::stack::Frame;
     use yash_env::system::Concurrent;
+    use yash_env::system::r#virtual::SIGTSTP;
     use yash_env::test_helper::assert_stderr;
 
     #[test]
@@ -220,8 +254,85 @@ mod tests {
     }
 
     // TODO exit_with_invalid_option
-    // TODO exit_from_interactive_shell_without_suspended_job
+
+    #[test]
+    fn exit_from_interactive_shell_without_suspended_job() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::with_message(
+                "stopped\n",
+            )));
+
+        let actual_result = main(&mut env, vec![]).now_or_never().unwrap();
+        let expected_result =
+            Result::with_exit_status_and_divert(ExitStatus::SUCCESS, Break(Divert::Exit(None)));
+        assert_eq!(actual_result, expected_result);
+    }
+
+    #[test]
+    fn exit_from_interactive_shell_with_suspended_job_not_in_posix_mode() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(SIGTSTP);
+        env.jobs.insert(job);
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::with_message(
+                "stopped\n",
+            )));
+
+        let actual_result = main(&mut env, vec![]).now_or_never().unwrap();
+        let expected_result = Result::with_exit_status_and_divert(
+            ExitStatus::FAILURE,
+            Break(Divert::Interrupt(None)),
+        );
+        assert_eq!(actual_result, expected_result);
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "stopped\n"));
+    }
+
     // TODO exit_from_interactive_shell_with_suspended_job_in_posix_mode
-    // TODO exit_from_interactive_shell_with_suspended_job_not_in_posix_mode
-    // TODO force_exit_from_interactive_shell_with_suspended_job
+
+    #[test]
+    fn force_exit_from_interactive_shell_with_suspended_job() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(SIGTSTP);
+        env.jobs.insert(job);
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::with_message(
+                "stopped\n",
+            )));
+        let args = Field::dummies(["-f"]);
+
+        let actual_result = main(&mut env, args).now_or_never().unwrap();
+        let expected_result =
+            Result::with_exit_status_and_divert(ExitStatus::SUCCESS, Break(Divert::Exit(None)));
+        assert_eq!(actual_result, expected_result);
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn exit_from_interactive_shell_with_suspended_job_without_config() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(SIGTSTP);
+        env.jobs.insert(job);
+        // No SuspendedJobsGuardConfig in env.any — feature is disabled
+
+        let actual_result = main(&mut env, vec![]).now_or_never().unwrap();
+        let expected_result =
+            Result::with_exit_status_and_divert(ExitStatus::SUCCESS, Break(Divert::Exit(None)));
+        assert_eq!(actual_result, expected_result);
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
 }

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,17 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - Unreleased
+
+### Added
+
+- The interactive shell now warns and refuses to exit when Ctrl+D (EOF) is
+  received while suspended jobs exist, similar to other major shells.
+- The `exit` built-in now refuses to exit with the same warning when there are
+  suspended jobs in an interactive shell.
+- The `exit` built-in has a new `-f`/`--force` option that forces the shell to
+  exit even when there are suspended jobs.
+
 ## [3.1.0] - 2026-06-11
 
 ### Added
@@ -342,6 +353,7 @@ later.
 
 - Initial release of the shell
 
+[3.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.2.0
 [3.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.1.0
 [3.0.8]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.8
 [3.0.7]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.7

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/src/startup.rs
+++ b/yash-cli/src/startup.rs
@@ -19,6 +19,8 @@
 use self::args::{Run, Source, Work};
 use std::str::FromStr as _;
 use yash_env::Env;
+use yash_env::input::IgnoreEofConfig;
+use yash_env::input::SuspendedJobsGuardConfig;
 use yash_env::io::Fd;
 use yash_env::option::Option::{Interactive, Monitor, Stdin};
 use yash_env::option::State::On;
@@ -132,6 +134,14 @@ where
 
 /// Inject dependencies into the environment.
 fn inject_dependencies<S: Runtime + 'static>(env: &mut Env<S>) {
+    env.any
+        .insert(Box::new(SuspendedJobsGuardConfig::with_message(
+            "# There are stopped jobs. Type `exit -f` to exit anyway.\n",
+        )));
+    env.any.insert(Box::new(IgnoreEofConfig::with_message(
+        "# Type `exit` to leave the shell when the ignore-eof option is on.\n",
+    )));
+
     env.any.insert(Box::new(IsKeyword::<S>(|_env, word| {
         yash_syntax::parser::lex::Keyword::from_str(word).is_ok()
     })));

--- a/yash-cli/src/startup/input.rs
+++ b/yash-cli/src/startup/input.rs
@@ -30,8 +30,8 @@ use std::ffi::CString;
 use thiserror::Error;
 use yash_env::Env;
 use yash_env::input::Echo;
+use yash_env::input::EofGuard;
 use yash_env::input::FdReader2;
-use yash_env::input::IgnoreEof;
 use yash_env::input::Reporter;
 use yash_env::io::Fd;
 use yash_env::io::move_fd_internal;
@@ -72,8 +72,9 @@ pub struct PrepareInputError<'a> {
 ///   applied to the input to show changes in job status before prompting for
 ///   the next command.
 /// - If the [`Interactive`] option is enabled and the source is read with a
-///   file descriptor, the [`IgnoreEof`] decorator is applied to the input to
-///   implement the [`IgnoreEof`](yash_env::option::IgnoreEof) shell option.
+///   file descriptor, the [`EofGuard`] decorator is applied to the input to
+///   implement the [`IgnoreEof`](yash_env::option::IgnoreEof) shell option
+///   and to protect against accidental exit when there are suspended jobs.
 ///
 /// The `RefCell` passed as the first argument should be shared with (and only
 /// with) the [`read_eval_loop`](yash_semantics::read_eval_loop) function that
@@ -156,7 +157,7 @@ where
 ///
 /// This function creates an [`FdReader2`] object from the given file descriptor
 /// and wraps it with the [`Echo`] decorator. If the [`Interactive`] option is
-/// enabled, the [`Prompter`], [`Reporter`], and [`IgnoreEof`] decorators are
+/// enabled, the [`Prompter`], [`Reporter`], and [`EofGuard`] decorators are
 /// applied to the input object.
 fn prepare_fd_input<'i, S>(fd: Fd, ref_env: &'i RefCell<&mut Env<S>>) -> Box<dyn InputObject + 'i>
 where
@@ -174,8 +175,6 @@ where
         // the job status is reported, and both should be shown again if an EOF is ignored.
         let prompter = Prompter::new(basic_input, ref_env);
         let reporter = Reporter::new(prompter, ref_env);
-        let message =
-            "# Type `exit` to leave the shell when the ignore-eof option is on.\n".to_string();
-        Box::new(IgnoreEof::new(reporter, fd, ref_env, message))
+        Box::new(EofGuard::new(reporter, fd, ref_env))
     }
 }

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -9,6 +9,21 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.1] - Unreleased
+
+### Added
+
+- `input::EofGuard` input decorator has been added. It replaces
+  `input::IgnoreEof` for use in interactive shells, combining the
+  `ignore-eof` option behavior with protection against accidental exit when
+  there are suspended jobs.
+- `input::SuspendedJobsGuardConfig` has been added. Store it in `env.any` to
+  enable the suspended-job protection in `EofGuard` and other components that
+  opt in. If absent, the protection is disabled.
+- `input::IgnoreEofConfig` has been added. Store it in `env.any` to enable the
+  `ignore-eof` EOF retry behavior in `EofGuard`. If absent, `EofGuard` does
+  not retry on EOF when the `ignore-eof` option is set.
+
 ## [0.15.0] - 2026-06-11
 
 ### Added
@@ -1369,6 +1384,7 @@ This version has been yanked due to an issue that prevents the crate from buildi
 
 - Initial implementation of the `yash-env` crate
 
+[0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.14.0
 [0.13.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.13.2

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-env/src/input.rs
+++ b/yash-env/src/input.rs
@@ -16,6 +16,33 @@
 
 //! Methods about passing [source](crate::source) code to the
 //! [parser](crate::parser).
+//!
+//! # Input decorators
+//!
+//! The [`Input`] trait is the core abstraction for reading source code lines.
+//! Several decorators wrap an inner [`Input`] to add behavior:
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | [`Memory`] | In-memory input from a pre-loaded string |
+//! | [`FdReader2`] | Reads from a file descriptor asynchronously |
+//! | [`Echo`] | Echoes each line read to stderr (for the `verbose` option) |
+//! | [`IgnoreEof`] | Retries on EOF when the `ignore-eof` option is on (simple interactive use) |
+//! | [`Reporter`] | Reports job status changes before each prompt |
+//! | [`EofGuard`] | Combines suspended-jobs protection with `ignore-eof` retry; prefer over [`IgnoreEof`] for the interactive read loop |
+//!
+//! ## Configuration stored in `env.any`
+//!
+//! [`EofGuard`] reads its behavior configuration from
+//! [`SuspendedJobsGuardConfig`] and [`IgnoreEofConfig`] stored in
+//! [`Env::any`](crate::Env::any):
+//!
+//! - [`SuspendedJobsGuardConfig`]: enables the suspended-jobs protection in
+//!   [`EofGuard`] (and any other component that opts in). If absent, the
+//!   protection is disabled.
+//! - [`IgnoreEofConfig`]: enables the `ignore-eof` retry behavior in
+//!   [`EofGuard`]. If absent, EOF is not retried even when the `ignore-eof`
+//!   option is on.
 
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -129,3 +156,6 @@ pub use ignore_eof::IgnoreEof;
 
 mod reporter;
 pub use reporter::Reporter;
+
+mod eof_guard;
+pub use eof_guard::{EofGuard, IgnoreEofConfig, SuspendedJobsGuardConfig};

--- a/yash-env/src/input/eof_guard.rs
+++ b/yash-env/src/input/eof_guard.rs
@@ -1,0 +1,634 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines the [`EofGuard`] input decorator, [`SuspendedJobsGuardConfig`], and
+//! [`IgnoreEofConfig`].
+
+use super::{Context, Input, Result};
+use crate::Env;
+use crate::io::Fd;
+use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off, On};
+use crate::system::Isatty;
+use crate::system::concurrency::WriteAll;
+use std::cell::RefCell;
+
+/// Configuration for the suspended-jobs exit guard.
+///
+/// When present in [`Env::any`](crate::Env::any), [`EofGuard`] refuses to exit
+/// when there are suspended jobs, printing [`message`](Self::message) to warn
+/// the user. Other components may also opt in to this protection by checking
+/// for this config.
+///
+/// Store this config in the environment with
+/// `env.any.insert(Box::new(config))`.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct SuspendedJobsGuardConfig {
+    /// Text displayed when exit is prevented because there are suspended jobs
+    pub message: String,
+}
+
+impl SuspendedJobsGuardConfig {
+    /// Creates a new `SuspendedJobsGuardConfig` with the given message.
+    #[must_use]
+    pub fn with_message<M: Into<String>>(message: M) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Configuration for the [`EofGuard`]'s `ignore-eof` behavior.
+///
+/// When present in [`Env::any`](crate::Env::any), [`EofGuard`] retries reading
+/// on EOF when the [`ignore-eof` option](crate::option::IgnoreEof) is enabled,
+/// printing [`message`](Self::message) to remind the user.
+///
+/// If absent from `env.any`, the `ignore-eof` EOF protection in [`EofGuard`]
+/// is disabled.
+///
+/// Store this config in the environment with
+/// `env.any.insert(Box::new(config))`.
+///
+/// Note that [`IgnoreEof`](crate::input::IgnoreEof) is not affected by this config.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct IgnoreEofConfig {
+    /// Text displayed when EOF is ignored due to the `ignore-eof` option
+    pub message: String,
+}
+
+impl IgnoreEofConfig {
+    /// Creates a new `IgnoreEofConfig` with the given message.
+    #[must_use]
+    pub fn with_message<M: Into<String>>(message: M) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// `Input` decorator that prevents premature exit on EOF
+///
+/// This is a decorator of [`Input`] that combines the behavior of the
+/// [`ignore-eof` shell option](crate::option::IgnoreEof) with protection
+/// against accidental exit when there are suspended jobs.
+///
+/// On EOF (empty line), the decorator retries reading if any of the following
+/// conditions is met (provided the shell is interactive, the input is a
+/// terminal, and the retry limit has not been reached):
+///
+/// 1. There are suspended jobs and [`SuspendedJobsGuardConfig`] is present in
+///    `env.any` — prints [`SuspendedJobsGuardConfig::message`].
+/// 2. The `ignore-eof` option is enabled and [`IgnoreEofConfig`] is present in
+///    `env.any` — prints [`IgnoreEofConfig::message`].
+///
+/// The retry limit is 50 consecutive EOFs per [`next_line`](Input::next_line)
+/// call. Once the limit is reached the empty string is returned, allowing the
+/// shell to exit.
+///
+/// If neither [`SuspendedJobsGuardConfig`] nor [`IgnoreEofConfig`] is present
+/// in `env.any`, the decorator passes through all input unchanged (no retries).
+///
+/// Unlike [`IgnoreEof`](crate::input::IgnoreEof), this decorator also checks
+/// for suspended jobs, so it should be used instead of `IgnoreEof` in the
+/// top-level interactive read loop.
+#[derive(Debug)]
+pub struct EofGuard<'a, 'b, S, T> {
+    /// Inner input to read from
+    inner: T,
+    /// File descriptor to be checked if it is a terminal
+    fd: Fd,
+    /// Environment to check the shell options, jobs, and system interface
+    env: &'a RefCell<&'b mut Env<S>>,
+}
+
+impl<'a, 'b, S, T> EofGuard<'a, 'b, S, T> {
+    /// Creates a new `EofGuard` decorator.
+    ///
+    /// The arguments match those of [`IgnoreEof::new`](crate::input::IgnoreEof::new)
+    /// except that there is no `message` argument — the messages are read from
+    /// [`SuspendedJobsGuardConfig`] and [`IgnoreEofConfig`] stored in `env.any`.
+    ///
+    /// `inner` is the wrapped input, `fd` is the terminal file descriptor to
+    /// check, and `env` is the shared environment.
+    pub fn new(inner: T, fd: Fd, env: &'a RefCell<&'b mut Env<S>>) -> Self {
+        Self { inner, fd, env }
+    }
+}
+
+// Not derived automatically because S may not implement Clone.
+impl<S, T: Clone> Clone for EofGuard<'_, '_, S, T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            fd: self.fd,
+            env: self.env,
+        }
+    }
+}
+
+impl<S: Isatty + WriteAll, T: Input> Input for EofGuard<'_, '_, S, T> {
+    #[allow(
+        clippy::await_holding_refcell_ref,
+        reason = "other decorators, the parser, or the executor do not run concurrently with this method"
+    )]
+    async fn next_line(&mut self, context: &Context) -> Result {
+        let mut remaining_tries = 50;
+
+        loop {
+            let line = self.inner.next_line(context).await?;
+
+            let env = self.env.borrow();
+
+            if !line.is_empty()
+                || env.options.get(Interactive) == Off
+                || remaining_tries == 0
+                || !env.system.isatty(self.fd)
+            {
+                return Ok(line);
+            }
+
+            // TODO: skip the suspended-jobs check in PosixlyCorrect mode
+            if let Some(config) = env.any.get::<SuspendedJobsGuardConfig>()
+                && env.jobs.iter().any(|(_, job)| job.state.is_stopped())
+            {
+                env.system.print_error(&config.message).await;
+            } else if env.options.get(IgnoreEofOption) == On
+                && let Some(config) = env.any.get::<IgnoreEofConfig>()
+            {
+                env.system.print_error(&config.message).await;
+            } else {
+                return Ok(line);
+            }
+
+            remaining_tries -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Memory;
+    use super::*;
+    use crate::job::{Job, Pid, ProcessState};
+    use crate::option::On;
+    use crate::system::r#virtual::{FdBody, FileBody, Inode, OpenFileDescription, VirtualSystem};
+    use crate::system::{Concurrent, Mode};
+    use crate::test_helper::assert_stderr;
+    use enumset::EnumSet;
+    use futures_util::FutureExt as _;
+    use std::rc::Rc;
+
+    fn set_stdin_to_tty(system: &mut VirtualSystem) {
+        system
+            .current_process_mut()
+            .set_fd(
+                Fd::STDIN,
+                FdBody {
+                    open_file_description: Rc::new(RefCell::new(OpenFileDescription::new(
+                        Rc::new(RefCell::new(Inode {
+                            body: FileBody::Terminal { content: vec![] },
+                            permissions: Mode::empty(),
+                        })),
+                        /* offset = */ 0,
+                        /* is_readable = */ true,
+                        /* is_writable = */ true,
+                        /* is_appending = */ false,
+                        /* is_nonblocking = */ false,
+                    ))),
+                    flags: EnumSet::empty(),
+                },
+            )
+            .unwrap();
+    }
+
+    fn set_stdin_to_regular_file(system: &mut VirtualSystem) {
+        system
+            .current_process_mut()
+            .set_fd(
+                Fd::STDIN,
+                FdBody {
+                    open_file_description: Rc::new(RefCell::new(OpenFileDescription::new(
+                        Rc::new(RefCell::new(Inode {
+                            body: FileBody::Regular {
+                                content: vec![],
+                                is_native_executable: false,
+                            },
+                            permissions: Mode::empty(),
+                        })),
+                        /* offset = */ 0,
+                        /* is_readable = */ true,
+                        /* is_writable = */ true,
+                        /* is_appending = */ false,
+                        /* is_nonblocking = */ false,
+                    ))),
+                    flags: EnumSet::empty(),
+                },
+            )
+            .unwrap();
+    }
+
+    /// `Input` decorator that returns EOF for the first `count` calls
+    /// and then reads from the inner input.
+    struct EofStub<T> {
+        inner: T,
+        count: usize,
+    }
+
+    impl<T: Input> Input for EofStub<T> {
+        async fn next_line(&mut self, context: &Context) -> Result {
+            if let Some(remaining) = self.count.checked_sub(1) {
+                self.count = remaining;
+                Ok("".to_string())
+            } else {
+                self.inner.next_line(context).await
+            }
+        }
+    }
+
+    #[test]
+    fn decorator_reads_from_inner_input() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig::default()));
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::default()));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(Memory::new("echo foo\n"), Fd::STDIN, &ref_env);
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+    }
+
+    #[test]
+    fn decorator_reads_input_again_on_eof_with_ignore_eof_option() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig {
+            message: "EOF ignored\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "EOF ignored\n"));
+    }
+
+    #[test]
+    fn decorator_reads_input_up_to_50_times() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig {
+            message: "EOF ignored\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 50,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "EOF ignored\n".repeat(50))
+        });
+    }
+
+    #[test]
+    fn decorator_returns_empty_line_after_reading_51_times() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig {
+            message: "EOF ignored\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 51,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "EOF ignored\n".repeat(50))
+        });
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_not_interactive() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        // Interactive is Off (default)
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig::default()));
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::default()));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_not_ignore_eof_and_no_suspended_jobs() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        // IgnoreEof is Off (default), no jobs
+        env.any.insert(Box::new(IgnoreEofConfig::default()));
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::default()));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_not_terminal() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_regular_file(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        env.any.insert(Box::new(IgnoreEofConfig::default()));
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::default()));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    // Counterpart to `decorator_reads_input_again_on_eof_with_ignore_eof_option`:
+    // without `IgnoreEofConfig` in `env.any`, the ignore-eof retry is disabled,
+    // so the decorator returns the EOF immediately.
+    #[test]
+    fn decorator_returns_immediately_if_no_ignore_eof_config() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        // No IgnoreEofConfig in env.any
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn decorator_ignores_eof_when_there_are_suspended_jobs() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        // IgnoreEof is Off, but there is a suspended job
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(crate::system::r#virtual::SIGTSTP);
+        env.jobs.insert(job);
+        env.any.insert(Box::new(SuspendedJobsGuardConfig {
+            message: "There are stopped jobs.\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "There are stopped jobs.\n")
+        });
+    }
+
+    // Counterpart to `decorator_ignores_eof_when_there_are_suspended_jobs`:
+    // without `SuspendedJobsGuardConfig` in `env.any`, the suspended-jobs guard
+    // is disabled, so the decorator returns the EOF immediately.
+    #[test]
+    fn decorator_returns_immediately_if_no_suspended_jobs_config() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        // IgnoreEof is Off, but there is a suspended job
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(crate::system::r#virtual::SIGTSTP);
+        env.jobs.insert(job);
+        // No SuspendedJobsGuardConfig in env.any
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    // The two guards are independent: even when a suspended job exists, if the
+    // suspended-jobs guard is not configured, the ignore-eof guard still applies
+    // when the `ignore-eof` option is on and `IgnoreEofConfig` is present.
+    #[test]
+    fn decorator_falls_back_to_ignore_eof_when_no_suspended_jobs_config() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(crate::system::r#virtual::SIGTSTP);
+        env.jobs.insert(job);
+        // Only IgnoreEofConfig is present; SuspendedJobsGuardConfig is absent
+        env.any.insert(Box::new(IgnoreEofConfig {
+            message: "EOF ignored\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, "EOF ignored\n"));
+    }
+
+    #[test]
+    fn suspended_jobs_message_takes_priority_over_ignore_eof_message() {
+        // The ignore-eof message typically tells the user to type `exit` to
+        // leave the shell, but a plain `exit` does not work when there are
+        // suspended jobs. The suspended-jobs message must take priority so the
+        // user is correctly directed to use `exit -f` instead.
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(IgnoreEofOption, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(crate::system::r#virtual::SIGTSTP);
+        env.jobs.insert(job);
+        env.any.insert(Box::new(IgnoreEofConfig {
+            message: "EOF ignored\n".to_string(),
+        }));
+        env.any.insert(Box::new(SuspendedJobsGuardConfig {
+            message: "There are stopped jobs.\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "echo foo\n");
+        assert_stderr(&state, |stderr| {
+            assert_eq!(stderr, "There are stopped jobs.\n")
+        });
+    }
+}

--- a/yash-env/src/input/ignore_eof.rs
+++ b/yash-env/src/input/ignore_eof.rs
@@ -42,6 +42,12 @@ use std::cell::RefCell;
 /// is obtained, an error occurs, or this process is repeated 50 times.
 ///
 /// [`Interactive`]: crate::option::Interactive
+///
+/// For the top-level interactive read loop, prefer [`EofGuard`] over this
+/// decorator. [`EofGuard`] also handles the case where there are suspended
+/// jobs, which this decorator does not.
+///
+/// [`EofGuard`]: crate::input::EofGuard
 #[derive(Debug)]
 pub struct IgnoreEof<'a, 'b, S, T> {
     /// Inner input to read from


### PR DESCRIPTION
Add an EofGuard input decorator to yash-env that protects against accidental shell termination. It combines two independent guards: a suspended-jobs guard and an ignore-eof guard, configured via the new SuspendedJobsGuardConfig and IgnoreEofConfig types. The suspended- jobs message takes priority over the ignore-eof message.

The exit built-in likewise refuses to terminate the shell when there are suspended jobs, with the -f/--force option to override.

Update yash-cli startup to wire up the guard, bump yash-env to 0.15.1 and yash-builtin to 0.18.1, and update changelogs and user docs.

(Squashed version of #806)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-f`/`--force` option to `exit` command for overriding suspended job protection
  * Interactive shell now prevents exit when suspended jobs exist and displays a warning
  * EOF/Ctrl+D input no longer exits the shell when suspended jobs are present

* **Documentation**
  * Updated `exit` command documentation with new `-f` option and job suspension behavior
  * Enhanced shell termination documentation with EOF-handling guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->