### PR TITLE
Reject making PWD/OLDPWD/OPTIND/OPTARG/LINENO read-only in portable mode

### DIFF
--- a/.agents/skills/bump-versions/SKILL.md
+++ b/.agents/skills/bump-versions/SKILL.md
@@ -49,12 +49,24 @@ From the diff, list every crate that needs a metadata update. A crate is
 "affected" if any of the following holds:
 
 - its own source/manifest changed, **or**
-- any of its workspace dependencies' required versions changed — **public or
-  private** (a private-dependency bump needs a changelog mention even though it
-  forces no version bump; see Step 4 and Step 5).
+- it directly depends (in `[dependencies]`; also check `[dev-dependencies]` for
+  completeness, though those don't affect published-crate compatibility) on
+  another workspace crate whose version changed in this cycle — **public or
+  private** dependency alike.
 
-Decide later (Step 2 / Step 4) whether each affected crate also needs a *version*
-bump; "affected" only means it needs attention here.
+**Find these dependents explicitly; do not rely on the initiating diff to
+surface them.** A version bump of `yash-env`, say, potentially affects *every*
+crate with `yash-env = { workspace = true }`, not just the one crate whose
+source you were asked to change. Run `grep -l '^<crate> = ' */Cargo.toml` for
+each crate bumped in Step 3 and add every hit (that isn't the crate itself) to
+the affected list — this is the step most easily skipped, because the code
+diff usually only touches one dependent directly.
+
+Decide later (Step 2 / Step 4) the version-bump *severity* for each affected
+crate; "affected" only means it needs attention here. But do not assume a
+dependency bump alone skips the version bump — see the note in Step 4's
+cross-crate propagation about public vs. private only changing *severity* and
+*root-requirement* handling, never whether a bump happens at all.
 
 ### Step 2 — Classify the change for each crate
 
@@ -168,14 +180,35 @@ whether to raise its root requirement using these three cases:
 When you do raise a requirement (cases 1 and 3-confirmed), set the root table
 entry to X's new version.
 
-**Cross-crate propagation:** when raising X's root requirement, for every crate
-that depends on X:
+**Cross-crate propagation:** for every crate that depends on X (found in Step
+1), recording X's new version is itself a changelog-worthy change and — per
+the Step 2 version-mapping table, where *compatible* and *patch-level* both
+bump `z` by exactly the same amount in 0.x — **normally earns the dependent
+its own patch-level (`z`) version bump, regardless of whether the dependency is
+public or private.** This holds even when X's bump was itself only
+patch-level, and even when nothing else about the dependent changed (real
+precedent: `yash-fnmatch` 1.1.1 → 1.1.2 solely for a *private* `thiserror`
+patch bump; `yash-syntax`, `yash-semantics`, and `yash-prompt` have each
+released solely for a *public* `yash-env` bump). Public vs. private changes
+two things only:
 
-- If the dependency is **public** (its items are re-exported) and X's bump was
-  breaking (case 1, i.e. a minor bump in 0.x), the dependent's own version must
-  bump too — loop back to Step 2 for that crate.
-- If the dependency is **private** (not re-exported), no version bump of the
-  dependent crate is required, but the changelog still mentions it (Step 5).
+- **Which changelog list the entry goes in** — "Public dependency versions" vs
+  "Private dependency versions" (Step 5; see "How to tell public from private"
+  below).
+- **Whether a *breaking* upstream bump propagates as breaking.** If the
+  dependency is **public** (its items are re-exported) and X's bump was
+  breaking (case 1, i.e. a minor bump in 0.x), the propagated severity is
+  breaking too — loop back to Step 2 for that crate instead of defaulting to
+  patch-level. If the dependency is **private**, the propagated severity stays
+  capped at patch-level even when X's own bump was breaking, since nothing in
+  the dependent's own public API changed.
+
+Whether the *root* requirement for X itself gets raised is the separate
+question decided just above (cases 1–3) — do not conflate "does the root
+requirement rise" with "does this dependent get a changelog entry and version
+bump." The two are independent: a crate can (and often does) get a patch bump
+purely to record a dependency note even while the root requirement for that
+dependency stays put (case 2).
 
 **How to tell public from private — trust the changelog history.**
 Do **not** try to re-derive a dependency's public/private status from the source

--- a/.agents/skills/bump-versions/SKILL.md
+++ b/.agents/skills/bump-versions/SKILL.md
@@ -80,8 +80,9 @@ crate's current major version.
 - **`yash-cli` (binary):** classify by **observable shell behavior**.
   - Behavior change or new feature → *compatible*; bug fix → *patch-level*.
   - `yash-cli` re-exports nothing, so only observable behavior drives its
-    version. A dependency bump alone never bumps `yash-cli` (though it is still
-    recorded in its changelog per Step 5).
+    version. A dependency bump alone never bumps `yash-cli`, and unlike every
+    other crate, its changelog never records dependency version changes either
+    — see the exception in Step 5.
 
 **Version mapping.** Every crate in this workspace follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Because most crates
@@ -244,6 +245,11 @@ Rules specific to this workflow:
 - **Dependency changes are mentioned.** If a `Cargo.toml` dependency was added,
   removed, or updated, note it in the changelog. List **private and public**
   dependency changes separately.
+- **Exception: `yash-cli` never gets a dependency-change entry.** Its
+  changelog header states it documents only observable shell behavior, not the
+  implementing library crates' versions — so even though `yash-cli` counts as
+  "affected" by a dependency's bump (Step 1), skip it here unless the same
+  change also has user-visible behavior to record under the rule above.
 
 > **Documentation is out of scope here.** If the change is user-visible, the
 > `docs/src` pages (and the "introduced in `yash-cli` x.y.z" version mention)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "yash-builtin"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "yash-env"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ version = "1.1.2"
 
 [[package]]
 name = "yash-semantics"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "assert_matches",
  "either",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "yash-syntax"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "assert_matches",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unix_path = "1.0.1"
 unix_str = "1.0.0"
 yash-arith = { path = "yash-arith", version = "0.3.0" }
 yash-builtin = { path = "yash-builtin", version = "0.21.0" }
-yash-env = { path = "yash-env", version = "0.15.4" }
+yash-env = { path = "yash-env", version = "0.15.5" }
 yash-executor = { path = "yash-executor", version = "1.0.1" }
 yash-fnmatch = { path = "yash-fnmatch", version = "1.1.1" }
 yash-prompt = { path = "yash-prompt", version = "0.14.0" }

--- a/docs/src/builtins/readonly.md
+++ b/docs/src/builtins/readonly.md
@@ -120,6 +120,8 @@ Note that executing the printed commands in the current context will fail becaus
 
 When making a variable read-only with a value, it is an error if the variable is already read-only.
 
+(Since 3.3.3) When the [`portable` option](../environment/options.md#portable) is set, it is an error to make the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` [variable][variables] read-only, since POSIX requires the shell to be able to update these variables.
+
 <!-- TODO: It is an error to specify a non-existing function for making it read-only. -->
 
 When printing variables<!-- TODO: or functions -->, it is an error if an operand names a non-existing variable<!-- TODO: or function -->.

--- a/docs/src/language/parameters/variables.md
+++ b/docs/src/language/parameters/variables.md
@@ -266,7 +266,7 @@ Arrays are a yash extension that POSIX does not specify, so scripts that use the
 
 (Since 3.3.1) The [`portable` option](../../environment/options.md#portable) rejects array assignment.
 
-(Since 3.3.3) The [`portable` option](../../environment/options.md#portable) rejects making the [`PWD`](#reserved-variable-names), [`OLDPWD`](#reserved-variable-names), [`OPTIND`](#reserved-variable-names), [`OPTARG`](#reserved-variable-names), or [`LINENO`](#reserved-variable-names) variable [read-only](#read-only-variables) with the [`readonly` built-in](../../builtins/readonly.md) or the [`typeset` built-in](../../builtins/typeset.md)'s `-r` option, since POSIX requires the shell to be able to update these variables.
+(Since 3.3.3) The [`portable` option](../../environment/options.md#portable) rejects making the [`PWD`](#pwd), [`OLDPWD`](#oldpwd), [`OPTIND`](#optind), [`OPTARG`](#optarg), or [`LINENO`](#lineno) variable [read-only](#read-only-variables) with the [`readonly` built-in](../../builtins/readonly.md) or the [`typeset` built-in](../../builtins/typeset.md)'s `-r` option, since POSIX requires the shell to be able to update these variables.
 
 [`cd` built-in]: ../../builtins/cd.md
 [`getopts` built-in]: ../../builtins/getopts.md

--- a/docs/src/language/parameters/variables.md
+++ b/docs/src/language/parameters/variables.md
@@ -266,6 +266,8 @@ Arrays are a yash extension that POSIX does not specify, so scripts that use the
 
 (Since 3.3.1) The [`portable` option](../../environment/options.md#portable) rejects array assignment.
 
+(Since 3.3.3) The [`portable` option](../../environment/options.md#portable) rejects making the [`PWD`](#reserved-variable-names), [`OLDPWD`](#reserved-variable-names), [`OPTIND`](#reserved-variable-names), [`OPTARG`](#reserved-variable-names), or [`LINENO`](#reserved-variable-names) variable [read-only](#read-only-variables) with the [`readonly` built-in](../../builtins/readonly.md) or the [`typeset` built-in](../../builtins/typeset.md)'s `-r` option, since POSIX requires the shell to be able to update these variables.
+
 [`cd` built-in]: ../../builtins/cd.md
 [`getopts` built-in]: ../../builtins/getopts.md
 [prompt]: ../../interactive/prompt.md

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -40,5 +40,6 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - (Since 3.3.0) A [parameter expansion](language/words/parameters.md) that uses a length or switch modifier with special parameter `*` or `@` (for example, `${#*}` or `${@:+word}`), or a trim modifier with special parameter `#`, `*`, or `@` (for example, `${#%word}` or `${*#word}`). POSIX leaves the results of these combinations unspecified.
 - (Since 3.3.2) The increment and decrement operators (`++` and `--`) in an [arithmetic expansion](language/words/arithmetic.md). POSIX does not require these operators.
 - (Since 3.3.1) Defining an [alias](language/aliases.md) with the [`alias` built-in](builtins/alias.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
+- (Since 3.3.3) Making the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` [variable](language/parameters/variables.md#reserved-variable-names) [read-only](language/parameters/variables.md#read-only-variables) with the [`readonly` built-in](builtins/readonly.md) or the [`typeset` built-in](builtins/typeset.md)'s `-r` option. POSIX requires the shell to be able to update these variables.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -17,8 +17,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
-- `typeset::NonPortableReadOnlyError`, a new error type, and
-  `typeset::ExecuteError::NonPortableReadOnlyVariable`, a new error variant
+- `typeset::ExecuteError::NonPortableReadOnlyVariable`, a new error variant
   that `typeset::SetVariables::execute` now returns when an operand would
   make the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` variable
   read-only while the `portable` shell option is on. The variable is not

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -13,6 +13,24 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.21.1] - Unreleased
+
+### Added
+
+- `typeset::NonPortableReadOnlyError`, a new error type, and
+  `typeset::ExecuteError::NonPortableReadOnlyVariable`, a new error variant
+  that `typeset::SetVariables::execute` now returns when an operand would
+  make the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` variable
+  read-only while the `portable` shell option is on. The variable is not
+  made read-only in that case.
+- The `readonly` built-in (`readonly::main`) and the typeset built-in's `-r`
+  option now fail, reporting an error, in the same situation.
+
+### Changed
+
+- Private dependency versions:
+    - yash-env 0.15.4 → 0.15.5
+
 ## [0.21.0] - 2026-07-16
 
 ### Changed
@@ -890,6 +908,7 @@ The `wait` built-in no longer treats suspended jobs as terminated jobs.
 
 - Initial implementation of the `yash-builtin` crate
 
+[0.21.1]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.21.1
 [0.21.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.21.0
 [0.20.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.20.0
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-builtin-0.19.0

--- a/yash-builtin/Cargo.toml
+++ b/yash-builtin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-builtin"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -330,42 +330,6 @@ impl<'a> From<&'a AssignReadOnlyError> for Report<'a> {
     }
 }
 
-/// Error that occurs when trying to make a variable read-only whose name
-/// POSIX requires the shell to keep assignable, while the [`Portable`]
-/// option is on
-#[derive(Clone, Debug, Eq, Error, PartialEq)]
-#[error("cannot make variable {name} read-only")]
-pub struct NonPortableReadOnlyError {
-    /// Name of the variable
-    pub name: Field,
-}
-
-impl NonPortableReadOnlyError {
-    /// Converts the error to a report.
-    #[must_use]
-    pub fn to_report(&self) -> Report<'_> {
-        let mut report = Report::new();
-        report.r#type = ReportType::Error;
-        report.title = "cannot make variable read-only".into();
-        report.snippets = Snippet::with_primary_span(
-            &self.name.origin,
-            format!("variable {} is reserved by the shell", self.name).into(),
-        );
-        report.footnotes.push(Footnote {
-            r#type: FootnoteType::Note,
-            label: "this error is reported because the `portable` shell option is enabled".into(),
-        });
-        report
-    }
-}
-
-impl<'a> From<&'a NonPortableReadOnlyError> for Report<'a> {
-    #[inline]
-    fn from(error: &'a NonPortableReadOnlyError) -> Self {
-        error.to_report()
-    }
-}
-
 /// Error that occurs when trying to cancel the read-only attribute of a
 /// variable or function
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -385,7 +349,7 @@ pub enum ExecuteError {
     AssignReadOnlyVariable(#[from] AssignReadOnlyError),
     /// Making a variable read-only whose name is not portable to make
     /// read-only
-    NonPortableReadOnlyVariable(#[from] NonPortableReadOnlyError),
+    NonPortableReadOnlyVariable(Field),
     /// Cancelling the read-only attribute of a variable
     UndoReadOnlyVariable(UndoReadOnlyError),
     /// Cancelling the read-only attribute of a function
@@ -402,7 +366,9 @@ impl std::fmt::Display for ExecuteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AssignReadOnlyVariable(e) => e.fmt(f),
-            Self::NonPortableReadOnlyVariable(e) => e.fmt(f),
+            Self::NonPortableReadOnlyVariable(field) => {
+                write!(f, "cannot make variable {field} read-only")
+            }
             Self::UndoReadOnlyVariable(e) => {
                 write!(f, "cannot cancel read-only-ness of variable `{}`", e.name)
             }
@@ -428,7 +394,11 @@ impl ExecuteError {
     pub fn to_report(&self) -> Report<'_> {
         let (title, location, label) = match self {
             Self::AssignReadOnlyVariable(error) => return error.to_report(),
-            Self::NonPortableReadOnlyVariable(error) => return error.to_report(),
+            Self::NonPortableReadOnlyVariable(field) => (
+                "cannot make variable read-only",
+                &field.origin,
+                format!("variable {field} is reserved by the shell").into(),
+            ),
             Self::UndoReadOnlyVariable(error) => (
                 "cannot cancel read-only-ness of variable",
                 &error.name.origin,
@@ -481,6 +451,11 @@ impl ExecuteError {
                 },
                 &mut report.snippets,
             ),
+            Self::NonPortableReadOnlyVariable(_) => report.footnotes.push(Footnote {
+                r#type: FootnoteType::Note,
+                label: "this error is reported because the `portable` shell option is enabled"
+                    .into(),
+            }),
             _ => { /* No additional spans */ }
         }
         report

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -347,7 +347,10 @@ impl NonPortableReadOnlyError {
         let mut report = Report::new();
         report.r#type = ReportType::Error;
         report.title = "cannot make variable read-only".into();
-        report.snippets = Snippet::with_primary_span(&self.name.origin, self.to_string().into());
+        report.snippets = Snippet::with_primary_span(
+            &self.name.origin,
+            format!("variable {} is reserved by the shell", self.name).into(),
+        );
         report.footnotes.push(Footnote {
             r#type: FootnoteType::Note,
             label: "this error is reported because the `portable` shell option is enabled".into(),

--- a/yash-builtin/src/typeset.rs
+++ b/yash-builtin/src/typeset.rs
@@ -37,10 +37,13 @@ use crate::common::report::{merge_reports, report_error, report_failure};
 use thiserror::Error;
 use yash_env::Env;
 use yash_env::function::Function;
+use yash_env::option::Option::Portable;
 use yash_env::option::State;
 use yash_env::semantics::Field;
 use yash_env::source::Location;
-use yash_env::source::pretty::{Report, ReportType, Snippet, Span, SpanRole, add_span};
+use yash_env::source::pretty::{
+    Footnote, FootnoteType, Report, ReportType, Snippet, Span, SpanRole, add_span,
+};
 use yash_env::system::Isatty;
 use yash_env::system::concurrency::WriteAll;
 use yash_env::variable::{Value, Variable};
@@ -327,6 +330,39 @@ impl<'a> From<&'a AssignReadOnlyError> for Report<'a> {
     }
 }
 
+/// Error that occurs when trying to make a variable read-only whose name
+/// POSIX requires the shell to keep assignable, while the [`Portable`]
+/// option is on
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("cannot make variable {name} read-only")]
+pub struct NonPortableReadOnlyError {
+    /// Name of the variable
+    pub name: Field,
+}
+
+impl NonPortableReadOnlyError {
+    /// Converts the error to a report.
+    #[must_use]
+    pub fn to_report(&self) -> Report<'_> {
+        let mut report = Report::new();
+        report.r#type = ReportType::Error;
+        report.title = "cannot make variable read-only".into();
+        report.snippets = Snippet::with_primary_span(&self.name.origin, self.to_string().into());
+        report.footnotes.push(Footnote {
+            r#type: FootnoteType::Note,
+            label: "this error is reported because the `portable` shell option is enabled".into(),
+        });
+        report
+    }
+}
+
+impl<'a> From<&'a NonPortableReadOnlyError> for Report<'a> {
+    #[inline]
+    fn from(error: &'a NonPortableReadOnlyError) -> Self {
+        error.to_report()
+    }
+}
+
 /// Error that occurs when trying to cancel the read-only attribute of a
 /// variable or function
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -344,6 +380,9 @@ pub struct UndoReadOnlyError {
 pub enum ExecuteError {
     /// Assigning to a read-only variable
     AssignReadOnlyVariable(#[from] AssignReadOnlyError),
+    /// Making a variable read-only whose name is not portable to make
+    /// read-only
+    NonPortableReadOnlyVariable(#[from] NonPortableReadOnlyError),
     /// Cancelling the read-only attribute of a variable
     UndoReadOnlyVariable(UndoReadOnlyError),
     /// Cancelling the read-only attribute of a function
@@ -360,6 +399,7 @@ impl std::fmt::Display for ExecuteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AssignReadOnlyVariable(e) => e.fmt(f),
+            Self::NonPortableReadOnlyVariable(e) => e.fmt(f),
             Self::UndoReadOnlyVariable(e) => {
                 write!(f, "cannot cancel read-only-ness of variable `{}`", e.name)
             }
@@ -385,6 +425,7 @@ impl ExecuteError {
     pub fn to_report(&self) -> Report<'_> {
         let (title, location, label) = match self {
             Self::AssignReadOnlyVariable(error) => return error.to_report(),
+            Self::NonPortableReadOnlyVariable(error) => return error.to_report(),
             Self::UndoReadOnlyVariable(error) => (
                 "cannot cancel read-only-ness of variable",
                 &error.name.origin,

--- a/yash-builtin/src/typeset/set_variables.rs
+++ b/yash-builtin/src/typeset/set_variables.rs
@@ -30,6 +30,7 @@ impl SetVariables {
     /// Executes the command.
     pub fn execute<S>(self, env: &mut Env<S>) -> Result<String, Vec<ExecuteError>> {
         let mut errors = Vec::new();
+        let portable = env.options.get(Portable) == State::On;
 
         'field: for mut field in self.variables {
             // Split the field into the name and the value.
@@ -60,6 +61,14 @@ impl SetVariables {
             for &(attr, state) in &self.attrs {
                 match (attr, state) {
                     (VariableAttr::ReadOnly, State::On) => {
+                        if portable
+                            && !yash_env::variable::is_portable_readonly_variable_name(&field.value)
+                        {
+                            errors.push(ExecuteError::NonPortableReadOnlyVariable(
+                                NonPortableReadOnlyError { name: field },
+                            ));
+                            continue 'field;
+                        }
                         variable.make_read_only(field.origin.clone())
                     }
                     (VariableAttr::ReadOnly, State::Off) => {
@@ -90,6 +99,7 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use yash_env::option::Option::AllExport;
+    use yash_env::option::Option::Portable;
     use yash_env::source::Location;
     use yash_env::variable::{Context, Variable};
 
@@ -190,6 +200,83 @@ mod tests {
         assert_eq!(bar.value, Some(Value::scalar("BAR")));
         assert_eq!(bar.last_assigned_location.as_ref(), Some(&bar_location));
         assert_eq!(bar.read_only_location.as_ref(), Some(&bar_location));
+    }
+
+    #[test]
+    fn setting_non_portable_readonly_variable_with_portable_option() {
+        let mut env = Env::new_virtual();
+        env.options.set(Portable, State::On);
+        let sv = SetVariables {
+            variables: Field::dummies(["PWD"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::On)],
+            scope: Scope::Global,
+        };
+        let pwd_location = sv.variables[0].origin.clone();
+
+        let errors = sv.execute(&mut env).unwrap_err();
+
+        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(error)] => {
+            assert_eq!(error.name.value, "PWD");
+            assert_eq!(error.name.origin, pwd_location);
+        });
+        let pwd = env.variables.get("PWD").unwrap();
+        assert_eq!(pwd.read_only_location, None);
+    }
+
+    #[test]
+    fn setting_non_portable_readonly_variable_with_value_and_portable_option() {
+        let mut env = Env::new_virtual();
+        env.options.set(Portable, State::On);
+        let sv = SetVariables {
+            variables: Field::dummies(["LINENO=1"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::On)],
+            scope: Scope::Global,
+        };
+
+        let errors = sv.execute(&mut env).unwrap_err();
+
+        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(error)] => {
+            assert_eq!(error.name.value, "LINENO");
+        });
+        // The value is assigned even though making the variable read-only failed.
+        let lineno = env.variables.get("LINENO").unwrap();
+        assert_eq!(lineno.value, Some(Value::scalar("1")));
+        assert_eq!(lineno.read_only_location, None);
+    }
+
+    #[test]
+    fn setting_other_readonly_variable_with_portable_option() {
+        let mut env = Env::new_virtual();
+        env.options.set(Portable, State::On);
+        let sv = SetVariables {
+            variables: Field::dummies(["foo"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::On)],
+            scope: Scope::Global,
+        };
+        let foo_location = sv.variables[0].origin.clone();
+
+        let result = sv.execute(&mut env);
+
+        assert_eq!(result, Ok("".to_string()));
+        let foo = env.variables.get("foo").unwrap();
+        assert_eq!(foo.read_only_location.as_ref(), Some(&foo_location));
+    }
+
+    #[test]
+    fn setting_non_portable_readonly_variable_without_portable_option() {
+        let mut env = Env::new_virtual();
+        let sv = SetVariables {
+            variables: Field::dummies(["PWD"]),
+            attrs: vec![(VariableAttr::ReadOnly, State::On)],
+            scope: Scope::Global,
+        };
+        let pwd_location = sv.variables[0].origin.clone();
+
+        let result = sv.execute(&mut env);
+
+        assert_eq!(result, Ok("".to_string()));
+        let pwd = env.variables.get("PWD").unwrap();
+        assert_eq!(pwd.read_only_location.as_ref(), Some(&pwd_location));
     }
 
     #[test]

--- a/yash-builtin/src/typeset/set_variables.rs
+++ b/yash-builtin/src/typeset/set_variables.rs
@@ -64,9 +64,7 @@ impl SetVariables {
                         if portable
                             && !yash_env::variable::is_portable_readonly_variable_name(&field.value)
                         {
-                            errors.push(ExecuteError::NonPortableReadOnlyVariable(
-                                NonPortableReadOnlyError { name: field },
-                            ));
+                            errors.push(ExecuteError::NonPortableReadOnlyVariable(field));
                             continue 'field;
                         }
                         variable.make_read_only(field.origin.clone())
@@ -215,9 +213,9 @@ mod tests {
 
         let errors = sv.execute(&mut env).unwrap_err();
 
-        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(error)] => {
-            assert_eq!(error.name.value, "PWD");
-            assert_eq!(error.name.origin, pwd_location);
+        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(field)] => {
+            assert_eq!(field.value, "PWD");
+            assert_eq!(field.origin, pwd_location);
         });
         let pwd = env.variables.get("PWD").unwrap();
         assert_eq!(pwd.read_only_location, None);
@@ -235,8 +233,8 @@ mod tests {
 
         let errors = sv.execute(&mut env).unwrap_err();
 
-        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(error)] => {
-            assert_eq!(error.name.value, "LINENO");
+        assert_matches!(&errors[..], [ExecuteError::NonPortableReadOnlyVariable(field)] => {
+            assert_eq!(field.value, "LINENO");
         });
         // The value is assigned even though making the variable read-only failed.
         let lineno = env.variables.get("LINENO").unwrap();

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,15 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - Unreleased
+
+### Changed
+
+- With the `portable` shell option enabled, the `readonly` built-in and the
+  typeset built-in's `-r` option now report an error, instead of making the
+  variable read-only, when the operand names the `PWD`, `OLDPWD`, `OPTIND`,
+  `OPTARG`, or `LINENO` variable.
+
 ## [3.3.2] - 2026-07-16
 
 ### Changed
@@ -408,6 +417,7 @@ later.
 
 - Initial release of the shell
 
+[3.3.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.3
 [3.3.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.2
 [3.3.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.1
 [3.3.0]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.0

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.3.2"
+version = "3.3.3"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -433,6 +433,11 @@ fn readonly_builtin() {
 }
 
 #[test]
+fn readonly_builtin_ex() {
+    run("readonly-y.sh");
+}
+
+#[test]
 fn redirection() {
     run("redir-p.sh")
 }

--- a/yash-cli/tests/scripted_test/readonly-y.sh
+++ b/yash-cli/tests/scripted_test/readonly-y.sh
@@ -1,7 +1,27 @@
 # readonly-y.sh: yash-specific test of the readonly built-in
 
-test_O -d -e n 'making PWD OLDPWD OPTIND OPTARG LINENO read-only is rejected' -o portable
-readonly PWD OLDPWD OPTIND OPTARG LINENO
+test_O -d -e n 'making PWD read-only is rejected' -o portable
+readonly PWD
+echo not reached
+__IN__
+
+test_O -d -e n 'making OLDPWD read-only is rejected' -o portable
+readonly OLDPWD
+echo not reached
+__IN__
+
+test_O -d -e n 'making OPTIND read-only is rejected' -o portable
+readonly OPTIND
+echo not reached
+__IN__
+
+test_O -d -e n 'making OPTARG read-only is rejected' -o portable
+readonly OPTARG
+echo not reached
+__IN__
+
+test_O -d -e n 'making LINENO read-only is rejected' -o portable
+readonly LINENO
 echo not reached
 __IN__
 

--- a/yash-cli/tests/scripted_test/readonly-y.sh
+++ b/yash-cli/tests/scripted_test/readonly-y.sh
@@ -25,8 +25,8 @@ readonly LINENO
 echo not reached
 __IN__
 
-test_O -d -e n 'making PWD OLDPWD OPTIND OPTARG LINENO read-only with values is rejected' -o portable
-readonly PWD=/tmp OLDPWD=/tmp OPTIND=1 OPTARG=x LINENO=1
+test_O -d -e n 'making PWD read-only with a value is rejected' -o portable
+readonly PWD=/tmp
 echo not reached
 __IN__
 

--- a/yash-cli/tests/scripted_test/readonly-y.sh
+++ b/yash-cli/tests/scripted_test/readonly-y.sh
@@ -1,0 +1,39 @@
+# readonly-y.sh: yash-specific test of the readonly built-in
+
+test_O -d -e n 'making PWD OLDPWD OPTIND OPTARG LINENO read-only is rejected' -o portable
+readonly PWD OLDPWD OPTIND OPTARG LINENO
+echo not reached
+__IN__
+
+test_O -d -e n 'making PWD OLDPWD OPTIND OPTARG LINENO read-only with values is rejected' -o portable
+readonly PWD=/tmp OLDPWD=/tmp OPTIND=1 OPTARG=x LINENO=1
+echo not reached
+__IN__
+
+test_oE 'readonly error message names the rejected variable' -o portable
+(readonly PWD) 2>result
+grep -Fq 'PWD' result && echo shown
+__IN__
+shown
+__OUT__
+
+test_oE 'typeset -r rejects PWD under the portable option' -o portable
+typeset -r PWD 2>/dev/null
+echo $?
+__IN__
+1
+__OUT__
+
+test_oE 'value is still assigned when making PWD read-only fails' -o portable
+typeset -r PWD=/somewhere 2>/dev/null
+echo "$PWD"
+__IN__
+/somewhere
+__OUT__
+
+test_oE 'readonly can make PWD read-only without the portable option'
+readonly PWD
+echo ok
+__IN__
+ok
+__OUT__

--- a/yash-env/CHANGELOG.md
+++ b/yash-env/CHANGELOG.md
@@ -13,6 +13,16 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.15.5] - Unreleased
+
+### Added
+
+- `variable::is_portable_readonly_variable_name`, which tests whether a
+  variable of the given name may be made read-only in a POSIXly-portable way.
+  It returns `false` for `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, and `LINENO`,
+  which POSIX requires the shell to be able to update, and `true` for any
+  other name.
+
 ## [0.15.4] - 2026-07-12
 
 ### Added
@@ -1430,6 +1440,7 @@ This version has been yanked due to an issue that prevents the crate from buildi
 
 - Initial implementation of the `yash-env` crate
 
+[0.15.5]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.5
 [0.15.4]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.4
 [0.15.3]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.3
 [0.15.2]: https://github.com/magicant/yash-rs/releases/tag/yash-env-0.15.2

--- a/yash-env/Cargo.toml
+++ b/yash-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-env"
-version = "0.15.4"
+version = "0.15.5"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-env/src/variable/constants.rs
+++ b/yash-env/src/variable/constants.rs
@@ -114,3 +114,30 @@ pub const PS4_INITIAL_VALUE: &str = "+ ";
 ///
 /// The `PWD` variable stores the current working directory.
 pub const PWD: &str = "PWD";
+
+/// Tests if a variable may be made read-only in a POSIXly-portable way.
+///
+/// POSIX requires the shell to be able to update the `PWD`, `OLDPWD`,
+/// `OPTIND`, `OPTARG`, and `LINENO` variables during normal operation, so
+/// making any of them read-only is not portable. This function returns
+/// `false` for these five variable names and `true` for any other name.
+#[must_use]
+pub fn is_portable_readonly_variable_name(name: &str) -> bool {
+    !matches!(name, PWD | OLDPWD | OPTIND | OPTARG | LINENO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_readonly_variable_name() {
+        assert!(!is_portable_readonly_variable_name(PWD));
+        assert!(!is_portable_readonly_variable_name(OLDPWD));
+        assert!(!is_portable_readonly_variable_name(OPTIND));
+        assert!(!is_portable_readonly_variable_name(OPTARG));
+        assert!(!is_portable_readonly_variable_name(LINENO));
+        assert!(is_portable_readonly_variable_name("foo"));
+        assert!(is_portable_readonly_variable_name("HOME"));
+    }
+}

--- a/yash-prompt/CHANGELOG.md
+++ b/yash-prompt/CHANGELOG.md
@@ -18,7 +18,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 ### Changed
 
 - Public dependency versions:
-    - yash-env 0.15.3 → 0.15.4
+    - yash-env 0.15.3 → 0.15.5
 
 ## [0.14.0] - 2026-07-09
 

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.19.1] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.15.4 → 0.15.5
+
 ## [0.19.0] - 2026-07-16
 
 ### Added
@@ -582,6 +589,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 - Initial implementation of the `yash-semantics` crate
 
+[0.19.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.19.1
 [0.19.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.19.0
 [0.18.1]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.18.1
 [0.18.0]: https://github.com/magicant/yash-rs/releases/tag/yash-semantics-0.18.0

--- a/yash-semantics/Cargo.toml
+++ b/yash-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-semantics"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-syntax/CHANGELOG.md
+++ b/yash-syntax/CHANGELOG.md
@@ -13,6 +13,13 @@ Terminology: A _public dependency_ is one that’s exposed through this crate’
 public API (e.g., re-exported types).
 A _private dependency_ is used internally and not visible to downstream users.
 
+## [0.23.2] - Unreleased
+
+### Changed
+
+- Public dependency versions:
+    - yash-env 0.15.4 → 0.15.5
+
 ## [0.23.1] - 2026-07-12
 
 ### Added
@@ -803,6 +810,7 @@ command.
 - Functionalities to parse POSIX shell scripts
 - Alias substitution support
 
+[0.23.2]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.23.2
 [0.23.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.23.1
 [0.23.0]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.23.0
 [0.22.1]: https://github.com/magicant/yash-rs/releases/tag/yash-syntax-0.22.1

--- a/yash-syntax/Cargo.toml
+++ b/yash-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-syntax"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"


### PR DESCRIPTION
## Description

[POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html#tag_08_01) says:

> If an attempt is made to mark any of the following variables as readonly, then either the [readonly](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/readonly.html) utility shall reject the attempt, or [readonly](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/readonly.html) shall succeed but the shell can still modify the variables outside of assignment context, or [readonly](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/readonly.html) shall succeed but use of a shell built-in that would otherwise modify such a variable shall fail.
> 
> - LINENO
> - OLDPWD
> - OPTARG
> - OPTIND
> - PWD

This pull request implements the rejection behavior when the `portable` shell option is on.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable-mode validation for `readonly` and `typeset -r`.
  * Attempts to mark `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` as read-only now report an error, while these variables remain writable.

* **Documentation**
  * Clarified portable-shell behavior and POSIX requirements for reserved variables.

* **Tests**
  * Added coverage for portable and non-portable read-only variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->