### PR TITLE
Make posixlycorrect disable the suspended-jobs exit guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "assert_matches",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "assert_matches",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.18.1" }
+yash-builtin = { path = "yash-builtin", version = "0.18.2" }
 yash-env = { path = "yash-env", version = "0.15.2" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
 yash-builtin = { path = "yash-builtin", version = "0.18.1" }
-yash-env = { path = "yash-env", version = "0.15.1" }
+yash-env = { path = "yash-env", version = "0.15.2" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.13.0" }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 
 - [Installation](installation.md)
 - [Getting started](getting_started.md)
+- [POSIX compliance](posix.md)
 - [Versioning and compatibility](versioning.md)
 - [Shell language](language/README.md)
     - [Words, tokens, and fields](language/words/README.md)

--- a/docs/src/environment/options.md
+++ b/docs/src/environment/options.md
@@ -216,7 +216,7 @@ Below is a list of all shell options in yash-rs, with their long and short names
 : (Since 3.0.0) If set, the shell returns the [exit status](../language/commands/exit_status.md) of the last command in a [pipeline](../language/commands/pipelines.md) that failed, instead of the last command's exit status. See [Catching errors across pipeline components](../language/commands/pipelines.md#catching-errors-across-pipeline-components) for details.
 
 **`posixlycorrect`**
-: If set, the shell behaves as POSIX-compliant as possible. Useful for portable scripts. <!-- TODO: link to POSIX compliance -->
+: If set, the shell behaves as POSIX-compliant as possible. Useful for portable scripts. See [Maximizing POSIX compliance](../posix.md#maximizing-posix-compliance) for the list of behaviors affected.
     - Enabled on startup if the shell is started as `sh`.
     - When unset, yash-rs may deviate from POSIX in some areas.
 

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -1,0 +1,15 @@
+# POSIX compliance
+
+**POSIX** (Portable Operating System Interface) is a set of standards specified by the IEEE to ensure compatibility among Unix-like operating systems. It defines a standard operating system interface and environment, including command-line utilities, shell scripting, and system calls.
+
+As of 2025, the latest version of POSIX is [POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/). The requirements for shells are mainly documented in the [Shell & Utilities](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/toc.html) volume. Yash-rs aims to comply with the POSIX standard, providing a consistent and portable environment for shell scripting and command execution.
+
+The shell currently supports running shell scripts and basic interactive features in a POSIX-compliant manner. See the [homepage](index.html) for an overview of implemented features. Progress on POSIX conformance and feature implementation is tracked in [GitHub Issues](https://github.com/magicant/yash-rs/issues) and the [GitHub Project](https://github.com/users/magicant/projects/2).
+
+Many features of yash-rs are still under development, and some may not yet be fully compliant with the POSIX standard. Any non-conforming behavior is described in the Compatibility section of each feature's documentation. These sections also clarify which aspects of the shell's behavior are POSIX requirements and which are shell-specific extensions.
+
+## Maximizing POSIX compliance
+
+Some behaviors of yash-rs prioritize convenience over POSIX compliance. The [`posixlycorrect` option](environment/options.md#posixlycorrect) disables such features. When this option is set:
+
+- The shell exits immediately even if there are suspended jobs, when the [`exit` built-in](builtins/exit.md) is executed or end-of-file is reached in an interactive shell. (See [Suspended jobs](termination.md#suspended-jobs).)

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -12,4 +12,4 @@ Many features of yash-rs are still under development, and some may not yet be fu
 
 Some behaviors of yash-rs prioritize convenience over POSIX compliance. The [`posixlycorrect` option](environment/options.md#posixlycorrect) disables such features. When this option is set:
 
-- The shell exits immediately even if there are suspended jobs, when the [`exit` built-in](builtins/exit.md) is executed or end-of-file is reached in an interactive shell. (See [Suspended jobs](termination.md#suspended-jobs).)
+- The shell no longer refuses to exit because of suspended jobs when the [`exit` built-in](builtins/exit.md) is executed or end-of-file is reached in an interactive shell. (See [Suspended jobs](termination.md#suspended-jobs).)

--- a/docs/src/termination.md
+++ b/docs/src/termination.md
@@ -42,6 +42,8 @@ This applies not only when end-of-file is reached but also when you use the [`ex
 
 This protection is only effective in [interactive shells](interactive/index.html). When it is triggered by end-of-file, the input must additionally be a terminal, and—as a safeguard against an input that repeatedly delivers EOF—entering 50 `eof` sequences in a row will still cause the shell to exit. The `exit` built-in, by contrast, refuses to exit whenever the shell is interactive, regardless of the input type.
 
+(Since 3.2.1) This protection can be disabled by setting the [`posixlycorrect` option](environment/options.md#posixlycorrect).
+
 ## Exiting subshells
 
 When one of the above conditions occurs in a [subshell](environment/index.html#subshells), the subshell exits. It does not directly cause the parent shell to exit, but the [exit status] of the subshell may affect the parent shell's behavior, conditionally causing it to exit if the `errexit` option is set.

--- a/docs/src/topic_index.md
+++ b/docs/src/topic_index.md
@@ -133,7 +133,7 @@
 - [`pipefail` shell option](environment/options.md#pipefail)
 - [pipeline](language/commands/pipelines.md)
 - [positional parameter](language/parameters/positional.md)
-- [POSIX](versioning.md#posix-conformance)
+- [POSIX](posix.md)
 - [`posixlycorrect` shell option](environment/options.md#posixlycorrect)
 - [`PPID` variable](language/parameters/variables.md#ppid)
 - [previous job](interactive/job_control.md#current-and-previous-jobs)

--- a/docs/src/versioning.md
+++ b/docs/src/versioning.md
@@ -1,15 +1,5 @@
 # Versioning and compatibility
 
-## POSIX conformance
-
-**POSIX** (Portable Operating System Interface) is a set of standards specified by the IEEE to ensure compatibility among Unix-like operating systems. It defines a standard operating system interface and environment, including command-line utilities, shell scripting, and system calls.
-
-As of 2025, the latest version of POSIX is [POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/). The requirements for shells are mainly documented in the [Shell & Utilities](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/toc.html) volume. Yash-rs aims to comply with the POSIX standard, providing a consistent and portable environment for shell scripting and command execution.
-
-The shell currently supports running shell scripts and basic interactive features in a POSIX-compliant manner. See the [homepage](index.html) for an overview of implemented features. Progress on POSIX conformance and feature implementation is tracked in [GitHub Issues](https://github.com/magicant/yash-rs/issues) and the [GitHub Project](https://github.com/users/magicant/projects/2).
-
-Many features of yash-rs are still under development, and some may not yet be fully compliant with the POSIX standard. Any non-conforming behavior is described in the Compatibility section of each feature's documentation. These sections also clarify which aspects of the shell's behavior are POSIX requirements and which are shell-specific extensions.
-
 ## Yash and yash-rs
 
 Yash-rs is the successor to [yash](https://github.com/magicant/yash), which is also a POSIX-compliant shell supporting both scripting and interactive use. Since yash-rs currently lacks advanced interactive features such as command history and line editing, yash is recommended for interactive use at this time.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.18.2] - Unreleased
+
+### Changed
+
+- The `exit` built-in no longer refuses to exit when there are suspended jobs
+  if the `posixlycorrect` option is on.
+
 ## [0.18.1] - 2026-06-15
 
 ### Added
@@ -830,6 +837,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.18.2]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.2
 [0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.1
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.17.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-builtin/src/exit.rs
+++ b/yash-builtin/src/exit.rs
@@ -45,13 +45,14 @@
 //!
 //! ## Suspended-jobs protection
 //!
-//! When [`yash_env::input::SuspendedJobsGuardConfig`] is present in `env.any`,
-//! the built-in refuses to exit if there are suspended jobs and the `-f` option
-//! is not given. It prints the configured message and returns
-//! [`Divert::Interrupt`] with exit status 1.
+//! When [`SuspendedJobsGuardConfig`] is present in `env.any` and the
+//! [`PosixlyCorrect`] option is off, the built-in refuses to exit if there are
+//! suspended jobs and the `-f` option is not given. It prints the configured
+//! message and returns [`Divert::Interrupt`] with exit status 1.
 //!
-//! If `SuspendedJobsGuardConfig` is absent from `env.any`, the check is
-//! skipped and the built-in exits normally.
+//! If `SuspendedJobsGuardConfig` is absent from `env.any`, or the
+//! `PosixlyCorrect` option is on, the check is skipped and the built-in exits
+//! normally.
 //!
 //! Note: [`yash_env::input::IgnoreEofConfig`] is used by
 //! [`yash_env::input::EofGuard`] for the `ignore-eof` option behavior and is
@@ -64,6 +65,8 @@ use std::ops::ControlFlow::Break;
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::input::SuspendedJobsGuardConfig;
+use yash_env::option::Off;
+use yash_env::option::Option::PosixlyCorrect;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
@@ -108,9 +111,9 @@ where
             Err(e) => return operand_parse_error(env, &arg.origin, e).await,
         },
     };
-    // TODO: skip this check in PosixlyCorrect mode
     if !force
         && env.is_interactive()
+        && env.options.get(PosixlyCorrect) == Off
         && let Some(config) = env.any.get::<SuspendedJobsGuardConfig>()
         && env.jobs.iter().any(|(_, job)| job.state.is_stopped())
     {
@@ -294,7 +297,27 @@ mod tests {
         assert_stderr(&state, |stderr| assert_eq!(stderr, "stopped\n"));
     }
 
-    // TODO exit_from_interactive_shell_with_suspended_job_in_posix_mode
+    #[test]
+    fn exit_from_interactive_shell_with_suspended_job_in_posix_mode() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(PosixlyCorrect, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(SIGTSTP);
+        env.jobs.insert(job);
+        env.any
+            .insert(Box::new(SuspendedJobsGuardConfig::with_message(
+                "stopped\n",
+            )));
+
+        let actual_result = main(&mut env, vec![]).now_or_never().unwrap();
+        let expected_result =
+            Result::with_exit_status_and_divert(ExitStatus::SUCCESS, Break(Divert::Exit(None)));
+        assert_eq!(actual_result, expected_result);
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
 
     #[test]
     fn force_exit_from_interactive_shell_with_suspended_job() {

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,14 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - Unreleased
+
+### Changed
+
+- The protection against exiting an interactive shell with suspended jobs, which
+  was introduced in 3.2.0, can now be disabled by setting the `posixlycorrect`
+  option.
+
 ## [3.2.0] - 2026-06-15
 
 ### Added
@@ -353,6 +361,7 @@ later.
 
 - Initial release of the shell
 
+[3.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.2.1
 [3.2.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.2.0
 [3.1.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.1.0
 [3.0.8]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.0.8

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.2] - Unreleased
+
+### Changed
+
+- `input::EofGuard` no longer blocks exit on EOF when there are suspended jobs
+  if the `posixlycorrect` option is on.
+
 ## [0.15.1] - 2026-06-15
 
 ### Added
@@ -1388,6 +1395,7 @@ This version has been yanked due to an issue that prevents the crate from buildi
 
 - Initial implementation of the `yash-env` crate
 
+[0.15.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.2
 [0.15.1]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.1
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.0
 [0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.14.0

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-env/src/input/eof_guard.rs
+++ b/yash-env/src/input/eof_guard.rs
@@ -20,7 +20,7 @@
 use super::{Context, Input, Result};
 use crate::Env;
 use crate::io::Fd;
-use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off, On};
+use crate::option::{IgnoreEof as IgnoreEofOption, Interactive, Off, On, PosixlyCorrect};
 use crate::system::Isatty;
 use crate::system::concurrency::WriteAll;
 use std::cell::RefCell;
@@ -91,8 +91,9 @@ impl IgnoreEofConfig {
 /// conditions is met (provided the shell is interactive, the input is a
 /// terminal, and the retry limit has not been reached):
 ///
-/// 1. There are suspended jobs and [`SuspendedJobsGuardConfig`] is present in
-///    `env.any` — prints [`SuspendedJobsGuardConfig::message`].
+/// 1. [`SuspendedJobsGuardConfig`] is present in `env.any`, the
+///    [`PosixlyCorrect`] option is off, and there are suspended jobs —
+///    prints [`SuspendedJobsGuardConfig::message`].
 /// 2. The `ignore-eof` option is enabled and [`IgnoreEofConfig`] is present in
 ///    `env.any` — prints [`IgnoreEofConfig::message`].
 ///
@@ -162,8 +163,8 @@ impl<S: Isatty + WriteAll, T: Input> Input for EofGuard<'_, '_, S, T> {
                 return Ok(line);
             }
 
-            // TODO: skip the suspended-jobs check in PosixlyCorrect mode
-            if let Some(config) = env.any.get::<SuspendedJobsGuardConfig>()
+            if env.options.get(PosixlyCorrect) == Off
+                && let Some(config) = env.any.get::<SuspendedJobsGuardConfig>()
                 && env.jobs.iter().any(|(_, job)| job.state.is_stopped())
             {
                 env.system.print_error(&config.message).await;
@@ -520,6 +521,38 @@ mod tests {
         assert_stderr(&state, |stderr| {
             assert_eq!(stderr, "There are stopped jobs.\n")
         });
+    }
+
+    #[test]
+    fn decorator_returns_immediately_if_posixly_correct_with_suspended_jobs() {
+        let mut system = VirtualSystem::new();
+        set_stdin_to_tty(&mut system);
+        let state = system.state.clone();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Interactive, On);
+        env.options.set(PosixlyCorrect, On);
+        let mut job = Job::new(Pid(42));
+        job.state = ProcessState::stopped(crate::system::r#virtual::SIGTSTP);
+        env.jobs.insert(job);
+        env.any.insert(Box::new(SuspendedJobsGuardConfig {
+            message: "There are stopped jobs.\n".to_string(),
+        }));
+        let ref_env = RefCell::new(&mut env);
+        let mut decorator = EofGuard::new(
+            EofStub {
+                inner: Memory::new("echo foo\n"),
+                count: 1,
+            },
+            Fd::STDIN,
+            &ref_env,
+        );
+
+        let result = decorator
+            .next_line(&Context::default())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result.unwrap(), "");
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
     }
 
     // Counterpart to `decorator_ignores_eof_when_there_are_suspended_jobs`:

--- a/yash-env/src/option.rs
+++ b/yash-env/src/option.rs
@@ -126,7 +126,7 @@ pub enum Option {
     Notify,
     /// Makes a pipeline reflect the exit status of the last failed component.
     PipeFail,
-    /// Disables most non-POSIX extensions.
+    /// Disables POSIX-incompatible features.
     PosixlyCorrect,
     /// Reads commands from the standard input.
     Stdin,


### PR DESCRIPTION
## Summary

- Adds a new `docs/src/posix.md` page documenting POSIX compliance and the behaviors that `posixlycorrect` disables; moves the POSIX overview out of `versioning.md`.
- `EofGuard` no longer blocks exit on EOF when there are suspended jobs if `posixlycorrect` is on (`yash-env` 0.15.2).
- The `exit` built-in no longer refuses to exit when there are suspended jobs if `posixlycorrect` is on (`yash-builtin` 0.18.2).

This is part of issue #807 (shell options regarding POSIX compliance), specifically the item: _Disable exit prevention that is otherwise activated when the shell has suspended jobs_.

## Test plan

- [ ] `cargo test` passes (new unit tests added in `yash-env::input::eof_guard` and `yash-builtin::exit` cover the `posixlycorrect` path)
- [ ] Interactive shell: start with `--posixlycorrect` (or set `posixlycorrect` at runtime), suspend a job with Ctrl-Z, then verify that `exit` and Ctrl-D both exit immediately without the "There are stopped jobs" warning
- [ ] Without `posixlycorrect`, the existing protection still triggers as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive POSIX compliance documentation with tracking of shell's conformance status.

* **Changed**
  * The `exit` command and interactive shell EOF handling now respect the `posixlycorrect` option, allowing exit even with suspended jobs when enabled.

* **Documentation**
  * Updated option descriptions and added POSIX compliance reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->