### PR TITLE
Reject -l and -p given together to the jobs built-in under portable

### DIFF
--- a/docs/src/builtins/jobs.md
+++ b/docs/src/builtins/jobs.md
@@ -119,6 +119,6 @@ When the built-in is used in a [subshell](../environment/index.html#subshells), 
 
 The POSIX standard only defines the `-l` and `-p` options. <!-- TODO: Other options are non-portable extensions. --> Previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
-POSIX does not define the behavior when both `-l` and `-p` options are used together. In most other shells, the option specified last takes effect. In yash-rs, the `-p` option takes precedence over `-l`, but this may change in future versions. Later releases of yash-rs might instead reject conflicting options.
+POSIX specifies the options as `-l|-p`, allowing only one of them, and does not define the behavior when both are used together. In most other shells, the option specified last takes effect. In yash-rs, the `-p` option takes precedence over `-l`, but this may change in future versions. (Since 3.3.5) The [`portable` option](../environment/options.md#portable) rejects the combination with an error. Repeating the same option is not a conflict and is accepted either way.
 
 A portable job ID must start with a `%`. If an operand does not have a leading `%`, the built-in assumes one silently, which is not portable.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -145,6 +145,11 @@ A _private dependency_ is used internally and not visible to downstream users.
   on. POSIX writes the options as `-v|-V`, allowing only one of them. Without
   the option, the last one specified still takes effect, and repeating the
   same option is accepted either way.
+- The `jobs` built-in (`jobs::main`) now rejects an invocation that has both
+  the `-l` and `-p` options when the `portable` shell option is on. POSIX
+  writes the options as `-l|-p`, allowing only one of them. Without the option,
+  `-p` still takes precedence over `-l`, and repeating the same option is
+  accepted either way.
 - The `.` built-in (`source::syntax::parse`) now rejects an operand after the
   file operand when the `portable` shell option is on. POSIX specifies the
   syntax as `. file`, so such an operand is an extension.

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -23,6 +23,7 @@
 use crate::common::output;
 use crate::common::report::report_error;
 use crate::common::report::report_failure;
+use crate::common::syntax::ConflictingOptionError;
 use crate::common::syntax::Mode;
 use crate::common::syntax::OptionSpec;
 use crate::common::syntax::parse_arguments;
@@ -32,7 +33,11 @@ use yash_env::job::fmt::Accumulator;
 use yash_env::job::id::FindError;
 use yash_env::job::id::parse;
 use yash_env::job::id::parse_tail;
+use yash_env::option::Option::Portable;
+use yash_env::option::State;
 use yash_env::semantics::Field;
+use yash_env::source::pretty::Footnote;
+use yash_env::source::pretty::FootnoteType;
 use yash_env::source::pretty::Report;
 use yash_env::source::pretty::ReportType;
 use yash_env::source::pretty::Snippet;
@@ -59,6 +64,10 @@ fn find_error_report(error: FindError, operand: &Field) -> Report<'_> {
 }
 
 /// Entry point for executing the `jobs` built-in
+///
+/// While the [`Portable`] shell option is on, the `-l` and `-p` options cannot
+/// be used together, as POSIX specifies the syntax as
+/// `jobs [-l|-p] [job_id…]`; the combination is rejected with an error.
 pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
 where
     S: Isatty + Signals + WriteAll,
@@ -67,6 +76,23 @@ where
         Ok(result) => result,
         Err(error) => return report_error(env, &error).await,
     };
