### PR TITLE
Improve scripted tests and document their conventions

### DIFF
--- a/.agents/skills/scripted-tests/SKILL.md
+++ b/.agents/skills/scripted-tests/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: scripted-tests
+description: 'Write scripted tests for the yash shell executable: file naming, the test_* harness aliases, exit status and output checks, skipping unsupported environments, and the environment a test case runs in. Use when shell-observable behavior changes and a test under yash-cli/tests/scripted_test is added, updated, or reviewed.'
+argument-hint: 'Which shell behavior needs a scripted test?'
+---
+
+# Scripted Tests
+
+Scripted tests run the built shell executable and compare what it produces
+against an expectation declared in the test file. Write them as follows unless
+you are instructed otherwise.
+
+The harness is [run-test.sh](../../../yash-cli/tests/scripted_test/run-test.sh),
+driven by [scripted_test.rs](../../../yash-cli/tests/scripted_test.rs). Read
+`run-test.sh` when you need a detail this skill does not cover.
+
+## When to write one
+
+- Add or update a scripted test whenever shell-observable behavior changes.
+  Unit tests cover the implementation; a scripted test covers what a user of the
+  shell executable can see.
+- Test through the shell's own interface: the exit status, the standard output,
+  and the standard error of a command line. Anything only reachable from Rust
+  belongs in a unit test instead.
+
+## Choosing the file
+
+- Test files live in
+  [yash-cli/tests/scripted_test](../../../yash-cli/tests/scripted_test/) and are
+  named after the feature they cover.
+- A `-p.sh` file tests behavior any POSIX-compliant shell must have. It sets
+  `posix="true"` near the top, which makes the harness invoke the testee as
+  `sh`. Do not put yash extensions in these files.
+- A `-y.sh` file tests yash-specific behavior, including behavior POSIX leaves
+  unspecified and options yash adds.
+- Add to the existing file for the feature. A new file needs a corresponding
+  `#[test]` function in `scripted_test.rs`; use `run_with_pty` rather than `run`
+  if the test needs a controlling terminal, as job control and interactive tests
+  do.
+
+## Anatomy of a test case
+
+A test case is one `test_*` alias, a name, optional harness options, optional
+arguments for the shell, and the here-documents that follow:
+
+```sh
+test_oE -e 0 'name of the test case' -o portable
+echo hello
+__IN__
+hello
+__OUT__
+```
+
+- The `__IN__` document is the shell's standard input. The operands after the
+  name are passed to the shell as command-line arguments (`-i`, `-m`,
+  `-o portable`, …).
+- The alias says which streams are checked. A lowercase letter means the stream
+  is compared against a here-document, an uppercase letter means it must be
+  empty, and an absent letter means it is not checked at all:
+
+  | Alias | Standard output | Standard error |
+  |---|---|---|
+  | `test_x` | not checked | not checked |
+  | `test_o` | `__OUT__` | not checked |
+  | `test_O` | must be empty | not checked |
+  | `test_e` | not checked | `__ERR__` |
+  | `test_E` | not checked | must be empty |
+  | `test_oe` | `__OUT__` | `__ERR__` |
+  | `test_oE` | `__OUT__` | must be empty |
+  | `test_Oe` | must be empty | `__ERR__` |
+  | `test_OE` | must be empty | must be empty |
+
+- The `-d` option requires the standard error to be non-empty without comparing
+  it. Use it for a case that must print a diagnostic whose exact wording is not
+  the point; it overrides the alias's standard error check.
+- The `-f` option inverts the result, for a case that documents an unfixed bug
+  or an unimplemented feature.
+
+## Checking the exit status
+
+- Check an exit status with the `-e` option, not by printing `$?` from inside
+  the test case. `-e` applies to the test case as a whole, so put the command
+  whose status matters last.
+- If the case has to run further commands after the one being tested, give the
+  status its own test case rather than echoing `$?`. A test case is cheap; a
+  `$?` in the middle of a case turns a status check into an output check and
+  hides which command the status came from.
+- `-e n` expects any non-zero status. `-e TERM` and other signal names expect
+  the shell to be killed by that signal.
+
+## Letting the harness compare
+
+- Prefer letting the harness compare the result: print what the test produces
+  and declare the expectation in a `__OUT__`/`__ERR__` section rather than
+  asserting inside the test case with `[ ... ]` and `test_x`. A harness
+  comparison shows the expected and the actual output when it fails, whereas an
+  in-case assertion only reports a non-zero exit status.
+- Assert inside the case only where the harness cannot express the check.
+- Where a value needs normalizing before it can be compared, print the
+  normalized value and let the expectation carry it. Keep the raw value in the
+  fallback branch so a failure still shows what was actually there:
+
+  ```sh
+  case $state in
+      T*) echo "job is stopped";;
+      *) echo "job state is $state";;
+  esac
+  ```
+
+## The environment a test case runs in
+
+- Each test file runs in a fresh empty working directory, so a test case may
+  create files freely.
+- To run the shell under test from within a test case, use the `TESTEE`
+  environment variable, which the harness exports with the path to the
+  executable. The working directory also contains a symbolic link named `sh`
+  that points at the testee, but it is what the harness itself uses to invoke
+  the testee as `sh`; a test case that runs plain `sh` finds whatever the
+  current `PATH` resolves, which is normally the system shell.
+- The `setup` function adds a script that runs before every test case in the
+  file. `setup -d` adds the default helpers (`echoraw`, `bracket`, `_sp`,
+  `_tab`, `_nl`). Call `macos_kill_workaround` before test cases that rely on a
+  self-sent signal being handled at a predictable time.
+- The test file itself is read by the shell that drives the harness, not by the
+  testee. Everything outside the here-documents — `skip` probes, `case`,
+  subshells, helper functions — must be portable POSIX shell code even in a
+  `-y.sh` file.
+
+## Skipping a test case
+
+- Where a test case depends on something the environment may not provide, probe
+  for it and set `skip` to a non-empty value instead of letting the case fail.
+  A failure that is not the shell's fault costs more to diagnose than a skip.
+- Wrap the test case in a subshell so the assignment does not leak into the
+  cases that follow:
+
+  ```sh
+  (
+  # The state keyword of ps is not specified by POSIX.
+  [ "$(ps -o state= -p $$ 2>/dev/null)" ] || skip="true"
+
+  test_o -e 0 'a test case that needs ps -o state'
+  ...
+  __IN__
+  ...
+  __OUT__
+  )
+  ```
+
+- Probe for the result, not just the exit status, where a utility may accept an
+  unknown request and quietly produce nothing.
+- The same idiom covers a behavior that depends on the platform, on the user
+  (running as root), or on a feature that is not implemented yet.
+
+## External utilities
+
+- A test case may use external utilities to observe what the shell did — `ps`
+  to read a process state, `diff` to compare files, `mkfifo` to synchronize.
+  Prefer POSIX-specified utilities and options; guard anything else with `skip`.
+- Command substitution does not strip the padding some utilities add. Use the
+  word-splitting idiom `$(echo $(...))` where the value is compared or matched.
+
+## Timing and synchronization
+
+- Every test should finish as quickly as it can. The goal is that on an
+  infinitely fast CPU the whole suite takes zero seconds, so a test case must
+  never wait for time to pass.
+- Never rely on a bare `sleep` to let something happen. Make the shell itself
+  provide the synchronization point.
+- A job that suspends itself in the foreground gives one for free: the shell
+  regains control only once the job has stopped, so what follows cannot race
+  with it.
+
+  ```sh
+  sh -c 'kill -s STOP $$'
+  ```
+
+- Otherwise use a FIFO (`mkfifo sync`) or poll for a definite condition, as
+  existing job control tests do.
+- Where a state change is inherently asynchronous, arrange the test so that the
+  comparison does not depend on when it happens — print the markers after the
+  job has finished rather than around it.
+
+## Before you are done
+
+- Run the tests with `cargo test -p yash-cli --test scripted_test`. The harness
+  prints the log only for a failing case; the full log of each file is left in
+  `target/tmp/<name>.log`, which is where a `SKIPPED` line shows up.
+- Confirm the new test fails without the change it covers. Temporarily undo the
+  behavior, check that the case fails and that it fails on the line you meant it
+  to, and restore the change. A scripted test that passes either way is worse
+  than none.

