### PR TITLE
Validate all job ID operands before a built-in takes effect

### DIFF
--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -60,6 +60,10 @@ A _private dependency_ is used internally and not visible to downstream users.
   signal sent and no job resumed. Previously, these built-ins acted on each
   operand in turn and reported a syntax error only after the effects of the
   preceding operands had taken place.
+- The `jobs` built-in now examines the syntax of all its operands before it
+  looks up any job, so that a syntax error in an operand is reported even if an
+  earlier operand names no job. It also reports the errors of all its operands
+  rather than only the first one.
 - `common::report::merge_reports` no longer repeats a footnote that is equal to
   one already collected from an earlier report. Built-ins that produce one
   error report per operand, such as `alias`, printed the same note once per

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -17,8 +17,10 @@ A _private dependency_ is used internally and not visible to downstream users.
 
 ### Added
 
-- `kill::send::Error::JobIdSyntax`, returned by `kill::send::resolve_target` for
+- `kill::send::Error::JobIdSyntax`, returned by `kill::send::parse_target` for
   a non-portable job ID.
+- `kill::send::Target`, the result of parsing a target operand of the `kill`
+  built-in, and `kill::send::parse_target`, which produces it.
 - `set::syntax::Error::NonPortableSeparator`, returned by `set::syntax::parse`
   for an invocation of the `set` built-in that uses `-` as a separator between
   options and operands while the `portable` shell option is on.
@@ -46,11 +48,17 @@ A _private dependency_ is used internally and not visible to downstream users.
 - `wait::search::resolve` now parses the job ID contained in a `wait::JobSpec`
   and takes a third parameter that tells whether the `portable` shell option is
   on. It no longer panics on a job ID without a leading `%`.
-- `kill::send::resolve_target` now takes a third parameter that tells whether
-  the `portable` shell option is on.
+- `kill::send::resolve_target` and `kill::send::send` now take a parsed
+  `kill::send::Target` instead of the raw target string. The syntax of a target
+  is now examined by `kill::send::parse_target`, which does not need the job
+  list.
 - The `set` built-in (`set::syntax::parse`) now rejects a `-` used as a
   separator between options and operands when the `portable` shell option is
   on.
+- The `kill` built-in now examines the syntax of all its targets before sending
+  any signal, so that a syntax error in a target leaves no signal sent.
+  Previously, the built-in acted on each target in turn and reported a syntax
+  error only after the signal had been sent for the preceding targets.
 - `common::report::merge_reports` no longer repeats a footnote that is equal to
   one already collected from an earlier report. Built-ins that produce one
   error report per operand, such as `alias`, printed the same note once per

--- a/yash-builtin/CHANGELOG.md
+++ b/yash-builtin/CHANGELOG.md
@@ -55,10 +55,11 @@ A _private dependency_ is used internally and not visible to downstream users.
 - The `set` built-in (`set::syntax::parse`) now rejects a `-` used as a
   separator between options and operands when the `portable` shell option is
   on.
-- The `kill` built-in now examines the syntax of all its targets before sending
-  any signal, so that a syntax error in a target leaves no signal sent.
-  Previously, the built-in acted on each target in turn and reported a syntax
-  error only after the signal had been sent for the preceding targets.
+- The `bg` and `kill` built-ins now examine the syntax of all their operands
+  before taking any action, so that a syntax error in an operand leaves no
+  signal sent and no job resumed. Previously, these built-ins acted on each
+  operand in turn and reported a syntax error only after the effects of the
+  preceding operands had taken place.
 - `common::report::merge_reports` no longer repeats a footnote that is equal to
   one already collected from an earlier report. Built-ins that produce one
   error report per operand, such as `alias`, printed the same note once per

--- a/yash-builtin/src/bg.rs
+++ b/yash-builtin/src/bg.rs
@@ -38,6 +38,7 @@ use crate::common::report::job;
 use crate::common::report::{merge_reports, report, report_error, report_simple_failure};
 use crate::common::syntax::Mode;
 use crate::common::syntax::parse_arguments;
+use itertools::Itertools as _;
 use std::fmt::Display;
 use thiserror::Error;
 use yash_env::Env;
@@ -46,6 +47,7 @@ use yash_env::io::Fd;
 use yash_env::job::JobList;
 use yash_env::job::ProcessState;
 use yash_env::job::id::FindError;
+use yash_env::job::id::JobId;
 use yash_env::job::id::ParseError;
 use yash_env::job::id::parse;
 use yash_env::option::Option::{Monitor, Portable};
@@ -118,15 +120,15 @@ impl OperandErrorKind {
 ///
 /// This type is shared with the `fg` built-in.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
-pub(crate) struct OperandError(pub(crate) Field, pub(crate) OperandErrorKind);
+pub(crate) struct OperandError<'a>(pub(crate) &'a Field, pub(crate) OperandErrorKind);
 
-impl Display for OperandError {
+impl Display for OperandError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}: {}", self.0.value, self.1)
     }
 }
 
-impl OperandError {
+impl OperandError<'_> {
     /// Converts the error to a [`Report`].
     #[must_use]
     pub fn to_report(&self) -> Report<'_> {
@@ -146,7 +148,7 @@ impl OperandError {
     }
 }
 
