### PR TITLE
Reject -l and -p given together to the jobs built-in

### DIFF
--- a/docs/src/builtins/jobs.md
+++ b/docs/src/builtins/jobs.md
@@ -47,6 +47,8 @@ You can use two options to change the output.
 
 The **`-l`** (**`--verbose`**) option displays additional details by inserting the process ID before each job state. The **`-p`** (**`--pgid-only`**) option outputs only the process ID of each job. In both cases, the process ID shown is that of the main process in the job, which is also the process group ID if the job is under job control.
 
+The two options are mutually exclusive. (Since 3.3.5) Specifying both is an error.
+
 <!--
 ### Filtering
 
@@ -61,6 +63,8 @@ job to report. If no operands are given, the built-in prints all jobs.
 ## Errors
 
 If an operand does not specify a valid job, the built-in prints an error message to the standard error and returns a non-zero exit status. An ambiguous job ID (matching multiple jobs) is also an error.
+
+(Since 3.3.5) Specifying both the `-l` and `-p` options is an error.
 
 The [`portable` option](../environment/options.md#portable) causes additional errors; see [Compatibility](#compatibility).
 
@@ -119,6 +123,6 @@ When the built-in is used in a [subshell](../environment/index.html#subshells), 
 
 The POSIX standard only defines the `-l` and `-p` options. <!-- TODO: Other options are non-portable extensions. --> Previous versions of yash supported additional options, which are not yet implemented in yash-rs.
 
-POSIX does not define the behavior when both `-l` and `-p` options are used together. In most other shells, the option specified last takes effect. In yash-rs, the `-p` option takes precedence over `-l`, but this may change in future versions. Later releases of yash-rs might instead reject conflicting options.
+POSIX specifies the options as `-l|-p` and does not define the behavior when both are used together. Other shells accept the combination, but what they do with it varies from shell to shell. (Since 3.3.5) yash-rs has no reason to prefer either option over the other, so it rejects the combination with an error, whichever order or spelling it is written in.
 
 A portable job ID must start with a `%`. If an operand does not have a leading `%`, the built-in assumes one silently, which is not portable.

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -145,6 +145,8 @@ A _private dependency_ is used internally and not visible to downstream users.
   on. POSIX writes the options as `-v|-V`, allowing only one of them. Without
   the option, the last one specified still takes effect, and repeating the
   same option is accepted either way.
+- The `jobs` built-in (`jobs::main`) now rejects an invocation that has both
+  the `-l` and `-p` options.
 - The `.` built-in (`source::syntax::parse`) now rejects an operand after the
   file operand when the `portable` shell option is on. POSIX specifies the
   syntax as `. file`, so such an operand is an extension.

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -23,6 +23,7 @@
 use crate::common::output;
 use crate::common::report::report_error;
 use crate::common::report::report_failure;
+use crate::common::syntax::ConflictingOptionError;
 use crate::common::syntax::Mode;
 use crate::common::syntax::OptionSpec;
 use crate::common::syntax::parse_arguments;
@@ -68,23 +69,30 @@ where
         Err(error) => return report_error(env, &error).await,
     };
 
-    let mut accumulator = Accumulator {
-        current_job_index: env.jobs.current_job(),
-        previous_job_index: env.jobs.previous_job(),
-        show_pid: false,
-        pgid_only: false,
-        print: String::new(),
-        indices_reported: Vec::new(),
-    };
-
-    // Apply options
-    for option in options {
+    // Find the first occurrence of each option.
+    let (mut l, mut p) = (None, None);
+    for (index, option) in options.iter().enumerate() {
         match option.spec.get_short() {
-            Some('l') => accumulator.show_pid = true,
-            Some('p') => accumulator.pgid_only = true,
+            Some('l') => l = l.or(Some(index)),
+            Some('p') => p = p.or(Some(index)),
             _ => unreachable!("unhandled option: {:?}", option),
         }
     }
+
+    // The `-l` and `-p` options are mutually exclusive.
+    if let (Some(l), Some(p)) = (l, p) {
+        let error = ConflictingOptionError::pick_from_indexes(options, [l, p]);
+        return report_error(env, &error).await;
+    }
+
+    let mut accumulator = Accumulator {
+        current_job_index: env.jobs.current_job(),
+        previous_job_index: env.jobs.previous_job(),
+        show_pid: l.is_some(),
+        pgid_only: p.is_some(),
+        print: String::new(),
+        indices_reported: Vec::new(),
+    };
 
     if operands.is_empty() {
         // Report all jobs
@@ -494,22 +502,49 @@ mod tests {
     }
 
     #[test]
-    fn p_option_cancels_l_option() {
+    fn conflicting_l_and_p_options() {
+        for args in [
+            Field::dummies(["-l", "-p"]),
+            Field::dummies(["-p", "-l"]),
+            Field::dummies(["-lp"]),
+        ] {
+            let system = VirtualSystem::new();
+            let state = Rc::clone(&system.state);
+            let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+            env.jobs.insert(Job::new(Pid(42)));
+
+            let mut env = env.push_frame(Frame::Builtin(Builtin {
+                name: Field::dummy("jobs"),
+                is_special: false,
+            }));
+            let result = main(&mut env, args.clone()).now_or_never().unwrap();
+            assert_eq!(result, Result::new(ExitStatus::ERROR), "{args:?}");
+            assert_stdout(&state, |stdout| assert_eq!(stdout, "", "{args:?}"));
+            assert_stderr(&state, |stderr| {
+                assert!(
+                    stderr.contains("conflicting options"),
+                    "{args:?}: stderr = {stderr:?}"
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn repeated_l_option() {
+        // Repeating the same option is not a conflict.
         let system = VirtualSystem::new();
         let state = Rc::clone(&system.state);
         let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
         let mut job = Job::new(Pid(42));
         job.name = "echo first".to_string();
         env.jobs.insert(job);
-        let mut job = Job::new(Pid(72));
-        job.state = ProcessState::stopped(SIGSTOP);
-        job.name = "echo second".to_string();
-        env.jobs.insert(job);
 
-        let args = Field::dummies(["-pl"]);
+        let args = Field::dummies(["-l", "-l"]);
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
-        assert_stdout(&state, |stdout| assert_eq!(stdout, "42\n72\n"));
+        assert_stdout(&state, |stdout| {
+            assert_eq!(stdout, "[1] +    42 Running              echo first\n")
+        });
     }
 
     #[test]

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - With `portable` enabled, the `command` built-in now rejects more than one operand given with the `-v` or `-V` option (for example, `command -v ls cat`). POSIX specifies the syntax as `command [-p][-v|-V] command_name`, which identifies one command at a time. The `type` built-in still accepts more than one operand, since POSIX spells its operands `name…`.
 - With `portable` enabled, the `command` built-in now rejects an invocation that has both the `-v` and `-V` options (for example, `command -v -V ls`). POSIX writes the options as `-v|-V`, allowing only one of them. Repeating the same option (for example, `command -v -v ls`) is still accepted.
 - With `portable` enabled, the `.` built-in now rejects an operand after the *file* operand (for example, `. ./script.sh foo`).
+- The `jobs` built-in now rejects an invocation that has both the `-l` and `-p` options. Previously `-p` took precedence over `-l`, which was not necessarily intuitive.
 
 ## [3.3.4] - 2026-07-31
 

--- a/yash-cli/tests/scripted_test/jobs-y.sh
+++ b/yash-cli/tests/scripted_test/jobs-y.sh
@@ -11,3 +11,11 @@ __IN__
 test_OE -e 0 'short option name still accepted under the portable option' -o portable
 jobs -l
 __IN__
+
+test_O -d -e 2 'jobs rejects -lp in one argument'
+jobs -lp
+__IN__
+
+test_OE -e 0 'jobs accepts a repeated -l option'
+jobs -l -l
+__IN__


### PR DESCRIPTION
## Description

POSIX writes the formatting options of the `jobs` built-in as `-l|-p`, but this implementation has let `-p` take precedence over `-l`. There is no good reason to prefer either option over the other, so this PR rejects the combination with an error instead.

- The check reuses `common::syntax::ConflictingOptionError`, as the `unset` built-in already does for `-f` and `-v`.
- Repeating the same option is not a conflict, since it raises no question of which of the two formats to use. Nor does the spelling matter, so `jobs -lp` is an error just as `jobs -l -p` is.
- The loop that examines the parsed options now records where each option first occurs, so a single pass both finds the conflict and decides the output format.
- The check lives in `jobs::main` rather than a new `syntax` submodule; the TODO to split the built-in into `syntax` and `semantics` submodules is left for its own change.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