--- a/.agents/skills/scripted-tests/SKILL.md
+++ b/.agents/skills/scripted-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scripted-tests
-description: 'Write scripted tests for the yash shell executable: file naming, the test_* harness aliases, exit status and output checks, skipping unsupported environments, and the environment a test case runs in. Use when shell-observable behavior changes and a test under yash-cli/tests/scripted_test is added, updated, or reviewed.'
+description: 'Write scripted tests for the yash shell executable: file naming, the test_* harness aliases, exit status and output checks, skipping unsupported environments, the environment a test case runs in, and cleaning up background jobs so no process is left behind. Use when shell-observable behavior changes and a test under yash-cli/tests/scripted_test is added, updated, or reviewed.'
 argument-hint: 'Which shell behavior needs a scripted test?'
 ---
 
@@ -180,6 +180,46 @@ __OUT__
 - Where a state change is inherently asynchronous, arrange the test so that the
   comparison does not depend on when it happens — print the markers after the
   job has finished rather than around it.
+
+## Leaving no process behind
+
+- A test case must not outlive itself. When the testee exits, every process it
+  started should be gone; a `sleep` that lingers after the suite has finished is
+  a defect in the test even when the case passes.
+- Do not leave a background job running at the end of a case. Kill it, and be
+  aware that the shell forks twice for an asynchronous external utility: the
+  asynchronous job is a subshell that forks again to exec the utility, so `$!`
+  names the subshell and `kill $!` leaves the utility orphaned.
+- With job control (`-m`), each job has its own process group, so a job ID
+  reaches the whole job. An `EXIT` trap is the tidiest place for it because it
+  does not disturb the exit status the case is checking:
+
+  ```sh
+  test_O -e 0 'a case that needs a background job' -m
+  trap 'kill -s KILL %1' EXIT
+  sleep 10&
+  ...
+  __IN__
+  ```
+
+- Without job control, the job has no process group of its own, so `kill %1`
+  fails with `target job is not job-controlled`. Use a job whose body is a
+  single built-in instead, so the job is one process that `kill $!` fully
+  covers. A `read` blocking on a FIFO waits without spawning anything:
+
+  ```sh
+  mkfifo fifo
+
+  test_OE -e 0 'a case that signals a background job'
+  read x <fifo &
+  kill -s KILL $!
+  wait $!
+  :
+  __IN__
+  ```
+
+- After adding a case that starts a process, run the suite and check with `ps`
+  that nothing is left behind.
 
 ## Before you are done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,8 @@ Run from repository root.
 
 - Follow Kent Beck's Canon TDD when implementing a feature or fixing a bug. Canon TDD ends with a refactoring phase; do not stop at a green test. This will guide you to the right amount of tests (neither too many nor too few). Use the [`unit-tests` skill](.agents/skills/unit-tests/SKILL.md) when writing the tests; it is the canonical guide to how unit tests are organized, named, and implemented in this workspace.
 - Put unit tests in the same file as the code they test, using `#[cfg(test)] mod tests { ... }`.