-impl<'a> From<&'a OperandError> for Report<'a> {
+impl<'a> From<&'a OperandError<'a>> for Report<'a> {
     #[inline]
     fn from(error: &'a OperandError) -> Self {
         error.to_report()
@@ -192,15 +194,33 @@ where
     Ok(())
 }
 
-/// Resumes the job specified by the operand.
-async fn resume_job_by_id<S>(env: &mut Env<S>, job_id: &str) -> Result<(), OperandErrorKind>
+/// Resumes the job specified by the job ID.
+async fn resume_job_by_id<S>(env: &mut Env<S>, job_id: JobId<'_>) -> Result<(), OperandErrorKind>
 where
     S: Signals + SendSignal + WriteAll,
 {
-    let job_id = parse(job_id, env.options.get(Portable))?;
     let index = job_id.find(&env.jobs)?;
     resume_job_by_index(env, index).await?;
     Ok(())
+}
+
+/// Reports the given operand errors, if any.
+///
+/// The exit status is the highest of the exit statuses the errors imply. If
+/// there is no error, this function returns the default (successful) result
+/// without printing anything.
+pub(crate) async fn report_operand_errors<S>(
+    env: &mut Env<S>,
+    errors: &[OperandError<'_>],
+) -> crate::Result
+where
+    S: Isatty + Signals + WriteAll,
+{
+    let Some(exit_status) = errors.iter().map(OperandError::exit_status).max() else {
+        return crate::Result::default();
+    };
+    let merged = merge_reports(errors).unwrap();
+    report(env, merged, exit_status).await
 }
 
 /// Entry point of the `bg` built-in
@@ -228,18 +248,27 @@ where
             report_simple_failure(env, "there is no job").await
         }
     } else {
+        // Parse all operands before resuming any job so that a syntax error in
+        // a later operand does not leave an earlier job resumed.
+        let portable = env.options.get(Portable);
+        let (job_ids, errors): (Vec<_>, Vec<_>) = operands
+            .iter()
+            .map(|operand| {
+                parse(&operand.value, portable).map_err(|error| OperandError(operand, error.into()))
+            })
+            .partition_result();
+        if !errors.is_empty() {
+            return report_operand_errors(env, &errors).await;
+        }
+
         let mut errors = Vec::new();
-        for operand in operands {
-            match resume_job_by_id(env, &operand.value).await {
+        for (operand, job_id) in operands.iter().zip(job_ids) {
+            match resume_job_by_id(env, job_id).await {
                 Ok(()) => {}
                 Err(error) => errors.push(OperandError(operand, error)),
             }
         }
-        let Some(exit_status) = errors.iter().map(OperandError::exit_status).max() else {
-            return crate::Result::default();
-        };
-        let merged = merge_reports(&errors).unwrap();
-        report(env, merged, exit_status).await
+        report_operand_errors(env, &errors).await
     }
 }
 
@@ -613,5 +642,33 @@ mod tests {
         assert_eq!(state.processes[&pgid].state(), ProcessState::Running);
         // Some error messages should be printed for the invalid operands.
         assert_stderr(&system.state, |stderr| assert_ne!(stderr, ""));
+    }
+
+    #[test]
+    fn main_resumes_no_job_if_a_later_operand_has_a_syntax_error() {
+        let system = VirtualSystem::new();
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        env.options.set(Monitor, On);
+        let pgid = Pid(100);
+        let mut job = Job::new(pgid);
+        job.job_controlled = true;
+        env.jobs.insert(job);
+        let mut leader = Process::with_parent_and_group(system.process_id, pgid);
+        _ = leader.set_state(ProcessState::stopped(SIGSTOP));
+        system.state.borrow_mut().processes.insert(pgid, leader);
+
+        // The second operand lacks the leading `%`, which is a syntax error.
+        let result = main(&mut env, Field::dummies(["%1", "1"]))
+            .now_or_never()
+            .unwrap();
+        assert_eq!(result, crate::Result::from(ExitStatus::ERROR));
+
+        // The first job should not have been resumed.
+        let state = system.state.borrow();
+        assert_eq!(
+            state.processes[&pgid].state(),
+            ProcessState::stopped(SIGSTOP)
+        );
+        assert_stdout(&system.state, |stdout| assert_eq!(stdout, ""));
     }
 }

--- a/yash-builtin/src/fg.rs
+++ b/yash-builtin/src/fg.rs
@@ -39,7 +39,8 @@
 use crate::bg::OperandError;
 use crate::bg::OperandErrorKind;
 use crate::bg::ResumeError;
-use crate::common::report::{report, report_error, report_simple_failure};
+use crate::bg::report_operand_errors;
+use crate::common::report::{report_error, report_simple_failure};
 use crate::common::syntax::Mode;
 use crate::common::syntax::parse_arguments;
 use std::ops::ControlFlow::Break;
@@ -225,10 +226,7 @@ where
         let operand = operands.into_iter().next().unwrap();
         match resume_job_by_id(env, &operand.value).await {
             Ok(result) => finish(env, result),
-            Err(kind) => {
-                let error = OperandError(operand, kind);
-                report(env, &error, error.exit_status()).await
-            }
+            Err(kind) => report_operand_errors(env, &[OperandError(&operand, kind)]).await,
         }
     }
 }

