### PR TITLE
Reject elective and extension built-ins under the portable option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "yash-cli"
-version = "3.3.3"
+version = "3.3.4"
 dependencies = [
  "assert_matches",
  "futures-util",

--- a/docs/src/builtins/README.md
+++ b/docs/src/builtins/README.md
@@ -66,6 +66,8 @@ POSIX.1-2024 defines these mandatory built-ins:
 
 Elective built-ins can be overridden by [functions] and are found in [command search](../language/commands/simple.md#command-search) regardless of `PATH`.
 
+When the [`portable` option](../environment/options.md#portable) is set, attempting to execute an elective built-in is **rejected** with an error, even though it is still found in command search.
+
 In yash-rs, the following elective built-in is implemented:
 
 - [`typeset`](typeset.md)
@@ -79,6 +81,8 @@ More may be added in the future.
 Like [elective built-ins](#elective-built-ins), they can be found in [command search](../language/commands/simple.md#command-search) without a corresponding executable in `PATH`, and they can be overridden by [functions].
 
 When the [`posixlycorrect` option](../environment/options.md#posixlycorrect) is set, extension built-ins are **ignored**: they are treated as non-existing during command search, so the shell falls through to searching for an external utility with the same name.
+
+When the [`portable` option](../environment/options.md#portable) is set, attempting to execute an extension built-in is **rejected** with an error, even though it is still found in command search.
 
 No extension built-ins are implemented in yash-rs yet.
 

--- a/docs/src/language/commands/simple.md
+++ b/docs/src/language/commands/simple.md
@@ -104,7 +104,7 @@ A simple command is executed by the shell in these steps:
 4. If there are any fields, the shell determines the target to execute based on the first field (the command name), as described in [Command search](#command-search) below. <!-- TODO: #530 - Since this step is performed after the assignments, the command search can be affected by the assignments in the previous step. -->
 5. The shell executes the target:
     - If the target is an external utility, it is executed in a [subshell](../../environment/index.html#subshells) with the fields as arguments. If the `execve` call used to execute the target fails with `ENOEXEC`, the shell tries to execute it as a script in a new shell process.
-    - If the target is a [built-in](../../builtins/index.html), it is executed in the current [shell environment] with the fields (except the first) as arguments.
+    - If the target is a [built-in](../../builtins/index.html), it is executed in the current [shell environment] with the fields (except the first) as arguments. However, if it is an [elective or extension built-in](../../builtins/index.html#elective-built-ins) and the [`portable` option](../../environment/options.md#portable) is on, the shell reports an error instead of executing it.
     - If the target is a [function], it is executed in the current [shell environment]. When entering a function, [positional parameters](../parameters/positional.md) are set to the fields (except the first), and restored when the function returns.
     - If no target is found, the shell reports an error.
     - If there was no command name (the first field), nothing is executed.
@@ -119,7 +119,7 @@ Redirections are canceled unless the target was the [`exec` special built-in](..
 1. If the command name contains a slash (`/`), it is treated as a pathname to an executable file target, regardless of whether the file exists or is executable.
 2. If the command name is a [special built-in] (like [`exec`](../../builtins/exec.md) or [`exit`](../../builtins/exit.md)), it is used as the target.
 3. If the command name is a [function], it is used as the target.
-4. If the command name is a [built-in] other than a [substitutive built-in], it is used as the target. [Extension built-ins] are excluded from this step when the [`posixlycorrect` option](../../environment/options.md#posixlycorrect) is on. <!-- TODO: reject elective and extension built-ins in portable mode -->
+4. If the command name is a [built-in] other than a [substitutive built-in], it is used as the target. [Extension built-ins] are excluded from this step when the [`posixlycorrect` option](../../environment/options.md#posixlycorrect) is on.
 5. The shell searches for the command name in the directories listed in the `PATH` [variable](../parameters/variables.md). The first matching executable regular file is a candidate target.
     - The value of `PATH` is treated as a sequence of pathnames separated by colons (`:`). An empty pathname in `PATH` refers to the current [working directory](../../environment/working_directory.md). For example, in the simple command `PATH=/bin:/usr/bin: ls`, the shell searches for `ls` in `/bin`, then `/usr/bin`, and finally the current directory.
     - If `PATH` is an array, each element is a pathname to search.

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -43,5 +43,6 @@ When the `portable` option is set, the shell rejects or ignores the following no
 - (Since 3.3.2) The increment and decrement operators (`++` and `--`) in an [arithmetic expansion](language/words/arithmetic.md). POSIX does not require these operators.
 - (Since 3.3.1) Defining an [alias](language/aliases.md) with the [`alias` built-in](builtins/alias.md) with a name that contains a character other than ASCII letters, digits, `!`, `%`, `,`, `-`, `@`, or `_`.
 - (Since 3.3.3) Making the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` [variable](language/parameters/variables.md#reserved-variable-names) [read-only](language/parameters/variables.md#read-only-variables) with the [`readonly` built-in](builtins/readonly.md) or the [`typeset` built-in](builtins/typeset.md)'s `-r` option. POSIX requires the shell to be able to update these variables.
+- (Since 3.3.4) Executing an [elective or extension built-in](builtins/index.html#elective-built-ins) (for example, [`typeset`](builtins/typeset.md)). Such a built-in is still found in [command search](language/commands/simple.md#command-search), but running it is rejected with an error.
 
 The `portable` option is still under development, so this list will be expanded as more checks are implemented.

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -9,6 +9,12 @@ used by other programs.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.4] - Unreleased
+
+### Changed
+
+- With `portable` enabled, executing an elective or extension built-in (for example, `typeset`) is now rejected with an error (exit status 126), even though the built-in is still found in command search.
+
 ## [3.3.3] - 2026-07-22
 
 ### Changed
@@ -426,6 +432,7 @@ later.
 
 - Initial release of the shell
 
+[3.3.4]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.4
 [3.3.3]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.3
 [3.3.2]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.2
 [3.3.1]: https://github.com/magicant/yash-rs/releases/tag/yash-cli-3.3.1

--- a/yash-cli/Cargo.toml
+++ b/yash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yash-cli"
-version = "3.3.3"
+version = "3.3.4"
 authors = ["WATANABE Yuki <magicant@wonderwand.net>"]
 edition = "2024"
 rust-version = "1.96.0"

--- a/yash-cli/tests/scripted_test/export-y.sh
+++ b/yash-cli/tests/scripted_test/export-y.sh
@@ -5,6 +5,11 @@ export foo-bar=1
 echo not reached
 __IN__
 
+test_O -d -e n 'export rejects variable name starting with a digit' -o portable
+export 1abc=1
+echo not reached
+__IN__
+
 test_OE -e 0 'export accepts non-portable variable name without the portable option'
 export foo-bar=1
 __IN__

--- a/yash-cli/tests/scripted_test/readonly-y.sh
+++ b/yash-cli/tests/scripted_test/readonly-y.sh
@@ -37,19 +37,9 @@ __IN__
 shown
 __OUT__
 
-test_oE 'typeset -r rejects PWD under the portable option' -o portable
-typeset -r PWD 2>/dev/null
-echo $?
+test_O -e 1 'readonly rejects PWD under the portable option' -o portable
+readonly PWD
 __IN__
-1
-__OUT__
-
-test_oE 'value is still assigned when making PWD read-only fails' -o portable
-typeset -r PWD=/somewhere 2>/dev/null
-echo "$PWD"
-__IN__
-/somewhere
-__OUT__
 
 test_OE -e 0 'readonly can make PWD read-only without the portable option'
 readonly PWD

--- a/yash-cli/tests/scripted_test/typeset-y.sh
+++ b/yash-cli/tests/scripted_test/typeset-y.sh
@@ -442,19 +442,8 @@ PATH=$PWD:$PATH
 typeset --help
 __IN__
 
-test_OE -d -e 1 'typeset rejects non-portable variable name under the portable option' -o portable
-typeset foo-bar=1
-__IN__
-
-test_o 'typeset does not create variable with non-portable name under the portable option' -o portable
-typeset foo-bar=1
-typeset -p | grep foo-bar= || echo not created
-__IN__
-not created
-__OUT__
-
-test_O -d -e 1 'typeset rejects variable name starting with a digit under the portable option' -o portable
-typeset 1abc=1
+test_OE -d -e 126 'typeset itself is rejected as an elective built-in under the portable option' -o portable
+typeset a=1
 __IN__
 
 test_OE -e 0 'typeset accepts non-portable variable name without the portable option'

--- a/yash-env/src/builtin.rs
+++ b/yash-env/src/builtin.rs
@@ -66,11 +66,10 @@ pub enum Type {
     /// Search and Execution](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_01_04)
     /// in POSIX XCU section 2.9.1.4.
     /// They are very similar to mandatory built-ins, but their behavior is not
-    /// specified by POSIX, so they are not portable. They cannot be used when
-    /// the (TODO TBD) option is set. <!-- An option that disables non-portable
-    /// behavior would make elective built-ins unusable even if found. An option
-    /// that disables non-conforming behavior would not affect elective
-    /// built-ins. -->
+    /// specified by POSIX, so they are not portable. When the
+    /// [`Portable`](crate::option::Portable) option is on, attempting to
+    /// execute one is rejected with an error, even though it is still found in
+    /// command search.
     ///
     /// We call them "elective" because it is up to the shell whether to
     /// implement them.
@@ -88,8 +87,9 @@ pub enum Type {
     /// - When the [`PosixlyCorrect`](crate::option::PosixlyCorrect) option is
     ///   on, they are ignored: they are regarded as non-existing utilities so
     ///   that the command search falls through to external utilities.
-    /// - When the (TODO TBD) option is on, they cannot be used even if found
-    ///   in command search.
+    /// - When the [`Portable`](crate::option::Portable) option is on,
+    ///   attempting to execute one is rejected with an error, even though it
+    ///   is still found in command search.
     Extension,
 
     /// Built-in that works like a standalone utility

--- a/yash-semantics/CHANGELOG.md
+++ b/yash-semantics/CHANGELOG.md
@@ -17,6 +17,7 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Changed
 
+- Executing an elective or extension built-in (`yash_env::builtin::Type::Elective` or `Extension`) now fails with an error (exit status 126) when the `portable` shell option is on. The built-in is still found in command search; only its execution is rejected.
 - Public dependency versions:
     - yash-env 0.15.4 → 0.15.5
 

--- a/yash-semantics/src/command/simple_command/builtin.rs
+++ b/yash-semantics/src/command/simple_command/builtin.rs
@@ -31,6 +31,8 @@ use std::pin::pin;
 use yash_env::Env;
 use yash_env::builtin::Builtin;
 use yash_env::io::print_error;
+use yash_env::option::Option::Portable;
+use yash_env::option::State::On;
 use yash_env::semantics::Divert;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
@@ -62,8 +64,6 @@ pub async fn execute_builtin<S: Runtime + 'static>(
     };
 
     let result = 'result: {
-        // TODO Reject elective and extension built-ins in portable mode
-
         let is_special = builtin.r#type == Special;
         let (mut env, export) = if is_special {
             (Either::Left(&mut *env), false)
@@ -79,15 +79,30 @@ pub async fn execute_builtin<S: Runtime + 'static>(
         print(env, xtrace).await;
 
         let name = fields.remove(0);
-        if builtin.r#type == Substitutive && search_path(env, &name.value).is_none() {
-            print_error(
-                env,
-                format!("cannot execute built-in utility {:?}", name.value).into(),
-                "utility not found in $PATH, so the built-in is ignored".into(),
-                &name.origin,
-            )
-            .await;
-            break 'result ExitStatus::NOT_FOUND.into();
+        match builtin.r#type {
+            Elective | Extension if env.options.get(Portable) == On => {
+                print_error(
+                    env,
+                    format!("cannot execute built-in utility {:?}", name.value).into(),
+                    "this built-in is not POSIX, so it cannot be used when the `portable` option \
+                     is on"
+                        .into(),
+                    &name.origin,
+                )
+                .await;
+                break 'result ExitStatus::NOEXEC.into();
+            }
+            Substitutive if search_path(env, &name.value).is_none() => {
+                print_error(
+                    env,
+                    format!("cannot execute built-in utility {:?}", name.value).into(),
+                    "utility not found in $PATH, so the built-in is ignored".into(),
+                    &name.origin,
+                )
+                .await;
+                break 'result ExitStatus::NOT_FOUND.into();
+            }
+            _ => {}
         }
 
         let env = &mut env.push_frame(FrameBuiltin { name, is_special }.into());
@@ -366,6 +381,45 @@ mod tests {
             let command: syntax::SimpleCommand = "echo hello".parse().unwrap();
             _ = command.execute(&mut env).now_or_never().unwrap();
             assert_eq!(env.exit_status, ExitStatus::SUCCESS);
+        }
+    }
+
+    #[test]
+    fn elective_and_extension_builtins_are_rejected_under_portable_option() {
+        for r#type in [Elective, Extension] {
+            let system = VirtualSystem::new();
+            let state = Rc::clone(&system.state);
+            let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+            env.options.set(Portable, On);
+            let mut echo_builtin = echo_builtin();
+            echo_builtin.r#type = r#type;
+            env.builtins.insert("echo", echo_builtin);
+
+            let command: syntax::SimpleCommand = "echo hello".parse().unwrap();
+            _ = command.execute(&mut env).now_or_never().unwrap();
+            assert_eq!(env.exit_status, ExitStatus::NOEXEC);
+            assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
+            assert_stderr(&state, |stderr| {
+                assert!(
+                    stderr.contains("cannot execute built-in utility \"echo\""),
+                    "type={type:?} stderr={stderr:?}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn special_and_mandatory_builtins_are_not_rejected_under_portable_option() {
+        for r#type in [Special, Mandatory] {
+            let mut env = Env::new_virtual();
+            env.options.set(Portable, On);
+            let mut echo_builtin = echo_builtin();
+            echo_builtin.r#type = r#type;
+            env.builtins.insert("echo", echo_builtin);
+
+            let command: syntax::SimpleCommand = "echo hello".parse().unwrap();
+            _ = command.execute(&mut env).now_or_never().unwrap();
+            assert_eq!(env.exit_status, ExitStatus::SUCCESS, "type={type:?}");
         }
     }
 


### PR DESCRIPTION
## Description

Command search still finds these built-ins, but executing one now fails with an error (exit status 126) when `portable` is on, matching the long-standing TODO in yash-env's `builtin::Type` docs.

Since typeset (the only elective built-in) is now unconditionally rejected under `portable`, its own non-portable-variable-name checks become unreachable through typeset itself; equivalent scripted coverage is kept via export/readonly, which share the same check.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Portable mode now rejects attempts to execute elective and extension built-ins, returning an error (status 126), while keeping them discoverable during command search.
  * Mandatory and special built-ins continue to execute normally in portable mode.
  * Updated portable-script guidance and command behavior documentation.
  * Updated the changelogs and version to 3.3.4.

* **Bug Fixes**
  * Portable-mode validation now correctly rejects unsupported variable declarations and assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->