### PR TITLE
Reject the reserved words ]], namespace, and select

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,42 @@
+#!/bin/sh
+# commit-msg hook: enforce that every line of the commit message is wrapped at
+# 72 characters or fewer, matching the convention in
+# .agents/skills/commit-message/SKILL.md.
+#
+# Exception: a line may exceed the limit when it contains a single
+# whitespace-delimited token (such as a long URL) that is itself longer than
+# the limit, because there is then no place to break the line to make it fit.
+#
+# Bypass with "git commit --no-verify" when necessary.
+
+max=72
+
+awk -v max="$max" '
+    # Stop at the scissors line that "git commit --verbose" inserts; the diff
+    # below it is not part of the commit message.
+    /^#.*>8/ { exit }
+    # Skip comment lines; git strips them from the final message.
+    /^#/ { next }
+    {
+        if (length($0) > max) {
+            # Length of the longest whitespace-delimited word on this line.
+            longest = 0
+            for (i = 1; i <= NF; i++)
+                if (length($i) > longest) longest = length($i)
+            # Only flag the line when it could have been wrapped to fit, i.e.
+            # no single word by itself exceeds the limit.
+            if (longest <= max) {
+                printf "commit-msg: line %d is %d characters (limit %d):\n  %s\n", \
+                    NR, length($0), max, $0 > "/dev/stderr"
+                bad = 1
+            }
+        }
+    }
+    END { if (bad) exit 1 }
+' "$1" || {
+    echo "commit-msg: wrap the commit message at ${max} characters" >&2
+    echo "commit-msg: e.g. pipe the body through 'fmt -w ${max}'; use --no-verify to bypass" >&2
+    exit 1
+}
+
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "yash-prompt"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "futures-util",
  "yash-env",
@@ -867,7 +867,7 @@ version = "1.1.2"
 
 [[package]]
 name = "yash-semantics"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.18.2" }