-- If shell-observable behavior changes, add/update scripted tests under [yash-cli/tests/scripted_test](yash-cli/tests/scripted_test/).
+- If shell-observable behavior changes, add/update scripted tests under [yash-cli/tests/scripted_test](yash-cli/tests/scripted_test/). Use the [`scripted-tests` skill](.agents/skills/scripted-tests/SKILL.md) when writing them; it is the canonical guide to the test harness and the conventions of these tests.
 - The scripted test harness entry point is [yash-cli/tests/scripted_test.rs](yash-cli/tests/scripted_test.rs), which invokes [yash-cli/tests/scripted_test/run-test.sh](yash-cli/tests/scripted_test/run-test.sh) as the test driver.
-- In a scripted test, prefer letting the harness compare the result: print what the test produces and declare the expectation in a `__OUT__`/`__ERR__` section (`test_o`, `test_oE`, `test_oe`, …) rather than asserting inside the test case with `[ ... ]` and `test_x`. A harness comparison shows the expected and actual output when it fails, whereas an in-case assertion only reports a non-zero exit status. Assert inside the case only where the harness cannot express the check.
 
 ## Code style
 

--- a/yash-cli/tests/scripted_test/bg-p.sh
+++ b/yash-cli/tests/scripted_test/bg-p.sh
@@ -2,11 +2,6 @@
 
 posix="true"
 
