### PR TITLE
Make yash-arith error enums non-exhaustive

### DIFF
--- a/yash-arith/CHANGELOG.md
+++ b/yash-arith/CHANGELOG.md
@@ -26,6 +26,9 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- The `TokenError`, `SyntaxError`, `EvalError`, and `ErrorCause` enums are now
+  non-exhaustive. (Note that `PortabilityError`, which was added in this
+  version, is also non-exhaustive.)
 - Public dependency versions
     - Rust 1.87.0 → 1.96.0
 

--- a/yash-arith/src/ast.rs
+++ b/yash-arith/src/ast.rs
@@ -264,6 +264,7 @@ pub enum Ast<'a> {
 
 /// Cause of a syntax error
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum SyntaxError {
     /// Error in tokenization
     #[error(transparent)]

--- a/yash-arith/src/ast/portability.rs
+++ b/yash-arith/src/ast/portability.rs
@@ -24,6 +24,7 @@ use thiserror::Error;
 
 /// Cause of an error because an expression contains a non-portable construct
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum PortabilityError {
     /// An increment or decrement operator is used while the `portable` option
     /// is on.

--- a/yash-arith/src/eval.rs
+++ b/yash-arith/src/eval.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 /// The type parameters `E1` and `E2` define the types of errors returned by the
 /// [`Env::get_variable`] and [`Env::assign_variable`] methods, respectively.
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum EvalError<E1, E2> {
     /// A variable value that is not a valid number
     #[error("invalid variable value: {0:?}")]

--- a/yash-arith/src/lib.rs
+++ b/yash-arith/src/lib.rs
@@ -80,6 +80,7 @@ impl Config {
 /// Cause of an arithmetic expansion error
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
 #[error(transparent)]
+#[non_exhaustive]
 pub enum ErrorCause<E1, E2> {
     /// Syntax error parsing the expression
     SyntaxError(#[from] SyntaxError),

--- a/yash-arith/src/token.rs
+++ b/yash-arith/src/token.rs
@@ -153,6 +153,7 @@ pub struct Token<'a> {
 
 /// Cause of a tokenization error
 #[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum TokenError {
     /// A value token contains an invalid character.
     #[error("invalid numeric constant")]

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -20,6 +20,8 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `expansion::initial::arith::ArithError::NonPortableIncrementDecrement`,
   which arithmetic expansion now returns when the `portable` shell option is
   enabled and the expression contains an increment or decrement operator.
+- `expansion::initial::arith::ArithError::Unrecognized`, which preserves the
+  message from an arithmetic error that `yash-semantics` does not recognize.
 
 ### Changed
 

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -112,6 +112,14 @@ pub enum ArithError {
     /// Assignment with a left-hand-side operand not being a variable
     #[error("assignment to a non-variable")]
     AssignmentToValue,
+
+    /// An arithmetic error not recognized by this crate
+    ///
+    /// This variant is used to wrap an error cause that is returned by future
+    /// versions of `yash_arith` but not yet recognized by this crate. The
+    /// associated string is the `Display` representation of the error cause.
+    #[error("{0}")]
+    Unrecognized(String),
 }
 
 impl ArithError {
@@ -133,7 +141,8 @@ impl ArithError {
             | DivisionByZero
             | LeftShiftingNegative
             | ReverseShifting
-            | AssignmentToValue => None,
+            | AssignmentToValue
+            | Unrecognized(_) => None,
             UnclosedParenthesis { opening_location } => {
                 Some((opening_location, "the opening parenthesis was here"))
             }
@@ -143,7 +152,8 @@ impl ArithError {
 }
 
 /// Error expanding an unset variable
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("unset variable `{param}`")]
 struct UnsetVariable {
     param: Param,
 }
@@ -202,7 +212,7 @@ fn convert_error_cause(
             ErrorCause::UnsetParameter { param }
         }
         EC::EvalError(EE::AssignVariableError(e)) => ErrorCause::AssignReadOnly(e),
-        _ => todo!(),
+        cause => ErrorCause::ArithError(Unrecognized(cause.to_string())),
     }
 }
 
@@ -325,6 +335,14 @@ mod tests {
     use yash_env::test_helper::in_virtual_system;
     use yash_env::variable::Scope::Global;
     use yash_env::variable::Value::Scalar;
+
+    #[test]
+    fn unrecognized_error() {
+        let error = ArithError::Unrecognized("new arithmetic error".into());
+
+        assert_eq!(error.to_string(), "new arithmetic error");
+        assert_eq!(error.related_location(), None);
+    }
 
     #[test]
     fn var_env_get_variable_success() {

--- a/yash-semantics/src/expansion/initial/arith.rs
+++ b/yash-semantics/src/expansion/initial/arith.rs
@@ -158,60 +158,51 @@ fn convert_error_cause(
     source: &Rc<Code>,
 ) -> ErrorCause {
     use ArithError::*;
+    use yash_arith::{
+        ErrorCause as EC, EvalError as EE, PortabilityError as PE, SyntaxError as SE,
+        TokenError as TE,
+    };
     match cause {
-        yash_arith::ErrorCause::SyntaxError(e) => match e {
-            yash_arith::SyntaxError::TokenError(e) => match e {
-                yash_arith::TokenError::InvalidNumericConstant => {
-                    ErrorCause::ArithError(InvalidNumericConstant)
-                }
-                yash_arith::TokenError::InvalidCharacter => {
-                    ErrorCause::ArithError(InvalidCharacter)
-                }
-            },
-            yash_arith::SyntaxError::IncompleteExpression => {
-                ErrorCause::ArithError(IncompleteExpression)
-            }
-            yash_arith::SyntaxError::MissingOperator => ErrorCause::ArithError(MissingOperator),
-            yash_arith::SyntaxError::UnclosedParenthesis { opening_location } => {
-                let opening_location = Location {
-                    code: Rc::clone(source),
-                    range: opening_location,
-                };
-                ErrorCause::ArithError(UnclosedParenthesis { opening_location })
-            }
-            yash_arith::SyntaxError::QuestionWithoutColon { question_location } => {
-                let question_location = Location {
-                    code: Rc::clone(source),
-                    range: question_location,
-                };
-                ErrorCause::ArithError(QuestionWithoutColon { question_location })
-            }
-            yash_arith::SyntaxError::ColonWithoutQuestion => {
-                ErrorCause::ArithError(ColonWithoutQuestion)
-            }
-            yash_arith::SyntaxError::InvalidOperator => ErrorCause::ArithError(InvalidOperator),
-        },
-        yash_arith::ErrorCause::PortabilityError(e) => match e {
-            yash_arith::PortabilityError::IncrementDecrement => {
-                ErrorCause::ArithError(NonPortableIncrementDecrement)
-            }
-        },
-        yash_arith::ErrorCause::EvalError(e) => match e {
-            yash_arith::EvalError::InvalidVariableValue(value) => {
-                ErrorCause::ArithError(InvalidVariableValue(value))
-            }
-            yash_arith::EvalError::Overflow => ErrorCause::ArithError(Overflow),
-            yash_arith::EvalError::DivisionByZero => ErrorCause::ArithError(DivisionByZero),
-            yash_arith::EvalError::LeftShiftingNegative => {
-                ErrorCause::ArithError(LeftShiftingNegative)
-            }
-            yash_arith::EvalError::ReverseShifting => ErrorCause::ArithError(ReverseShifting),
-            yash_arith::EvalError::AssignmentToValue => ErrorCause::ArithError(AssignmentToValue),
-            yash_arith::EvalError::GetVariableError(UnsetVariable { param }) => {
-                ErrorCause::UnsetParameter { param }
-            }
-            yash_arith::EvalError::AssignVariableError(e) => ErrorCause::AssignReadOnly(e),
-        },
+        EC::SyntaxError(SE::TokenError(TE::InvalidNumericConstant)) => {
+            ErrorCause::ArithError(InvalidNumericConstant)
+        }
+        EC::SyntaxError(SE::TokenError(TE::InvalidCharacter)) => {
+            ErrorCause::ArithError(InvalidCharacter)
+        }
+        EC::SyntaxError(SE::IncompleteExpression) => ErrorCause::ArithError(IncompleteExpression),
+        EC::SyntaxError(SE::MissingOperator) => ErrorCause::ArithError(MissingOperator),
+        EC::SyntaxError(SE::UnclosedParenthesis { opening_location }) => {
+            let opening_location = Location {
+                code: Rc::clone(source),
+                range: opening_location,
+            };
+            ErrorCause::ArithError(UnclosedParenthesis { opening_location })
+        }
+        EC::SyntaxError(SE::QuestionWithoutColon { question_location }) => {
+            let question_location = Location {
+                code: Rc::clone(source),
+                range: question_location,
+            };
+            ErrorCause::ArithError(QuestionWithoutColon { question_location })
+        }
+        EC::SyntaxError(SE::ColonWithoutQuestion) => ErrorCause::ArithError(ColonWithoutQuestion),
+        EC::SyntaxError(SE::InvalidOperator) => ErrorCause::ArithError(InvalidOperator),
+        EC::PortabilityError(PE::IncrementDecrement) => {
+            ErrorCause::ArithError(NonPortableIncrementDecrement)
+        }
+        EC::EvalError(EE::InvalidVariableValue(value)) => {
+            ErrorCause::ArithError(InvalidVariableValue(value))
+        }
+        EC::EvalError(EE::Overflow) => ErrorCause::ArithError(Overflow),
+        EC::EvalError(EE::DivisionByZero) => ErrorCause::ArithError(DivisionByZero),
+        EC::EvalError(EE::LeftShiftingNegative) => ErrorCause::ArithError(LeftShiftingNegative),
+        EC::EvalError(EE::ReverseShifting) => ErrorCause::ArithError(ReverseShifting),
+        EC::EvalError(EE::AssignmentToValue) => ErrorCause::ArithError(AssignmentToValue),
+        EC::EvalError(EE::GetVariableError(UnsetVariable { param })) => {
+            ErrorCause::UnsetParameter { param }
+        }
+        EC::EvalError(EE::AssignVariableError(e)) => ErrorCause::AssignReadOnly(e),
+        _ => todo!(),
     }
 }
 


### PR DESCRIPTION
## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and displaying previously unrecognized arithmetic errors.
  * Added clearer error messages for unset variables.

* **Compatibility**
  * Public error types can now gain new variants without requiring exhaustive matching updates, improving forward compatibility.

* **Documentation**
  * Updated changelogs to document the new error handling and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->