### PR TITLE
Reject non-portable assignment names in portable mode

### DIFF
--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -34,5 +34,6 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - A command name ending with a `:` (for example, `foo:`). POSIX [reserves words](language/words/keywords.md) whose final character is a `:` for possible future use, so using one where a reserved word would be recognized produces unspecified results. The lone `:` ([colon built-in](builtins/colon.md)) is not affected.
 - A [`for` loop](language/commands/loops.md#for-loops) [variable name](language/parameters/variables.md#variable-names) that is quoted, contains an expansion, or starts with a digit. POSIX requires the name to be an unquoted word consisting solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit.
 - A [function](language/functions.md) name that is quoted, contains an expansion, or starts with a digit. POSIX requires the name to be an unquoted word consisting solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit.
+- An [assignment](language/commands/simple.md#syntax) name that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-cli/tests/scripted_test/simple-y.sh
+++ b/yash-cli/tests/scripted_test/simple-y.sh
@@ -41,3 +41,27 @@ __OUT__
 test_O -d -e 127 'without portable, a command name ending with a colon is parsed'
 foo:
 __IN__
+
+# A portable name consists solely of underscores, digits, and alphabetics from
+# the portable character set, not starting with a digit. The portable option
+# rejects assignment names that do not meet this form, since other
+# POSIX-conforming shells may not support them.
+
+test_O -d -e 2 'portable option rejects an assignment name starting with a digit' -o portable
+1a=foo
+__IN__
+
+test_O -d -e 2 'portable option rejects an assignment name with a non-portable character' -o portable
+a.b=foo
+__IN__
+
+test_oE 'portable option allows a portable assignment name' -o portable
+_Az9=foo
+echo "$_Az9"
+__IN__
+foo
+__OUT__
+
+test_OE -e 0 'without portable, an assignment name starting with a digit is accepted'
+1a=foo
+__IN__

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -51,6 +51,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       contains an expansion, or starts with a digit.
     - `NonPortableFunctionName` for a function name that is quoted, contains
       an expansion, or starts with a digit.
+    - `NonPortableAssignmentName` for an assignment name that contains a
+      character other than underscores, digits, and alphabetics from the
+      portable character set, or that starts with a digit.
 - `parser::SyntaxError::footnotes` and `parser::ErrorCause::footnotes`, which
   return supplementary footnotes (a `source::pretty::FootnoteType` and its text)
   to render with the error, such as a note that the error is reported because
@@ -96,6 +99,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       not starting with a digit.
     - A function name that is quoted, contains an expansion, or starts with a
       digit (`SyntaxError::NonPortableFunctionName`), for the same reason.
+    - An assignment name that contains a character other than underscores,
+      digits, and alphabetics from the portable character set, or that starts
+      with a digit (`SyntaxError::NonPortableAssignmentName`).
 - `parser::Error::to_report` now attaches a `note:` footnote to errors caused by
   the `portable` option, clarifying that the construct is rejected only because
   the option is enabled.

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -279,6 +279,14 @@ pub enum SyntaxError {
     /// is quoted, contains an expansion, or otherwise does not meet this
     /// requirement.
     NonPortableFunctionName,
+    /// An assignment name is not a portable name while the `portable` option
+    /// is on.
+    ///
+    /// A portable name consists solely of underscores, digits, and
+    /// alphabetics from the portable character set, not starting with a
+    /// digit. This is raised when the assignment name does not meet this
+    /// form, since other POSIX-conforming shells may not support it.
+    NonPortableAssignmentName,
 }
 
 impl SyntaxError {
@@ -388,6 +396,7 @@ impl SyntaxError {
             TooLongHexEscape => "more than two hexadecimal digits follow `\\x`",
             NonPortableForName => "the for loop variable name is not portable",
             NonPortableFunctionName => "the function name is not portable",
+            NonPortableAssignmentName => "the assignment name is not portable",
         }
     }
 
@@ -501,6 +510,7 @@ impl SyntaxError {
             TooLongHexEscape => "use at most two hexadecimal digits",
             NonPortableForName => "not a POSIX variable name",
             NonPortableFunctionName => "not a POSIX name",
+            NonPortableAssignmentName => "not a POSIX variable name",
         }
     }
 
@@ -528,7 +538,8 @@ impl SyntaxError {
             | NonPortableEscape
             | TooLongHexEscape
             | NonPortableForName
-            | NonPortableFunctionName => &[(
+            | NonPortableFunctionName
+            | NonPortableAssignmentName => &[(
                 FootnoteType::Note,
                 "this error is reported because the `portable` shell option is enabled",
             )],

--- a/yash-syntax/src/parser/simple_command.rs
+++ b/yash-syntax/src/parser/simple_command.rs
@@ -23,6 +23,7 @@ use super::error::Error;
 use super::error::SyntaxError;
 use super::lex::Operator::{CloseParen, Newline, OpenParen};
 use super::lex::TokenId::{Operator, Token};
+use super::lex::is_portable_name;
 use crate::syntax::Array;
 use crate::syntax::Assign;
 use crate::syntax::ExpansionMode;
@@ -222,6 +223,13 @@ impl Parser<'_, '_> {
                     continue;
                 }
             };
+
+            if self.mode().portable && !is_portable_name(&assign.name) {
+                return Err(Error {
+                    cause: SyntaxError::NonPortableAssignmentName.into(),
+                    location: assign.location,
+                });
+            }
 
             let units = match &assign.value {
                 Scalar(Word { units, .. }) => units,
@@ -895,6 +903,72 @@ mod tests {
         assert_eq!(sc.assigns.len(), 1);
         assert_eq!(sc.assigns[0].name, "a");
         assert_eq!(sc.assigns[0].value.to_string(), "b:");
+    }
+
+    #[test]
+    fn assignment_name_starting_with_digit_rejected_in_portable_mode() {
+        let mut lexer = Lexer::with_code("1a=b");
+        lexer.set_mode(portable_mode());
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.simple_command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::NonPortableAssignmentName)
+        );
+        assert_eq!(*e.location.code.value.borrow(), "1a=b");
+        assert_eq!(e.location.range, 0..4);
+    }
+
+    #[test]
+    fn assignment_name_with_non_portable_character_rejected_in_portable_mode() {
+        let mut lexer = Lexer::with_code("a.b=c");
+        lexer.set_mode(portable_mode());
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.simple_command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::NonPortableAssignmentName)
+        );
+    }
+
+    #[test]
+    fn array_assignment_name_starting_with_digit_rejected_in_portable_mode() {
+        let mut lexer = Lexer::with_code("1a=(b c)");
+        lexer.set_mode(portable_mode());
+        let mut parser = Parser::new(&mut lexer);
+
+        let e = parser.simple_command().now_or_never().unwrap().unwrap_err();
+        assert_eq!(
+            e.cause,
+            ErrorCause::Syntax(SyntaxError::NonPortableAssignmentName)
+        );
+    }
+
+    #[test]
+    fn assignment_portable_name_allowed_in_portable_mode() {
+        let mut lexer = Lexer::with_code("_Az9=b");
+        lexer.set_mode(portable_mode());
+        let mut parser = Parser::new(&mut lexer);
+
+        let result = parser.simple_command().now_or_never().unwrap();
+        let sc = result.unwrap().unwrap().unwrap();
+        assert_eq!(sc.assigns.len(), 1);
+        assert_eq!(sc.assigns[0].name, "_Az9");
+        assert_eq!(sc.assigns[0].value.to_string(), "b");
+    }
+
+    #[test]
+    fn assignment_non_portable_name_allowed_without_portable_mode() {
+        let mut lexer = Lexer::with_code("1a=b");
+        let mut parser = Parser::new(&mut lexer);
+
+        let result = parser.simple_command().now_or_never().unwrap();
+        let sc = result.unwrap().unwrap().unwrap();
+        assert_eq!(sc.assigns.len(), 1);
+        assert_eq!(sc.assigns[0].name, "1a");
+        assert_eq!(sc.assigns[0].value.to_string(), "b");
     }
 
     #[test]


### PR DESCRIPTION
A portable name consists solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit. yash-rs previously accepted any literal word before an unquoted `=` as an assignment name, including names starting with a digit or containing characters outside the portable set; other POSIX-conforming shells are not guaranteed to support such names, so this was a non-portable extension.

Add SyntaxError::NonPortableAssignmentName, reported in simple_command() in the portable parsing mode when the assignment name fails the existing is_portable_name check (already used for parameter names, for-loop variable names, and function names). The check applies before array-vs-scalar assignment detection, so array assignments are covered too. Without the portable option, behavior is unchanged.

Add unit tests, extend the simple-y.sh scripted test, and update yash-syntax's changelog and the portable option documentation to match the pattern established for the other portable-mode name checks (e.g. NonPortableFunctionName).

This addresses the "Reject assignment with non-portable names" checklist entry in issue #807.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable script handling so assignment names with invalid characters or leading digits are now rejected.
  * Portable-name rules now apply consistently to assignment syntax, including array-style assignments.
  * Non-portable assignment names continue to work when portable mode is off.

* **Documentation**
  * Updated the portable scripting guide to describe the assignment-name restrictions.
  * Added changelog notes for the new rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->