-# The "sleep 0" commands in the test cases below are a hack to ensure that the
-# shell receives SIGCHLD and takes in the latest status of the background jobs.
-# Without this, the "wait" built-in may return before the background jobs are
-# actually resumed.
-
 cat >job1 <<'__END__'
 exec sh -c 'kill -s STOP $$; echo'
 __END__
@@ -25,7 +20,6 @@ test_o 'default operand chooses most recently suspended job' -m
 :&
 sh -c 'kill -s STOP $$; echo 1'
 bg >/dev/null
-sleep 0
 wait
 __IN__
 1
@@ -40,7 +34,6 @@ __IN__
 test_O -e 17 'resumed job is awaitable' -m
 sh -c 'kill -s STOP $$; exit 17'
 bg >/dev/null
-sleep 0
 wait %
 __IN__
 
@@ -49,7 +42,6 @@ sh -c 'kill -s STOP $$; trap "" TTIN; head -n 1 /dev/tty'
 # The shell is ignoring SIGTTIN, so the "head" command will just fail with EIO
 # when it tries to read from the terminal in the background.
 bg >/dev/null
-sleep 0
 wait %
 __IN__
 
@@ -59,7 +51,6 @@ test_o 'specifying job ID' -m
 echo -
 bg %./job1 >/dev/null
 bg %./job2 >/dev/null
-sleep 0
 wait
 __IN__
 -
@@ -72,7 +63,6 @@ test_o 'specifying more than one job ID' -m
 ./job2
 echo -
 bg %./job1 %./job2 >/dev/null
-sleep 0
 wait
 __IN__
 -

--- a/yash-cli/tests/scripted_test/bg-p.sh
+++ b/yash-cli/tests/scripted_test/bg-p.sh
@@ -71,9 +71,10 @@ __IN__
 __OUT__
 
 test_O -e 0 'bg prints resumed job' -m
-sleep 1&
+trap 'kill -s KILL %1' EXIT
+sleep 10&
 bg >bg.out
-grep -qx '\[[[:digit:]][[:digit:]]*][[:blank:]]*sleep 1' bg.out
+grep -qx '\[[[:digit:]][[:digit:]]*][[:blank:]]*sleep 10' bg.out
 __IN__
 
 test_O -e 17 'bg updates $!' -m

--- a/yash-cli/tests/scripted_test/getopts-y.sh
+++ b/yash-cli/tests/scripted_test/getopts-y.sh
@@ -50,20 +50,20 @@ __ERR__
 )
 
 : TODO https://github.com/magicant/yash-rs/issues/448
-test_Oe -d -e 1 -f 'invalid operand variable name'
+test_O -d -e 1 -f 'invalid operand variable name'
 getopts '' =
 __IN__
 
 test_O -d -e 2 'getopts rejects non-portable variable name' -o portable
-getopts a foo-bar a-
+getopts a foo-bar -a
 __IN__
 
 test_O -d -e 2 'getopts rejects variable name starting with a digit' -o portable
-getopts a 1abc a-
+getopts a 1abc -a
 __IN__
 
 test_OE -e 0 'getopts accepts non-portable variable name without the portable option'
