### PR TITLE
Warn about arguments to the true and false built-ins under portable

### DIFF
--- a/docs/src/builtins/false.md
+++ b/docs/src/builtins/false.md
@@ -42,3 +42,5 @@ The `false` utility is specified by POSIX.1-2024.
 POSIX allows `false` to return any non-zero exit status, but most implementations return 1.
 
 Most implementations ignore any arguments, but some implementations may respond to them. For example, the GNU coreutils implementation accepts the `--help` and `--version` options. For maximum portability, avoid passing arguments to `false`.
+
+POSIX lists both the OPTIONS and OPERANDS sections of `false` as "None.", which means a conforming implementation need not support any option or operand. (Since 3.3.5) When the [`portable` option](../environment/options.md#portable) is set, the built-in prints a warning if it is given any argument, including a lone `--`. The warning does not affect the exit status, and the argument is still ignored.

--- a/docs/src/builtins/true.md
+++ b/docs/src/builtins/true.md
@@ -39,3 +39,5 @@ See [And-or lists](../language/commands/exit_status.md#and-or-lists) for example
 The `true` utility is specified by POSIX.1-2024.
 
 Most implementations ignore any arguments, but some implementations respond to them. For example, the GNU coreutils implementation accepts the `--help` and `--version` options. For maximum portability, avoid passing arguments to `true`. To pass and ignore arguments, use the [`:` (colon) built-in](colon.md) instead.
+
+POSIX lists both the OPTIONS and OPERANDS sections of `true` as "None.", which means a conforming implementation need not support any option or operand. (Since 3.3.5) When the [`portable` option](../environment/options.md#portable) is set, the built-in prints a warning if it is given any argument, including a lone `--`. The warning does not affect the exit status, and the argument is still ignored.

--- a/docs/src/posix.md
+++ b/docs/src/posix.md
@@ -57,8 +57,6 @@ Rules for writing the lists below. Ask the maintainer when a case is unclear.
 - Order the items within each list by where their linked page appears in
   SUMMARY.md. The linked page is the one that documents the item in full,
   including the portable alternative.
-- When a list has no items yet, leave the list out entirely rather than writing
-  an empty one.
 -->
 
 ### Features that cause an error
@@ -90,6 +88,12 @@ The shell reports an error and does not run the construct:
 - (Since 3.3.3) Making the `PWD`, `OLDPWD`, `OPTIND`, `OPTARG`, or `LINENO` [variable](language/parameters/variables.md#reserved-variable-names) read-only with the [`readonly` built-in](builtins/readonly.md).
 - (Since 3.3.4) Executing the [`.` built-in](builtins/source.md) under the name `source`.
 - (Since 3.3.2) The increment and decrement operators (`++` and `--`) in an [arithmetic expression](arithmetic.md).
+
+### Features that trigger a warning
+
+The shell prints a warning to the standard error and runs the construct anyway:
+
+- (Since 3.3.5) An argument, including a lone `--`, given to the [`false`](builtins/false.md) or [`true`](builtins/true.md) built-in.
 
 ### Features that are ignored
 

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -153,6 +153,12 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `typeset::syntax::parse` now takes a `common::syntax::Mode` as a second
   parameter, allowing the caller to control whether non-portable option syntax
   is accepted.
+- `r#true::main` and `r#false::main` now require the system type parameter to
+  implement `Isatty` and `WriteAll`. While the `portable` shell option is on,
+  they print a warning to the standard error if they are given any argument,
+  since POSIX lists both the OPTIONS and OPERANDS sections of the `true` and
+  `false` utilities as "None.". The warning does not affect the exit status,
+  and the arguments are still ignored.
 - Public dependency versions:
     - yash-env 0.16.0 → 0.16.1
 

--- a/yash-builtin/src/common.rs
+++ b/yash-builtin/src/common.rs
@@ -24,6 +24,7 @@ use yash_env::io::Fd;
 use yash_env::system::Isatty;
 use yash_env::system::concurrency::WriteAll;
 
+pub(crate) mod no_arg;
 pub mod report;
 pub mod syntax;
 

--- a/yash-builtin/src/common/no_arg.rs
+++ b/yash-builtin/src/common/no_arg.rs
@@ -1,0 +1,142 @@
+// This file is part of yash, an extended POSIX shell.
+// Copyright (C) 2026 WATANABE Yuki
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Support for built-ins that POSIX specifies with no options and no operands
+//!
+//! POSIX describes the [`true`](crate::r#true) and [`false`](crate::r#false)
+//! built-ins with both the OPTIONS and OPERANDS sections listed as "None.",
+//! which XCU 1.4 Utility Description Defaults defines as meaning the
+//! implementation need not support any options or operands. An argument given
+//! to such a built-in therefore has no portable meaning, so this module warns
+//! about it while the `portable` shell option is on.
+
+use super::report::prepare_report_message_and_divert;
+use yash_env::Env;
+use yash_env::option::Option::Portable;
+use yash_env::option::State;
+use yash_env::semantics::Field;
+use yash_env::source::pretty::{Footnote, FootnoteType, Report, ReportType, Snippet};
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
+
+/// Warns that the built-in was given an argument, if it was and the `portable`
+/// shell option is on.
+///
+/// The message is only a warning: it does not affect the exit status, and the
+/// built-in still does what it would have done without the argument.
+pub(crate) async fn warn_if_any_argument<S>(env: &mut Env<S>, args: &[Field])
+where
+    S: Isatty + WriteAll,
+{
+    let Some(first) = args.first() else { return };
+    if env.options.get(Portable) != State::On {
+        return;
+    }
+
+    let mut report = Report::new();
+    report.r#type = ReportType::Warning;
+    report.title = "non-portable argument".into();
+    report.snippets = Snippet::with_primary_span(
+        &first.origin,
+        "POSIX does not require this built-in to accept any argument".into(),
+    );
+    report.footnotes.push(Footnote {
+        r#type: FootnoteType::Note,
+        label: "this warning is reported because the `portable` shell option is enabled".into(),
+    });
+
+    let (message, _divert) = prepare_report_message_and_divert(env, report);
+    env.system.print_error(&message).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::VirtualSystem;
+    use yash_env::option::State::{Off, On};
+    use yash_env::system::Concurrent;
+    use yash_env::test_helper::assert_stderr;
+
+    #[test]
+    fn no_warning_without_arguments() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+
+        warn_if_any_argument(&mut env, &[]).now_or_never().unwrap();
+
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn no_warning_without_portable_option() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, Off);
+        let args = Field::dummies(["foo"]);
+
+        warn_if_any_argument(&mut env, &args)
+            .now_or_never()
+            .unwrap();
+
+        assert_stderr(&state, |stderr| assert_eq!(stderr, ""));
+    }
+
+    #[test]
+    fn warning_with_portable_option() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["foo"]);
+
+        warn_if_any_argument(&mut env, &args)
+            .now_or_never()
+            .unwrap();
+
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("non-portable argument"), "{stderr:?}");
+            assert!(stderr.contains("foo"), "{stderr:?}");
+            assert!(stderr.contains("portable"), "{stderr:?}");
+        });
+    }
+
+    #[test]
+    fn warning_points_at_the_first_argument_only() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["--", "bar"]);
+
+        warn_if_any_argument(&mut env, &args)
+            .now_or_never()
+            .unwrap();
+
+        assert_stderr(&state, |stderr| {
+            assert_eq!(
+                stderr.matches("non-portable argument").count(),
+                1,
+                "{stderr:?}"
+            );
+            assert!(!stderr.contains("bar"), "{stderr:?}");
+        });
+    }
+}

