### PR TITLE
Ignore environment variables that do not have a portable name in initialization

### DIFF
--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -23,7 +23,7 @@ Even when yash-rs conforms to POSIX, it also implements extensions that POSIX do
 
 Unlike [`posixlycorrect`](environment/options.md#posixlycorrect), which changes how the shell behaves to maximize POSIX conformance, `portable` does not alter the behavior of POSIX-conformant constructs. It only restricts the shell to features that are portable across POSIX-conforming shells, reporting an error or ignoring a feature when a non-portable construct is used. The two options are independent and can be combined.
 
-When the `portable` option is set, the shell rejects the following non-portable constructs:
+When the `portable` option is set, the shell rejects or ignores the following non-portable features:
 
 - (Since 3.3.0) The `;;&` and `;|` terminators in [case commands](language/commands/case.md).
 - (Since 3.3.0) The non-portable [redirection](language/redirections/index.html) operators `>>|` and `<<<`.
@@ -35,6 +35,7 @@ When the `portable` option is set, the shell rejects the following non-portable 
 - (Since 3.3.0) A [`for` loop](language/commands/loops.md#for-loops) [variable name](language/parameters/variables.md#variable-names) that is quoted, contains an expansion, or starts with a digit. POSIX requires the name to be an unquoted word consisting solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit.
 - (Since 3.3.0) A [function](language/functions.md) name that is quoted, contains an expansion, or starts with a digit. POSIX requires the name to be an unquoted word consisting solely of underscores, digits, and alphabetics from the portable character set, not starting with a digit.
 - (Since 3.3.0) A [function](language/functions.md) name that is the same as a [special built-in](builtins/index.html#special-built-ins) utility name (for example, `break` or `export`). POSIX does not allow a function to have the same name as a special built-in. This does not apply to other built-ins, such as `cd`, or to `source`, which is not a POSIX-mandated special built-in.
+- (Since 3.3.3) At shell startup, inherited [environment variables](language/parameters/variables.md#environment-variables) whose names start with a digit or contain a character other than ASCII letters, digits, and underscores.
 - (Since 3.3.0) An [assignment](language/commands/simple.md#syntax) name that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
 - (Since 3.3.3) An operand of the [`export` built-in](builtins/export.md), the [`readonly` built-in](builtins/readonly.md), the [`typeset` built-in](builtins/typeset.md), the [`read` built-in](builtins/read.md), or the [`getopts` built-in](builtins/getopts.md) specifying a [variable name](language/parameters/variables.md#variable-names) that contains a character other than underscores, digits, and alphabetics from the portable character set, or that starts with a digit.
 - (Since 3.3.1) An [array assignment](language/parameters/variables.md#arrays) (`name=(...)`). Array assignment is a yash extension that POSIX does not specify.

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -13,15 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- With the `portable` shell option enabled, the `readonly` built-in and the
-  typeset built-in's `-r` option now report an error, instead of making the
-  variable read-only, when the operand names the `PWD`, `OLDPWD`, `OPTIND`,
-  `OPTARG`, or `LINENO` variable.
-- With the `portable` shell option enabled, the `export`, `readonly`,
-  typeset, `read`, and `getopts` built-ins now report an error, instead of
-  creating or updating the variable, when the variable name in an operand is
-  not portable, that is, when it is empty, starts with a digit, or contains
-  a character other than ASCII letters, digits, and underscores.
+- With `portable` enabled:
+    - At startup, ignore environment variables with non-portable names.
+    - Reject attempts to:
+        - Make `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` read-only via `readonly` or `typeset -r`.
+        - Create or update variables with non-portable names via `export`, `readonly`, `typeset`, `read`, or `getopts`.
+
+A portable variable name is non-empty, does not start with a digit, and contains only ASCII letters, digits, and underscores.
 
 ### Fixed
 

--- a/yash-cli/src/lib.rs
+++ b/yash-cli/src/lib.rs
@@ -33,7 +33,7 @@ use std::ops::ControlFlow::{Break, Continue};
 use std::rc::Rc;
 use yash_env::Env;
 use yash_env::RealSystem;
-use yash_env::option::{Interactive, On};
+use yash_env::option::{Interactive, On, Portable};
 use yash_env::semantics::{Divert, ExitStatus, exit_or_raise};
 use yash_env::system::concurrency::WriteAll;
 use yash_env::system::resource::GetRlimit;
@@ -86,7 +86,16 @@ where
     };
 
     // Import environment variables
-    env.variables.extend_env(std::env::vars());
+    let portable = run
+        .options
+        .iter()
+        .rev()
+        .find_map(|&(option, state)| (option == Portable).then_some(state))
+        == Some(On);
+    env.variables.extend_env(
+        std::env::vars()
+            .filter(|(name, _)| !portable || yash_env::variable::is_portable_variable_name(name)),
+    );
 
     let work = self::startup::configure_environment(env, run).await;
 

--- a/yash-cli/tests/scripted_test/startup-y.sh
+++ b/yash-cli/tests/scripted_test/startup-y.sh
@@ -1,5 +1,25 @@
 # startup-y.sh: yash-specific test of shell startup
 
+test_oE 'startup: portable option ignores environment variable with non-portable name'
+env 'non-portable=value' "$TESTEE" -o portable -c 'command env' |
+    grep '^non-portable=value$' || echo ignored
+__IN__
+ignored
+__OUT__
+
+test_oE 'startup: portable option imports environment variable with portable name'
+env portable_name=value "$TESTEE" -o portable -c 'echo "$portable_name"'
+__IN__
+value
+__OUT__
+
+test_oE 'startup: disabled portable option imports environment variable with non-portable name'
+env 'non-portable=value' "$TESTEE" -o portable +o portable -c 'command env' |
+    grep '^non-portable=value$'
+__IN__
+non-portable=value
+__OUT__
+
 # TODO not working as expected
 test_oE -e 0 -f 'negating -c and enabling -s' -c +c -s
 echo ok


### PR DESCRIPTION
## Description

When portable is enabled at startup, filter inherited environment variables before initializing shell variables. This is part of #807.

## Checklist

- [x] Code follows the existing style and conventions
- [ ] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portable mode now imports only environment variables with portable names.
  * Non-portable variable names are ignored during shell startup when portable mode is enabled.
  * Portable mode can be enabled or disabled through startup options as expected.

* **Documentation**
  * Updated portable-option documentation to clarify that non-portable features may be rejected or ignored.
  * Added a clear definition of valid portable variable names and documented the new environment-variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->