### PR TITLE
Fix double-quoted words not marked as quoted by Unquote

### DIFF
--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the manual for the constructs it rejects. More checks will be added in
   future releases.
 
+### Fixed
+
+- A here-document whose delimiter is quoted with double quotes or
+  `$'...'` (e.g. `<<"EOF"`) is now correctly treated as quoted. Previously,
+  such a delimiter consisting only of literal characters was misdetected as
+  unquoted, so the here-document body was incorrectly subject to parameter,
+  command, and arithmetic expansion.
+
 ## [3.2.1] - 2026-06-21
 
 ### Changed

--- a/yash-cli/tests/scripted_test/redir-p.sh
+++ b/yash-cli/tests/scripted_test/redir-p.sh
@@ -425,6 +425,14 @@ ec\
 ho
 __OUT__
 
+test_oE -e 0 'no parameter expansion with double-quoted here-document delimiter'
+cat <<"END"
+foo=$foo
+END
+__IN__
+foo=$foo
+__OUT__
+
 test_O -e n 'expansion error in here-document'
 echo not printed <<END
 ${a?}

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -77,6 +77,14 @@ A _private dependency_ is used internally and not visible to downstream users.
 - Public dependency versions:
     - yash-env 0.15.0 → 0.15.3
 
+### Fixed
+
+- `Unquote` implementations for `WordUnit::DoubleQuote` and
+  `WordUnit::DollarSingleQuote` now always report the word as quoted,
+  regardless of its content. Previously, a double-quoted or
+  dollar-single-quoted word consisting only of literal characters (e.g.
+  `"EOF"`) was incorrectly treated as unquoted.
+
 ## [0.22.0] - 2026-06-11
 
 ### Changed

--- a/yash-syntax/src/syntax/conversions.rs
+++ b/yash-syntax/src/syntax/conversions.rs
@@ -455,8 +455,14 @@ impl Unquote for WordUnit {
                 w.write_str(inner)?;
                 Ok(true)
             }
-            DoubleQuote(inner) => inner.write_unquoted(w),
-            DollarSingleQuote(inner) => inner.write_unquoted(w),
+            DoubleQuote(inner) => {
+                inner.write_unquoted(w)?;
+                Ok(true)
+            }
+            DollarSingleQuote(inner) => {
+                inner.write_unquoted(w)?;
+                Ok(true)
+            }
             Tilde { name, .. } => {
                 write!(w, "~{name}")?;
                 Ok(false)
@@ -898,6 +904,30 @@ mod tests {
         word.parse_tilde_front();
         let (unquoted, is_quoted) = word.unquote();
         assert_eq!(unquoted, "~a/bcde");
+        assert_eq!(is_quoted, true);
+    }
+
+    #[test]
+    fn word_unquote_double_quote_with_only_literal_content() {
+        let word = Word::from_str(r#""EOF""#).unwrap();
+        let (unquoted, is_quoted) = word.unquote();
+        assert_eq!(unquoted, "EOF");
+        assert_eq!(is_quoted, true);
+    }
+
+    #[test]
+    fn word_unquote_double_quote_with_expansion() {
+        let word = Word::from_str(r#""$foo""#).unwrap();
+        let (unquoted, is_quoted) = word.unquote();
+        assert_eq!(unquoted, "$foo");
+        assert_eq!(is_quoted, true);
+    }
+
+    #[test]
+    fn word_unquote_dollar_single_quote() {
+        let word = Word::from_str(r"$'EOF'").unwrap();
+        let (unquoted, is_quoted) = word.unquote();
+        assert_eq!(unquoted, "EOF");
         assert_eq!(is_quoted, true);
     }
 


### PR DESCRIPTION
## Description

WordUnit::write_unquoted forwarded the "is quoted" result of DoubleQuote and DollarSingleQuote contents verbatim instead of always reporting true, unlike SingleQuote. As a result, a word like "EOF" or $'EOF' consisting only of literal characters was treated as unquoted.

This caused here-document delimiters such as <<"EOF" to be misdetected as unquoted, so the here-document body was incorrectly subject to parameter expansion even though the delimiter was quoted.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)