-getopts a foo-bar a-
+getopts a foo-bar -a
 __IN__
 
 test_O -d -e 2 'unset OPTIND'
@@ -121,10 +121,10 @@ test_O -d -e 2 'invalid option'
 getopts --no-such-option a o -a
 __IN__
 
-test_Oe -d -e 2 'missing operand (0)'
+test_O -d -e 2 'missing operand (0)'
 getopts
 __IN__
 
-test_Oe -d -e 2 'missing operand (1)'
+test_O -d -e 2 'missing operand (1)'
 getopts a
 __IN__

--- a/yash-cli/tests/scripted_test/kill-y.sh
+++ b/yash-cli/tests/scripted_test/kill-y.sh
@@ -42,8 +42,14 @@ test_O -d -e 2 'attached signal argument rejected under the portable option' -o 
 kill -sCONT $$
 __IN__
 
+# The test cases below need a background job to send signals to. The job body
+# must be a built-in blocking on this FIFO rather than an external command like
+# "sleep": the shell forks again to run an external command, so $! would name
+# the intermediate subshell and the utility would survive the signal.
+mkfifo fifo
+
 test_OE -e 0 'signal number argument to -s accepted without the portable option'
-sleep 10 &
+read x <fifo &
 kill -s 9 $!
 wait $!
 :
@@ -91,7 +97,7 @@ kill -0 $$
 __IN__
 
 test_OE -e 0 'bare signal name starting with s accepted under the portable option' -o portable
-sleep 10 &
+read x <fifo &
 kill -stop $!
 kill -cont $!
 kill -s KILL $!

--- a/yash-cli/tests/scripted_test/path-y.sh
+++ b/yash-cli/tests/scripted_test/path-y.sh
@@ -127,7 +127,7 @@ __OUT__
 mkdir extendedglob2
 cd extendedglob2
 mkdir -p a/a/a a/a/b a/b/a a/b/b b/a/a b/a/b b/b/a b/b/b
-for d in */*/*; do (cd -- "$d"; ln -s ../../.. a; ln -s ../../.. b) done
+for d in */*/*; do (cd -- "$d"; ln -s ../../.. a; ln -s ../../.. b); done
 )
 
 (

--- a/yash-cli/tests/scripted_test/wait-y.sh
+++ b/yash-cli/tests/scripted_test/wait-y.sh
@@ -5,6 +5,7 @@ wait %
 __IN__
 
 test_O -d -e 1 'ambiguous job ID reported as a runtime failure' -m
+trap 'kill -s KILL %1 %2' EXIT
 sleep 10 & sleep 11 &
 wait %sleep
 __IN__


### PR DESCRIPTION
Improves the scripted tests under `yash-cli/tests/scripted_test` and
documents their conventions.

- Adds a `scripted-tests` skill collecting the conventions that were
  previously only discoverable by reading `run-test.sh`: which stream
  each `test_*` alias compares, how `-e` and the `skip` variable work,
  and that code outside the here-documents runs in the driver shell
  rather than the testee. `AGENTS.md` now points at the skill.
- Removes the `sleep 0` hack from `bg-p.sh`; the race it worked around
  cannot happen since `wait` always waits with job control off.
- Stops three test cases from leaving stray `sleep` processes alive for
  the whole test suite, and documents the rule in the skill.
- Fixes three `getopts` test cases that never ran: `test_Oe -d` wrote no
  `__ERR__` section, so the here-document swallowed the rest of the
  file and silently skipped every case after line 53.
- Adds the separator POSIX requires between a compound command and a
  following reserved word, so a strictly conforming shell can read the
  test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134kQ5CKTTm1GvAt6QqxPb5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for writing and validating scripted shell tests.
  * Updated project testing expectations to reference the new testing guide.

* **Tests**
  * Updated job control, signal handling, option parsing, path handling, and process cleanup tests.
  * Reduced timing-dependent synchronization in background job tests.
  * Improved cleanup of background processes and corrected a path-related test setup issue.
  * Refined output checks for selected option-parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->