+yash-builtin = { path = "yash-builtin", version = "0.19.0" }
 yash-env = { path = "yash-env", version = "0.15.3" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
-yash-prompt = { path = "yash-prompt", version = "0.13.0" }
+yash-prompt = { path = "yash-prompt", version = "0.14.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.17.0" }
-yash-syntax = { path = "yash-syntax", version = "0.22.1" }
+yash-semantics = { path = "yash-semantics", version = "0.18.0" }
+yash-syntax = { path = "yash-syntax", version = "0.23.0" }
 
 [workspace.lints.clippy]
 allow_attributes_without_reason = "warn"

--- a/docs/src/language/words/keywords.md
+++ b/docs/src/language/words/keywords.md
@@ -6,6 +6,7 @@ Some words have special meaning in shell syntax. These **reserved words** must b
 - `{` – Start of a [grouping](../commands/grouping.md#braces)
 - `}` – End of a [grouping](../commands/grouping.md#braces)
 - `[[` – Start of a double bracket command
+- `]]` – End of a double bracket command (since 3.3.0)
 - `case` – [Case command](../commands/case.md)
 - `do` – Start of a loop or conditional block
 - `done` – End of a loop or conditional block
@@ -17,17 +18,16 @@ Some words have special meaning in shell syntax. These **reserved words** must b
 - `function` – [Function](../functions.md) definition
 - `if` – [If command](../commands/exit_status.md#if-commands)
 - `in` – Delimiter for a [for loop](../commands/loops.md#for-loops) and [case command](../commands/case.md)
+- `namespace` – Namespace declaration (since 3.3.0)
+- `select` – Select command (since 3.3.0)
 - `then` – Then clause
 - `until` – [Until loop](../commands/loops.md#while-and-until-loops)
 - `while` – [While loop](../commands/loops.md#while-and-until-loops)
 
-Currently, `[[` and `function` are only recognized as reserved words; their functionality is not yet implemented.
+The reserved words `[[`, `]]`, `function`, `namespace`, and `select` are recognized but not yet implemented. Using these reserved words will result in a syntax error.
 
 Additionally, the POSIX standard allows for the following optional reserved words:
 
-- `]]` – End of a double bracket command
-- `namespace` – Namespace declaration
-- `select` – Select command
 - `time` – Time command
 - Any words that end with a colon (`:`)
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.19.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-semantics (optional) 0.17.0 → 0.18.0
+
 ## [0.18.2] - 2026-06-21
 
 ### Changed
@@ -837,6 +844,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.19.0
 [0.18.2]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.2
 [0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.1
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.18.2"
+version = "0.19.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the manual for the constructs it rejects. More checks will be added in
   future releases.
 
+### Changed
+
+- The shell now recognizes `]]` as a reserved word and reports a syntax error
+  when it is used as a command name, instead of running it as an ordinary
+  command.
+
 ### Fixed
 
 - A here-document whose delimiter is quoted with double quotes or

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shell now recognizes `]]` as a reserved word and reports a syntax error
   when it is used as a command name, instead of running it as an ordinary
   command.
+- The shell now recognizes `namespace` and `select` as reserved words and
+  reports a syntax error for them (they are reserved for future use but not yet
+  implemented), instead of running them as ordinary commands.
 
 ### Fixed
 

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -137,6 +137,11 @@ fn bg_builtin() {
 }
 
 #[test]
+fn bracket_ex() {
+    run("bracket-y.sh")
+}
+
+#[test]
 fn break_builtin() {
     run("break-p.sh")
 }

--- a/yash-cli/tests/scripted_test/bracket-y.sh
+++ b/yash-cli/tests/scripted_test/bracket-y.sh
@@ -1,0 +1,5 @@
+# bracket-y.sh: yash-specific test of double-bracket reserved words
+
+test_O -d -e 2 'the ]] reserved word cannot be a command name'
+]]
+__IN__

--- a/yash-cli/tests/scripted_test/command-y.sh
+++ b/yash-cli/tests/scripted_test/command-y.sh
@@ -148,7 +148,7 @@ __OUT__
 
 test_oE -e 0 'describing reserved words (-V)'
 command -V if then else elif fi do done case esac while until for function \
-    { } ! in [[ ]]
+    { } ! in [[ ]] select namespace
 __IN__
 if: keyword
 then: keyword
@@ -169,6 +169,8 @@ function: keyword
 in: keyword
 [[: keyword
 ]]: keyword
+select: keyword
+namespace: keyword
 __OUT__
 
 # TODO Option not yet implemented

--- a/yash-cli/tests/scripted_test/command-y.sh
+++ b/yash-cli/tests/scripted_test/command-y.sh
@@ -148,7 +148,7 @@ __OUT__
 
 test_oE -e 0 'describing reserved words (-V)'
 command -V if then else elif fi do done case esac while until for function \
-    { } ! in
+    { } ! in [[ ]]
 __IN__
 if: keyword
 then: keyword
@@ -167,6 +167,8 @@ function: keyword
 }: keyword
 !: keyword
 in: keyword
+[[: keyword
+]]: keyword
 __OUT__
 
 # TODO Option not yet implemented

--- a/yash-cli/tests/scripted_test/redir-y.sh
+++ b/yash-cli/tests/scripted_test/redir-y.sh
@@ -1,6 +1,19 @@
 # redir-y.sh: yash-specific test of redirections
 
+test_OE -e 0 'without portable, an IO_NUMBER operand is accepted'
+> 1
+: < 1>/dev/null
+__IN__
+
+test_O -d -e 2 'an IO_LOCATION prefix is not supported'
+{n}>/dev/null
+__IN__
+
 # The portable option rejects non-portable redirection operators and operands.
+
+test_O -d -e 2 'portable option rejects an IO_LOCATION prefix' -o portable
+{n}>/dev/null
+__IN__
 
 test_O -d -e 2 'portable option rejects the >>| operator' -o portable
 echo not reached >>| /dev/null
@@ -17,11 +30,6 @@ __IN__
 
 test_O -d -e 2 'portable option rejects an IO_LOCATION as operand' -o portable
 : < {n}>/dev/null
-__IN__
-
-test_OE -e 0 'without portable, an IO_NUMBER operand is accepted'
-> 1
-: < 1>/dev/null
 __IN__
 
 test_oE 'portable option allows the portable redirection operators' -o portable

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.14.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-syntax 0.22.0 → 0.23.0
+
 ## [0.13.0] - 2026-06-11
 
 ### Changed
@@ -183,6 +190,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-prompt` crate
 
+[0.14.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.14.0
 [0.13.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.13.0
 [0.12.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.12.0
 [0.11.0]: https://github.com/magicant/yash-rs/releases/tag/yash-prompt-0.11.0

--- a/yash-prompt/Cargo.toml
+++ b/yash-prompt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-prompt"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,7 +13,7 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
-## [0.17.1] - Unreleased
+## [0.18.0] - Unreleased
 
 ### Changed
 
@@ -23,7 +23,7 @@ A _private dependency_ is used internally and not visible to downstream users.
   syntax take effect on subsequent input.
 - Public dependency versions:
     - yash-env 0.15.0 → 0.15.3
-    - yash-syntax 0.22.0 → 0.22.1
+    - yash-syntax 0.22.0 → 0.23.0
 
 ## [0.17.0] - 2026-06-11
 
@@ -557,7 +557,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
-[0.17.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.17.1
+[0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.17.0
 [0.16.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.16.0
 [0.15.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.15.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,10 +13,14 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
-## [0.22.1] - Unreleased
+## [0.23.0] - Unreleased
 
 ### Added
 
+- `parser::lex::Keyword::CloseBracketBracket` representing the `]]` reserved
+  word, which yash now recognizes as the counterpart of the opening `[[`.
+- `parser::SyntaxError::CloseBracketBracketAsCommandName`, raised when `]]` is
+  used as a command name.
 - `parser::lex::Lexer::mode` and `parser::lex::Lexer::set_mode` for querying and
   updating the parsing mode (`yash_env::parser::Mode`) of a lexer. The parser and
   lexer consult the mode to decide which syntax to accept.
@@ -46,6 +50,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The parser now recognizes `]]` as a reserved word and rejects it when used as
+  a command name (`SyntaxError::CloseBracketBracketAsCommandName`), rather than
+  treating it as an ordinary word.
 - The parser now rejects the following non-portable constructs when the lexer's
   parsing mode has `portable` enabled. Without the mode, they are accepted as
   before:
@@ -742,7 +749,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
-[0.22.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.22.1
+[0.23.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.23.0
 [0.22.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.22.0
 [0.21.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.21.0
 [0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.20.0

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -17,10 +17,14 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
-- `parser::lex::Keyword::CloseBracketBracket` representing the `]]` reserved
-  word, which yash now recognizes as the counterpart of the opening `[[`.
+- New `parser::lex::Keyword` variants for reserved words that yash now
+  recognizes: `CloseBracketBracket`, `Namespace` and `Select` for `]]`,
+  `namespace` and `select`, respectively.
 - `parser::SyntaxError::CloseBracketBracketAsCommandName`, raised when `]]` is
   used as a command name.
+- `parser::SyntaxError::UnsupportedNamespaceCommand` and
+  `parser::SyntaxError::UnsupportedSelectCommand`, raised when a `namespace` or
+  `select` command is used, since they are not yet implemented.
 - `parser::lex::Lexer::mode` and `parser::lex::Lexer::set_mode` for querying and
   updating the parsing mode (`yash_env::parser::Mode`) of a lexer. The parser and
   lexer consult the mode to decide which syntax to accept.
@@ -53,6 +57,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The parser now recognizes `]]` as a reserved word and rejects it when used as
   a command name (`SyntaxError::CloseBracketBracketAsCommandName`), rather than
   treating it as an ordinary word.
+- The parser now recognizes `namespace` and `select` as reserved words and
+  rejects them as unsupported commands
+  (`SyntaxError::UnsupportedNamespaceCommand` and
+  `SyntaxError::UnsupportedSelectCommand`), rather than treating them as
+  ordinary words.
 - The parser now rejects the following non-portable constructs when the lexer's
   parsing mode has `portable` enabled. Without the mode, they are accepted as
   before:

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-syntax/src/parser/command.rs
+++ b/yash-syntax/src/parser/command.rs
@@ -22,7 +22,7 @@
 use super::core::Parser;
 use super::core::Rec;
 use super::core::Result;
-use super::lex::Keyword::{Function, OpenBracketBracket};
+use super::lex::Keyword::{Function, Namespace, OpenBracketBracket, Select};
 use super::lex::TokenId::Token;
 use super::{Error, SyntaxError};
 use crate::syntax::Command;
@@ -50,6 +50,16 @@ impl Parser<'_, '_> {
                     }
                     Token(Some(OpenBracketBracket)) => {
                         let cause = SyntaxError::UnsupportedDoubleBracketCommand.into();
+                        let location = next.word.location.clone();
+                        Err(Error { cause, location })
+                    }
+                    Token(Some(Namespace)) => {
+                        let cause = SyntaxError::UnsupportedNamespaceCommand.into();
+                        let location = next.word.location.clone();
+                        Err(Error { cause, location })
+                    }
+                    Token(Some(Select)) => {
+                        let cause = SyntaxError::UnsupportedSelectCommand.into();
                         let location = next.word.location.clone();
                         Err(Error { cause, location })
                     }
@@ -150,6 +160,41 @@ mod tests {
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(*e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 1..3);
+    }
+
+    #[test]
+    fn parser_command_namespace() {
+        let mut lexer = Lexer::with_code(" namespace foo { echo; }");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::UnsupportedNamespaceCommand)
+        );
+        assert_eq!(*e.location.code.value.borrow(), " namespace foo { echo; }");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 1..10);
+    }
+
+    #[test]
+    fn parser_command_select() {
+        let mut lexer = Lexer::with_code(" select i in a b; do echo; done");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::UnsupportedSelectCommand)
+        );
+        assert_eq!(
+            *e.location.code.value.borrow(),
+            " select i in a b; do echo; done"
+        );
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 1..7);
     }
 
     #[test]

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -159,6 +159,8 @@ pub enum SyntaxError {
     InvalidFunctionBody,
     /// The keyword `in` is used as a command name.
     InAsCommandName,
+    /// The keyword `]]` is used as a command name.
+    CloseBracketBracketAsCommandName,
     /// A pipeline is missing after a `&&` or `||` token.
     MissingPipeline(AndOr),
     /// Two successive `!` tokens.
@@ -288,8 +290,14 @@ impl SyntaxError {
                 "the delimiter to close the here-document content is missing"
             }
             UnclosedArrayValue { .. } => "the array assignment value is not closed",
-            UnopenedGrouping | UnopenedSubshell | UnopenedLoop | UnopenedDoClause | UnopenedIf
-            | UnopenedCase | InAsCommandName => "the compound command delimiter is unmatched",
+            UnopenedGrouping
+            | UnopenedSubshell
+            | UnopenedLoop
+            | UnopenedDoClause
+            | UnopenedIf
+            | UnopenedCase
+            | InAsCommandName
+            | CloseBracketBracketAsCommandName => "the compound command delimiter is unmatched",
             UnclosedGrouping { .. } => "the grouping is not closed",
             EmptyGrouping => "the grouping is missing its content",
             UnclosedSubshell { .. } => "the subshell is not closed",
@@ -421,7 +429,9 @@ impl SyntaxError {
             UnopenedCase => "not in a `case` command",
             UnclosedCase { .. } => "expected `esac`",
             MissingFunctionBody | InvalidFunctionBody => "expected a compound command",
-            InAsCommandName => "cannot be used as a command name",
+            InAsCommandName | CloseBracketBracketAsCommandName => {
+                "cannot be used as a command name"
+            }
             DoubleNegation => "only one `!` allowed",
             BangAfterBar => "`!` not allowed here",
             RedundantToken => "unexpected token",

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -193,6 +193,10 @@ pub enum SyntaxError {
     UnsupportedFunctionDefinitionSyntax,
     /// A `[[ ... ]]` command is used.
     UnsupportedDoubleBracketCommand,
+    /// A `namespace` command is used.
+    UnsupportedNamespaceCommand,
+    /// A `select` command is used.
+    UnsupportedSelectCommand,
     /// A process redirection (`>(...)` or `<(...)`) is used.
     UnsupportedProcessRedirection,
     /// A `((...))` arithmetic command is used at the beginning of a command
@@ -350,6 +354,8 @@ impl SyntaxError {
             UnicodeEscapeOutOfRange => "the Unicode escape is out of range",
             UnsupportedFunctionDefinitionSyntax
             | UnsupportedDoubleBracketCommand
+            | UnsupportedNamespaceCommand
+            | UnsupportedSelectCommand
             | UnsupportedProcessRedirection => "unsupported syntax",
             UnsupportedArithmeticCommand => "`((` is ambiguous at the start of a command",
             UnsupportedExtendedGlob => "`!(` is ambiguous at the start of a command",
@@ -445,6 +451,8 @@ impl SyntaxError {
             UnicodeEscapeOutOfRange => "not a valid Unicode scalar value",
             UnsupportedFunctionDefinitionSyntax => "the `function` keyword is not yet supported",
             UnsupportedDoubleBracketCommand => "the `[[ ... ]]` command is not yet supported",
+            UnsupportedNamespaceCommand => "the `namespace` command is not yet supported",
+            UnsupportedSelectCommand => "the `select` command is not yet supported",
             UnsupportedProcessRedirection => "process redirection is not yet supported",
             UnsupportedArithmeticCommand => {
                 "other shells read this as an arithmetic command; insert a space for nested subshells"

--- a/yash-syntax/src/parser/lex/keyword.rs
+++ b/yash-syntax/src/parser/lex/keyword.rs
@@ -39,6 +39,8 @@ pub enum Keyword {
     Bang,
     /// `[[`
     OpenBracketBracket,
+    /// `]]`
+    CloseBracketBracket,
     Case,
     Do,
     Done,
@@ -67,6 +69,7 @@ impl Keyword {
         match self {
             Bang => "!",
             OpenBracketBracket => "[[",
+            CloseBracketBracket => "]]",
             Case => "case",
             Do => "do",
             Done => "done",
@@ -95,8 +98,8 @@ impl Keyword {
         use Keyword::*;
         match self {
             Do | Done | Elif | Else | Esac | Fi | Then | CloseBrace => true,
-            Bang | OpenBracketBracket | Case | For | Function | If | In | Until | While
-            | OpenBrace => false,
+            Bang | OpenBracketBracket | CloseBracketBracket | Case | For | Function | If | In
+            | Until | While | OpenBrace => false,
         }
     }
 }
@@ -114,6 +117,7 @@ impl FromStr for Keyword {
         match s {
             "!" => Ok(Bang),
             "[[" => Ok(OpenBracketBracket),
+            "]]" => Ok(CloseBracketBracket),
             "case" => Ok(Case),
             "do" => Ok(Do),
             "done" => Ok(Done),

--- a/yash-syntax/src/parser/lex/keyword.rs
+++ b/yash-syntax/src/parser/lex/keyword.rs
@@ -52,6 +52,8 @@ pub enum Keyword {
     Function,
     If,
     In,
+    Namespace,
+    Select,
     Then,
     Until,
     While,
@@ -81,6 +83,8 @@ impl Keyword {
             Function => "function",
             If => "if",
             In => "in",
+            Namespace => "namespace",
+            Select => "select",
             Then => "then",
             Until => "until",
             While => "while",
@@ -99,7 +103,7 @@ impl Keyword {
         match self {
             Do | Done | Elif | Else | Esac | Fi | Then | CloseBrace => true,
             Bang | OpenBracketBracket | CloseBracketBracket | Case | For | Function | If | In
-            | Until | While | OpenBrace => false,
+            | Namespace | Select | Until | While | OpenBrace => false,
         }
     }
 }
@@ -129,6 +133,8 @@ impl FromStr for Keyword {
             "function" => Ok(Function),
             "if" => Ok(If),
             "in" => Ok(In),
+            "namespace" => Ok(Namespace),
+            "select" => Ok(Select),
             "then" => Ok(Then),
             "until" => Ok(Until),
             "while" => Ok(While),

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -36,9 +36,8 @@ fn error_type_for_trailing_token_in_command_line(token_id: TokenId) -> Option<Sy
         EndOfInput => None,
         Token(None) | IoNumber | IoLocation => Some(MissingSeparator),
         Token(Some(keyword)) => match keyword {
-            Bang | OpenBracketBracket | Case | For | Function | If | Until | While | OpenBrace => {
-                Some(MissingSeparator)
-            }
+            Bang | OpenBracketBracket | Case | For | Function | If | Namespace | Select | Until
+            | While | OpenBrace => Some(MissingSeparator),
             Do => Some(UnopenedLoop),
             Done => Some(UnopenedDoClause),
             Elif | Else | Fi | Then => Some(UnopenedIf),

--- a/yash-syntax/src/parser/list.rs
+++ b/yash-syntax/src/parser/list.rs
@@ -44,6 +44,7 @@ fn error_type_for_trailing_token_in_command_line(token_id: TokenId) -> Option<Sy
             Elif | Else | Fi | Then => Some(UnopenedIf),
             Esac => Some(UnopenedCase),
             In => Some(InAsCommandName),
+            CloseBracketBracket => Some(CloseBracketBracketAsCommandName),
             CloseBrace => Some(UnopenedGrouping),
         },
         Operator(operator) => match operator {
@@ -385,6 +386,22 @@ mod tests {
         assert_eq!(e.location.code.start_line_number.get(), 1);
         assert_eq!(*e.location.code.source, Source::Unknown);
         assert_eq!(e.location.range, 9..10);
+    }
+
+    #[test]
+    fn parser_command_line_close_bracket_bracket_as_command_name() {
+        let mut lexer = Lexer::with_code("]]");
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.command_line().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::CloseBracketBracketAsCommandName)
+        );
+        assert_eq!(*e.location.code.value.borrow(), "]]");
+        assert_eq!(e.location.code.start_line_number.get(), 1);
+        assert_eq!(*e.location.code.source, Source::Unknown);
+        assert_eq!(e.location.range, 0..2);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Implements #807.

Reserved words:

- Recognize `]]` as a reserved word (the counterpart of the opening `[[`) and
  reject it when used as a command name.
- Recognize `namespace` and `select` as reserved words and reject them as
  unsupported commands, the same way the `function` keyword and the `[[`
  command are rejected. They are reserved for future use but not yet
  implemented.
- All three are rejected regardless of the parsing mode.

Redirection:

- Add scripted tests confirming that a `{n}` I/O location prefix is rejected
  both with and without the `portable` option. It already produced an
  `InvalidIoLocation` error; the tests guard against the portable mode being
  relaxed to accept it.

Because the new `Keyword` variants are a breaking change to `yash-syntax`, the
crate versions, workspace dependency requirements, changelogs, and the
reserved-words documentation are updated accordingly.

Out of scope: this branch also adds a `commit-msg` git hook that enforces
72-character message lines (`.githooks/commit-msg` plus a `core.hooksPath`
setting). It is unrelated to #807 but was done in passing on this branch.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition of additional shell reserved words, including `]]`, `namespace`, and `select`.
  * Improved error reporting when unsupported or invalid command forms are used.

* **Bug Fixes**
  * Commands starting with reserved words now fail with clearer syntax errors instead of being treated as ordinary commands.
  * Commit messages are now checked for overly long non-comment lines during commit creation.

* **Documentation**
  * Updated changelogs and language docs to reflect the expanded reserved-word behavior.

* **Tests**
  * Added and updated scripted tests covering reserved-word handling and redirection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->