--- a/yash-builtin/src/false.rs
+++ b/yash-builtin/src/false.rs
@@ -21,13 +21,52 @@
 //! [`false` built-in]: https://magicant.github.io/yash-rs/builtins/false.html
 
 use crate::Result;
+use crate::common::no_arg::warn_if_any_argument;
 use yash_env::Env;
 use yash_env::semantics::ExitStatus;
 use yash_env::semantics::Field;
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Executes the `false` built-in.
 ///
 /// This is the main entry point for the `false` built-in.
-pub async fn main<S>(_env: &mut Env<S>, _args: Vec<Field>) -> Result {
+///
+/// The built-in ignores its arguments, but warns about them while the
+/// `portable` shell option is on. The warning does not affect the exit status.
+pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
+where
+    S: Isatty + WriteAll,
+{
+    warn_if_any_argument(env, &args).await;
     Result::new(ExitStatus::FAILURE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::VirtualSystem;
+    use yash_env::option::Option::Portable;
+    use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
+    use yash_env::test_helper::assert_stderr;
+
+    #[test]
+    fn returns_failure_with_arguments_under_portable_option() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["foo"]);
+
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        // The argument is only warned about; it does not affect the result.
+        assert_eq!(result, Result::new(ExitStatus::FAILURE));
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("non-portable argument"), "{stderr:?}");
+        });
+    }
 }

