### PR TITLE
Reject increment and decrement operators in portable mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,14 +502,14 @@ dependencies = [
 
 [[package]]
 name = "yash-arith"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "yash-builtin"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "assert_matches",
  "either",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -598,7 +598,7 @@ version = "1.1.2"
 
 [[package]]
 name = "yash-semantics"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "assert_matches",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ tempfile = "3.8.0"
 thiserror = "2.0.4"
 unix_path = "1.0.1"
 unix_str = "1.0.0"
-yash-arith = { path = "yash-arith", version = "0.2.3" }
-yash-builtin = { path = "yash-builtin", version = "0.20.0" }
+yash-arith = { path = "yash-arith", version = "0.3.0" }
+yash-builtin = { path = "yash-builtin", version = "0.21.0" }
 yash-env = { path = "yash-env", version = "0.15.4" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.14.0" }
 yash-quote = { path = "yash-quote", version = "1.1.1" }
-yash-semantics = { path = "yash-semantics", version = "0.18.0" }
+yash-semantics = { path = "yash-semantics", version = "0.19.0" }
 yash-syntax = { path = "yash-syntax", version = "0.23.0" }
 
 [workspace.lints.clippy]

--- a/docs/src/arithmetic.md
+++ b/docs/src/arithmetic.md
@@ -148,3 +148,5 @@ POSIX.1-2024 defines arithmetic expressions on the basis of C.
 POSIX requires support for `signed long` integers. This implementation uses signed 64-bit integers, which is at least as wide as `long` on all common platforms. Future versions may support wider integers. Other implementations may only support narrower integers.
 
 POSIX does not require support for the `++` and `--` operators. Dash 0.5.12 treats the `++` prefix operator as two `+` operators, effectively making it a no-op.
+
+(Since 3.3.2) The [`portable` shell option](environment/options.md#portable) rejects the use of the `++` and `--` operators.

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -38,6 +38,7 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - (Since 3.3.0) An [assignment](language/commands/simple.md#syntax) name that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
 - (Since 3.3.1) An [array assignment](language/parameters/variables.md#arrays) (`name=(...)`). Array assignment is a yash extension that POSIX does not specify.
 - (Since 3.3.0) A [parameter expansion](language/words/parameters.md) that uses a length or switch modifier with special parameter `*` or `@` (for example, `${#*}` or `${@:+word}`), or a trim modifier with special parameter `#`, `*`, or `@` (for example, `${#%word}` or `${*#word}`). POSIX leaves the results of these combinations unspecified.
+- (Since 3.3.2) The increment and decrement operators (`++` and `--`) in an [arithmetic expansion](language/words/arithmetic.md). POSIX does not require these operators.
 - (Since 3.3.1) Defining an [alias](language/aliases.md) with the [`alias` built-in](builtins/alias.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-arith/CHANGELOG.md
+++ b/yash-arith/CHANGELOG.md
@@ -13,7 +13,16 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
-## [0.2.4] - Unreleased
+## [0.3.0] - Unreleased
+
+### Added
+
+- `Config` and `eval_with_config`, which allow callers to reject non-portable
+  constructs before evaluating an arithmetic expression. The original `eval`
+  function remains available and uses the default configuration.
+- `PortabilityError` and the `ErrorCause::PortabilityError` variant for
+  reporting non-portable constructs. Currently, increment and decrement
+  operators can be reported as non-portable.
 
 ### Changed
 
@@ -70,7 +79,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Fundamental items for performing arithmetic expansion
 
-[0.2.4]: https://github.com/magicant/yash-rs/releases/tag/yash-arith-0.2.4
+[0.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-arith-0.3.0
 [0.2.3]: https://github.com/magicant/yash-rs/releases/tag/yash-arith-0.2.3
 [0.2.2]: https://github.com/magicant/yash-rs/releases/tag/yash-arith-0.2.2
 [0.2.1]: https://github.com/magicant/yash-rs/releases/tag/yash-arith-0.2.1

--- a/yash-arith/Cargo.toml
+++ b/yash-arith/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-arith"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -25,8 +25,9 @@ use crate::token::TokenValue;
 use std::ops::Range;
 use thiserror::Error;
 
-// TODO: POSIX does not require the increment/decrement operators. Maybe we
-// should provide an option to reject those non-portable operators.
+pub(crate) mod portability;
+
+pub use portability::PortabilityError;
 
 /// Prefix operator kind
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/yash-arith/src/ast/portability.rs
+++ b/yash-arith/src/ast/portability.rs
@@ -1,0 +1,135 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Items for verifying portability of parsed expressions
+
+use super::Ast;
+use super::PostfixOperator;
+use super::PrefixOperator;
+use std::ops::Range;
+use thiserror::Error;
+
+/// Cause of an error because an expression contains a non-portable construct
+#[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+pub enum PortabilityError {
+    /// An increment or decrement operator is used while the `portable` option
+    /// is on.
+    #[error("the increment and decrement operators are not portable")]
+    IncrementDecrement,
+}
+
+/// Description of a non-portable construct found in an expression
+#[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[error("{cause}")]
+pub struct Error {
+    /// Cause of the error
+    pub cause: PortabilityError,
+    /// Range of the non-portable construct in the parsed expression
+    pub location: Range<usize>,
+}
+
+/// Checks that the parsed expression contains no non-portable constructs.
+pub fn check(ast: &[Ast<'_>]) -> Result<(), Error> {
+    let location = ast
+        .iter()
+        .filter_map(|node| match node {
+            Ast::Prefix {
+                operator: PrefixOperator::Increment | PrefixOperator::Decrement,
+                location,
+            }
+            | Ast::Postfix {
+                operator: PostfixOperator::Increment | PostfixOperator::Decrement,
+                location,
+            } => Some(location),
+            _ => None,
+        })
+        .min_by_key(|location| location.start);
+
+    match location {
+        Some(location) => Err(Error {
+            cause: PortabilityError::IncrementDecrement,
+            location: location.clone(),
+        }),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::parse;
+    use crate::token::PeekableTokens;
+
+    fn check_expression(expression: &str) -> Result<(), Error> {
+        let ast = parse(PeekableTokens::from(expression)).unwrap();
+        check(&ast)
+    }
+
+    #[test]
+    fn portable_expression() {
+        assert_eq!(check_expression("foo = -(1 + 2)"), Ok(()));
+    }
+
+    #[test]
+    fn prefix_increment_and_decrement() {
+        for (expression, location) in [("  ++foo", 2..4), ("--bar  ", 0..2)] {
+            assert_eq!(
+                check_expression(expression),
+                Err(Error {
+                    cause: PortabilityError::IncrementDecrement,
+                    location,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn postfix_increment_and_decrement() {
+        for (expression, location) in [("  foo++", 5..7), ("bar--  ", 3..5)] {
+            assert_eq!(
+                check_expression(expression),
+                Err(Error {
+                    cause: PortabilityError::IncrementDecrement,
+                    location,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn non_portable_operator_in_unevaluated_operand() {
+        assert_eq!(
+            check_expression("1 || foo++"),
+            Err(Error {
+                cause: PortabilityError::IncrementDecrement,
+                location: 8..10,
+            })
+        );
+    }
+
+    #[test]
+    fn first_non_portable_operator_in_source_order() {
+        // Prefix operators appear in the AST from the innermost to the
+        // outermost, which is the reverse of their order in the source.
+        assert_eq!(
+            check_expression("++--foo + bar++"),
+            Err(Error {
+                cause: PortabilityError::IncrementDecrement,
+                location: 0..2,
+            })
+        );
+    }
+}

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -45,6 +45,7 @@ pub use token::Value;
 
 mod ast;
 
+pub use ast::PortabilityError;
 pub use ast::SyntaxError;
 
 mod env;
@@ -55,12 +56,35 @@ mod eval;
 
 pub use eval::EvalError;
 
+/// Configuration for arithmetic expansion
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct Config {
+    /// Restrict arithmetic expansion to portable constructs only.
+    ///
+    /// If this option is on, the increment and decrement operators (`++` and
+    /// `--`) are rejected with a [`PortabilityError::IncrementDecrement`]
+    /// error.
+    pub portable: bool,
+}
+
+impl Config {
+    /// Creates a new configuration with the default settings.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Cause of an arithmetic expansion error
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
 #[error(transparent)]
 pub enum ErrorCause<E1, E2> {
     /// Syntax error parsing the expression
     SyntaxError(#[from] SyntaxError),
+    /// Error because the parsed expression contains a non-portable construct
+    PortabilityError(#[from] PortabilityError),
     /// Error evaluating the parsed expression
     EvalError(#[from] EvalError<E1, E2>),
 }
@@ -90,6 +114,15 @@ impl<E1, E2> From<ast::Error> for Error<E1, E2> {
     }
 }
 
+impl<E1, E2> From<ast::portability::Error> for Error<E1, E2> {
+    fn from(e: ast::portability::Error) -> Self {
+        Error {
+            cause: e.cause.into(),
+            location: e.location,
+        }
+    }
+}
+
 impl<E1, E2> From<eval::Error<E1, E2>> for Error<E1, E2> {
     fn from(e: eval::Error<E1, E2>) -> Self {
         Error {
@@ -99,22 +132,49 @@ impl<E1, E2> From<eval::Error<E1, E2>> for Error<E1, E2> {
     }
 }
 
+/// Performs arithmetic expansion with the specified configuration.
+pub fn eval_with_config<E: Env>(
+    expression: &str,
+    env: &mut E,
+    config: Config,
+) -> Result<Value, Error<E::GetVariableError, E::AssignVariableError>> {
+    let tokens = PeekableTokens::from(expression);
+    let ast = ast::parse(tokens)?;
+    if config.portable {
+        ast::portability::check(&ast)?;
+    }
+    let term = eval::eval(&ast, env)?;
+    let value = eval::into_value(term, env)?;
+    Ok(value)
+}
+
 /// Performs arithmetic expansion
 pub fn eval<E: Env>(
     expression: &str,
     env: &mut E,
 ) -> Result<Value, Error<E::GetVariableError, E::AssignVariableError>> {
-    let tokens = PeekableTokens::from(expression);
-    let ast = ast::parse(tokens)?;
-    let term = eval::eval(&ast, env)?;
-    let value = eval::into_value(term, env)?;
-    Ok(value)
+    eval_with_config(expression, env, Config::default())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn eval_with_portable_config_rejects_before_evaluation() {
+        let mut env = HashMap::from([("foo".to_owned(), "41".to_owned())]);
+        let config = Config { portable: true };
+
+        assert_eq!(
+            eval_with_config("foo++", &mut env, config),
+            Err(Error {
+                cause: ErrorCause::PortabilityError(PortabilityError::IncrementDecrement),
+                location: 3..5,
+            })
+        );
+        assert_eq!(env["foo"], "41");
+    }
 
     #[test]
     fn decimal_integer_constants() {

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.21.0] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-semantics (optional) 0.18.0 → 0.19.0
+
 ## [0.20.0] - 2026-07-12
 
 ### Added
@@ -883,6 +890,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.21.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.21.0
 [0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.20.0
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.19.0
 [0.18.2]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.18.2

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,14 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - Unreleased
+
+### Changed
+
+- With the `portable` shell option enabled, arithmetic expansions now reject
+  the increment and decrement operators (`++` and `--`) because POSIX does not
+  require them.
+
 ## [3.3.1] - 2026-07-12
 
 ### Changed
@@ -401,6 +409,7 @@ later.
 
 - Initial release of the shell
 
+[3.3.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.2
 [3.3.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.1
 [3.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.0
 [3.2.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.2.2

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.3.1"
+version = "3.3.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -132,6 +132,11 @@ fn arithmetic_expansion() {
 }
 
 #[test]
+fn arithmetic_expansion_ex() {
+    run("arith-y.sh")
+}
+
+#[test]
 fn asynchronous_list() {
     run("async-p.sh")
 }

--- a/yash-cli/tests/scripted_test/arith-y.sh
+++ b/yash-cli/tests/scripted_test/arith-y.sh
@@ -1,0 +1,19 @@
+# arith-y.sh: yash-specific tests of arithmetic expansion
+
+# POSIX does not require the increment and decrement operators. The portable
+# option rejects them in arithmetic expansion.
+
+test_O -d -e 2 'portable option rejects prefix increment' -o portable
+echo $((++foo))
+__IN__
+
+test_O -d -e 2 'portable option rejects postfix decrement' -o portable
+echo $((foo--))
+__IN__
+
+test_oE 'without portable, increment and decrement operators are accepted'
+foo=1
+echo $((++foo)) $((foo--)) "$foo"
+__IN__
+2 2 1
+__OUT__

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,6 +13,19 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.19.0] - Unreleased
+
+### Added
+
+- `expansion::initial::arith::ArithError::NonPortableIncrementDecrement`,
+  which arithmetic expansion now returns when the `portable` shell option is
+  enabled and the expression contains an increment or decrement operator.
+
+### Changed
+
+- Public dependency versions:
+    - yash-arith 0.2.3 → 0.3.0
+
 ## [0.18.1] - 2026-07-12
 
 ### Changed
@@ -566,6 +579,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.19.0
 [0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.18.1
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.18.0
 [0.17.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.17.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-semantics/src/expansion.rs
+++ b/yash-semantics/src/expansion.rs
@@ -237,11 +237,15 @@ impl ErrorCause {
         use ErrorCause::*;
         match self {
             CommandSubstError(_)
-            | ArithError(_)
             | AssignReadOnly(_)
             | VacantExpansion(_)
             | NonassignableParameter(_)
             | Interrupted(_) => None,
+
+            ArithError(self::ArithError::NonPortableIncrementDecrement) => {
+                Some("this error is reported because the `portable` shell option is enabled")
+            }
+            ArithError(_) => None,
 
             UnsetParameter { .. } => Some("unset parameters are disallowed by the nounset option"),
         }

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -27,8 +27,9 @@ use crate::expansion::AssignReadOnlyError;
 use crate::expansion::expand_text;
 use std::ops::Range;
 use std::rc::Rc;
-use yash_arith::eval;
-use yash_env::option::Option::Unset;
+use yash_arith::Config;
+use yash_arith::eval_with_config;
+use yash_env::option::Option::{Portable, Unset};
 use yash_env::option::State::{Off, On};
 use yash_env::variable::Scope::Global;
 use yash_syntax::source::Code;
@@ -82,6 +83,11 @@ pub enum ArithError {
     #[error("invalid use of operator")]
     InvalidOperator,
 
+    /// An increment or decrement operator is used while the `portable` option
+    /// is on.
+    #[error("the increment and decrement operators are not portable")]
+    NonPortableIncrementDecrement,
+
     /// A variable value that is not a valid number
     #[error("invalid variable value: {0:?}")]
     InvalidVariableValue(String),
@@ -120,6 +126,7 @@ impl ArithError {
             | MissingOperator
             | ColonWithoutQuestion
             | InvalidOperator
+            | NonPortableIncrementDecrement
             | InvalidVariableValue(_)
             | Overflow
             | DivisionByZero
@@ -182,6 +189,11 @@ fn convert_error_cause(
                 ErrorCause::ArithError(ColonWithoutQuestion)
             }
             yash_arith::SyntaxError::InvalidOperator => ErrorCause::ArithError(InvalidOperator),
+        },
+        yash_arith::ErrorCause::PortabilityError(e) => match e {
+            yash_arith::PortabilityError::IncrementDecrement => {
+                ErrorCause::ArithError(NonPortableIncrementDecrement)
+            }
         },
         yash_arith::ErrorCause::EvalError(e) => match e {
             yash_arith::EvalError::InvalidVariableValue(value) => {
@@ -263,13 +275,16 @@ pub async fn expand<S: Runtime + 'static>(
         env.last_command_subst_exit_status = exit_status;
     }
 
-    let result = eval(
+    let mut config = Config::new();
+    config.portable = env.inner.options.get(Portable) == On;
+    let result = eval_with_config(
         &expression,
         &mut VarEnv {
             env: env.inner,
             expression: &expression,
             expansion_location: location,
         },
+        config,
     );
 
     match result {
@@ -389,6 +404,38 @@ mod tests {
         };
         assert_eq!(result, Ok(Phrase::Char(c)));
         assert_eq!(env.last_command_subst_exit_status, None);
+    }
+
+    #[test]
+    fn increment_decrement_allowed_without_portable_option() {
+        let text = "foo++".parse().unwrap();
+        let location = Location::dummy("my location");
+        let mut env = yash_env::Env::new_virtual();
+        let mut env2 = Env::new(&mut env);
+
+        let result = expand(&text, &location, &mut env2).now_or_never().unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(env.variables.get_scalar("foo"), Some("1"));
+    }
+
+    #[test]
+    fn increment_decrement_rejected_with_portable_option() {
+        let text = "foo++".parse().unwrap();
+        let location = Location::dummy("my location");
+        let mut env = yash_env::Env::new_virtual();
+        env.options.set(Portable, On);
+        let mut env = Env::new(&mut env);
+
+        let result = expand(&text, &location, &mut env).now_or_never().unwrap();
+
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.cause,
+            ErrorCause::ArithError(ArithError::NonPortableIncrementDecrement)
+        );
+        assert_eq!(*error.location.code.value.borrow(), "foo++");
+        assert_eq!(error.location.range, 3..5);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Check parsed arithmetic expressions for non-portable constructs before evaluation. When the portable option is enabled, report prefix and postfix increment and decrement operators, even in operands that would not be evaluated.

Preserve the default behavior of eval and provide eval_with_config for callers that enable portability checks.

## Todo

- [x] Implement the rejection logic
- [x] Add an explanation to the error message stating that this error occurs because of portable mode

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added portable-mode validation for arithmetic expansions.
  * The `++` and `--` operators are now rejected when the `portable` shell option is enabled.
  * These operators remain available when portable mode is disabled.

* **Documentation**
  * Updated arithmetic and POSIX portability documentation to describe this behavior.

* **Bug Fixes**
  * Prevented non-portable arithmetic expressions from modifying variables before reporting an error.

* **Tests**
  * Added scripted and unit coverage for portable/non-portable increment/decrement handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->