### PR TITLE
Split Mode::non_portable_option_names into two fields

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -24,6 +24,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `common::syntax::ParseError::NonPortableShortOption`, returned when a short
   option marked with `OptionSpec::extension` is used while the `portable`
   shell option is on.
+- The public `common::syntax::Mode::long_option_names` field for controlling
+  whether the parser accepts long option names, and the separate
+  `common::syntax::Mode::extension_options` field for controlling whether it
+  accepts options marked with `OptionSpec::extension`.
 - `common::syntax::Mode::option_arguments_in_same_field` for controlling
   whether a short option's argument may be attached to the option name, and
   `common::syntax::ParseError::UnseparatedOptionArgument` for reporting an
@@ -71,11 +75,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   option is on.
 - `common::syntax::Mode::with_env` now enables non-portable option syntax based
   on the `Portable` shell option instead of `PosixlyCorrect`. This includes long
-  options, extension-marked short options, and short-option arguments occurring
-  in the same field as the option name.
-- `common::syntax::Mode::accepts_long_options` and `accept_long_options` have
-  been removed. The option is now controlled directly through the public
-  `non_portable_option_names` field of `Mode`.
+  options, extension-marked options, and short-option arguments occurring in
+  the same field as the option name.
 - `common::syntax::ParseError::UnsupportedLongOption` has been renamed to
   `NonPortableLongOption`.
 - The `exit` built-in (`exit::main`) now rejects its `-f` option, in addition
@@ -111,6 +112,12 @@ A _private dependency_ is used internally and not visible to downstream users.
   is accepted.
 - Public dependency versions:
     - yash-env 0.16.0 → 0.16.1
+
+### Removed
+
+- `common::syntax::Mode::accepts_long_options` and
+  `common::syntax::Mode::accept_long_options`. Use the `long_option_names` and
+  `extension_options` fields of `Mode` instead.
 
 ## [0.22.0] - 2026-07-31
 

--- a/yash-builtin/src/common/syntax.rs
+++ b/yash-builtin/src/common/syntax.rs
@@ -1040,7 +1040,7 @@ mod tests {
     }
 
     #[test]