--- a/yash-builtin/src/true.rs
+++ b/yash-builtin/src/true.rs
@@ -21,12 +21,51 @@
 //! [`true` built-in]: https://magicant.github.io/yash-rs/builtins/true.html
 
 use crate::Result;
+use crate::common::no_arg::warn_if_any_argument;
 use yash_env::Env;
 use yash_env::semantics::Field;
+use yash_env::system::Isatty;
+use yash_env::system::concurrency::WriteAll;
 
 /// Executes the `true` built-in.
 ///
 /// This is the main entry point for the `true` built-in.
-pub async fn main<S>(_env: &mut Env<S>, _args: Vec<Field>) -> Result {
+///
+/// The built-in ignores its arguments, but warns about them while the
+/// `portable` shell option is on. The warning does not affect the exit status.
+pub async fn main<S>(env: &mut Env<S>, args: Vec<Field>) -> Result
+where
+    S: Isatty + WriteAll,
+{
+    warn_if_any_argument(env, &args).await;
     Result::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt as _;
+    use std::rc::Rc;
+    use yash_env::VirtualSystem;
+    use yash_env::option::Option::Portable;
+    use yash_env::option::State::On;
+    use yash_env::system::Concurrent;
+    use yash_env::test_helper::assert_stderr;
+
+    #[test]
+    fn returns_success_with_arguments_under_portable_option() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, On);
+        let args = Field::dummies(["foo"]);
+
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        // The argument is only warned about; it does not affect the result.
+        assert_eq!(result, Result::default());
+        assert_stderr(&state, |stderr| {
+            assert!(stderr.contains("non-portable argument"), "{stderr:?}");
+        });
+    }
 }

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - With `portable` enabled, the `command` built-in now rejects more than one operand given with the `-v` or `-V` option (for example, `command -v ls cat`). POSIX specifies the syntax as `command [-p][-v|-V] command_name`, which identifies one command at a time. The `type` built-in still accepts more than one operand, since POSIX spells its operands `name…`.
 - With `portable` enabled, the `command` built-in now rejects an invocation that has both the `-v` and `-V` options (for example, `command -v -V ls`). POSIX writes the options as `-v|-V`, allowing only one of them. Repeating the same option (for example, `command -v -v ls`) is still accepted.
 - With `portable` enabled, the `.` built-in now rejects an operand after the *file* operand (for example, `. ./script.sh foo`).
+- With `portable` enabled, the `true` and `false` built-ins now print a warning if they are given any argument, including a lone `--` (for example, `true foo` or `false --`). POSIX lists both the OPTIONS and OPERANDS sections of these utilities as "None.", so a conforming implementation need not support any argument. The warning goes to the standard error and does not affect the exit status; the arguments are still ignored.
 - The `jobs` built-in now rejects an invocation that has both the `-l` and `-p` options. Previously `-p` took precedence over `-l`, which was not necessarily intuitive.
 
 ## [3.3.4] - 2026-07-31

--- a/yash-cli/tests/scripted_test.rs
+++ b/yash-cli/tests/scripted_test.rs
@@ -267,6 +267,11 @@ fn false_builtin() {
 }
 
 #[test]
+fn false_builtin_ex() {
+    run("false-y.sh")
+}
+
+#[test]
 fn fg_builtin() {
     run_with_pty("fg-p.sh")
 }
