### PR TITLE
Use CARGO_BUILD_WARNINGS instead of RUSTFLAGS/RUSTDOCFLAGS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
-      RUSTDOCFLAGS: -D warnings
+      CARGO_BUILD_WARNINGS: deny
     permissions:
       contents: read
     steps:
@@ -51,7 +50,7 @@ jobs:
   extra:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      CARGO_BUILD_WARNINGS: deny
     permissions:
       contents: read
     steps:
@@ -63,7 +62,7 @@ jobs:
   release-build:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      CARGO_BUILD_WARNINGS: deny
     permissions:
       contents: read
     steps:
@@ -102,6 +101,8 @@ jobs:
       run: ./check-msrv.sh -v
   windows:
     runs-on: windows-latest
+    env:
+      CARGO_BUILD_WARNINGS: deny
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Rust 1.97.0 adds CARGO_BUILD_WARNINGS, a Cargo-level setting that denies build and doc warnings without relying on
RUSTFLAGS/RUSTDOCFLAGS. Switch the check, extra, and release-build jobs to it, replacing the separate RUSTFLAGS and RUSTDOCFLAGS entries.

Also set CARGO_BUILD_WARNINGS: deny on the windows job, which previously had no warnings-as-errors setting at all.

See: https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and validation workflow to use a more consistent warnings-as-errors setting across CI jobs.
  * Improved Windows job configuration to match the rest of the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->