--- a/yash-builtin/src/jobs.rs
+++ b/yash-builtin/src/jobs.rs
@@ -22,16 +22,19 @@
 
 use crate::common::output;
 use crate::common::report::job;
+use crate::common::report::merge_reports;
 use crate::common::report::report_error;
 use crate::common::report::report_failure;
 use crate::common::syntax::ConflictingOptionError;
 use crate::common::syntax::Mode;
 use crate::common::syntax::OptionSpec;
 use crate::common::syntax::parse_arguments;
+use itertools::Itertools as _;
 use std::fmt::Display;
 use yash_env::Env;
 use yash_env::builtin::Result;
 use yash_env::job::fmt::Accumulator;
+use yash_env::job::id::JobId;
 use yash_env::job::id::ParseError;
 use yash_env::job::id::parse_tail;
 use yash_env::option::Option::Portable;
@@ -70,6 +73,18 @@ fn parse_error_report<'a>(error: ParseError, operand: &'a Field) -> Report<'a> {
     let mut report = operand_error_report(&error, operand);
     report.footnotes = job::non_portable_footnotes(error);
     report
+}
+
+/// Parses an operand into a job ID.
+///
+/// Unless `portable` is [`State::On`], an operand may omit the leading `%`.
+fn parse_operand(operand: &str, portable: State) -> std::result::Result<JobId<'_>, ParseError> {
+    let tail = match operand.strip_prefix('%') {
+        Some(tail) => tail,
+        None if portable == State::Off => operand,
+        None => return Err(ParseError::MissingPercent),
+    };
+    parse_tail(tail, portable)
 }
 
 /// Entry point for executing the `jobs` built-in
@@ -113,34 +128,37 @@ where
             accumulator.add(index, job, &env.system)
         }
     } else {
-        // Report jobs specified by the operands
+        // Parse all operands before reporting any job so that an error in a
+        // later operand is not masked by an earlier one.
         let portable = env.options.get(Portable);
-        for operand in operands {
-            let tail = match operand.value.strip_prefix('%') {
-                Some(tail) => tail,
-                None if portable == State::Off => &operand.value,
-                None => {
-                    let report = parse_error_report(ParseError::MissingPercent, &operand);
-                    return report_error(env, report).await;
-                }
-            };
-            let job_id = match parse_tail(tail, portable) {
-                Ok(job_id) => job_id,
-                Err(error) => {
-                    let report = parse_error_report(error, &operand);
-                    return report_error(env, report).await;
-                }
-            };
-            match job_id.find(&env.jobs) {
-                Ok(index) => accumulator.add(index, &env.jobs[index], &env.system),
-                Err(error) => {
-                    // TODO Returning here masks the errors of the remaining
-                    // operands. Collect all operand errors and report them
-                    // together instead.
-                    let report = operand_error_report(&error, &operand);
-                    return report_failure(env, report).await;
-                }
-            }
+        let (job_ids, reports): (Vec<_>, Vec<_>) = operands
+            .iter()
+            .map(|operand| {
+                parse_operand(&operand.value, portable)
+                    .map_err(|error| parse_error_report(error, operand))
+            })
+            .partition_result();
+        if let Some(report) = merge_reports(reports) {
+            return report_error(env, report).await;
+        }
+
+        // Likewise, find all the jobs before reporting any of them.
+        let (indexes, reports): (Vec<_>, Vec<_>) = job_ids
+            .into_iter()
+            .zip(&operands)
+            .map(|(job_id, operand)| {
+                job_id
+                    .find(&env.jobs)
+                    .map_err(|error| operand_error_report(&error, operand))
+            })
+            .partition_result();
+        if let Some(report) = merge_reports(reports) {
+            return report_failure(env, report).await;
+        }
+
+        // Report jobs specified by the operands
+        for index in indexes {
+            accumulator.add(index, &env.jobs[index], &env.system)
         }
     }
 
@@ -673,5 +691,78 @@ mod tests {
         let result = main(&mut env, args).now_or_never().unwrap();
         assert_eq!(result, Result::new(ExitStatus::SUCCESS));
         assert_stdout(&state, |stdout| assert_eq!(stdout, "72\n"));
+    }
+
+    #[test]
+    fn syntax_error_reported_before_job_search_error() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, State::On);
+        env.jobs.insert(Job::new(Pid(42)));
+
+        // The first operand names no job and the second is a syntax error.
+        let args = Field::dummies(["%no_such_job", "%"]);
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        assert_eq!(result, Result::new(ExitStatus::ERROR));
+        assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
+        assert_stderr(&state, |stderr| {
+            assert!(
+                stderr.contains("a lone '%' is not a portable job ID"),
+                "stderr = {stderr:?}",
+            );
+            assert!(!stderr.contains("job not found"), "stderr = {stderr:?}");
+        });
+    }
+
+    #[test]
+    fn all_syntax_errors_reported_together() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        env.options.set(Portable, State::On);
+        env.jobs.insert(Job::new(Pid(42)));
+
+        let args = Field::dummies(["%", "1"]);
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        assert_eq!(result, Result::new(ExitStatus::ERROR));
+        assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
+        assert_stderr(&state, |stderr| {
+            assert!(
+                stderr.contains("a lone '%' is not a portable job ID"),
+                "stderr = {stderr:?}",
+            );
+            assert!(
+                stderr.contains("a job ID must start with a '%'"),
+                "stderr = {stderr:?}",
+            );
+            let note = "this error is reported because the `portable` shell option is enabled";
+            assert_eq!(stderr.matches(note).count(), 1, "stderr = {stderr:?}");
+        });
+    }
+
+    #[test]
+    fn all_job_search_errors_reported_together() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system)));
+        let mut job = Job::new(Pid(42));
+        job.name = "echo first".to_string();
+        env.jobs.insert(job);
+
+        let args = Field::dummies(["%no_such_job", "%another_missing_job"]);
+        let result = main(&mut env, args).now_or_never().unwrap();
+
+        assert_eq!(result, Result::new(ExitStatus::FAILURE));
+        assert_stdout(&state, |stdout| assert_eq!(stdout, ""));
+        assert_stderr(&state, |stderr| {
+            assert_eq!(
+                stderr.matches("job not found").count(),
+                2,
+                "stderr = {stderr:?}"
+            );
+        });
     }
 }