@@ -551,6 +556,11 @@ fn trap_ex_2() {
 #[test]
 fn true_builtin() {
     run("true-p.sh")
+}
+
+#[test]
+fn true_builtin_ex() {
+    run("true-y.sh")
 }
 
 #[test]

--- a/yash-cli/tests/scripted_test/false-y.sh
+++ b/yash-cli/tests/scripted_test/false-y.sh
@@ -1,0 +1,28 @@
+# false-y.sh: yash-specific test of the false built-in
+
+test_OE -e n 'false ignores arguments'
+false foo -x --
+__IN__
+
+test_OE -e n 'false without arguments is silent under the portable option' -o portable
+false
+__IN__
+
+test_O -d -e n 'false warns about an operand under the portable option' -o portable
+false foo
+__IN__
+
+test_O -d -e n 'false warns about an option-like argument under the portable option' -o portable
+false -x
+__IN__
+
+test_O -d -e n 'false warns about -- under the portable option' -o portable
+false --
+__IN__
+
+test_oE 'false argument warning mentions the portable option' -o portable
+(false foo) 2>result
+grep -Fq portable result && echo shown
+__IN__
+shown
+__OUT__

--- a/yash-cli/tests/scripted_test/true-y.sh
+++ b/yash-cli/tests/scripted_test/true-y.sh
@@ -1,0 +1,28 @@
+# true-y.sh: yash-specific test of the true built-in
+
+test_OE -e 0 'true ignores arguments'
+true foo -x --
+__IN__
+
+test_OE -e 0 'true without arguments is silent under the portable option' -o portable
+true
+__IN__
+
+test_O -d -e 0 'true warns about an operand under the portable option' -o portable
+true foo
+__IN__
+
+test_O -d -e 0 'true warns about an option-like argument under the portable option' -o portable
+true -x
+__IN__
+
+test_O -d -e 0 'true warns about -- under the portable option' -o portable
+true --
+__IN__
+
+test_oE 'true argument warning mentions the portable option' -o portable
+(true foo) 2>result
+grep -Fq portable result && echo shown
+__IN__
+shown
+__OUT__


### PR DESCRIPTION
## Description

POSIX lists both the OPTIONS and OPERANDS sections of the `true` and `false` utilities as "None.", which XCU 1.4 Utility Description Defaults defines as meaning the implementation need not support any. The requirement to accept a leading `--` applies only to utilities that *do* accept operands, so it does not reach these two; the note about `--` on the `true` page is in the informative APPLICATION USAGE section. No argument to `true` or `false` is therefore portable, and this PR makes the built-ins say so while the `portable` option is on.

- The reaction is a **warning**, not an error, and the exit status stays 0 for `true` and 1 for `false`. These two built-ins are the ones scripts lean on to carry a fixed exit status through a conditional, so turning an argument into a failure would silently invert the control flow of an existing script the moment `portable` is enabled, and turning it into an error for `false` would be indistinguishable from the value the script wanted. A message on the standard error tells the author what is not portable without changing what the script does.
- This is the first item in the "features that trigger a warning" list that 00c032f5 prepared in `docs/src/posix.md`. The authoring rule about omitting an empty list goes with it, now that every reaction the rules enumerate has one.
- The check lives in a shared `common::no_arg` module rather than in each built-in, since the two would otherwise construct the same report twice. It is `pub(crate)`, so it adds no public API; the trait bounds the printing needs do change the signatures of `r#true::main` and `r#false::main`.
- The arguments are not parsed at all. Running them through the option parser would report an unknown option for `true -x`, which is a different reaction to a construct that is non-portable for the same single reason.

Part of #807.

```
$ yash3 -o portable -c 'true foo bar'
warning: non-portable argument
 --> <command_string>:1:6
  |
1 | true foo bar
  | ---- ^^^ POSIX does not require this built-in to accept any argument
  | |
  | while executing the true built-in
  |
  = note: this warning is reported because the `portable` shell option is enabled
```

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In portable mode, `true` and `false` now warn when given arguments, including `--`.
  * Arguments continue to be ignored, and each command preserves its existing exit status.
  * Warnings identify the relevant argument and are written to standard error.

* **Documentation**
  * Updated POSIX compatibility guidance and changelogs to describe argument handling and warning behavior.

* **Tests**
  * Added coverage for warnings, ignored arguments, option-like arguments, and unchanged exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->