### PR TITLE
Ignore extension built-ins when posixlycorrect is on

### DIFF
--- a/docs/src/builtins/README.md
+++ b/docs/src/builtins/README.md
@@ -72,6 +72,16 @@ In yash-rs, the following elective built-in is implemented:
 
 More may be added in the future.
 
+### Extension built-ins
+
+**Extension built-ins** are non-conforming extensions to the POSIX shell that are not permitted by POSIX Command Search and Execution.
+
+Like [elective built-ins](#elective-built-ins), they can be found in [command search](../language/commands/simple.md#command-search) without a corresponding executable in `PATH`, and they can be overridden by [functions].
+
+When the [`posixlycorrect` option](../environment/options.md#posixlycorrect) is set, extension built-ins are **ignored**: they are treated as non-existing during command search, so the shell falls through to searching for an external utility with the same name.
+
+No extension built-ins are implemented in yash-rs yet.
+
 ### Substitutive built-ins
 
 **Substitutive built-ins** replace external utilities to avoid process creation overhead for common tasks.

--- a/docs/src/language/commands/simple.md
+++ b/docs/src/language/commands/simple.md
@@ -119,7 +119,7 @@ Redirections are canceled unless the target was the [`exec` special built-in](..
 1. If the command name contains a slash (`/`), it is treated as a pathname to an executable file target, regardless of whether the file exists or is executable.
 2. If the command name is a [special built-in] (like [`exec`](../../builtins/exec.md) or [`exit`](../../builtins/exit.md)), it is used as the target.
 3. If the command name is a [function], it is used as the target.
-4. If the command name is a [built-in] other than a [substitutive built-in], it is used as the target. <!-- TODO: reject elective and extension built-ins in POSIX mode -->
+4. If the command name is a [built-in] other than a [substitutive built-in], it is used as the target. [Extension built-ins] are excluded from this step when the [`posixlycorrect` option](../../environment/options.md#posixlycorrect) is on. <!-- TODO: reject elective and extension built-ins in portable mode -->
 5. The shell searches for the command name in the directories listed in the `PATH` [variable](../parameters/variables.md). The first matching executable regular file is a candidate target.
     - The value of `PATH` is treated as a sequence of pathnames separated by colons (`:`). An empty pathname in `PATH` refers to the current [working directory](../../environment/working_directory.md). For example, in the simple command `PATH=/bin:/usr/bin: ls`, the shell searches for `ls` in `/bin`, then `/usr/bin`, and finally the current directory.
     - If `PATH` is an array, each element is a pathname to search.
@@ -141,6 +141,7 @@ POSIX allows caching pathnames found during command search, but yash-rs does not
     - 126 if the target was identified but could not be executed (e.g., unsupported file type or permission denied)
 
 [built-in]: ../../builtins/index.html
+[Extension built-ins]: ../../builtins/index.html#extension-built-ins
 [function]: ../functions.md
 [shell environment]: ../../environment/index.html
 [special built-in]: ../../builtins/index.html#special-built-ins

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -13,3 +13,6 @@ Many features of yash-rs are still under development, and some may not yet be fu
 Some behaviors of yash-rs prioritize convenience over POSIX compliance. The [`posixlycorrect` option](environment/options.md#posixlycorrect) disables such features. When this option is set:
 
 - The shell no longer refuses to exit because of suspended jobs when the [`exit` built-in](builtins/exit.md) is executed or end-of-file is reached in an interactive shell. (See [Suspended jobs](termination.md#suspended-jobs).)
+- [Extension built-ins](builtins/index.html#extension-built-ins) are ignored (treated as non-existing), so the shell falls through to searching for an external utility with the same name.
+
+This list may be expanded in the future as more features are added to the shell.

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -17,6 +17,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `semantics::command::search` functions now ignore
+  `builtin::Type::Extension` built-ins when the `posixlycorrect` option is
+  on, treating them as non-existing and falling through to external utilities.
 - `input::EofGuard` no longer blocks exit on EOF when there are suspended jobs
   if the `posixlycorrect` option is on.
 

--- a/yash-env/src/builtin.rs
+++ b/yash-env/src/builtin.rs
@@ -81,13 +81,15 @@ pub enum Type {
     /// Extension built-ins are non-conformant extensions to the POSIX shell.
     /// Like elective built-ins, they can be executed without `$PATH` search
     /// finding a corresponding external utility. However, since this behavior
-    /// does not conform to [Command
-    /// Search and Execution](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_01_04)
-    /// in POSIX XCU section 2.9.1.4, they cannot be used when the (TODO TBD)
-    /// option is set. <!-- An option that disables non-conforming behavior
-    /// would make extension built-ins regarded as non-existing utilities. An
-    /// option that disables non-portable behavior would make extension
-    /// built-ins unusable even if found. -->
+    /// does not conform to [Command Search and
+    /// Execution](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_01_04)
+    /// in POSIX XCU section 2.9.1.4:
+    ///
+    /// - When the [`PosixlyCorrect`](crate::option::PosixlyCorrect) option is
+    ///   on, they are ignored: they are regarded as non-existing utilities so
+    ///   that the command search falls through to external utilities.
+    /// - When the (TODO TBD) option is on, they cannot be used even if found
+    ///   in command search.
     Extension,
 
     /// Built-in that works like a standalone utility

--- a/yash-env/src/semantics/command/search.rs
+++ b/yash-env/src/semantics/command/search.rs
@@ -346,11 +346,64 @@ mod tests {
     use super::*;
     use crate::builtin::Type::{Elective, Extension, Mandatory};
     use crate::function::{FunctionBody, FunctionBodyObject, FunctionSet};
+    use crate::option::Off;
     use crate::source::Location;
     use crate::variable::Value;
     use assert_matches::assert_matches;
     use std::collections::HashMap;
     use std::collections::HashSet;
+
+    #[test]
+    fn env_builtin_returns_special_builtin() {
+        let mut env = Env::new_virtual();
+        let builtin = Builtin::new(Special, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.builtin("foo"), Some(builtin));
+    }
+
+    #[test]
+    fn env_builtin_returns_mandatory_builtin() {
+        let mut env = Env::new_virtual();
+        let builtin = Builtin::new(Mandatory, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.builtin("foo"), Some(builtin));
+    }
+
+    #[test]
+    fn env_builtin_returns_elective_builtin() {
+        let mut env = Env::new_virtual();
+        let builtin = Builtin::new(Elective, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.builtin("foo"), Some(builtin));
+    }
+
+    #[test]
+    fn env_builtin_returns_extension_builtin_if_not_posixly_correct() {
+        let mut env = Env::new_virtual();
+        let builtin = Builtin::new(Extension, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.options.get(PosixlyCorrect), Off);
+        assert_eq!(env.builtin("foo"), Some(builtin));
+    }
+
+    #[test]
+    fn env_builtin_does_not_return_extension_builtin_if_posixly_correct() {
+        let mut env = Env::new_virtual();
+        env.options.set(PosixlyCorrect, On);
+        let builtin = Builtin::new(Extension, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.builtin("foo"), None);
+    }
+
+    #[test]
+    fn env_builtin_returns_substitutive_builtin() {
+        // The `$PATH` check for substitutive built-ins is part of `search`, not
+        // `builtin`, so `builtin` returns the built-in regardless of `$PATH`.
+        let mut env = Env::new_virtual();
+        let builtin = Builtin::new(Substitutive, |_, _| unreachable!());
+        env.builtins.insert("foo", builtin);
+        assert_eq!(env.builtin("foo"), Some(builtin));
+    }
 
     #[derive(Default)]
     struct DummyEnv {
@@ -774,17 +827,5 @@ mod tests {
         assert_matches!(search(&mut env, "foo"), Some(Target::External { path }) => {
             assert_eq!(*path, *c"foo");
         });
-    }
-
-    #[test]
-    fn extension_builtin_is_ignored_when_posixly_correct() {
-        let mut env = Env::new_virtual();
-        env.options.set(PosixlyCorrect, On);
-        env.builtins
-            .insert("foo", Builtin::new(Extension, |_, _| unreachable!()));
-
-        let target = search(&mut env, "foo");
-        assert!(target.is_none(), "target = {target:?}");
-        assert_matches!(classify(&env, "foo"), Target::External { .. });
     }
 }

--- a/yash-env/src/semantics/command/search.rs
+++ b/yash-env/src/semantics/command/search.rs
@@ -33,13 +33,18 @@
 //! as a target, a corresponding executable file must be present in a directory
 //! specified in the `PATH` variable.
 //!
+//! [Extension] built-ins are ignored (treated
+//! as non-existing) when the [`PosixlyCorrect`] option is on, so the search
+//! falls through to external utilities in that case.
+//!
 //! [command search]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_01_04
 //! [simple command]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_01
 
 use crate::Env;
 use crate::builtin::Builtin;
-use crate::builtin::Type::{Special, Substitutive};
+use crate::builtin::Type::{Extension, Special, Substitutive};
 use crate::function::Function;
+use crate::option::{On, PosixlyCorrect};
 use crate::path::PathBuf;
 use crate::system::IsExecutableFile;
 use crate::variable::Expansion;
@@ -214,7 +219,9 @@ impl<S: IsExecutableFile> PathEnv for Env<S> {
 
 impl<S> ClassifyEnv<S> for Env<S> {
     fn builtin(&self, name: &str) -> Option<Builtin<S>> {
-        self.builtins.get(name).copied()
+        let builtin = self.builtins.get(name).copied()?;
+        let available = builtin.r#type != Extension || self.options.get(PosixlyCorrect) != On;
+        available.then_some(builtin)
     }
 
     #[inline]
@@ -767,5 +774,17 @@ mod tests {
         assert_matches!(search(&mut env, "foo"), Some(Target::External { path }) => {
             assert_eq!(*path, *c"foo");
         });
+    }
+
+    #[test]
+    fn extension_builtin_is_ignored_when_posixly_correct() {
+        let mut env = Env::new_virtual();
+        env.options.set(PosixlyCorrect, On);
+        env.builtins
+            .insert("foo", Builtin::new(Extension, |_, _| unreachable!()));
+
+        let target = search(&mut env, "foo");
+        assert!(target.is_none(), "target = {target:?}");
+        assert_matches!(classify(&env, "foo"), Target::External { .. });
     }
 }

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -62,7 +62,7 @@ pub async fn execute_builtin<S: Runtime + 'static>(
     };
 
     let result = 'result: {
-        // TODO Reject elective and extension built-ins in POSIX mode
+        // TODO Reject elective and extension built-ins in portable mode
 
         let is_special = builtin.r#type == Special;
         let (mut env, export) = if is_special {


### PR DESCRIPTION
## Description

Implements the "Ignore extension built-ins" item from #807.

When the `posixlycorrect` option is on, `Env<S>`'s implementation of `ClassifyEnv<S>::builtin()` now returns `None` for `Type::Extension` built-ins. This causes both `classify()` and `search()` in `yash_env::semantics::command::search` to treat extension built-ins as non-existing and fall through to external utilities with the same name — matching the POSIX command-search requirement.

Since no extension built-ins are currently registered, this is an internal behavior change with no observable shell effect yet.

The change is centralized in `Env<S>::builtin()`, so the `command` built-in's `SearchEnv` adapter inherits the filtering automatically. The distinction between *ignore* (skip in command search; `posixlycorrect`) and *reject* (found but refused at execution time; future `portable` option) is reflected in the updated doc comments and the remaining TODO in `yash-semantics`.

Docs updated: a new "Extension built-ins" section in the built-ins overview, a note in the command-search steps, and an entry in the POSIX compliance page.

Relates to #807.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [ ] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)
  - No observable shell behavior changes yet, since no extension built-ins are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * When the `posixlycorrect` option is enabled, extension built-ins are ignored during command search, so the shell falls back to searching for an external utility with the same name.
* **Documentation**
  * Added and clarified documentation for “Extension built-ins,” including how `posixlycorrect` affects command search and POSIX compliance behavior.
* **Tests**
  * Added test coverage to confirm extension built-ins are not selected in `posixlycorrect` mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->