-    fn argument_taking_option_adjacent_to_another_option() {
+    fn argument_taking_short_option_after_other_short_options_in_cluster() {
         let specs = &[
             OptionSpec::new()
                 .short('a')
@@ -1314,13 +1314,6 @@ mod tests {
         let specs = &[OptionSpec::new().short('a')];
 
         let arguments = Field::dummies(["-x"]);
-        let error = parse_arguments(&[], Mode::default(), arguments).unwrap_err();
-        assert_matches!(&error, ParseError::UnknownShortOption('x', field) => {
-            assert_eq!(field.value, "-x");
-        });
-        assert_eq!(error.to_string(), "unknown option 'x'");
-
-        let arguments = Field::dummies(["-x"]);
         let error = parse_arguments(specs, Mode::default(), arguments).unwrap_err();
         assert_matches!(&error, ParseError::UnknownShortOption('x', field) => {
             assert_eq!(field.value, "-x");
@@ -1362,7 +1355,7 @@ mod tests {
     }
 
     #[test]
-    fn non_portable_short_option() {
+    fn extension_short_option_rejected_without_extension_option() {
         let specs = &[OptionSpec::new().short('f').extension(true)];
 
         let arguments = Field::dummies(["-f"]);
@@ -1376,7 +1369,7 @@ mod tests {
     }
 
     #[test]
-    fn non_portable_short_option_within_cluster() {
+    fn extension_short_option_within_cluster_rejected_without_extension_option() {
         let specs = &[
             OptionSpec::new().short('a'),
             OptionSpec::new().short('f').extension(true),

--- a/yash-builtin/src/common/syntax.rs
+++ b/yash-builtin/src/common/syntax.rs
@@ -185,13 +185,9 @@ impl OptionSpec<'_> {
     ///
     /// An option marked as an extension does not exist in the POSIX
     /// specification of the built-in it belongs to, regardless of whether it
-    /// is given a short or long name. When
-    /// [`Mode::non_portable_option_names`] is `false`, an
-    /// extension option is rejected even when spelled as a short option.
-    /// This is unlike a long option name, which is always rejected under the
-    /// same condition regardless of whether its underlying option is marked
-    /// as an extension, because POSIX does not define long option names at
-    /// all.
+    /// is given a short or long name. When [`Mode::extension_options`] is
+    /// `false`, an extension option is rejected regardless of whether it is
+    /// spelled as a short or long option.
     pub const fn is_extension(&self) -> bool {
         self.extension
     }
@@ -259,7 +255,8 @@ impl OptionSpec<'_> {
 /// ```
 /// # use yash_builtin::common::syntax::Mode;
 /// let mode = Mode::default();
-/// assert!(!mode.non_portable_option_names);
+/// assert!(!mode.long_option_names);
+/// assert!(!mode.extension_options);
 /// assert!(!mode.option_arguments_in_same_field);
 /// # // TODO other properties
 /// ```
@@ -270,25 +267,35 @@ impl OptionSpec<'_> {
 /// ```
 /// # use yash_builtin::common::syntax::Mode;
 /// let mode = Mode::with_extensions();
-/// assert!(mode.non_portable_option_names);
+/// assert!(mode.long_option_names);
+/// assert!(mode.extension_options);
 /// assert!(mode.option_arguments_in_same_field);
 /// # // TODO other properties
 /// ```
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Mode {
-    /// Whether the parser accepts non-portable option names or not
+    /// Whether the parser accepts long option names or not
     ///
-    /// This governs two kinds of options:
-    ///
-    /// - Any long option name (like `--foo`), which is itself a non-portable
-    ///   extension to the POSIX Utility Syntax Guidelines regardless of the
-    ///   underlying option.
-    /// - Any short option whose [`OptionSpec`] is marked as an extension
-    ///   (see [`OptionSpec::is_extension`]), because such an option does not
-    ///   exist in POSIX at all.
+    /// A long option name (like `--foo`) is itself a non-portable extension to
+    /// the POSIX Utility Syntax Guidelines, regardless of whether the
+    /// underlying option is defined in POSIX. While this field is `false`, a
+    /// long option name is rejected with [`ParseError::NonPortableLongOption`].
     ///
     /// The default value is `false`.
-    pub non_portable_option_names: bool,
+    pub long_option_names: bool,
+
+    /// Whether the parser accepts options marked as extensions or not
+    ///
+    /// An option whose [`OptionSpec`] is marked as an extension (see
+    /// [`OptionSpec::is_extension`]) does not exist in the POSIX specification
+    /// of the built-in it belongs to. While this field is `false`, such an
+    /// option is rejected with [`ParseError::NonPortableShortOption`] or
+    /// [`ParseError::NonPortableLongOption`], depending on whether it is
+    /// spelled as a short or long option.
+    ///
+    /// The default value is `false`.
+    pub extension_options: bool,
 
     /// Whether an option argument may occur in the same field as a short option
     ///
@@ -305,7 +312,8 @@ impl Mode {
     /// Returns a new `Mode` with non-portable extensions enabled.
     pub const fn with_extensions() -> Self {
         Mode {
-            non_portable_option_names: true,
+            long_option_names: true,
+            extension_options: true,
             option_arguments_in_same_field: true,
         }
     }
@@ -358,13 +366,15 @@ pub enum ParseError<'a> {
 
     /// Short option whose spec is marked as a [non-portable extension](`OptionSpec::is_extension`)
     ///
-    /// This error occurs only when [`Mode::non_portable_option_names`] is `false`.
+    /// This error occurs only when [`Mode::extension_options`] is `false`.
     #[error("non-portable option {0:?}")]
     NonPortableShortOption(char, Field, &'a OptionSpec<'a>),
 
     /// Long option that is defined in an option spec but disabled
     ///
-    /// This error occurs only when [`Mode::non_portable_option_names`] is `false`.
+    /// This error occurs when [`Mode::long_option_names`] is `false`, and also
+    /// when the option is marked as an [extension](OptionSpec::is_extension)
+    /// while [`Mode::extension_options`] is `false`.
     #[error("non-portable option {:?}", .0.value)]
     NonPortableLongOption(Field, &'a OptionSpec<'a>),
 
@@ -490,7 +500,7 @@ fn parse_short_options<'a, I: Iterator<Item = Field>>(
             None => return Err(ParseError::UnknownShortOption(c, field)),
             Some(spec) => spec,
         };
-        if spec.is_extension() && !mode.non_portable_option_names {
+        if spec.is_extension() && !mode.extension_options {
             return Err(ParseError::NonPortableShortOption(c, field, spec));
         }
         match spec.get_argument() {
@@ -587,7 +597,9 @@ fn parse_long_option<'a, I: Iterator<Item = Field>>(
     };
 
     let spec = match long_match(option_specs, name) {
-        Ok(spec) if mode.non_portable_option_names => spec,
+        Ok(spec) if mode.long_option_names && (mode.extension_options || !spec.is_extension()) => {
+            spec
+        }
         Ok(spec) => return Err(ParseError::NonPortableLongOption(field, spec)),
         Err(matched_specs) => {
             return Err(if matched_specs.is_empty() {
@@ -1380,22 +1392,73 @@ mod tests {
     }
 
     #[test]
-    fn extension_short_option_allowed_with_extensions() {
-        let specs = &[OptionSpec::new().short('f').extension(true)];
+    fn extension_short_option_allowed_with_extension_option() {
+        let specs = &[OptionSpec::new().short('f').long("force").extension(true)];
+        let mode = Mode {
+            extension_options: true,
+            ..Mode::default()
+        };
 
         let arguments = Field::dummies(["-f"]);
-        let (options, operands) =
-            parse_arguments(specs, Mode::with_extensions(), arguments).unwrap();
+        let (options, operands) = parse_arguments(specs, mode, arguments).unwrap();
         assert_eq!(options.len(), 1, "options = {options:?}");
         assert_eq!(options[0].spec.get_short(), Some('f'));
         assert_eq!(operands, []);
     }
 
     #[test]
+    fn extension_long_option_rejected_without_extension_option() {
+        let specs = &[OptionSpec::new().short('f').long("force").extension(true)];
+        let mode = Mode {
+            long_option_names: true,
+            ..Mode::default()
+        };
+
+        let arguments = Field::dummies(["--force"]);
+        let error = parse_arguments(specs, mode, arguments).unwrap_err();
+        assert_matches!(&error, ParseError::NonPortableLongOption(field, spec) => {
+            assert_eq!(field.value, "--force");
+            assert_eq!(*spec, &specs[0]);
+        });
+    }
+
+    #[test]
+    fn non_extension_long_option_allowed_with_long_option_names() {
+        let specs = &[OptionSpec::new().short('f').long("force")];
+        let mode = Mode {
+            long_option_names: true,
+            ..Mode::default()
+        };
+
+        let arguments = Field::dummies(["--force"]);
+        let (options, operands) = parse_arguments(specs, mode, arguments).unwrap();
+        assert_eq!(options.len(), 1, "options = {options:?}");
+        assert_eq!(options[0].spec.get_long(), Some("force"));
+        assert_eq!(operands, []);
+    }
+
+    #[test]
+    fn non_extension_long_option_rejected_without_long_option_names() {
+        let specs = &[OptionSpec::new().short('f').long("force")];
+        let mode = Mode {
+            extension_options: true,
+            ..Mode::default()
+        };
+
+        let arguments = Field::dummies(["--force"]);
+        let error = parse_arguments(specs, mode, arguments).unwrap_err();
+        assert_matches!(&error, ParseError::NonPortableLongOption(field, spec) => {
+            assert_eq!(field.value, "--force");
+            assert_eq!(*spec, &specs[0]);
+        });
+    }
+
+    #[test]
     fn mode_with_env_enables_extensions_by_default() {
         let env = yash_env::Env::new_virtual();
         let mode = Mode::with_env(&env);
-        assert!(mode.non_portable_option_names);
+        assert!(mode.long_option_names);
+        assert!(mode.extension_options);
         assert!(mode.option_arguments_in_same_field);
     }
 
@@ -1405,7 +1468,8 @@ mod tests {
         let mut env = yash_env::Env::new_virtual();
         env.options.set(Portable, On);
         let mode = Mode::with_env(&env);
-        assert!(!mode.non_portable_option_names);
+        assert!(!mode.long_option_names);
+        assert!(!mode.extension_options);
         assert!(!mode.option_arguments_in_same_field);
     }
 

--- a/yash-builtin/src/typeset/syntax.rs
+++ b/yash-builtin/src/typeset/syntax.rs
@@ -160,7 +160,7 @@ pub enum ParseError {
     /// Long option used while POSIX portability is required
     ///
     /// POSIX does not specify long options at all, so any `--name` or `++name`
-    /// form is rejected while [`Mode::non_portable_option_names`] is `false`.
+    /// form is rejected while [`Mode::long_option_names`] is `false`.
     /// This error applies to the `--` and `++` prefixes only; the `--`
     /// separator and short options remain acceptable. An option that cannot be
     /// canceled is still reported as
@@ -297,9 +297,7 @@ fn try_parse_long<'a, I: Iterator<Item = Field>>(
         Some(spec) if negate && spec.attr.is_none() => {
             Err(ParseError::UncancelableLongOption(field))
         }
-        Some(_spec) if !mode.non_portable_option_names => {
-            Err(ParseError::NonPortableLongOption(field))
-        }
+        Some(_spec) if !mode.long_option_names => Err(ParseError::NonPortableLongOption(field)),
         Some(spec) => Ok(Some(OptionOccurrence {
             spec,
             state: if negate { State::Off } else { State::On },
@@ -314,12 +312,13 @@ fn try_parse_long<'a, I: Iterator<Item = Field>>(
 /// recognized by the parser.
 ///
 /// The second argument selects the syntax this parser accepts. This parser
-/// honors only [`Mode::non_portable_option_names`], which governs whether long
+/// honors only [`Mode::long_option_names`], which governs whether long
 /// options are accepted; while it is `false`, a long option is rejected with
 /// [`ParseError::NonPortableLongOption`]. The other fields of [`Mode`] describe
-/// syntax this parser cannot produce: no option of the typeset built-in family
-/// takes an argument, and its operands are never numbers. A future version is
-/// expected to honor `options_after_operands` as well.
+/// syntax this parser cannot produce for now: the typeset built-in family has
+/// its own [`OptionSpec`] type that cannot mark an option as an extension, no
+/// option of the family takes an argument, and its operands are never numbers.
+/// A future version is expected to honor `options_after_operands` as well.
 ///
 /// The third argument is a list of command line arguments to be parsed.
 ///
@@ -602,12 +601,11 @@ mod tests {
 
     #[test]
     fn parse_long_print_option_without_operands() {
-        let result = parse(
-            ALL_OPTIONS,
-            Mode::with_extensions(),
-            Field::dummies(["--print"]),
-        )
-        .unwrap();
+        let mode = Mode {
+            long_option_names: true,
+            ..Mode::default()
+        };
+        let result = parse(ALL_OPTIONS, mode, Field::dummies(["--print"])).unwrap();
         assert_matches!(&result.0[..], [option] => {
             assert_eq!(option.spec, &PRINT_OPTION);
             assert_eq!(option.state, State::On);


### PR DESCRIPTION
## Description

The single flag conflated two independent axes of non-portable option syntax: long option names, which POSIX does not define at all, and options marked as extensions, which are absent from the POSIX specification of the built-in that owns them. Callers had no way to enable one without the other.

`common::syntax::Mode` now exposes `long_option_names` and `extension_options` separately. A long option is accepted only when `long_option_names` is on and, if its spec is marked as an extension, `extension_options` is on as well; an extension short option is now governed by `extension_options` alone, independent of long option support.

`Mode` becomes `non_exhaustive` so later syntax axes can be added without breaking construction.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate controls for enabling long option names and extension options.
  * Improved parser behavior for independently handling extension short options and long options.
  * Updated environment-based shell modes to apply option controls according to portability settings.

* **Documentation**
  * Clarified parser and typeset option support, configuration, and limitations.

* **Breaking Changes**
  * Replaced the previous long-option control APIs with the new configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->