### PR TITLE
Reject non-portable parameter modifiers

### DIFF
--- a/docs/src/language/words/parameters.md
+++ b/docs/src/language/words/parameters.md
@@ -203,4 +203,7 @@ The result is unspecified in POSIX for:
 - a length or switch modifier applied to special parameter `*` or `@`
 - a trim modifier applied to special parameter `#`, `*`, or `@`
 
+(Since 3.3.0) The [`portable` shell option] rejects these unspecified combinations.
+
 [special parameter]: ../parameters/special.md
+[`portable` shell option]: ../../environment/options.md#portable

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -36,5 +36,6 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - A [function](language/functions.md) name that is quoted, contains an expansion, or starts with a digit. POSIX requires the name to be an unquoted word consisting solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit.
 - A [function](language/functions.md) name that is the same as a [special built-in](builtins/index.html#special-built-ins) utility name (for example, `break` or `export`). POSIX does not allow a function to have the same name as a special built-in. This does not apply to other built-ins, such as `cd`, or to `source`, which is not a POSIX-mandated special built-in.
 - An [assignment](language/commands/simple.md#syntax) name that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
+- A [parameter expansion](language/words/parameters.md) that uses a length or switch modifier with special parameter `*` or `@` (for example, `${#*}` or `${@:+word}`), or a trim modifier with special parameter `#`, `*`, or `@` (for example, `${#%word}` or `${*#word}`). POSIX leaves the results of these combinations unspecified.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -371,6 +371,11 @@ fn parameter_expansion() {
     run("param-p.sh")
 }
 
+#[test]
+fn parameter_expansion_ex() {
+    run("param-y.sh")
+}
+
 // a.k.a. globbing
 #[test]
 fn pathname_expansion() {

--- a/yash-cli/tests/scripted_test/param-y.sh
+++ b/yash-cli/tests/scripted_test/param-y.sh
@@ -1,0 +1,46 @@
+# param-y.sh: yash-specific test of parameter expansion
+
+test_O -d -e 2 'portable option rejects length modifier on $*' -o portable
+echo ${#*}
+__IN__
+
+test_O -d -e 2 'portable option rejects length modifier on $@' -o portable
+echo ${#@}
+__IN__
+
+test_O -d -e 2 'portable option rejects switch modifier on $*' -o portable
+echo ${*+x}
+__IN__
+
+test_O -d -e 2 'portable option rejects switch modifier on $@' -o portable
+echo ${@:+x}
+__IN__
+
+test_O -d -e 2 'portable option rejects trim modifier on $#' -o portable
+echo ${#%x}
+__IN__
+
+test_O -d -e 2 'portable option rejects prefix trim modifier on $#' -o portable
+echo ${##x}
+__IN__
+
+test_O -d -e 2 'portable option rejects trim modifier on $*' -o portable
+echo ${*#x}
+__IN__
+
+test_O -d -e 2 'portable option rejects trim modifier on $@' -o portable
+echo ${@%x}
+__IN__
+
+test_O -e 0 'without portable, unspecified parameter modifiers are accepted'
+set -- ax bx
+: ${#*}
+: ${#@}
+: ${*+x}
+: ${@:+x}
+: ${#%x}
+: ${##x}
+: ${###x}
+: ${*#x}
+: ${@%x}
+__IN__

--- a/yash-semantics/src/expansion/initial/param.rs
+++ b/yash-semantics/src/expansion/initial/param.rs
@@ -91,20 +91,15 @@ impl<S: Runtime + 'static> Expand<S> for ParamRef<'_> {
             }
         }
 
-        // TODO Reject POSIXly unspecified combinations of name and modifier
-
         // Other modifiers //
         match self.modifier {
             Modifier::None | Modifier::Switch(_) => (),
 
-            Modifier::Length => {
-                // TODO Reject ${#*} and ${#@} in POSIX mode
-                match &mut value {
-                    None => value = Some(Value::scalar("0")),
-                    Some(Value::Scalar(v)) => to_length(v),
-                    Some(Value::Array(vs)) => vs.iter_mut().for_each(to_length),
-                }
-            }
+            Modifier::Length => match &mut value {
+                None => value = Some(Value::scalar("0")),
+                Some(Value::Scalar(v)) => to_length(v),
+                Some(Value::Array(vs)) => vs.iter_mut().for_each(to_length),
+            },
 
             Modifier::Trim(trim) => {
                 if let Some(value) = &mut value {

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -58,6 +58,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       special built-in utility name (see
       `yash_env::builtin::is_posix_special_builtin_name`), since POSIX does
       not allow a function to override a special built-in.
+    - `NonPortableParamModifier` for parameter expansions where POSIX leaves
+      the result unspecified because a length or switch modifier is applied to
+      `*` or `@`, or a trim modifier is applied to `#`, `*`, or `@`.
 - `parser::SyntaxError::footnotes` and `parser::ErrorCause::footnotes`, which
   return supplementary footnotes (a `source::pretty::FootnoteType` and its text)
   to render with the error, such as a note that the error is reported because
@@ -108,6 +111,9 @@ A _private dependency_ is used internally and not visible to downstream users.
       with a digit (`SyntaxError::NonPortableAssignmentName`).
     - A function name that is the same as a special built-in utility name
       (`SyntaxError::SpecialBuiltinFunctionName`).
+    - A parameter expansion where POSIX leaves the result unspecified because a
+      length or switch modifier is applied to `*` or `@`, or a trim modifier is
+      applied to `#`, `*`, or `@` (`SyntaxError::NonPortableParamModifier`).
 - `parser::Error::to_report` now attaches a `note:` footnote to errors caused by
   the `portable` option, clarifying that the construct is rejected only because
   the option is enabled.

--- a/yash-syntax/src/parser/error.rs
+++ b/yash-syntax/src/parser/error.rs
@@ -295,6 +295,14 @@ pub enum SyntaxError {
     /// [`POSIX_SPECIAL_BUILTIN_NAMES`](yash_env::builtin::POSIX_SPECIAL_BUILTIN_NAMES)
     /// for the list of names this applies to.
     SpecialBuiltinFunctionName,
+    /// A parameter expansion combines a special parameter with a modifier whose
+    /// result POSIX leaves unspecified, while the `portable` option is on.
+    ///
+    /// POSIX leaves the result unspecified for a length or switch modifier
+    /// applied to the special parameter `*` or `@` (as in `${#*}` or
+    /// `${@:-x}`), and for a trim modifier applied to the special parameter
+    /// `#`, `*`, or `@` (as in `${#%x}` or `${*#x}`).
+    NonPortableParamModifier,
 }
 
 impl SyntaxError {
@@ -408,6 +416,7 @@ impl SyntaxError {
             SpecialBuiltinFunctionName => {
                 "the function name is the same as a special built-in utility"
             }
+            NonPortableParamModifier => "the parameter expansion is not portable",
         }
     }
 
@@ -523,6 +532,9 @@ impl SyntaxError {
             NonPortableFunctionName => "not a POSIX name",
             NonPortableAssignmentName => "not a POSIX variable name",
             SpecialBuiltinFunctionName => "conflicts with a special built-in utility",
+            NonPortableParamModifier => {
+                "POSIX leaves this parameter/modifier combination unspecified"
+            }
         }
     }
 
@@ -552,7 +564,8 @@ impl SyntaxError {
             | NonPortableForName
             | NonPortableFunctionName
             | NonPortableAssignmentName
-            | SpecialBuiltinFunctionName => &[(
+            | SpecialBuiltinFunctionName
+            | NonPortableParamModifier => &[(
                 FootnoteType::Note,
                 "this error is reported because the `portable` shell option is enabled",
             )],

--- a/yash-syntax/src/parser/lex/braced_param.rs
+++ b/yash-syntax/src/parser/lex/braced_param.rs
@@ -76,6 +76,19 @@ fn type_of_id(id: &str) -> Option<ParamType> {
     Some(ParamType::Variable)
 }
 
+/// Tests if POSIX leaves the combination of parameter and modifier unspecified.
+#[must_use]
+fn has_non_portable_modifier(r#type: ParamType, modifier: &Modifier) -> bool {
+    use Modifier::*;
+    use ParamType::Special;
+    use SpecialParam::*;
+
+    matches!(
+        (r#type, modifier),
+        (Special(Asterisk | At), Length | Switch(_)) | (Special(Number | Asterisk | At), Trim(_))
+    )
+}
+
 impl WordLexer<'_, '_> {
     /// Tests if there is a length prefix (`#`).
     ///
@@ -189,6 +202,12 @@ impl WordLexer<'_, '_> {
             }
             (false, suffix) => suffix,
         };
+
+        if self.mode().portable && has_non_portable_modifier(param.r#type, &modifier) {
+            let cause = SyntaxError::NonPortableParamModifier.into();
+            let location = self.location_range(start_index..self.index());
+            return Err(Error { cause, location });
+        }
 
         Ok(Some(BracedParam {
             param,
@@ -864,5 +883,77 @@ mod tests {
         assert_eq!(param.location.range, 0..8);
 
         assert_eq!(lexer.peek_char().now_or_never().unwrap(), Ok(Some('z')));
+    }
+
+    fn portable_mode() -> yash_env::parser::Mode {
+        let mut mode = yash_env::parser::Mode::default();
+        mode.portable = true;
+        mode
+    }
+
+    #[test]
+    fn lexer_braced_param_non_portable_modifier_rejected_in_portable_mode() {
+        for code in [
+            "${#*}", "${#@}", "${*+x}", "${*-x}", "${*=x}", "${*?x}", "${@:+x}", "${@:-x}",
+            "${*#x}", "${*##x}", "${*%x}", "${@#x}", "${@%%x}", "${#%x}", "${##x}", "${###x}",
+        ] {
+            let mut lexer = Lexer::with_code(code);
+            lexer.set_mode(portable_mode());
+            lexer.peek_char().now_or_never().unwrap().unwrap();
+            lexer.consume_char();
+            let mut lexer = WordLexer {
+                lexer: &mut lexer,
+                context: WordContext::Word,
+            };
+
+            let e = lexer.braced_param(0).now_or_never().unwrap().unwrap_err();
+            assert_eq!(
+                e.cause,
+                ErrorCause::Syntax(SyntaxError::NonPortableParamModifier),
+                "code={code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn lexer_braced_param_portable_modifier_accepted_in_portable_mode() {
+        // These combinations are portable (or are disambiguated as a length
+        // modifier or a switch applied to the special parameter `#`), so they
+        // are accepted even with the `portable` option on.
+        for code in [
+            "${#foo}", "${#1}", "${#?}", "${#-}", "${#$}", "${#!}", "${#0}", "${##}", "${#+x}",
+            "${#-x}", "${#?x}", "${#=x}", "${foo#x}", "${foo%x}", "${1#x}", "${?+x}",
+        ] {
+            let mut lexer = Lexer::with_code(code);
+            lexer.set_mode(portable_mode());
+            lexer.peek_char().now_or_never().unwrap().unwrap();
+            lexer.consume_char();
+            let mut lexer = WordLexer {
+                lexer: &mut lexer,
+                context: WordContext::Word,
+            };
+
+            let result = lexer.braced_param(0).now_or_never().unwrap();
+            assert_matches!(result, Ok(Some(_)), "code={code:?}");
+        }
+    }
+
+    #[test]
+    fn lexer_braced_param_non_portable_modifier_accepted_without_portable_mode() {
+        for code in [
+            "${#*}", "${#@}", "${*+x}", "${@:-x}", "${*#x}", "${@%%x}", "${#%x}", "${##x}",
+            "${###x}",
+        ] {
+            let mut lexer = Lexer::with_code(code);
+            lexer.peek_char().now_or_never().unwrap().unwrap();
+            lexer.consume_char();
+            let mut lexer = WordLexer {
+                lexer: &mut lexer,
+                context: WordContext::Word,
+            };
+
+            let result = lexer.braced_param(0).now_or_never().unwrap();
+            assert_matches!(result, Ok(Some(_)), "code={code:?}");
+        }
     }
 }


### PR DESCRIPTION
## Description

Reject POSIXly unspecified special-parameter modifier combinations when the portable parsing mode is enabled: a length or switch modifier on `*` or `@`, and a trim modifier on `#`, `*`, or `@`. Outside portable mode these extensions are still accepted.

Add the NonPortableParamModifier syntax error, parser and scripted tests covering both modes, and document the new check.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable-mode handling for parameter expansions: unsupported modifier combinations are now rejected consistently, matching POSIX portability rules.
  * Added clearer error messaging when a parameter expansion uses a non-portable modifier combination.

* **Documentation**
  * Updated portability docs to explain which parameter-expansion forms are rejected in portable mode.

* **Tests**
  * Expanded test coverage for portable and non-portable parameter-expansion cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->