--- a/yash-builtin/src/kill/send.rs
+++ b/yash-builtin/src/kill/send.rs
@@ -16,17 +16,20 @@
 
 //! Implementation of `Command::Send`
 //!
-//! [`execute`] calls [`send`] for each target and reports all errors.
-//! [`send`] uses [`resolve_target`] to determine the argument to the
-//! [`kill`](SendSignal::kill) system call.
+//! [`execute`] works in two phases. It first applies [`parse_target`] to every
+//! target to check the syntax of all of them, and aborts without sending any
+//! signal if some target is invalid. Only then does it call [`send`] for each
+//! parsed target and report all errors. [`send`] uses [`resolve_target`] to
+//! determine the argument to the [`kill`](SendSignal::kill) system call.
 
 use crate::common::report::job;
 use crate::common::report::{merge_reports, report, report_failure};
+use itertools::Itertools as _;
 use std::num::{NonZero, ParseIntError};
 use thiserror::Error;
 use yash_env::Env;
 use yash_env::job::Pid;
-use yash_env::job::id::{ParseError, parse_tail};
+use yash_env::job::id::{JobId, ParseError, parse_tail};
 use yash_env::job::{JobList, id::FindError};
 use yash_env::option::Option::Portable;
 use yash_env::option::State;
@@ -63,29 +66,54 @@ pub enum Error {
     System(#[from] Errno),
 }
 
-/// Resolves the specified target into a process (group) ID.
+/// Target of a signal, as parsed from a command-line operand
+///
+/// A target is either a job ID or a process (group) ID. See [`parse_target`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Target<'a> {
+    /// Process ID, or process group ID if negative
+    ProcessId(Pid),
+    /// Job ID
+    JobId(JobId<'a>),
+}
+
+/// Parses the specified target.
 ///
 /// The target may be specified as a job ID, a process ID, or a process group
 /// ID. In case of a process group ID, the value should be negative.
 ///
-/// If `portable` is [`State::On`], a non-portable job ID is rejected with
+/// This function only examines the syntax of the target; it does not need the
+/// job list to tell whether the target is valid. If `portable` is
+/// [`State::On`], a non-portable job ID is rejected with
 /// [`Error::JobIdSyntax`].
-pub fn resolve_target(jobs: &JobList, target: &str, portable: State) -> Result<Pid, Error> {
-    if let Some(tail) = target.strip_prefix('%') {
-        let job_id = parse_tail(tail, portable)?;
-        let index = job_id.find(jobs)?;
-        let job = &jobs[index];
-        if !job.is_owned {
-            Err(Error::Unowned)
-        } else if !job.job_controlled {
-            Err(Error::Unmonitored)
-        } else if !job.state.is_alive() {
-            Err(Error::Finished)
-        } else {
-            Ok(-job.pid)
+pub fn parse_target(target: &str, portable: State) -> Result<Target<'_>, Error> {
+    match target.strip_prefix('%') {
+        Some(tail) => Ok(Target::JobId(parse_tail(tail, portable)?)),
+        None => Ok(Target::ProcessId(Pid(target.parse()?))),
+    }
+}
+
+/// Resolves the specified target into a process (group) ID.
+///
+/// A job ID is resolved into the process group ID of the job it names, which
+/// requires the job to be alive and controlled by the current shell
+/// environment. A process (group) ID is returned as is.
+pub fn resolve_target(jobs: &JobList, target: Target<'_>) -> Result<Pid, Error> {
+    match target {
+        Target::ProcessId(pid) => Ok(pid),
+        Target::JobId(job_id) => {
+            let index = job_id.find(jobs)?;
+            let job = &jobs[index];
+            if !job.is_owned {
+                Err(Error::Unowned)
+            } else if !job.job_controlled {
+                Err(Error::Unmonitored)
+            } else if !job.state.is_alive() {
+                Err(Error::Finished)
+            } else {
+                Ok(-job.pid)
+            }
         }
-    } else {
-        Ok(Pid(target.parse()?))
     }
 }
 
@@ -93,9 +121,9 @@ pub fn resolve_target(jobs: &JobList, target: &str, portable: State) -> Result<P
 pub async fn send<S: SendSignal>(
     env: &mut Env<S>,
     signal: Option<Number>,
-    target: &Field,
+    target: Target<'_>,
 ) -> Result<(), Error> {
-    let pid = resolve_target(&env.jobs, &target.value, env.options.get(Portable))?;
+    let pid = resolve_target(&env.jobs, target)?;
     env.system.kill(pid, signal).await?;
     Ok(())
 }
@@ -146,7 +174,7 @@ impl TargetError<'_> {
             format!("{}: {}", self.target.value, self.error).into(),
         );
         // A job ID is rejected here only when the `portable` option is on:
-        // `resolve_target` supplies the leading `%` itself.
+        // `parse_target` supplies the leading `%` itself.
         if let Error::JobIdSyntax(error) = self.error {
             report.footnotes = job::non_portable_footnotes(error);
         }
@@ -199,9 +227,22 @@ where
 {
     let signal_number = NonZero::new(signal).map(Number::from_raw_unchecked);
 
+    // Parse all targets before sending any signal so that a syntax error in a
+    // later target does not leave the signal sent to an earlier one.
+    let portable = env.options.get(Portable);
+    let (parsed_targets, errors): (Vec<_>, Vec<_>) = targets
+        .iter()
+        .map(|target| {
+            parse_target(&target.value, portable).map_err(|error| TargetError { target, error })
+        })
+        .partition_result();
+    if !errors.is_empty() {
+        return report_target_errors(env, &errors).await;
+    }
+
     let mut errors = Vec::new();
-    for target in targets {
-        match send(env, signal_number, target).await {
+    for (target, parsed_target) in targets.iter().zip(parsed_targets) {
+        match send(env, signal_number, parsed_target).await {
             Ok(()) => (),
             Err(Error::System(Errno::EINVAL)) => {
                 let origin = signal_origin.unwrap();
@@ -212,10 +253,22 @@ where
         }
     }
 
+    report_target_errors(env, &errors).await
+}
+
+/// Reports the given target errors, if any.
+///
+/// The exit status is the highest of the exit statuses the errors imply. If
+/// there is no error, this function returns the default (successful) result
+/// without printing anything.
+async fn report_target_errors<S>(env: &mut Env<S>, errors: &[TargetError<'_>]) -> crate::Result
+where
+    S: Isatty + Signals + WriteAll,
+{
     let Some(exit_status) = errors.iter().map(TargetError::exit_status).max() else {
         return crate::Result::default();
     };
-    let merged = merge_reports(&errors).unwrap();
+    let merged = merge_reports(errors).unwrap();
     report(env, merged, exit_status).await
 }
 
@@ -230,17 +283,35 @@ mod tests {
     use yash_env::option::Option::Portable;
     use yash_env::semantics::ExitStatus;
     use yash_env::system::Concurrent;
-    use yash_env::system::r#virtual::VirtualSystem;
+    use yash_env::system::r#virtual::{Process, SIGSTOP, VirtualSystem};
     use yash_env::test_helper::assert_stderr;
+
+    #[test]
+    fn parse_target_process_ids() {
+        let result = parse_target("123", State::Off);
+        assert_eq!(result, Ok(Target::ProcessId(Pid(123))));
+
+        let result = parse_target("-456", State::Off);
+        assert_eq!(result, Ok(Target::ProcessId(Pid(-456))));
+    }
+
+    #[test]
+    fn parse_target_job_ids() {
+        let result = parse_target("%my", State::Off);
+        assert_eq!(result, Ok(Target::JobId(JobId::NamePrefix("my"))));
+
+        let result = parse_target("%", State::Off);
+        assert_eq!(result, Ok(Target::JobId(JobId::CurrentJob)));
+    }
 
     #[test]
     fn resolve_target_process_ids() {
         let jobs = JobList::new();
 
-        let result = resolve_target(&jobs, "123", State::Off);
+        let result = resolve_target(&jobs, Target::ProcessId(Pid(123)));
         assert_eq!(result, Ok(Pid(123)));
 
-        let result = resolve_target(&jobs, "-456", State::Off);
+        let result = resolve_target(&jobs, Target::ProcessId(Pid(-456)));
         assert_eq!(result, Ok(Pid(-456)));
     }
 
@@ -254,14 +325,14 @@ mod tests {
         job.name = "my job".into();
         jobs.insert(job);
 
-        let result = resolve_target(&jobs, "%my", State::Off);
+        let result = resolve_target(&jobs, Target::JobId(JobId::NamePrefix("my")));
         assert_eq!(result, Ok(Pid(-123)));
     }
 
     #[test]
     fn resolve_target_job_find_error() {
         let jobs = JobList::new();
-        let result = resolve_target(&jobs, "%my", State::Off);
+        let result = resolve_target(&jobs, Target::JobId(JobId::NamePrefix("my")));
         assert_eq!(result, Err(Error::JobIdSearch(FindError::NotFound)));
     }
 
@@ -275,7 +346,7 @@ mod tests {
         job.name = "my job".into();
         jobs.insert(job);
 
-        let result = resolve_target(&jobs, "%my", State::Off);
+        let result = resolve_target(&jobs, Target::JobId(JobId::NamePrefix("my")));
         assert_eq!(result, Err(Error::Unowned));
     }
 
@@ -289,7 +360,7 @@ mod tests {
         job.name = "my job".into();
         jobs.insert(job);
 
-        let result = resolve_target(&jobs, "%my", State::Off);
+        let result = resolve_target(&jobs, Target::JobId(JobId::NamePrefix("my")));
         assert_eq!(result, Err(Error::Unmonitored));
     }
 
@@ -303,14 +374,13 @@ mod tests {
         job.name = "my job".into();
         jobs.insert(job);
 
-        let result = resolve_target(&jobs, "%my", State::Off);
+        let result = resolve_target(&jobs, Target::JobId(JobId::NamePrefix("my")));
         assert_eq!(result, Err(Error::Finished));
     }
 
     #[test]
-    fn resolve_target_rejects_lone_percent_when_portable() {
-        let jobs = JobList::new();
-        let result = resolve_target(&jobs, "%", State::On);
+    fn parse_target_rejects_lone_percent_when_portable() {
+        let result = parse_target("%", State::On);
         assert_eq!(result, Err(Error::JobIdSyntax(ParseError::LonePercent)));
     }
 
@@ -334,9 +404,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_invalid_string() {
-        let jobs = JobList::new();
-        let result = resolve_target(&jobs, "abc", State::Off);
+    fn parse_target_invalid_string() {
+        let result = parse_target("abc", State::Off);
         assert_matches!(result, Err(Error::ProcessId(_)));
     }
 
@@ -408,5 +477,37 @@ mod tests {
             let note = "this error is reported because the `portable` shell option is enabled";
             assert_eq!(stderr.matches(note).count(), 1, "stderr = {stderr:?}");
         });
+    }
+
+    #[test]
+    fn execute_sends_no_signal_when_a_later_target_has_a_syntax_error() {
+        let system = VirtualSystem::new();
+        let state = Rc::clone(&system.state);
+        let mut env = Env::with_system(Rc::new(Concurrent::new(system.clone())));
+        env.options.set(Portable, State::On);
+        let pid = Pid(123);
+        let mut job = Job::new(pid);
+        job.job_controlled = true;
+        job.is_owned = true;
+        job.state = ProcessState::Running;
+        env.jobs.insert(job);
+        let process = Process::with_parent_and_group(system.process_id, pid);
+        state.borrow_mut().processes.insert(pid, process);
+
+        let result = execute(
+            &mut env,
+            SIGSTOP.as_raw(),
+            None,
+            &Field::dummies(["%1", "%"]),
+        )
+        .now_or_never()
+        .unwrap();
+
+        assert_eq!(result, crate::Result::from(ExitStatus::ERROR));
+        // The signal must not have been sent to the first target.
+        assert_eq!(
+            state.borrow().processes[&pid].state(),
+            ProcessState::Running
+        );
     }
 }

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `wait` built-in now exits with status 1, rather than 2, for an ambiguous job ID such as `wait %sleep` when more than one job name starts with `sleep`.
 - With `portable` enabled, the `set` built-in now rejects a `-` used as a separator between options and operands (for example, `set - foo` or `set -a - foo`) as an error.
 - With `portable` enabled, the shell command line now rejects `-` and `--` given together as option-operand separators (for example, `yash3 - -- myscript`) as an error.
-- The `kill` built-in now examines the syntax of all its targets before sending any signal. A syntax error in a target now leaves no signal sent, whereas the built-in previously acted on the targets preceding the erroneous one. For example, `kill %1 %` with `portable` enabled no longer sends the signal to job 1 before rejecting the lone `%`.
+- The `bg` and `kill` built-ins now examine the syntax of all their operands before taking any action. A syntax error in an operand now leaves no signal sent and no job resumed, whereas these built-ins previously acted on the operands preceding the erroneous one. For example, `kill %1 %` with `portable` enabled no longer sends the signal to job 1 before rejecting the lone `%`.
 
 ## [3.4.0] - 2026-08-22
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `wait` built-in now exits with status 1, rather than 2, for an ambiguous job ID such as `wait %sleep` when more than one job name starts with `sleep`.
 - With `portable` enabled, the `set` built-in now rejects a `-` used as a separator between options and operands (for example, `set - foo` or `set -a - foo`) as an error.
 - With `portable` enabled, the shell command line now rejects `-` and `--` given together as option-operand separators (for example, `yash3 - -- myscript`) as an error.
+- The `kill` built-in now examines the syntax of all its targets before sending any signal. A syntax error in a target now leaves no signal sent, whereas the built-in previously acted on the targets preceding the erroneous one. For example, `kill %1 %` with `portable` enabled no longer sends the signal to job 1 before rejecting the lone `%`.
 
 ## [3.4.0] - 2026-08-22
 

--- a/yash-cli/CHANGELOG.md
+++ b/yash-cli/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - With `portable` enabled, the `set` built-in now rejects a `-` used as a separator between options and operands (for example, `set - foo` or `set -a - foo`) as an error.
 - With `portable` enabled, the shell command line now rejects `-` and `--` given together as option-operand separators (for example, `yash3 - -- myscript`) as an error.
 - The `bg` and `kill` built-ins now examine the syntax of all their operands before taking any action. A syntax error in an operand now leaves no signal sent and no job resumed, whereas these built-ins previously acted on the operands preceding the erroneous one. For example, `kill %1 %` with `portable` enabled no longer sends the signal to job 1 before rejecting the lone `%`.
+- The `jobs` built-in now reports the errors of all its operands rather than only the first one, and reports a syntax error in an operand even if an earlier operand names no job.
 
 ## [3.4.0] - 2026-08-22
 

--- a/yash-cli/tests/scripted_test/bg-y.sh
+++ b/yash-cli/tests/scripted_test/bg-y.sh
@@ -9,3 +9,29 @@ test_O -d -e 2 'operand without the leading % rejected as a syntax error' -m
 sh -c 'kill -s STOP $$'
 bg 1
 __IN__
+
+(
+# The state keyword of ps is not specified by POSIX. Skip the test case where
+# it is not supported rather than reporting a failure that is not the shell's.
+[ "$(ps -o state= -p $$ 2>/dev/null)" ] || skip="true"
+
+# The job below is suspended, so its process must still be in the stopped
+# state ("T") after bg has rejected the operands. The test case resumes the
+# job at the end so that the process does not linger.
+test_o -d -e 0 'bg resumes no job when a later operand has a syntax error' -m
+sh -c 'kill -s STOP $$'
+bg %1 1
+echo "bg: $?"
+# The unquoted expansion drops the padding some ps implementations add.
+state=$(echo $(ps -o state= -p "$(jobs -p %1)"))
+case $state in
+    T*) echo "job is stopped";;
+    *) echo "job state is $state";;
+esac
+kill -s CONT %1
+wait %1
+__IN__
+bg: 2
+job is stopped
+__OUT__
+)

--- a/yash-cli/tests/scripted_test/jobs-y.sh
+++ b/yash-cli/tests/scripted_test/jobs-y.sh
@@ -27,3 +27,12 @@ __IN__
 test_O -d -e 2 'operand without the leading % rejected under the portable option' -o portable
 jobs 1
 __IN__
+
+test_o -d -e 0 'jobs reports no job when a later operand has a syntax error' -m -o portable
+sleep 10&
+jobs %1 %
+echo "jobs: $?"
+kill -s KILL %1
+__IN__
+jobs: 2
+__OUT__

--- a/yash-cli/tests/scripted_test/kill-y.sh
+++ b/yash-cli/tests/scripted_test/kill-y.sh
@@ -116,3 +116,30 @@ __IN__
 test_O -d -e 2 'target that is neither a job ID nor a process ID rejected as a syntax error'
 kill -s CONT foo
 __IN__
+
+(
+# The state keyword of ps is not specified by POSIX. Skip the test case where
+# it is not supported rather than reporting a failure that is not the shell's.
+[ "$(ps -o state= -p $$ 2>/dev/null)" ] || skip="true"
+
+# The job below is suspended, so its process must still be in the stopped
+# state ("T") after kill has rejected the targets. Had the signal been sent,
+# the process would have been killed and left as a zombie. The test case
+# resumes the job at the end so that the process does not linger.
+test_o -d -e 0 'kill sends no signal when a later target has a syntax error' -m
+sh -c 'kill -s STOP $$'
+kill -s KILL %1 foo
+echo "kill: $?"
+# The unquoted expansion drops the padding some ps implementations add.
+state=$(echo $(ps -o state= -p "$(jobs -p %1)"))
+case $state in
+    T*) echo "job is stopped";;
+    *) echo "job state is $state";;
+esac
+kill -s CONT %1
+wait %1
+__IN__
+kill: 2
+job is stopped
+__OUT__
+)


### PR DESCRIPTION
## Description

The built-ins that take a job ID acted on their operands one at a time, so a syntax error in a later operand was reported only after the preceding operands had already taken effect. With `set --portable`, `sleep 100& kill %1 %` sent the signal to job 1 before rejecting the lone `%`. A built-in's side effects should be all or nothing as far as they can be, so each of these built-ins now validates the syntax of every operand before it does anything.

Only *syntax* errors gate the side effects. Errors that depend on the state of the job list — a job that is not found, an ambiguous job ID, a job that is not job-controlled — are still reported per operand and do not stop the other operands from being processed. `kill` cannot be all or nothing anyway (an `ESRCH` from `kill 99999 %1` is knowable only at send time), so "everything decidable without a side effect is decided first" is the line that stays consistent across the three built-ins.

`wait` already resolved every operand before waiting, and `fg` takes a single operand, so neither changes.

One commit per built-in:

- **`kill`** ([send.rs:230](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L230)) — `execute` parses all targets, then sends. The former `resolve_target` is split: `parse_target` ([send.rs:89](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L89)) checks the syntax without consulting the job list and yields a `Target` ([send.rs:73](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L73)), and `resolve_target` ([send.rs:101](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L101)) turns a parsed target into a process (group) ID. Both phases report through `report_target_errors` ([send.rs:264](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L264)).
- **`bg`** ([bg.rs:251](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/bg.rs#L251)) — same two phases. `OperandError` now borrows its operand ([bg.rs:123](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/bg.rs#L123)) so the parsed `JobId`s, which borrow the operands too, survive into the resuming phase instead of being parsed again; `resume_job_by_id` ([bg.rs:198](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/bg.rs#L198)) takes a parsed job ID. `fg` shares the type and now reports its operand error through the same helper ([fg.rs:229](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/fg.rs#L229)).
- **`jobs`** ([jobs.rs:131](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/jobs.rs#L131)) — parses every operand, then finds every job, and reports the errors of a phase together. This also settles the `TODO Returning here masks the errors of the remaining operands`: the built-in used to return on the first error. It printed nothing when an operand was in error, so what changes is which errors are reported, not what is printed on success.

### Decisions

Ordered by how likely they are to be contentious. The first was settled by asking; the rest were taken on the reasoning given.

- **Only syntax errors gate the side effects**, rather than the full resolution of every operand (*asked*). Full resolution would make `bg` and `jobs` truly all or nothing, but `kill` would then refuse to signal job 1 in `kill %1 %2` merely because `%2` has finished, which contradicts the documented "exit status is zero if the signal is sent to at least one process for each operand".
- **`jobs` reports the errors of all its operands**, not only the first (*content*). The alternative is to move the syntax check forward and leave the job-search errors reporting one at a time, but the `TODO` in the code asks for exactly this and the other job ID built-ins already collect their errors.
- **No new submodules** (*derivable*). The phases live inside the existing modules; `jobs.rs` keeps its `TODO Split into syntax and semantics submodules`. The alternative is to split `jobs.rs` into `syntax`/`semantics` as most built-ins are laid out, but the title, footnotes and exit-status rules of each built-in's error reporting are already worked out where they are, and separating the phases needs no module boundary. It can follow as its own commit.
- **`kill::send`'s public API changes** (*derivable*). `resolve_target` and `send` take a parsed `Target` instead of the raw string. yash-builtin 0.24.0 is unreleased, so a breaking change costs nothing here. The alternative is to keep the signatures and parse the string a second time in the sending phase.
- **Error messages are unchanged** (*content*). Titles, footnotes and the error-to-exit-status mapping stay as they are; only the number of errors reported and whether the side effect happens change.
- **Versions are unchanged** (*derivable*). yash-builtin 0.24.0 and yash-cli 3.4.1 are both unreleased, and 0.24.0 is already a minor bump, so the changelogs only gain entries.
- **No documentation change**. The manual is deliberately left silent: documenting the new behavior would commit to it, and the author would rather keep the freedom to change it again.

### Testing

Unit tests cover the case where a later operand is invalid and the earlier one must be untouched: [send.rs:483](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/kill/send.rs#L483), [bg.rs:648](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/bg.rs#L648), and [jobs.rs:697](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/jobs.rs#L697), [jobs.rs:720](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/jobs.rs#L720), [jobs.rs:747](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-builtin/src/jobs.rs#L747).

The scripted tests for `bg` ([bg-y.sh:21](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-cli/tests/scripted_test/bg-y.sh#L21)) and `kill` ([kill-y.sh:129](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-cli/tests/scripted_test/kill-y.sh#L129)) suspend a job and then read the process state with `ps -o state=`, so what they check is the state of the process itself rather than the built-in's own output. With the syntax check removed, both fail on that line: the process is gone, since `bg` lets the job run to completion and `kill` kills it. The `state` keyword is not specified by POSIX, so each of the two test cases is guarded by a probe that sets `skip` where `ps` does not support it. `jobs` ([jobs-y.sh:31](https://github.com/magicant/yash-rs/blob/prevent-side-effect-on-job-id-syntax-error/yash-cli/tests/scripted_test/jobs-y.sh#L31)) checks the standard output, which is the built-in's only side effect.

Each commit was checked out on its own and `cargo test -p yash-builtin -p yash-cli` run against it, so the intermediate states are green too.

## Checklist

- [x] Code follows the existing style and conventions
- [x] Unit tests are added in the same file as the code being tested
- [x] If the change affects observable behavior of the shell executable, scripted tests are added or updated (`yash-cli/tests/scripted_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `bg`, `jobs`, and `kill` now validate all operands before taking action, preventing partial execution when a later operand is invalid.
  - `jobs` reports errors for every invalid or unresolved operand instead of stopping at the first error.
  - Error messages retain relevant operand context.
  - `kill` consistently validates target syntax and reports appropriate exit statuses across supported modes.
- **Tests**
  - Added coverage confirming invalid operands do not resume jobs, send signals, or produce partial job listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
