### PR TITLE
Reject non-portable alias names in portable mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "assert_matches",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.19.0" }
+yash-builtin = { path = "yash-builtin", version = "0.20.0" }
 yash-env = { path = "yash-env", version = "0.15.3" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }

--- a/docs/src/builtins/alias.md
+++ b/docs/src/builtins/alias.md
@@ -26,6 +26,8 @@ Each operand must be of the form `name=value` or `name`. The first form defines 
 
 It is an error if an operand without `=` refers to an alias that does not exist.
 
+(Since 3.3.1) With the [`portable` option](../environment/options.md#portable) on, it is an error to define an alias whose name contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`. The alias is not defined in that case.
+
 ## Exit status
 
 Zero unless an error occurs.

--- a/docs/src/language/aliases.md
+++ b/docs/src/language/aliases.md
@@ -38,7 +38,7 @@ This expands to `test "$(date +%Y)" = 2001 && echo "Happy millennium!"`, printin
 
 By POSIX.1-2024, alias names can use ASCII letters, digits, and `!`, `%`, `,`, `-`, `@`, `_`. Yash-rs allows any literal word as an alias name (no [quotes](words/quoting.md) or [expansions](words/index.html#word-expansion)). Alias names are case-sensitive.
 
-(Since 3.3.1) When the [`portable` option](../environment/options.md#portable) is set, aliases with other characters in their names are ignored.
+(Since 3.3.1) When the [`portable` option](../environment/options.md#portable) is set, aliases with other characters in their names are ignored. Additionally, the [`alias` built-in](../builtins/alias.md) refuses to define such an alias, reporting an error instead.
 
 ## Recursion
 

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -37,9 +37,10 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - (Since 3.3.0) A [function](language/functions.md) name that is the same as a [special built-in](builtins/index.html#special-built-ins) utility name (for example, `break` or `export`). POSIX does not allow a function to have the same name as a special built-in. This does not apply to other built-ins, such as `cd`, or to `source`, which is not a POSIX-mandated special built-in.
 - (Since 3.3.0) An [assignment](language/commands/simple.md#syntax) name that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
 - (Since 3.3.0) A [parameter expansion](language/words/parameters.md) that uses a length or switch modifier with special parameter `*` or `@` (for example, `${#*}` or `${@:+word}`), or a trim modifier with special parameter `#`, `*`, or `@` (for example, `${#%word}` or `${*#word}`). POSIX leaves the results of these combinations unspecified.
+- (Since 3.3.1) Defining an [alias](language/aliases.md) with the [`alias` built-in](builtins/alias.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
 
 The option also makes the shell ignore the following non-portable constructs:
 
-- (Since 3.3.1) An [alias](language/aliases.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
+- (Since 3.3.1) Substituting an [alias](language/aliases.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,10 +13,20 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
-## [0.19.1] - Unreleased
+## [0.20.0] - Unreleased
+
+### Added
+
+- `alias::semantics::Error::NonPortableAliasName`, a new error variant that
+  `alias::semantics::Command::execute` now returns when an operand would
+  define an alias whose name is not POSIXly portable while the `portable`
+  shell option is on. The alias is not defined in that case.
+- The `alias` built-in (`alias::main`) now fails, reporting an error, in the
+  same situation.
 
 ### Changed
 
+- `alias::semantics::Error` is now `#[non_exhaustive]`.
 - Private dependency versions:
     - itertools 0.14.0 → 0.15.0
 
@@ -851,7 +861,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
-[0.19.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.19.1
+[0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.20.0
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.19.0
 [0.18.2]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.2
 [0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.1

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -73,8 +73,14 @@ where
 mod tests {
     use super::*;
     use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::VirtualSystem;
+    use yash_env::option::Option::Portable;
+    use yash_env::option::State::On;
     use yash_env::semantics::ExitStatus;
     use yash_env::source::Source;
+    use yash_env::system::Concurrent;
+    use yash_env::test_helper::assert_stderr;
 
     #[test]
     fn builtin_defines_alias() {
@@ -94,6 +100,42 @@ mod tests {
         assert_eq!(alias.origin.code.start_line_number.get(), 1);
         assert_eq!(*alias.origin.code.source, Source::Unknown);
         assert_eq!(alias.origin.range, 0..11);
+    }
+
+    #[test]
+    fn builtin_errors_on_non_portable_alias_name() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["a.b=x"]);
+
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        assert_eq!(result, Result::new(ExitStatus::FAILURE));
+        assert!(!env.aliases.contains("a.b"));
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("not portable"), "stderr = {stderr:?}");
+            assert!(stderr.contains("a.b"), "stderr = {stderr:?}");
+        });
+    }
+
+    #[test]
+    fn builtin_mixed_non_portable_name_and_other_error() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["a.b=x", "missing"]);
+
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        assert_eq!(result, Result::new(ExitStatus::FAILURE));
+        assert!(!env.aliases.contains("a.b"));
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("not portable"), "stderr = {stderr:?}");
+            assert!(stderr.contains("not found"), "stderr = {stderr:?}");
+        });
     }
 
     #[test]

--- a/yash-builtin/src/alias.rs
+++ b/yash-builtin/src/alias.rs
@@ -27,6 +27,8 @@ use crate::common::report::report_error;
 use crate::common::report::report_failure;
 use crate::common::syntax::Mode;
 use crate::common::syntax::parse_arguments;
+use std::mem::Discriminant;
+use std::mem::discriminant;
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::semantics::Field;
@@ -43,6 +45,29 @@ pub struct Command {
 
 pub mod semantics;
 
+/// Groups the given errors by kind.
+///
+/// Errors of the same kind (e.g. two [`NonPortableAliasName`] errors) end up
+/// in the same group regardless of where they occur among the operands, so
+/// that [`main`] can report each kind as its own message rather than merging
+/// unrelated kinds of errors under one misleading shared title. The groups
+/// are returned in the order in which each kind first appears in `errors`.
+///
+/// [`NonPortableAliasName`]: semantics::Error::NonPortableAliasName
+fn group_errors_by_kind(
+    errors: &[semantics::Error],
+) -> Vec<(Discriminant<semantics::Error>, Vec<&semantics::Error>)> {
+    let mut groups: Vec<(_, Vec<_>)> = Vec::new();
+    for error in errors {
+        let kind = discriminant(error);
+        match groups.iter_mut().find(|(k, _)| *k == kind) {
+            Some((_, group)) => group.push(error),
+            None => groups.push((kind, vec![error])),
+        }
+    }
+    groups
+}
+
 /// Entry point for executing the `alias` built-in
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
@@ -53,10 +78,12 @@ where
     match parse_arguments(&[], mode, args) {
         Ok((_options, operands)) => {
             let command = Command { operands };
-            let (result, errors) = command.execute(env).await;
-            let mut result = output(env, &result).await;
-            if let Some(report) = merge_reports(&errors) {
-                result = result.max(report_failure(env, report).await);
+            let (output_string, errors) = command.execute(env).await;
+            let mut result = output(env, &output_string).await;
+            for (_, group) in group_errors_by_kind(&errors) {
+                if let Some(report) = merge_reports(group) {
+                    result = result.max(report_failure(env, report).await);
+                }
             }
             result
         }
@@ -133,9 +160,65 @@ mod tests {
         assert_eq!(result, Result::new(ExitStatus::FAILURE));
         assert!(!env.aliases.contains("a.b"));
         assert_stderr(&state, |stderr| {
+            // The two unrelated kinds of errors are reported as separate
+            // messages, each with a title that accurately describes it,
+            // rather than being merged under one misleading shared title.
+            assert!(
+                stderr.contains("cannot define alias with non-portable name"),
+                "stderr = {stderr:?}"
+            );
+            assert!(
+                stderr.contains("cannot print alias definition"),
+                "stderr = {stderr:?}"
+            );
             assert!(stderr.contains("not portable"), "stderr = {stderr:?}");
             assert!(stderr.contains("not found"), "stderr = {stderr:?}");
         });
+    }
+
+    #[test]
+    fn group_errors_by_kind_merges_non_adjacent_errors_of_the_same_kind() {
+        let a_b = semantics::Error::NonPortableAliasName {
+            name: Field::dummy("a.b"),
+        };
+        let missing = semantics::Error::NonExistentAlias {
+            name: Field::dummy("missing"),
+        };
+        let c_d = semantics::Error::NonPortableAliasName {
+            name: Field::dummy("c.d"),
+        };
+        let errors = vec![a_b.clone(), missing.clone(), c_d.clone()];
+
+        let groups = group_errors_by_kind(&errors);
+
+        assert_eq!(
+            groups,
+            [
+                (discriminant(&a_b), vec![&a_b, &c_d]),
+                (discriminant(&missing), vec![&missing])
+            ]
+        );
+    }
+
+    #[test]
+    fn group_errors_by_kind_orders_groups_by_first_occurrence() {
+        let missing = semantics::Error::NonExistentAlias {
+            name: Field::dummy("missing"),
+        };
+        let a_b = semantics::Error::NonPortableAliasName {
+            name: Field::dummy("a.b"),
+        };
+        let errors = vec![missing.clone(), a_b.clone()];
+
+        let groups = group_errors_by_kind(&errors);
+
+        assert_eq!(
+            groups,
+            [
+                (discriminant(&missing), vec![&missing]),
+                (discriminant(&a_b), vec![&a_b])
+            ]
+        );
     }
 
     #[test]

--- a/yash-builtin/src/alias/semantics.rs
+++ b/yash-builtin/src/alias/semantics.rs
@@ -21,16 +21,26 @@ use thiserror::Error;
 use yash_env::Env;
 use yash_env::alias::Alias;
 use yash_env::alias::HashEntry;
+use yash_env::alias::is_portable_alias_name;
+use yash_env::option::Option::Portable;
+use yash_env::option::State::On;
 use yash_env::semantics::Field;
-use yash_env::source::pretty::{Report, ReportType, Snippet};
+use yash_env::source::Location;
+use yash_env::source::pretty::{Footnote, FootnoteType, Report, ReportType, Snippet};
 use yash_quote::quoted;
 
 /// Error in executing the alias built-in
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// Printing a non-existent alias
     #[error("alias {name} not found")]
     NonExistentAlias { name: Field },
+
+    /// Defining an alias whose name is not POSIXly portable while the
+    /// [`Portable`] option is on
+    #[error("alias name `{name}` is not portable")]
+    NonPortableAliasName { name: Field },
 }
 
 impl Error {
@@ -39,12 +49,21 @@ impl Error {
     pub fn to_report(&self) -> Report<'_> {
         let mut report = Report::new();
         report.r#type = ReportType::Error;
-        report.title = "cannot print alias definition".into();
-        report.snippets = match self {
+        match self {
             Self::NonExistentAlias { name } => {
-                Snippet::with_primary_span(&name.origin, self.to_string().into())
+                report.title = "cannot print alias definition".into();
+                report.snippets = Snippet::with_primary_span(&name.origin, self.to_string().into());
             }
-        };
+            Self::NonPortableAliasName { name } => {
+                report.title = "cannot define alias with non-portable name".into();
+                report.snippets = Snippet::with_primary_span(&name.origin, self.to_string().into());
+                report.footnotes.push(Footnote {
+                    r#type: FootnoteType::Note,
+                    label: "this error is reported because the `portable` shell option is enabled"
+                        .into(),
+                });
+            }
+        }
         report
     }
 }
@@ -59,8 +78,13 @@ impl<'a> From<&'a Error> for Report<'a> {
 /// Defines an alias.
 ///
 /// If `name_value` is of the form `name=value`, defines an alias named `name`
-/// that expands to `value`. Otherwise, returns `Err(name_value)`.
-fn define<S>(env: &mut Env<S>, name_value: Field) -> Result<(), Field> {
+/// that expands to `value` and returns `Ok(Ok(()))`. Otherwise, returns
+/// `Err(name_value)`.
+///
+/// When the [`Portable`] option is on and the alias name is not POSIXly
+/// portable, the alias is not defined and
+/// `Ok(Err(Error::NonPortableAliasName { .. }))` is returned instead.
+fn define<S>(env: &mut Env<S>, name_value: Field) -> Result<Result<(), Error>, Field> {
     let Some(equal) = name_value.value.find('=') else {
         return Err(name_value);
     };
@@ -68,17 +92,31 @@ fn define<S>(env: &mut Env<S>, name_value: Field) -> Result<(), Field> {
     let name = {
         let mut name = name_value.value;
         name.truncate(equal);
-        // TODO Reject invalid name
         name.shrink_to_fit();
         name
     };
+
+    if env.options.get(Portable) == On && !is_portable_alias_name(&name) {
+        let name_len = name.chars().count();
+        let start = name_value.origin.range.start;
+        return Ok(Err(Error::NonPortableAliasName {
+            name: Field {
+                value: name,
+                origin: Location {
+                    range: start..start + name_len,
+                    code: name_value.origin.code.clone(),
+                },
+            },
+        }));
+    }
+
     // TODO Support global aliases
     let global = false;
 
     env.aliases
         .replace(HashEntry::new(name, replacement, global, name_value.origin));
 
-    Ok(())
+    Ok(Ok(()))
 }
 
 /// Prints the definition of an alias.
@@ -128,9 +166,13 @@ impl Command {
             }
         } else {
             for operand in self.operands {
-                if let Err(operand) = define(env, operand) {
-                    let result = find_and_print(env, operand, &mut output);
-                    errors.extend(result.err());
+                match define(env, operand) {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => errors.push(error),
+                    Err(operand) => {
+                        let result = find_and_print(env, operand, &mut output);
+                        errors.extend(result.err());
+                    }
                 }
             }
         }
@@ -158,7 +200,7 @@ mod tests {
             },
         );
 
-        assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(Ok(())));
         assert_eq!(
             *env.aliases.get("foo").unwrap().0,
             Alias {
@@ -177,6 +219,45 @@ mod tests {
         let result = define(&mut env, field.clone());
         assert_eq!(result, Err(field));
         assert_eq!(env.aliases.len(), 0);
+    }
+
+    #[test]
+    fn defining_non_portable_alias_name_with_portable_option() {
+        let mut env = Env::new_virtual();
+        env.options.set(Portable, On);
+        let origin = Location::dummy("a.b=x");
+
+        let result = define(
+            &mut env,
+            Field {
+                value: "a.b=x".into(),
+                origin: origin.clone(),
+            },
+        );
+
+        assert_eq!(
+            result,
+            Ok(Err(Error::NonPortableAliasName {
+                name: Field {
+                    value: "a.b".into(),
+                    origin: Location {
+                        range: 0..3,
+                        code: origin.code.clone(),
+                    },
+                },
+            }))
+        );
+        assert!(!env.aliases.contains("a.b"));
+    }
+
+    #[test]
+    fn defining_non_portable_alias_name_without_portable_option() {
+        let mut env = Env::new_virtual();
+
+        let result = define(&mut env, Field::dummy("a.b=x"));
+
+        assert_eq!(result, Ok(Ok(())));
+        assert!(env.aliases.contains("a.b"));
     }
 
     #[test]
@@ -252,6 +333,38 @@ mod tests {
                 name: Field::dummy("bar")
             }]
         );
+    }
+
+    #[test]
+    fn executing_collects_non_portable_name_and_other_errors() {
+        let mut env = Env::new_virtual();
+        env.options.set(Portable, On);
+        let operands = Field::dummies(["a.b=x", "missing", "good=1"]);
+        let a_b_code = operands[0].origin.code.clone();
+        let command = Command { operands };
+
+        let (output, errors) = command.execute(&mut env).now_or_never().unwrap();
+
+        assert_eq!(output, "");
+        assert_eq!(
+            errors,
+            [
+                Error::NonPortableAliasName {
+                    name: Field {
+                        value: "a.b".into(),
+                        origin: Location {
+                            range: 0..3,
+                            code: a_b_code,
+                        },
+                    }
+                },
+                Error::NonExistentAlias {
+                    name: Field::dummy("missing")
+                },
+            ]
+        );
+        assert!(!env.aliases.contains("a.b"));
+        assert!(env.aliases.contains("good"));
     }
 
     #[test]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - With the `portable` shell option enabled, aliases with names containing
   characters other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`
-  are ignored during alias substitution.
+  are ignored during alias substitution. The `alias` built-in also now reports
+  an error, instead of defining the alias, when such a name is given as an
+  operand.
 
 ## [3.3.0] - 2026-07-09
 

--- a/yash-cli/tests/scripted_test/alias-y.sh
+++ b/yash-cli/tests/scripted_test/alias-y.sh
@@ -1,10 +1,21 @@
 # alias-y.sh: yash-specific test of aliases
 
-test_oE 'portable option ignores aliases with non-portable names' -o portable
-alias a.b='echo substituted'
-a.b 2>/dev/null || echo ignored
+test_O 'portable option ignores aliases with non-portable names' -o portable
+alias no.such.utility='echo substituted'
+no.such.utility
 __IN__
-ignored
+
+test_oE 'alias built-in errors on non-portable alias names' -o portable
+alias a.b='echo substituted' 2>result
+echo $?
+grep -Fq 'not portable' result && echo errored
+grep -Fq 'a.b' result && echo name_shown
+alias a.b >/dev/null 2>&1 || echo not_defined
+__IN__
+1
+errored
+name_shown
+not_defined
 __OUT__
 
 test_oE 'portable option expands aliases with portable names' -o portable

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -15,6 +15,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ## [0.15.4] - Unreleased
 
+### Added
+
+- `alias::is_portable_alias_name`, which tests whether a string is a
+  POSIXly-portable alias name (non-empty and consisting only of ASCII letters,
+  digits, and the characters `!`, `%`, `,`, `-`, `@`, and `_`).
+
 ### Changed
 
 - Private dependency versions:

--- a/yash-env/src/alias.rs
+++ b/yash-env/src/alias.rs
@@ -197,3 +197,29 @@ impl<S: Debug> Glossary for Env<S> {
         self.aliases.is_empty()
     }
 }
+
+/// Tests if a string is a POSIXly-portable alias name.
+///
+/// A portable alias name is a non-empty string consisting only of ASCII
+/// letters, digits, and the characters `!`, `%`, `,`, `-`, `@`, and `_`.
+#[must_use]
+pub fn is_portable_alias_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '!' | '%' | ',' | '-' | '@' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_alias_name() {
+        assert!(is_portable_alias_name("aZ09!%,-@_"));
+        assert!(!is_portable_alias_name(""));
+        assert!(!is_portable_alias_name("a.b"));
+        assert!(!is_portable_alias_name("a/b"));
+        assert!(!is_portable_alias_name("a b"));
+        assert!(!is_portable_alias_name("a\u{e9}"));
+    }
+}

--- a/yash-syntax/src/alias.rs
+++ b/yash-syntax/src/alias.rs
@@ -21,25 +21,3 @@
 
 #[doc(no_inline)]
 pub use yash_env::alias::*;
-
-/// Tests if a string is a POSIXly-portable alias name.
-pub(crate) fn is_portable_alias_name(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '!' | '%' | ',' | '-' | '@' | '_'))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn portable_alias_name() {
-        assert!(is_portable_alias_name("aZ09!%,-@_"));
-        assert!(!is_portable_alias_name(""));
-        assert!(!is_portable_alias_name("a.b"));
-        assert!(!is_portable_alias_name("a/b"));
-        assert!(!is_portable_alias_name("a b"));
-        assert!(!is_portable_alias_name("a\u{e9}"));
-    }
-}


### PR DESCRIPTION
## Description

KornShell and mksh raise an error when attempting to define an alias with an invalid name. yash should do the same when the `portable` option is enabled.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * With the `portable` option enabled, defining aliases with non-portable names now reports an error and does not create the alias.
  * Alias substitution continues to ignore non-portable alias names.

* **Bug Fixes**
  * Errors from multiple alias definitions are now reported separately with accurate messages.

* **Documentation**
  * Updated alias portability behavior in user documentation and changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->