+
+    if env.options.get(Portable) == State::On {
+        // POSIX writes the two options as `-l|-p`, so only one may be used.
+        // Repeating the same option is not a conflict.
+        let l = options.iter().position(|o| o.spec.get_short() == Some('l'));
+        let p = options.iter().position(|o| o.spec.get_short() == Some('p'));
+        if let (Some(l), Some(p)) = (l, p) {
+            let error = ConflictingOptionError::pick_from_indexes(options, [l, p]);
+            let mut report = error.to_report();
+            report.footnotes.push(Footnote {
+                r#type: FootnoteType::Note,
+                label: "this error is reported because the `portable` shell option is enabled"
+                    .into(),
+            });
+            return report_error(env, report).await;
+        }
+    }
 
     let mut accumulator = Accumulator {
         current_job_index: env.jobs.current_job(),
@@ -510,6 +536,52 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         assert_stdout(&state, |stdout| assert_eq!(stdout, "42\n72\n"));
+    }
+
+    #[test]
+    fn conflicting_l_and_p_options_portable() {
+        // With the portable option on, -l and -p cannot be used together.
+        for args in [
+            Field::dummies(["-l", "-p"]),
+            Field::dummies(["-p", "-l"]),
+            Field::dummies(["-lp"]),
+        ] {
+            let system = VirtualSystem::new();
+            let state = Rc::clone(&system.state);
+            let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+            env.options.set(Portable, State::On);
+            env.jobs.insert(Job::new(Pid(42)));
+
+            let mut env = env.push_frame(Frame::Builtin(Builtin {
+                name: Field::dummy("jobs"),
+                is_special: false,
+            }));
+            let result = main(&mut env, args.clone()).now_or_never().unwrap();
+            assert_eq!(result, Result::new(ExitStatus::ERROR), "{args:?}");
+            assert_stdout(&state, |stdout| assert_eq!(stdout, "", "{args:?}"));
+            assert_stderr(&state, |stderr| {
+                assert!(stderr.contains("portable"), "{args:?}: stderr = {stderr:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn repeated_l_or_p_option_portable() {
+        // Repeating the same option is not a conflict.
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, State::On);
+        let mut job = Job::new(Pid(42));
+        job.name = "echo first".to_string();
+        env.jobs.insert(job);
+
+        let args = Field::dummies(["-l", "-l"]);
+        let result = main(&mut env, args).now_or_never().unwrap();
+        assert_eq!(result, Result::new(ExitStatus::SUCCESS));
+        assert_stdout(&state, |stdout| {
+            assert_eq!(stdout, "[1] +    42 Running              echo first\n")
+        });
     }
 
     #[test]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - With `portable` enabled, the `command` built-in now rejects more than one operand given with the `-v` or `-V` option (for example, `command -v ls cat`). POSIX specifies the syntax as `command [-p][-v|-V] command_name`, which identifies one command at a time. The `type` built-in still accepts more than one operand, since POSIX spells its operands `name…`.
 - With `portable` enabled, the `command` built-in now rejects an invocation that has both the `-v` and `-V` options (for example, `command -v -V ls`). POSIX writes the options as `-v|-V`, allowing only one of them. Repeating the same option (for example, `command -v -v ls`) is still accepted.
 - With `portable` enabled, the `.` built-in now rejects an operand after the *file* operand (for example, `. ./script.sh foo`).
+- With `portable` enabled, the `jobs` built-in now rejects an invocation that has both the `-l` and `-p` options (for example, `jobs -l -p`). POSIX writes the options as `-l|-p`, allowing only one of them. Repeating the same option (for example, `jobs -l -l`) is still accepted.
 
 ## [3.3.4] - 2026-07-31
 

--- a/yash-cli/tests/scripted_test/jobs-y.sh
+++ b/yash-cli/tests/scripted_test/jobs-y.sh
@@ -11,3 +11,30 @@ __IN__
 test_OE -e 0 'short option name still accepted under the portable option' -o portable
 jobs -l
 __IN__
+
+test_OE -e 0 'jobs accepts -l and -p together without the portable option'
+jobs -l -p
+__IN__
+
+test_O -d -e 2 'jobs rejects -l and -p together under the portable option' -o portable
+jobs -l -p
+__IN__
+
+test_O -d -e 2 'jobs rejects -p and -l together under the portable option' -o portable
+jobs -p -l
+__IN__
+
+test_O -d -e 2 'jobs rejects -lp in one argument under the portable option' -o portable
+jobs -lp
+__IN__
+
+test_oE 'jobs conflicting option error message mentions the portable option' -o portable
+(jobs -l -p) 2>result
+grep -Fq portable result && echo shown
+__IN__
+shown
+__OUT__
+
+test_OE -e 0 'jobs accepts a repeated -l under the portable option' -o portable
+jobs -l -l
+__IN__


### PR DESCRIPTION
## Description

Part of #807: rejects `-l` and `-p` given together to the `jobs` built-in when the `portable` shell option is on.

POSIX writes the formatting options as `-l|-p`, allowing only one of them. Without `portable`, `-p` still takes precedence over `-l` as before.

Details:

- The check reuses `common::syntax::ConflictingOptionError` and adds the same `portable` footnote that the other portable-only errors carry, following #858 for `command -v -V`.
- Repeating the same option (`jobs -l -l`) is not a conflict: POSIX bars the combination, not the repetition.
- The combination is rejected however it is spelled, so `jobs -lp` is an error too.
- The check lives in `jobs::main` rather than a new `jobs::syntax` submodule; the existing TODO to split the built-in into syntax and semantics submodules is left for its own change. No public API is added.
- `docs/src/posix.md` needs no new item: the entry covering non-portable option syntax across built-ins already lists `jobs` and, since #858, already covers a combination of options POSIX does not allow.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * `jobs` now rejects simultaneous `-l` and `-p` options when portable mode is enabled.
  * Repeated identical options remain accepted.
  * Without portable mode, `-p` continues to take precedence.

* **Documentation**
  * Updated compatibility documentation and changelogs to describe the revised option behavior.

* **Tests**
  * Added coverage for conflicting option combinations and repeated options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->